### PR TITLE
fix(rollup-plugin-lwc-compiler): Fix peer-dependencies

### DIFF
--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -19,8 +19,8 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "lwc-compiler": "0.17.10",
-    "lwc-engine": "0.17.10"
+    "lwc-compiler": "~0.17.13",
+    "lwc-engine": "~0.17.13"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
## Details

When running installing the latest `lwc-engine`, `lwc-compiler` and `rollup-plugin-lwc-compiler`, npm is complaining that the rollup plugin doesn't meet the peer dependency requirements:

```sh
$ npm install --save-dev lwc-engine lwc-compiler rollup-plugin-lwc-compiler
npm WARN rollup-plugin-lwc-compiler@0.17.13 requires a peer of lwc-compiler@0.17.10 but none is installed. You must install peer dependencies yourself.
npm WARN rollup-plugin-lwc-compiler@0.17.13 requires a peer of lwc-engine@0.17.10 but none is installed. You must install peer dependencies yourself.
```

**Note:** The peer-dependency has been updated to accept fix (using the `~` modifier) on `lwc-compiler` and `lwc-engine`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No