### PR TITLE
fix(compiler): fix test-transform assert

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/api-decorator.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/api-decorator.test.js
@@ -11,18 +11,17 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    constructor() {
-                        this.test = 1;
-                    }
+export default class Test {
+  constructor() {
+    this.test = 1;
+  }
 
-                }
-                Test.publicProps = {
-                    test: {
-                        config: 0
-                    }
-                };
-            `,
+}
+Test.publicProps = {
+  test: {
+    config: 0
+  }
+};`,
         }
     });
 
@@ -38,24 +37,23 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Outer {
-                    constructor() {
-                        var _class, _temp;
+export default class Outer {
+  constructor() {
+    var _class, _temp;
 
-                        this.a = (_temp = _class = class {}, _class.publicProps = {
-                            innerA: {
-                                config: 0
-                            }
-                        }, _temp);
-                    }
+    this.a = (_temp = _class = class {}, _class.publicProps = {
+      innerA: {
+        config: 0
+      }
+    }, _temp);
+  }
 
-                }
-                Outer.publicProps = {
-                    outer: {
-                        config: 0
-                    }
-                };
-            `
+}
+Outer.publicProps = {
+  outer: {
+    config: 0
+  }
+};`
         }
     });
 
@@ -69,17 +67,16 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    get publicGetter() {
-                        return 1;
-                    }
-                }
-                Test.publicProps = {
-                    publicGetter: {
-                        config: 1
-                    }
-                };
-            `
+export default class Test {
+  get publicGetter() {
+    return 1;
+  }
+}
+Test.publicProps = {
+  publicGetter: {
+    config: 1
+  }
+};`
         }
     });
 
@@ -97,21 +94,19 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    get something() {
-                        return this.s;
-                    }
-
-                    set something(value) {
-                        this.s = value;
-                    }
-                }
-                Test.publicProps = {
-                    something: {
-                        config: 3
-                    }
-                };
-            `
+export default class Test {
+  get something() {
+    return this.s;
+  }
+  set something(value) {
+    this.s = value;
+  }
+}
+Test.publicProps = {
+  something: {
+    config: 3
+  }
+};`
         }
     });
 
@@ -147,35 +142,33 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    constructor() {
-                        this._a = true;
-                        this._b = false;
-                    }
+export default class Test {
+  constructor() {
+    this._a = true;
+    this._b = false;
+  }
 
-                    get a() {
-                        return this._a;
-                    }
-                    set a(value) {
-                        this._a = value;
-                    }
-
-                    get b() {
-                        return this._b;
-                    }
-                    set b(value) {
-                        this._b = value;
-                    }
-                }
-                Test.publicProps = {
-                    a: {
-                        config: 3
-                    },
-                    b: {
-                        config: 3
-                    }
-                };
-            `
+  get a() {
+    return this._a;
+  }
+  set a(value) {
+    this._a = value;
+  }
+  get b() {
+    return this._b;
+  }
+  set b(value) {
+    this._b = value;
+  }
+}
+Test.publicProps = {
+  a: {
+    config: 3
+  },
+  b: {
+    config: 3
+  }
+};`
         }
     })
 
@@ -199,35 +192,32 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Text {
-                    get aloneGet() {}
+export default class Text {
+  get aloneGet() {}
+  get myget() {}
+  set myget(x) {
+    return 1;
+  }
+  m1() {}
+  m2() {}
 
-                    get myget() {}
-                    set myget(x) {
-                        return 1;
-                    }
-
-                    m1() {}
-                    m2() {}
-
-                    static get ctorGet() {
-                        return 1;
-                    }
-                }
-                Text.ctor = "ctor";
-                Text.publicProps = {
-                    publicProp: {
-                        config: 0
-                    },
-                    aloneGet: {
-                        config: 1
-                    },
-                    myget: {
-                        config: 3
-                    }
-                };
-                Text.publicMethods = ["m1"];
-            `
+  static get ctorGet() {
+    return 1;
+  }
+}
+Text.ctor = "ctor";
+Text.publicProps = {
+  publicProp: {
+    config: 0
+  },
+  aloneGet: {
+    config: 1
+  },
+  myget: {
+    config: 3
+  }
+};
+Text.publicMethods = ["m1"];`
         }
     });
 
@@ -284,13 +274,12 @@ describe('Public Props', () => {
     `, {
         output: {
             code: `
-                export default class Test {}
-                Test.publicProps = {
-                    data: {
-                        config: 0
-                    }
-                };
-            `
+export default class Test {}
+Test.publicProps = {
+  data: {
+    config: 0
+  }
+};`
         }
     });
 
@@ -381,11 +370,10 @@ describe('Public Methods', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    foo() {}
-                }
-                Test.publicMethods = ['foo'];
-            `
+export default class Test {
+  foo() {}
+}
+Test.publicMethods = ['foo'];`
         }
     });
 
@@ -423,8 +411,16 @@ describe('metadata', () => {
         }
     `, {
         output: {
-            metadata: {
-                apiProperties: [{ name: 'todo' }, { name: 'index' }]
+            metadata: { 
+                apiMethods: [], 
+                apiProperties: [
+                    { name: "todo" },
+                    { name: "index" }
+                ],
+                declarationLoc: {
+                    end: { column: 1, line: 13 },
+                    start: { column: 0, line: 3 }
+                }
             }
         }
     });
@@ -445,7 +441,12 @@ describe('metadata', () => {
     `, {
         output: {
             metadata: {
-                apiProperties: []
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: {
+                    end: { column: 1, line: 12 },
+                    start: { column: 0, line: 3 }
+                }
             }
         }
     });

--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
@@ -48,18 +48,15 @@ describe('Element import', () => {
         export default class Test extends Component {}
     `, {
         output: {
-            code: `
-                import _tmpl from './test.html';
-                import { Element as Component } from 'engine';
+            code: `import _tmpl from './test.html';
+import { Element as Component } from 'engine';
+export default class Test extends Component {
+  render() {
+    return _tmpl;
+  }
 
-                export default class Test extends Component {
-                render() {
-                    return _tmpl;
-                }
-
-                }
-                Test.style = _tmpl.style;
-            `
+}
+Test.style = _tmpl.style;`
         }
     });
 });
@@ -70,17 +67,15 @@ describe('render method', () => {
         export default class Test extends Element {}
     `, {
         output: {
-            code: `
-                import _tmpl from "./test.html";
-                import { Element } from "engine";
-                export default class Test extends Element {
-                render() {
-                    return _tmpl;
-                }
+            code: `import _tmpl from "./test.html";
+import { Element } from "engine";
+export default class Test extends Element {
+  render() {
+    return _tmpl;
+  }
 
-                }
-                Test.style = _tmpl.style;
-            `
+}
+Test.style = _tmpl.style;`
         }
     });
 
@@ -91,12 +86,10 @@ describe('render method', () => {
         }
     `, {
         output: {
-            code: `
-                import { Element } from "engine";
-                export default class Test extends Element {
-                    render() {}
-                }
-            `
+            code: `import { Element } from "engine";
+export default class Test extends Element {
+  render() {}
+}`
         }
     });
 
@@ -108,20 +101,16 @@ describe('render method', () => {
         export default class Test2 extends Element {}
     `, {
         output: {
-            code: `
-                import _tmpl from './test.html';
-                import { Element } from 'engine';
+            code: `import _tmpl from './test.html';
+import { Element } from 'engine';
+class Test1 extends Element {}
+export default class Test2 extends Element {
+  render() {
+    return _tmpl;
+  }
 
-                class Test1 extends Element {}
-
-                export default class Test2 extends Element {
-                    render() {
-                        return _tmpl;
-                    }
-
-                }
-                Test2.style = _tmpl.style;
-            `
+}
+Test2.style = _tmpl.style;`
         }
     })
 });
@@ -135,7 +124,10 @@ describe('metadata', () => {
     `, {
         output: {
             metadata: {
-                doc: 'Foo doc', declarationLoc: { start: { line: 3, column: 0 }, end: { line: 4, column: 1 }}
+                apiMethods: [], 
+                apiProperties: [],
+                doc: 'Foo doc',
+                declarationLoc: { start: { line: 3, column: 0 }, end: { line: 4, column: 1 }}
             }
         }
     });
@@ -150,7 +142,10 @@ describe('metadata', () => {
     `, {
         output: {
             metadata: {
-                doc: 'Foo doc'
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: { end: { column: 1, line: 6 }, start: { column: 0, line: 5 } }, 
+                doc: "Foo doc"
             }
         }
     });
@@ -166,6 +161,9 @@ describe('metadata', () => {
     `, {
         output: {
             metadata: {
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: { end: { column: 1, line: 7 }, start: { column: 0, line: 6 } }, 
                 doc: 'multi\nline'
             }
         }
@@ -180,7 +178,10 @@ describe('metadata', () => {
     `, {
         output: {
             metadata: {
-                doc: 'last'
+                apiMethods: [], 
+                apiProperties: [], 
+                declarationLoc: { end: { column: 1, line: 5 }, start: { column: 0, line: 4 } },
+                doc: "last"
             }
         }
     });
@@ -192,7 +193,14 @@ describe('metadata', () => {
         }
     `, {
         output: {
-            metadata: {}
+            metadata: {
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: {
+                    end: { column: 1, line: 4 },
+                    start: { column: 0, line: 3 }
+                }
+            }
         }
     });
 
@@ -203,7 +211,14 @@ describe('metadata', () => {
         }
     `, {
         output: {
-            metadata: {}
+            metadata: {
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: {
+                    end: { column: 1, line: 4 },
+                    start: { column: 0, line: 3 }
+                }
+            }
         }
     });
 
@@ -214,7 +229,14 @@ describe('metadata', () => {
         }
     `, {
         output: {
-            metadata: {}
+            metadata: {
+                apiMethods: [],
+                apiProperties: [],
+                declarationLoc: {
+                    end: { column: 1, line: 4 },
+                    start: { column: 0, line: 3 }
+                }
+            }
         }
     });
 });

--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/track-decorator.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/track-decorator.test.js
@@ -11,11 +11,10 @@ describe('Wired field', () => {
     `, {
         output: {
             code: `
-                export default class Test {}
-                Test.track = {
-                    record: 1
-                };
-            `
+export default class Test {}
+Test.track = {
+  record: 1
+};`
         }
     });
 
@@ -29,18 +28,17 @@ describe('Wired field', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    constructor() {
-                        this.record = {
-                            value: 'test'
-                        };
-                    }
+export default class Test {
+  constructor() {
+    this.record = {
+      value: 'test'
+    };
+  }
 
-                }
-                Test.track = {
-                    record: 1
-                };
-            `
+}
+Test.track = {
+  record: 1
+};`
         }
     });
 

--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/utils/test-transform.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/utils/test-transform.js
@@ -55,9 +55,12 @@ function pluginTest(plugin, opts = {}) {
             expect(transformError).toMatchObject(errorFromObject(expected.error));
         } else if (expected.output) {
             const output = testTransform(actual);
-
-            expect(output.code).toBe(output.code);
-            expect(output.metadata).toEqual(output.metadata);
+            if (expected.output.code) {
+                expect(output.code).toBe(expected.output.code);
+            }
+            if (expected.output.metadata) {
+                expect(output.metadata).toEqual(expected.output.metadata);
+            }
         } else {
             throw new TypeError(`Transform test expect an object with either error or output.`);
         }

--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.test.js
@@ -12,15 +12,14 @@ describe('Wired field', () => {
     `, {
         output: {
             code: `
-                export default class Test {}
-                Test.wire = {
-                    innerRecord: {
-                        params: { recordId: "recordId" },
-                        static: { fields: ["Account", 'Rate'] },
-                        type: "record"
-                    }
-                };
-            `
+export default class Test {}
+Test.wire = {
+  innerRecord: {
+    params: { recordId: "recordId" },
+    static: { fields: ["Account", 'Rate'] },
+    type: "record"
+  }
+};`
         }
     });
 
@@ -48,16 +47,15 @@ describe('Wired field', () => {
     `, {
         output: {
             code: `
-                import { record } from 'data-service';
-                export default class Test {}
-                Test.wire = {
-                    innerRecord: {
-                        params: {},
-                        static: {},
-                        adapter: record
-                    }
-                };
-            `
+import { record } from 'data-service';
+export default class Test {}
+Test.wire = {
+  innerRecord: {
+    params: {},
+    static: {},
+    adapter: record
+  }
+};`
         }
     });
 
@@ -154,20 +152,19 @@ describe('Wired field', () => {
     `, {
         output: {
             code: `
-                export default class Test {}
-                Test.wire = {
-                    wired1: {
-                        params: { recordId: "recordId" },
-                        static: { fields: ["Address"] },
-                        type: "record"
-                    },
-                    wired2: {
-                        params: { recordId: "recordId" },
-                        static: { fields: ["Name"] },
-                        type: "record"
-                    }
-                };
-            `
+export default class Test {}
+Test.wire = {
+  wired1: {
+    params: { recordId: 'recordId' },
+    static: { fields: ['Address'] },
+    type: 'record'
+  },
+  wired2: {
+    params: { recordId: 'recordId' },
+    static: { fields: ['Name'] },
+    type: 'record'
+  }
+};`
         }
     });
 });
@@ -182,18 +179,17 @@ describe('Wired method', () => {
     `, {
         output: {
             code: `
-                export default class Test {
-                    innerRecordMethod() {}
-                }
-                Test.wire = {
-                    innerRecordMethod: {
-                        params: { recordId: "recordId" },
-                        static: { fields: ["Account", 'Rate'] },
-                        type: "record",
-                        method: 1
-                    }
-                };
-            `
+export default class Test {
+  innerRecordMethod() {}
+}
+Test.wire = {
+  innerRecordMethod: {
+    params: { recordId: "recordId" },
+    static: { fields: ["Account", 'Rate'] },
+    type: "record",
+    method: 1
+  }
+};`
         }
     });
 


### PR DESCRIPTION
## Details
This was part of #76, but it should be fixed as soon as possible so we have real unit test coverage. @rsalvador I also change to only output `declarationLoc` when there is `sanitized` jsdoc.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No