### PR TITLE
fix(lwc-engine): Refactor destroy hooks to avoid memory leaks

### DIFF
--- a/packages/lwc-engine/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/lwc-engine/src/3rdparty/snabbdom/snabbdom.ts
@@ -251,7 +251,6 @@ export function init(
             // text nodes do not have logic associated to them
             if (isVNode(ch)) {
                 if (!isTextVNode(ch)) {
-                    invokeDestroyHook(ch);
                     listeners = cbs.remove.length + 1;
                     rm = createRmCb(ch.elm as Node, listeners);
                     for (i = 0; i < cbs.remove.length; ++i) {
@@ -262,6 +261,7 @@ export function init(
                     } else {
                         rm();
                     }
+                    invokeDestroyHook(ch);
                 } else {
                     api.removeChild(parentElm, ch.elm as Node);
                 }

--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -89,9 +89,8 @@ const hook: Hooks = {
     create(oldVNode: VNode, vnode: VNode) {
         createVM(vnode.sel as string, vnode.elm as HTMLElement, vnode.data.slotset);
     },
-    remove(vnode: VNode, removeCallback) {
+    destroy(vnode: VNode) {
         removeVM(getCustomElementVM(vnode.elm as HTMLElement));
-        removeCallback();
     }
 };
 


### PR DESCRIPTION
## Details

On a trivial template like:

```html
<template if:true={showChildWrap}>
    <div>
        <simple-item></simple-item>
    </div>
</template>
```
We don't call `disconnectedCallback` due to a missing destroy hooks. Moreover the order is incorrect.

This PR adds the right destroy hooks and changes order of execution in snabbdom to allow proper DOM destruction.

@caridy  to follow up on the Snabdom changes.

## Does this PR introduce a breaking change?

* [x] No