### PR TITLE
refactor(engine): strict separation between watcher and the decorators

### DIFF
--- a/packages/lwc-engine/src/framework/language.ts
+++ b/packages/lwc-engine/src/framework/language.ts
@@ -89,8 +89,11 @@ export function isNumber(obj: any): obj is number {
 
 const OtS = {}.toString;
 export function toString(obj: any): string {
-    if (obj && typeof obj === 'object' && !obj.toString) {
+    if (obj && obj.toString) {
+        return obj.toString();
+    } else if (typeof obj === 'object') {
         return OtS.call(obj);
+    } else {
+        return obj + '';
     }
-    return obj + '';
 }


### PR DESCRIPTION
## Details

This PR is the first change in preparation for the two main objectives:

* provide infrastructure for readonly objects via membrane for anything that is passed down
* provide infrastructure for decorators and other artifacts to participate as reactive objects (first class citizens)

This PR disconnect the decorators from the VM, so they can call to observe mutations, and notify of mutations on any object, whether it is reactive or not. 
