### PR TITLE
chore(all): remove dist folder during clean

### DIFF
--- a/packages/lwc-compiler/package.json
+++ b/packages/lwc-compiler/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "ISC",
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "echo 'Building compiler...' && DIR=`pwd` && cd ../../ && tsc -p $DIR/tsconfig.json",
     "build:all": "",
     "build:umd": "webpack --progress",

--- a/packages/lwc-engine/package.json
+++ b/packages/lwc-engine/package.json
@@ -6,6 +6,7 @@
   "module": "dist/modules/es2017/engine.js",
   "typings": "types/engine.d.ts",
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "concurrently \"yarn build:es-and-cjs\" \"yarn build:umd:prod\" \"yarn build:umd:dev\"",
     "test": "DIR=`pwd` && cd ../../ && yarn test $DIR",
     "build:umd:dev": "rollup -c scripts/rollup.config.umd.dev.js",

--- a/packages/lwc-template-compiler/package.json
+++ b/packages/lwc-template-compiler/package.json
@@ -6,6 +6,7 @@
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "DIR=`pwd` && cd ../../ && tsc -p $DIR/tsconfig.json",
     "test": "DIR=`pwd` && cd ../../ && yarn test $DIR"
   },

--- a/packages/lwc-wire-service/package.json
+++ b/packages/lwc-wire-service/package.json
@@ -5,6 +5,7 @@
   "main": "dist/commonjs/es2017/wire-service.js",
   "module": "dist/modules/es2017/wire-service.js",
   "scripts": {
+    "clean": "rm -rf dist",
     "lint": "eslint src playground",
     "build": "concurrently \"yarn build:es-and-cjs\" \"yarn build:umd:dev\"",
     "build:umd:dev": "rollup -c rollup.config.umd.dev.js",

--- a/packages/observable-membrane/package.json
+++ b/packages/observable-membrane/package.json
@@ -6,6 +6,7 @@
   "module": "dist/modules/observable-membrane.js",
   "jsnext:main": "dist/modules/observable-membrane.js",
   "scripts": {
+    "clean": "rm -rf dist",
     "test": "echo 'Testing observable membrane...' && DIR=`pwd` && cd ../../ && jest $DIR",
     "types": "tsc",
     "lint": "eslint src/**/*.ts",

--- a/packages/postcss-plugin-lwc/package.json
+++ b/packages/postcss-plugin-lwc/package.json
@@ -5,6 +5,7 @@
   "main": "dist/commonjs/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "echo 'Building postcss plugin...' && DIR=`pwd` && cd ../../ && tsc -p $DIR/tsconfig.json",
     "test": "DIR=`pwd` && cd ../../ && jest $DIR"
   },


### PR DESCRIPTION
## Details

Remove `dist` folder in addition to `node_modules` during `yarn clean` to help avoid releasing stale artifacts.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:
