### PR TITLE
fix(engine): Render error with empty slotset iterator

### DIFF
--- a/packages/lwc-engine/src/framework/template.ts
+++ b/packages/lwc-engine/src/framework/template.ts
@@ -58,7 +58,7 @@ function validateSlots(vm: VM, html: any) {
         const { cmpSlots = EmptySlots } = vm;
         const { slots = EmptyArray } = html;
         for (const slotName in cmpSlots) {
-            assert.isTrue(isArray(cmpSlots[slotName]) && cmpSlots[slotName].length > 0, `Slots can only be set to a non-empty array, instead received ${toString(cmpSlots[slotName])} for slot ${slotName} in ${vm}.`);
+            assert.isTrue(isArray(cmpSlots[slotName]), `Slots can only be set to an array, instead received ${toString(cmpSlots[slotName])} for slot ${slotName} in ${vm}.`);
             if (ArrayIndexOf.call(slots, slotName) === -1) {
                 // TODO: this should never really happen because the compiler should always validate
                 assert.logWarning(`Ignoring unknown provided slot name "${slotName}" in ${vm}. This is probably a typo on the slot attribute.`);

--- a/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/child/child.html
+++ b/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/child/child.html
@@ -1,0 +1,4 @@
+<template>
+    <slot></slot>
+    <div>Rendered ok</div>
+</template>

--- a/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/child/child.js
+++ b/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/child/child.js
@@ -1,0 +1,5 @@
+import { Element } from 'engine';
+
+export default class Child extends Element {
+    @track isTrue = true;
+}

--- a/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.html
+++ b/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.html
@@ -1,0 +1,5 @@
+<template>
+    <x-child>
+        <template for:each={items} for:item="item"></template>
+    </x-child>
+</template>

--- a/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.js
+++ b/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.js
@@ -1,0 +1,7 @@
+import { Element, api } from 'engine';
+
+export default class EmptySlotIterator extends Element {
+    @api get items() {
+        return ['foo', 'bar'];
+    }
+}

--- a/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.spec.js
+++ b/packages/lwc-integration/src/components/slots/test-empty-slot-iterator/empty-slot-iterator.spec.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+describe('Slots with empty iterators should render', () => {
+    const URL = 'http://localhost:4567/empty-slot-iterator';
+    let element;
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should have rendered element in slot correctly', function () {
+        const element = browser.element('x-child');
+        assert.equal(element.getText(), 'Rendered ok');
+    });
+});


### PR DESCRIPTION
## Details

Having an empty iterator inside of a `$default$` slot causes the engine to throw because it receives an empty array. The fix is the remove this check since an empty array is not problematic for the engine.

This is part of getting snabbdom to work properly in core.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:
