### PR TITLE
fix(engine): do not use global removeEventListener

### DIFF
--- a/packages/lwc-engine/src/framework/modules/events.ts
+++ b/packages/lwc-engine/src/framework/modules/events.ts
@@ -1,6 +1,6 @@
 import { isUndefined } from "../language";
 import { VNode, Module } from "../../3rdparty/snabbdom/types";
-import { addEventListener } from "../dom";
+import { addEventListener, removeEventListener } from "../dom";
 
 function handleEvent(event: Event, vnode: VNode) {
     const { type } = event;


### PR DESCRIPTION
## Details

Do not use global removeEventListener. Fixes IE11.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements: