### PR TITLE
fix(engine): fixes #90: prevent invalid values in forceTagName

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/api.spec.ts
@@ -9,11 +9,11 @@ describe('api', () => {
 
         it('should call the Ctor factory for circular dependencies', () => {
             const factory = function() { return class extends Element {
-                static forceTagName = 'p';
+                static forceTagName = 'input';
             }; };
             factory.__circular__ = true;
             const vnode = api.c('x-foo', factory, { className: 'foo' });
-            expect(vnode.tag).toBe('p');
+            expect(vnode.tag).toBe('input');
         });
 
         it('should convert className to a classMap property', () => {
@@ -71,11 +71,11 @@ describe('api', () => {
 
         it('should support forceTagName static definition to force tagname on root node', () => {
             class Bar extends Element {
-                static forceTagName = 'div';
+                static forceTagName = 'input';
             }
             const element = createElement('x-foo', { is: Bar });
             document.body.appendChild(element);
-            expect(element.tagName).toBe('DIV');
+            expect(element.tagName).toBe('INPUT');
             // the "is" attribute is only inserted after the element is connected
             expect(element.getAttribute('is')).toBe('x-foo');
         });
@@ -88,7 +88,7 @@ describe('api', () => {
 
         it('should ignore forceTagName static definition if "is" attribute is defined in template', () => {
             function html($api) {
-                return [$api.c('span', Bar, { attrs: { is: "x-bar" } })];
+                return [$api.c('button', Bar, { attrs: { is: "x-bar" } })];
             }
             class Foo extends Element {
                 render() {
@@ -96,13 +96,31 @@ describe('api', () => {
                 }
             }
             class Bar extends Element {
-                static forceTagName = 'div';
+                static forceTagName = 'input';
             }
             const elm = createElement('x-foo', { is: Foo });
             document.body.appendChild(elm);
-            const span = elm.querySelector('span') as Element;
-            expect(span.tagName).toEqual('SPAN');
+            const span = elm.querySelector('button') as Element;
+            expect(span.tagName).toEqual('BUTTON');
             expect(span.getAttribute('is')).toEqual('x-bar');
+        });
+
+        it('should throw when forceTagName cannot have a shadow root attached to it', () => {
+            class Bar extends Element {
+                static forceTagName = 'div'; // it can't be a div
+            }
+            expect(() => {
+                createElement('x-foo', { is: Bar });
+            }).toThrow();
+        });
+
+        it('should throw when forceTagName cannot have a shadow root attached to it', () => {
+            class Bar extends Element {
+                static forceTagName = 'x-bar'; // it can't be a custom element name
+            }
+            expect(() => {
+                createElement('x-foo', { is: Bar });
+            }).toThrow();
         });
 
     });

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -35,7 +35,7 @@ export interface Component {
 export interface ComponentConstructor {
     new (): Component;
     readonly name: string;
-    readonly forceTagName?: string;
+    readonly forceTagName?: keyof HTMLElementTagNameMap;
     readonly publicMethods?: string[];
     readonly observedAttributes?: string[];
     readonly publicProps?: PropsDef;

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -31,7 +31,7 @@ import { createWiredPropertyDescriptor } from "./decorators/wire";
 import { createTrackedPropertyDescriptor } from "./decorators/track";
 import { createPublicPropertyDescriptor, createPublicAccessorDescriptor } from "./decorators/api";
 import { Element as BaseElement, getCustomElementVM } from "./html-element";
-import { EmptyObject, getPropNameFromAttrName } from "./utils";
+import { EmptyObject, getPropNameFromAttrName, assertValidForceTagName } from "./utils";
 import { invokeComponentAttributeChangedCallback } from "./invoker";
 import { OwnerKey, VM, VMElement } from "./vm";
 
@@ -559,6 +559,9 @@ export function getCtorByTagName(tagName: string): ComponentConstructor | undefi
 }
 
 export function registerComponent(tagName: string, Ctor: ComponentConstructor) {
+    if (process.env.NODE_ENV !== 'production') {
+        assertValidForceTagName(Ctor);
+    }
     if (!isUndefined(TagNameToCtor[tagName])) {
         if (TagNameToCtor[tagName] === Ctor) {
             return;

--- a/packages/lwc-engine/src/framework/dom.ts
+++ b/packages/lwc-engine/src/framework/dom.ts
@@ -1,3 +1,5 @@
+import { ArrayIndexOf } from "./language";
+
 // Few more execptions that are using the attribute name to match the property in lowercase.
 // this list was compiled from https://msdn.microsoft.com/en-us/library/ms533062(v=vs.85).aspx
 // and https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes

--- a/packages/lwc-engine/src/framework/language.ts
+++ b/packages/lwc-engine/src/framework/language.ts
@@ -97,3 +97,11 @@ export function toString(obj: any): string {
         return obj + '';
     }
 }
+
+const {
+    indexOf: StringIndexOf,
+} = String.prototype;
+
+export {
+    StringIndexOf,
+};


### PR DESCRIPTION
## Does this PR introduce a breaking change?

* No

But if someone (including tests) are attempting to use forceTagName to an invalid value, now it will throw.
Scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
```
