### PR TITLE
fix(compiler): contenteditable should map to contentEditable

### DIFF
--- a/packages/lwc-template-compiler/src/parser/constants.ts
+++ b/packages/lwc-template-compiler/src/parser/constants.ts
@@ -58,7 +58,7 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     'bgcolor': 'bgColor',
     'colspan': 'colSpan',
     'rowspan': 'rowSpan',
-    'contentEditable': 'contentEditable',
+    'contenteditable': 'contentEditable',
     'crossorigin': 'crossOrigin',
     'datetime': 'dateTime',
     'formaction': 'formAction',


### PR DESCRIPTION
## Details

`contenteditable` should map to `contentEditable`

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No