### PR TITLE
fix(compiler): Lock in rollup version 0.50.0

### DIFF
--- a/packages/lwc-compiler/package.json
+++ b/packages/lwc-compiler/package.json
@@ -59,7 +59,7 @@
     "lwc-template-compiler": "0.17.8",
     "postcss": "^6.0.13",
     "postcss-plugin-lwc": "0.17.8",
-    "rollup": "~0.50.0",
+    "rollup": "0.50.0",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-replace": "^2.0.0"
   }


### PR DESCRIPTION
## PR Checklist

**What kind of change does this PR introduce?** (add 'x' - [x])

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:

**The PR fulfills these requirements:**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Both unit and integration tests pass
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The PR title follows conventional commit format:
      ```
            commit-type(optional scope): commit description.
      ```
      
      Supported commit types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test.
      Supported scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
      
      
 - More details on LWC semantic commit can be found [here](https://git.soma.salesforce.com/lwc/lwc/blob/master/CONTRIBUTING.md#commit).
      
      

#### Other information:

Fix for W-4640609: Imported items are not being remapped to the imported symbol inside the constructor. Note that the more recent rollup version, 0.54.0, also works. Regression starts at 0.50.1.
