### PR TITLE
refactor(engine): enabling internal componentUpdated() hook for `@wire`

### DIFF
--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -4,7 +4,7 @@ import { vmBeingRendered, invokeComponentCallback } from "./invoker";
 import { EmptyArray, SPACE_CHAR } from "./utils";
 import { renderVM, createVM, appendVM, removeVM, VM } from "./vm";
 import { registerComponent } from "./def";
-import { ComponentConstructor, markComponentAsDirty, isValidEvent } from "./component";
+import { ComponentConstructor, markComponentAsDirty, isValidEvent, componentUpdated } from "./component";
 
 import { VNode, VNodeData, VNodes, VElement, VComment, VText, Hooks } from "../3rdparty/snabbdom/types";
 import { getCustomElementVM } from "./html-element";
@@ -79,6 +79,7 @@ const hook: Hooks = {
         if (vm.cmpSlots !== oldVNode.data.slotset && !vm.isDirty) {
             markComponentAsDirty(vm);
         }
+        componentUpdated(vm);
         renderVM(vm);
     },
     insert(vnode: VNode) {

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -88,6 +88,14 @@ export function linkComponent(vm: VM) {
     }
 }
 
+export function componentUpdated(vm: VM) {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.vm(vm);
+    }
+    // TODO: @vince will use this method to notify the wire decorators
+    // that the component's public properties were updated
+}
+
 export function clearReactiveListeners(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.vm(vm);

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -133,8 +133,16 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
     let methods = getPublicMethodsHash(Ctor);
     let wire = getWireHash(Ctor);
     const track = getTrackHash(Ctor);
-
     const proto = Ctor.prototype;
+    let {
+        connectedCallback,
+        disconnectedCallback,
+        renderedCallback,
+        errorCallback,
+    } = proto;
+    const superProto = getPrototypeOf(Ctor);
+    const superDef: ComponentDef | null = superProto !== BaseElement ? getComponentDef(superProto) : null;
+
     for (const propName in props) {
         const propDef = props[propName];
         // initializing getters and setters for each public prop on the target prototype
@@ -159,6 +167,20 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
             createPublicPropertyDescriptor(proto, propName, descriptor);
         }
     }
+    if (track) {
+        for (const propName in track) {
+            const descriptor = getOwnPropertyDescriptor(proto, propName);
+            // TODO: maybe these conditions should be always applied.
+            if (process.env.NODE_ENV !== 'production') {
+                const { get, set, configurable, writable } = descriptor || EmptyObject;
+                assert.isTrue(!get && !set, `Compiler Error: A decorator can only be applied to a public field.`);
+                assert.isTrue(configurable !== false, `Compiler Error: A decorator can only be applied to a configurable property.`);
+                assert.isTrue(writable !== false, `Compiler Error: A decorator can only be applied to a writable property.`);
+            }
+            // initializing getters and setters for each public prop on the target prototype
+            createTrackedPropertyDescriptor(proto, propName, descriptor);
+        }
+    }
     if (wire) {
         for (const propName in wire) {
             if (wire[propName].method) {
@@ -177,29 +199,7 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
             createWiredPropertyDescriptor(proto, propName, descriptor);
         }
     }
-    if (track) {
-        for (const propName in track) {
-            const descriptor = getOwnPropertyDescriptor(proto, propName);
-            // TODO: maybe these conditions should be always applied.
-            if (process.env.NODE_ENV !== 'production') {
-                const { get, set, configurable, writable } = descriptor || EmptyObject;
-                assert.isTrue(!get && !set, `Compiler Error: A decorator can only be applied to a public field.`);
-                assert.isTrue(configurable !== false, `Compiler Error: A decorator can only be applied to a configurable property.`);
-                assert.isTrue(writable !== false, `Compiler Error: A decorator can only be applied to a writable property.`);
-            }
-            // initializing getters and setters for each public prop on the target prototype
-            createTrackedPropertyDescriptor(proto, propName, descriptor);
-        }
-    }
 
-    let {
-        connectedCallback,
-        disconnectedCallback,
-        renderedCallback,
-        errorCallback,
-    } = proto;
-    const superProto = getPrototypeOf(Ctor);
-    const superDef: ComponentDef | null = superProto !== BaseElement ? getComponentDef(superProto) : null;
     if (!isNull(superDef)) {
         props = assign(create(null), superDef.props, props);
         methods = assign(create(null), superDef.methods, methods);
@@ -211,7 +211,7 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
     }
 
     props = assign(create(null), HTML_PROPS, props);
-    const descriptors = createDescriptorMap(props, methods);
+    const descriptors = createHostElementPropertyDescriptorMap(props, methods);
 
     const def: ComponentDef = {
         name,
@@ -369,7 +369,7 @@ export function prepareForAttributeMutationFromTemplate(elm: Element, key: strin
     }
 }
 
-function createDescriptorMap(publicProps: PropsDef, publicMethodsConfig: MethodDef): PropertyDescriptorMap {
+function createHostElementPropertyDescriptorMap(publicProps: PropsDef, publicMethodsConfig: MethodDef): PropertyDescriptorMap {
     // replacing mutators and accessors on the element itself to catch any mutation
     const descriptors: PropertyDescriptorMap = {
         getAttribute: {

--- a/packages/lwc-engine/src/framework/upgrade.ts
+++ b/packages/lwc-engine/src/framework/upgrade.ts
@@ -2,7 +2,7 @@ import assert from "./assert";
 import { isUndefined, isFunction, assign, hasOwnProperty } from "./language";
 import { createVM, removeVM, appendVM, renderVM } from "./vm";
 import { registerComponent, getCtorByTagName, prepareForAttributeMutationFromTemplate, ViewModelReflection } from "./def";
-import { ComponentConstructor } from "./component";
+import { ComponentConstructor, componentUpdated } from "./component";
 import { getCustomElementVM } from "./html-element";
 
 const { removeChild, appendChild, insertBefore, replaceChild } = Node.prototype;
@@ -72,6 +72,7 @@ export function createElement(sel: string, options: any = {}): HTMLElement {
     // Handle insertion and removal from the DOM manually
     element[ConnectingSlot] = () => {
         const vm = getCustomElementVM(element);
+        componentUpdated(vm);
         removeVM(vm); // moving the element from one place to another is observable via life-cycle hooks
         appendVM(vm);
         // TODO: this is the kind of awkwardness introduced by "is" attribute


### PR DESCRIPTION
## Details

* Preliminary work to support the folding of wire service into the wire decorator
* `componentUpdated()` is a new internal hook that will be called when all public props have been changed
* Reordering how the decorators are applied
  - make wire decorator the last one
  - get the protototype object ready before any decorator is evaluated

## Does this PR introduce a breaking change?

* No
