### PR TITLE
feat(engine): abstraction for create/insert/remove/render to support CE

### DIFF
--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -45,9 +45,7 @@ const hook: Hooks = {
         if (vm.cmpSlots !== oldVNode.data.slotset && !vm.isDirty) {
             markComponentAsDirty(vm);
         }
-        if (vm.isDirty) {
-            renderVM(vm);
-        }
+        renderVM(vm);
     },
     insert(vnode: VNode) {
         const vm = getCustomElementVM(vnode.elm as HTMLElement);


### PR DESCRIPTION
## Details

Instead of guarding in multiple places before carry-on any of these operations, we can just short-circuit on the spot. This will also help to support creation of registered elements.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
