### PR TITLE
fix(engine): [0.17.17] Empty string in classname and styles

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/template-test.ts
+++ b/packages/lwc-engine/src/framework/__tests__/template-test.ts
@@ -303,6 +303,32 @@ describe('template', () => {
         });
     });
 
+    describe('style', () => {
+        it('should not render empty style attribute to DOM', () => {
+            const tmpl = ($api, $cmp) => {
+                return [$api.h('div', {
+                    key: 1,
+                    style: $cmp.getStyle,
+                }, [])]
+            }
+
+            class MyComponent extends Element {
+                get getStyle() {
+                    return '';
+                }
+                render() {
+                    return tmpl;
+                }
+            }
+
+            const element = createElement('x-foo', { is: MyComponent });
+            document.body.appendChild(element);
+
+            // there should not be a style="" attribute in the DOM
+            expect(element.innerHTML).toBe('<div></div>');
+        });
+    })
+
     describe('token', () => {
         it('adds token to the host element if template has a token', () => {
             const styledTmpl: Template = () => [];

--- a/packages/lwc-engine/src/framework/modules/styles.ts
+++ b/packages/lwc-engine/src/framework/modules/styles.ts
@@ -6,6 +6,8 @@ import {
 import { EmptyObject } from '../utils';
 import { VNode, Module } from "../../3rdparty/snabbdom/types";
 
+const { removeAttribute } = Element.prototype;
+
 const DashCharCode = 45;
 
 function updateStyle(oldVnode: VNode, vnode: VNode) {
@@ -23,9 +25,11 @@ function updateStyle(oldVnode: VNode, vnode: VNode) {
     }
 
     let name: string;
-    const style = (vnode.elm as HTMLElement).style;
-
-    if (isString(newStyle)) {
+    const elm = (vnode.elm as HTMLElement);
+    const { style } = elm;
+    if (isUndefined(newStyle) || newStyle as any === '') {
+        removeAttribute.call(elm, 'style');
+    } else if (isString(newStyle)) {
         style.cssText = newStyle;
     } else {
         if (!isUndefined(oldStyle)) {

--- a/packages/lwc-engine/src/framework/utils.ts
+++ b/packages/lwc-engine/src/framework/utils.ts
@@ -4,7 +4,7 @@ import { create, seal, ArrayPush, freeze, isFunction, ArrayIndexOf, isUndefined 
 export type Callback = () => void;
 
 let nextTickCallbackQueue: Callback[] = [];
-const SPACE_CHAR = 32;
+export const SPACE_CHAR = 32;
 
 export const EmptyObject = seal(create(null));
 export const EmptyArray = seal([]);
@@ -75,34 +75,3 @@ export function getAttrNameFromPropName(propName: string): string {
 }
 
 export const usesNativeSymbols = typeof Symbol() === 'symbol';
-
-const classNameToClassMap = create(null);
-
-export function getMapFromClassName(className: string): Record<string, boolean> {
-    let map = classNameToClassMap[className];
-    if (map) {
-        return map;
-    }
-    map = {};
-    let start = 0;
-    let i;
-    const len = className.length;
-    for (i = 0; i < len; i++) {
-        if (className.charCodeAt(i) === SPACE_CHAR) {
-            if (i > start) {
-                map[className.slice(start, i)] = true;
-            }
-            start = i + 1;
-        }
-    }
-
-    if (i > start) {
-        map[className.slice(start, i)] = true;
-    }
-    classNameToClassMap[className] = map;
-    if (process.env.NODE_ENV !== 'production') {
-        // just to make sure that this object never changes as part of the diffing algo
-        freeze(map);
-    }
-    return map;
-}

--- a/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.html
+++ b/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.html
@@ -1,0 +1,5 @@
+<template>
+    <div onclick={handleClick} class={computedClassName}>
+        Classname
+    </div>
+</template>

--- a/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.js
+++ b/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.js
@@ -1,0 +1,9 @@
+import { Element, track } from "engine";
+
+export default class EmptyClassname extends Element {
+    @track computedClassName = 'foo';
+
+    handleClick() {
+        this.computedClassName = '';
+    }
+}

--- a/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.spec.js
+++ b/packages/lwc-integration/src/components/rendering/test-toggle-empty-classname/toggle-empty-classname.spec.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+describe('Toggling to empty classname', () => {
+    const URL = 'http://localhost:4567/toggle-empty-classname';
+    let element;
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should have the right value', function () {
+        const element = browser.element('toggle-empty-classname');
+        element.click();
+
+        const className = browser.getAttribute('toggle-empty-classname div', 'class');
+        assert.deepEqual(className, '');
+    });
+});


### PR DESCRIPTION
## Details
Snabdom 2.0 exposed some issues with our diffing logic. This pr aims to fix issues regarding empty string class and style attributes.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:


