### PR TITLE
fix(lwc-engine): Add pragma to engine artifacts

### DIFF
--- a/packages/lwc-engine/scripts/rollup.config.es-and-cjs.js
+++ b/packages/lwc-engine/scripts/rollup.config.es-and-cjs.js
@@ -9,7 +9,7 @@ const entry = path.resolve(__dirname, '../src/framework/main.ts');
 const commonJSDirectory = path.resolve(__dirname, '../dist/commonjs');
 const modulesDirectory = path.resolve(__dirname, '../dist/modules');
 
-const banner = (`/**\n * Copyright (C) 2017 salesforce.com, inc.\n */`);
+const banner = (`/* proxy-compat-disable */`);
 const footer = `/** version: ${version} */`;
 
 function rollupConfig(config) {

--- a/packages/lwc-engine/scripts/rollup.config.umd.dev.js
+++ b/packages/lwc-engine/scripts/rollup.config.umd.dev.js
@@ -9,7 +9,7 @@ const { generateTargetName, ignoreCircularDependencies } = require('./engine.rol
 const input = path.resolve(__dirname, '../src/framework/main.ts');
 const outputDir = path.resolve(__dirname, '../dist/umd');
 
-const banner = (`/**\n * Copyright (C) 2017 salesforce.com, inc.\n */`);
+const banner = (`/* proxy-compat-disable */`);
 const footer = `/** version: ${version} */`;
 
 

--- a/packages/lwc-engine/scripts/rollup.config.umd.prod.js
+++ b/packages/lwc-engine/scripts/rollup.config.umd.prod.js
@@ -10,7 +10,7 @@ const { generateTargetName, ignoreCircularDependencies } = require('./engine.rol
 
 const entry = path.resolve(__dirname, '../src/framework/main.ts');
 const outputDir = path.resolve(__dirname, '../dist/umd');
-const banner = (`/**\n * Copyright (C) 2017 salesforce.com, inc.\n */`);
+const banner = (`/* proxy-compat-disable */`);
 const footer = `/** version: ${version} */`;
 
 function inlineMinifyPlugin() {

--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -18,7 +18,7 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "lwc-compiler": "~0.17.17",
-    "lwc-engine": "~0.17.17"
+    "lwc-compiler": "0.18.x",
+    "lwc-engine": "0.18.x"
   }
 }


### PR DESCRIPTION
## Details
When running COMPAT transpilation (in any rollup plugin) guarantee that engine its ignored.

Fix #155 