### PR TITLE
fix(compiler): invalid metadata used in decorator index

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/api-decorator.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/api-decorator.test.js
@@ -420,7 +420,16 @@ describe('metadata', () => {
                 declarationLoc: {
                     end: { column: 1, line: 13 },
                     start: { column: 0, line: 3 }
-                }
+                },
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [
+                        { imported: ['api'], source: 'engine', specifiers: [{ imported: 'api', kind: 'named', local: 'api' }] },
+                        { imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }
+                    ]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -446,7 +455,16 @@ describe('metadata', () => {
                 declarationLoc: {
                     end: { column: 1, line: 12 },
                     start: { column: 0, line: 3 }
-                }
+                },
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [
+                        { imported: ['api'], source: 'engine', specifiers: [{ imported: 'api', kind: 'named', local: 'api' }] },
+                        { imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }
+                    ]
+                },
+                usedHelpers: []
             }
         }
     });

--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/component.test.js
@@ -126,8 +126,14 @@ describe('metadata', () => {
             metadata: {
                 apiMethods: [], 
                 apiProperties: [],
+                declarationLoc: { start: { line: 3, column: 0 }, end: { line: 4, column: 1 }},
                 doc: 'Foo doc',
-                declarationLoc: { start: { line: 3, column: 0 }, end: { line: 4, column: 1 }}
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -145,7 +151,13 @@ describe('metadata', () => {
                 apiMethods: [],
                 apiProperties: [],
                 declarationLoc: { end: { column: 1, line: 6 }, start: { column: 0, line: 5 } }, 
-                doc: "Foo doc"
+                doc: "Foo doc",
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -164,7 +176,13 @@ describe('metadata', () => {
                 apiMethods: [],
                 apiProperties: [],
                 declarationLoc: { end: { column: 1, line: 7 }, start: { column: 0, line: 6 } }, 
-                doc: 'multi\nline'
+                doc: 'multi\nline',
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -181,8 +199,14 @@ describe('metadata', () => {
                 apiMethods: [], 
                 apiProperties: [], 
                 declarationLoc: { end: { column: 1, line: 5 }, start: { column: 0, line: 4 } },
-                doc: "last"
-            }
+                doc: "last",
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
+            },
         }
     });
 
@@ -199,7 +223,13 @@ describe('metadata', () => {
                 declarationLoc: {
                     end: { column: 1, line: 4 },
                     start: { column: 0, line: 3 }
-                }
+                },
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -217,7 +247,13 @@ describe('metadata', () => {
                 declarationLoc: {
                     end: { column: 1, line: 4 },
                     start: { column: 0, line: 3 }
-                }
+                },
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });
@@ -235,7 +271,13 @@ describe('metadata', () => {
                 declarationLoc: {
                     end: { column: 1, line: 4 },
                     start: { column: 0, line: 3 }
-                }
+                },
+                marked: [],
+                modules: {
+                    exports: { exported: ['Foo'], specifiers: [{ exported: "default", kind: "local", local: "Foo" }] },
+                    imports: [{ imported: ['Element'], source: 'engine', specifiers: [{ imported: 'Element', kind: 'named', local: 'Element' }] }]
+                },
+                usedHelpers: []
             }
         }
     });

--- a/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
+++ b/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
@@ -128,7 +128,7 @@ module.exports = function decoratorVisitor({ types: t }) {
 
             const decorators = getLwcDecorators(decoratorImportSpecifiers);
 
-            state.file.metadata = Object.assign({}, state.metadata, {
+            state.file.metadata = Object.assign({}, state.file.metadata, {
                 apiProperties: [],
                 apiMethods: []
             });
@@ -140,7 +140,7 @@ module.exports = function decoratorVisitor({ types: t }) {
                 // Note: In the (extremely rare) case of multiple classes in the same file, only the metadata about the
                 // last class will be returned
                 const metadata = transform(t, klass, decorators);
-                state.file.metadata = Object.assign({}, state.metadata, metadata);
+                state.file.metadata = Object.assign({}, state.file.metadata, metadata);
             }
 
             removeDecorators(decorators);


### PR DESCRIPTION
## Details
Addressing discussion [here](https://github.com/salesforce/lwc/pull/76/files/9eeb8bea3c3c347ed9fce2996d73a6f26caa6364#r167119667) I believe it should've been `state.file.metadata`

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No