### PR TITLE
fix(compiler): Fix compiler bundle

### DIFF
--- a/packages/lwc-compiler/webpack.config.js
+++ b/packages/lwc-compiler/webpack.config.js
@@ -14,6 +14,14 @@ module.exports = function (/*env*/) {
             path: path.resolve(__dirname, 'dist/umd/'),
             filename: 'compiler.js',
         },
+        resolve: {
+            alias: {
+                // Forcing the resolution of the CommonJS Module instead of the ES Module for the "rollup-plugin-replace".
+                // There is a discrepancy between the 2 "rollup-plugin-replace" artifacts. Let's use the CommonJS one
+                // to be consistent with the behavior when running the compiler in NodeJs.
+                'rollup-plugin-replace': 'rollup-plugin-replace/dist/rollup-plugin-replace.cjs.js',
+            },
+        },
         plugins: [
             new StringReplacePlugin()
         ],


### PR DESCRIPTION
## Details

Currently generated compiler using `webpack` throws the following error:

```
TypeError: __WEBPACK_IMPORTED_MODULE_1_rollup_plugin_replace__ is not a function
```

This PR fixes the build issue, by forcing `webpack` to resolve the CommonJS version of `rollup-plugin-replace` instead of the ES Module.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No