### PR TITLE
fix(transform-lwc-class): Restrict import specifiers on engine

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
@@ -3,6 +3,31 @@ const pluginTest = require('./utils/test-transform').pluginTest(
 );
 
 describe('Element import', () => {
+    pluginTest('throws if using default import on engine', `
+        import engine from 'engine';
+    `, {
+        error: {
+            message: `test.js: Invalid import. "engine" doesn't have default export.`,
+            loc: {
+                line: 1,
+                column: 7,
+            }
+        }
+    });
+
+    pluginTest('throws if using namespace import on engine', `
+        import * as engine from 'engine';
+        export default class extends engine.Element {}
+    `, {
+        error: {
+            message: `test.js: Invalid import. Namespace imports are not allowed on "engine", instead use named imports "import { Element } from 'engine'".`,
+            loc: {
+                line: 1,
+                column: 7,
+            }
+        }
+    });
+
     pluginTest('throw an error if the component class is anonymous', `
         import { Element } from 'engine';
 

--- a/packages/babel-plugin-transform-lwc-class/src/component.js
+++ b/packages/babel-plugin-transform-lwc-class/src/component.js
@@ -1,12 +1,12 @@
 const { basename } = require('path');
 const commentParser = require('comment-parser');
-const { findClassMethod, findClassProperty, staticClassProperty, getImportSpecifiers } = require('./utils');
-const { LWC_PACKAGE_ALIAS, LWC_PACKAGE_EXPORTS, LWC_COMPONENT_PROPERTIES } = require('./constants');
+const { findClassMethod, findClassProperty, staticClassProperty, getEngineImportSpecifiers } = require('./utils');
+const { LWC_PACKAGE_EXPORTS, LWC_COMPONENT_PROPERTIES } = require('./constants');
 
-module.exports = function ({ types: t, }) {
+module.exports = function ({ types: t }) {
     return {
         Program(path, state) {
-            const engineImportSpecifiers = getImportSpecifiers(path, LWC_PACKAGE_ALIAS);
+            const engineImportSpecifiers = getEngineImportSpecifiers(path);
 
             // Store on state local identifiers referencing engine base component
             state.componentBaseClassImports = engineImportSpecifiers.filter(({ name }) => (

--- a/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
+++ b/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
@@ -3,7 +3,7 @@ const wire = require('./wire');
 const track = require('./track');
 
 const { LWC_PACKAGE_ALIAS, DECORATOR_TYPES } = require('../constants');
-const { getImportSpecifiers, isClassMethod, isSetterClassMethod, isGetterClassMethod } = require('../utils');
+const { getEngineImportSpecifiers, isClassMethod, isSetterClassMethod, isGetterClassMethod } = require('../utils');
 
 const DECORATOR_TRANSFORMS = [
     api,
@@ -121,7 +121,7 @@ function removeImportSpecifiers(specifiers) {
 module.exports = function decoratorVisitor({ types: t }) {
     return {
         Program(path, state) {
-            const engineImportSpecifiers = getImportSpecifiers(path, LWC_PACKAGE_ALIAS);
+            const engineImportSpecifiers = getEngineImportSpecifiers(path);
             const decoratorImportSpecifiers = engineImportSpecifiers.filter(({ name }) => (
                 isLwcDecoratorName(name)
             ));


### PR DESCRIPTION
## Details

The `babel-plugin-transform-lwc-class` now block namespace imports and default imports on `engine`. The compiler will now throw the following errors:

*  usage of namespace import: `Invalid import. Namespace imports are not allowed on "engine", instead use named imports "import { Element } from 'engine'".`
* usage of default import: `Invalid import. "engine" doesn't have default export.`

Fix #56 

## Does this PR introduce a breaking change?

* [X] Yes
* [ ] No

If yes, please describe the impact and migration path for existing applications:

While it's a breaking change, the usage of namespace import is not something that we have advocated so far. If existing code is using namespace import on `engine`, the component would not have been compiled properly. Since the breaking change impact is minimal, it will not probably require a codemod.