### PR TITLE
feat(engine): issue #153 adds a mechanism for LDS to create readonly obj

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/api.spec.ts
@@ -1,6 +1,6 @@
 import * as api from '../api';
 import { Element } from "../html-element";
-import { createElement } from './../main';
+import { createElement } from '../main';
 import { RenderAPI } from '../api';
 
 describe('api', () => {

--- a/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
@@ -1,7 +1,7 @@
 import { Element } from "../html-element";
 import { createElement } from "../upgrade";
-import assertLogger from './../assert';
-import { register } from "./../services";
+import assertLogger from '../assert';
+import { register } from "../services";
 import { ViewModelReflection } from "../def";
 import { VNode } from "../../3rdparty/snabbdom/types";
 import { Component } from "../component";

--- a/packages/lwc-engine/src/framework/__tests__/template.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/template.spec.ts
@@ -1,7 +1,7 @@
 import * as target from '../template';
 import * as globalApi from '../api';
 import { Element } from "../html-element";
-import { createElement } from './../main';
+import { createElement } from '../main';
 import { ViewModelReflection } from '../def';
 import { Template } from '../template';
 

--- a/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
@@ -1,5 +1,5 @@
 import { Element } from "../html-element";
-import { createElement } from './../main';
+import { createElement } from '../main';
 import { ViewModelReflection } from "../def";
 
 describe('watcher', () => {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
@@ -1,0 +1,33 @@
+import { Element } from "../../html-element";
+import { createElement } from "../../upgrade";
+import readonly from "../readonly";
+
+describe('readonly.ts', () => {
+    describe('readonly()', () => {
+        it('should throw when invoking it with no arguments', () => {
+            expect(() => {
+                readonly();
+            }).toThrow();
+        });
+
+        it('should throw when invoking it with more than one argument', () => {
+            expect(() => {
+                readonly({}, {});
+            }).toThrow();
+        });
+
+        it('should produce a readonly object that does not allow expandos', () => {
+            const o = readonly({});
+            expect(() => {
+                o.something = 1;
+            }).toThrow();
+        });
+
+        it('should produce a readonly object that does not allow mutations', () => {
+            const o = readonly({ something: 1 });
+            expect(() => {
+                o.something = 2;
+            }).toThrow();
+        });
+    });
+});

--- a/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
@@ -1,6 +1,7 @@
 import { Element } from "../../html-element";
 import { createElement } from "../../upgrade";
 import track from "../track";
+import readonly from "../readonly";
 
 describe('track.ts', () => {
     describe('integration', () => {
@@ -246,17 +247,42 @@ describe('track.ts', () => {
         expect(elm1.counter).toBe(countVal);
     });
 
-    describe('@track misuse', () => {
-        it('should throw when invoking track as a function', () => {
+    describe('track()', () => {
+        it('should throw when invoking it with no arguments', () => {
+            expect(() => {
+                track();
+            }).toThrow();
+        });
+
+        it('should throw when invoking it with more than one argument', () => {
+            expect(() => {
+                track({}, {});
+            }).toThrow();
+        });
+
+        it('should throw when invoking it with a readonly object', () => {
+            expect(() => {
+                track(readonly({}));
+            }).toThrow();
+        });
+
+        it('should produce a trackable object', () => {
+            let counter = 0;
             class MyComponent extends Element {
                 constructor() {
                     super();
-                    track();
+                    this.foo = track({ bar: 1 });
+                }
+                renderedCallback() {
+                    this.foo.bar = 2;
+                    counter += 1;
                 }
             }
-            expect(() => {
-                createElement('x-foo', { is: MyComponent });
-            }).toThrow('@track may only be used as a decorator.');
+            const elm = createElement('x-foo', { is: MyComponent });
+            document.body.appendChild(elm);
+            return Promise.resolve(() => {
+                expect(counter).toBe(2); // two rendering phases due to the mutation of this.foo
+            });
         });
     });
 });

--- a/packages/lwc-engine/src/framework/decorators/readonly.ts
+++ b/packages/lwc-engine/src/framework/decorators/readonly.ts
@@ -1,0 +1,13 @@
+import assert from "../assert";
+import { membrane as reactiveMembrane } from '../reactive';
+
+// when used with exactly one argument, we assume it is a function invocation.
+export default function readonly(obj: any): any {
+    if (process.env.NODE_ENV !== 'production') {
+        // TODO: enable the usage of this function as @readonly decorator
+        if (arguments.length !== 1) {
+            assert.fail("@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value.");
+        }
+    }
+    return reactiveMembrane.getReadOnlyProxy(obj);
+}

--- a/packages/lwc-engine/src/framework/decorators/track.ts
+++ b/packages/lwc-engine/src/framework/decorators/track.ts
@@ -4,13 +4,16 @@ import { isRendering, vmBeingRendered } from "../invoker";
 import { observeMutation, notifyMutation } from "../watcher";
 import { VMElement } from "../vm";
 import { getCustomElementVM } from "../html-element";
-import { membrane as reactiveMembrane } from './../reactive';
+import { membrane as reactiveMembrane } from '../reactive';
 
 // stub function to prevent misuse of the @track decorator
-export default function track() {
+export default function track(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {
-        assert.fail("@track may only be used as a decorator.");
+        if (arguments.length !== 1) {
+            assert.fail("@track can be used as a decorator or as a function with one argument to produce a trackable version of the provided value.");
+        }
     }
+    return reactiveMembrane.getProxy(obj);
 }
 
 // TODO: how to allow symbols as property keys?

--- a/packages/lwc-engine/src/framework/main.ts
+++ b/packages/lwc-engine/src/framework/main.ts
@@ -8,10 +8,5 @@ export { unwrap } from "./reactive";
 export { dangerousObjectMutation } from "./reactive";
 export { default as api } from "./decorators/api";
 export { default as track } from "./decorators/track";
+export { default as readonly } from "./decorators/readonly";
 export { default as wire } from "./decorators/wire";
-
-// TODO: REMOVE THIS https://github.com/salesforce/lwc/issues/153
-import { membrane } from "./reactive";
-export function createReadOnlyObject(obj: any): any {
-    return membrane.getReadOnlyProxy(obj);
-}

--- a/packages/lwc-engine/src/framework/modules/styles.ts
+++ b/packages/lwc-engine/src/framework/modules/styles.ts
@@ -3,7 +3,7 @@ import {
     isString,
     isUndefined,
     StringCharCodeAt,
-} from './../language';
+} from '../language';
 import { EmptyObject } from '../utils';
 import { VNode, Module } from "../../3rdparty/snabbdom/types";
 import { removeAttribute } from '../dom';

--- a/packages/observable-membrane/src/__tests__/read-only-handler.spec.ts
+++ b/packages/observable-membrane/src/__tests__/read-only-handler.spec.ts
@@ -276,4 +276,16 @@ describe('ReadOnlyHandler', () => {
         expect(accessSpy).toHaveBeenCalledTimes(2);
         expect(accessSpy).toHaveBeenLastCalledWith(obj.foo, 'bar');
     });
+    it('should throw when attempting to get the proxy from a read only proxy', function() {
+        const target = new ReactiveMembrane((value) => value, {
+            propertyMemberChange: () => {},
+            propertyMemberAccess: () => {},
+        });
+        const obj = [{ foo: 'bar' }];
+
+        const readOnly = target.getReadOnlyProxy(obj);
+        expect(() => {
+            target.getProxy(readOnly);
+        }).toThrow();
+    });
 });

--- a/packages/observable-membrane/src/reactive-membrane.ts
+++ b/packages/observable-membrane/src/reactive-membrane.ts
@@ -101,8 +101,8 @@ export class ReactiveMembrane {
     propertyMemberChange: ReactiveMembraneEventHander;
     propertyMemberAccess: ReactiveMembraneEventHander;
     objectGraph: WeakMap<any, ReactiveState> = new WeakMap();
-    constructor(distrotion: ReactiveMembraneDistortionCallback, eventMap: ReactiveMembraneEventHandlerMap) {
-        this.distortion = distrotion;
+    constructor(distortion: ReactiveMembraneDistortionCallback, eventMap: ReactiveMembraneEventHandlerMap) {
+        this.distortion = distortion;
         this.propertyMemberChange = eventMap.propertyMemberChange;
         this.propertyMemberAccess = eventMap.propertyMemberAccess;
     }
@@ -110,7 +110,12 @@ export class ReactiveMembrane {
     getProxy(value: any) {
         const distorted = invokeDistortion(this, value);
         if (isObservable(distorted)) {
-            return getReactiveState(this, distorted).reactive;
+            const o = getReactiveState(this, distorted);
+            if (o.readOnly === value) {
+                // TODO: add error code
+                throw new TypeError(`Read only object is not observable.`);
+            }
+            return o.reactive;
         }
         return distorted;
     }

--- a/packages/observable-membrane/src/shared.ts
+++ b/packages/observable-membrane/src/shared.ts
@@ -52,7 +52,7 @@ export const unwrap = getKey ?
     : (replicaOrAny: any): any => (replicaOrAny && replicaOrAny[TargetSlot]) || replicaOrAny;
 
 export function isObservable(value: any): boolean {
-    if (!value) {
+    if (value == null) {
         return false;
     }
     if (isArray(value)) {


### PR DESCRIPTION
This PR introduces a preliminary way for LDS and other libs to create qualifying objects that can be consumed by LWC (without a degradation), and at the same time, facilitate the creation of `readonly` and `track` objects in those libraries without the double proxification.

## Does this PR introduce a breaking change?

* No

## Features

* introduce `readonly` method that can be imported from `"engine"`.
* open up the ability to call `track` as a method, instead of just being a decorator.

```js
const something = { x: 1, y: { z: 2 }};
const foo = readonly(something);
const bar = track(something);
```

## Invariants

* a readonly object can't be tracked anymore because track means that you will attempt to mutate it at some point. it now throws.

