### PR TITLE
fix(compiler): allow multiple @wire for different properties or methods

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.test.js
@@ -91,49 +91,6 @@ describe('Wired field', () => {
             },
         }
     });
-});
-
-describe('Wired method', () => {
-    pluginTest('transforms wired method', `
-        import { wire } from 'engine';
-        export default class Test {
-            @wire("record", { recordId: "$recordId", fields: ["Account", 'Rate']})
-            innerRecordMethod() {}
-        }
-    `, {
-        output: {
-            code: `
-                export default class Test {
-                    innerRecordMethod() {}
-                }
-                Test.wire = {
-                    innerRecordMethod: {
-                        params: { recordId: "recordId" },
-                        static: { fields: ["Account", 'Rate'] },
-                        type: "record",
-                        method: 1
-                    }
-                };
-            `
-        }
-    });
-
-    pluginTest('throws when wired method is combined with @api', `
-        import { api, wire } from 'engine';
-        export default class Test {
-            @api
-            @wire('record', { recordId: '$recordId', fields: ['Name'] })
-            wiredWithApi() {}
-        }
-    `, {
-        error: {
-            message: 'test.js: @wire method or property cannot be used with @api',
-            loc: {
-                line: 2,
-                column: 20,
-            },
-        }
-    });
 
     pluginTest('throws when wired property is combined with @api', `
         import { api, wire } from 'engine';
@@ -179,6 +136,77 @@ describe('Wired method', () => {
     `, {
         error: {
             message: 'test.js: Method or property can only have 1 @wire decorator',
+            loc: {
+                line: 2,
+                column: 20,
+            },
+        }
+    });
+
+    pluginTest('should not throw when using 2 separate wired decorators', `
+         import { wire } from 'engine';
+         export default class Test {
+             @wire('record', { recordId: '$recordId', fields: ['Address'] })
+             wired1;
+             @wire('record', { recordId: '$recordId', fields: ['Name'] })
+             wired2;
+        }
+    `, {
+        output: {
+            code: `
+                export default class Test {}
+                Test.wire = {
+                    wired1: {
+                        params: { recordId: "recordId" },
+                        static: { fields: ["Address"] },
+                        type: "record"
+                    },
+                    wired2: {
+                        params: { recordId: "recordId" },
+                        static: { fields: ["Name"] },
+                        type: "record"
+                    }
+                };
+            `
+        }
+    });
+});
+
+describe('Wired method', () => {
+    pluginTest('transforms wired method', `
+        import { wire } from 'engine';
+        export default class Test {
+            @wire("record", { recordId: "$recordId", fields: ["Account", 'Rate']})
+            innerRecordMethod() {}
+        }
+    `, {
+        output: {
+            code: `
+                export default class Test {
+                    innerRecordMethod() {}
+                }
+                Test.wire = {
+                    innerRecordMethod: {
+                        params: { recordId: "recordId" },
+                        static: { fields: ["Account", 'Rate'] },
+                        type: "record",
+                        method: 1
+                    }
+                };
+            `
+        }
+    });
+
+    pluginTest('throws when wired method is combined with @api', `
+        import { api, wire } from 'engine';
+        export default class Test {
+            @api
+            @wire('record', { recordId: '$recordId', fields: ['Name'] })
+            wiredWithApi() {}
+        }
+    `, {
+        error: {
+            message: 'test.js: @wire method or property cannot be used with @api',
             loc: {
                 line: 2,
                 column: 20,

--- a/packages/babel-plugin-transform-lwc-class/src/decorators/wire/validate.js
+++ b/packages/babel-plugin-transform-lwc-class/src/decorators/wire/validate.js
@@ -33,7 +33,8 @@ function validateWireParameters(path) {
 function validateUsageWithOtherDecorators(path, decorators) {
     decorators.forEach(decorator => {
         if (path !== decorator.path
-            && decorator.name === WIRE_DECORATOR) {
+            && decorator.name === WIRE_DECORATOR
+            && decorator.path.parentPath.node === path.parentPath.node) {
             throw path.buildCodeFrameError('Method or property can only have 1 @wire decorator');
         }
         if ((decorator.name === API_DECORATOR || decorator.name === TRACK_DECORATOR)


### PR DESCRIPTION
## Details
We have a bug that would prevent you to have more than one @wire in a LWC class.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:
