### PR TITLE
fix: Revert preventDefault polyfill

### DIFF
--- a/packages/lwc-compiler/package.json
+++ b/packages/lwc-compiler/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.40",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",
     "babel-plugin-transform-lwc-class": "0.19.0-0",
-    "babel-preset-compat": "0.17.38",
+    "babel-preset-compat": "0.17.39",
     "babel-preset-minify": "0.4.0-alpha.caaefb4c",
     "cssnano": "^3.10.0",
     "lwc-template-compiler": "0.19.0-0",

--- a/packages/lwc-integration/package.json
+++ b/packages/lwc-integration/package.json
@@ -23,8 +23,8 @@
     "sauce:prod_compat": "MODE=prod_compat yarn build:prod_compat && MODE=prod_compat wdio ./scripts/wdio.sauce.conf.js"
   },
   "devDependencies": {
-    "babel-preset-compat": "0.17.38",
-    "compat-polyfills": "0.17.38",
+    "babel-preset-compat": "0.17.39",
+    "compat-polyfills": "0.17.39",
     "deepmerge": "^1.5.2",
     "dotenv": "^4.0.0",
     "fs-extra": "^4.0.2",
@@ -32,7 +32,7 @@
     "lwc-compiler": "0.19.0-0",
     "lwc-engine": "0.19.0-0",
     "minimist": "^1.2.0",
-    "rollup-plugin-compat": "0.17.38",
+    "rollup-plugin-compat": "0.17.39",
     "rollup-plugin-lwc-compiler": "0.19.0-0",
     "wdio-junit-reporter": "^0.3.1",
     "wdio-mocha-framework": "^0.5.10",

--- a/packages/lwc-integration/src/components/events/test-default-prevented/default-prevented.spec.js
+++ b/packages/lwc-integration/src/components/events/test-default-prevented/default-prevented.spec.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
-describe('Composed events', () => {
+
+// This test is now disable waiting for a proper fix to event.preventDefault()
+describe.skip('Composed events', () => {
     const URL = 'http://localhost:4567/default-prevented';
     let element;
 

--- a/packages/lwc-wire-service/package.json
+++ b/packages/lwc-wire-service/package.json
@@ -27,7 +27,7 @@
     "lwc-engine": "0.19.0-0",
     "lwc-jest-transformer": "0.17.15",
     "rollup": "~0.56.2",
-    "rollup-plugin-compat": "0.17.38",
+    "rollup-plugin-compat": "0.17.39",
     "rollup-plugin-lwc-compiler": "0.19.0-0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0"

--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "^7.1.2",
     "lwc-module-resolver": "0.19.0-0",
-    "rollup-plugin-compat": "0.17.38",
+    "rollup-plugin-compat": "0.17.39",
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,9 +943,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-compat@0.17.38:
-  version "0.17.38"
-  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.38/e3de390dbbaa75da7eabf8d4b00b934042536167.tgz#e3de390dbbaa75da7eabf8d4b00b934042536167"
+babel-compat@0.17.39:
+  version "0.17.39"
+  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.39/a8a0b078f012f2da540cb64aa5d3113c83c39706.tgz#a8a0b078f012f2da540cb64aa5d3113c83c39706"
 
 babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
@@ -1457,9 +1457,9 @@ babel-plugin-transform-property-literals@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-proxy-compat@0.17.38:
-  version "0.17.38"
-  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.38/19231822ba952d99e09ceb84f9ba79cf3f1377ef.tgz#19231822ba952d99e09ceb84f9ba79cf3f1377ef"
+babel-plugin-transform-proxy-compat@0.17.39:
+  version "0.17.39"
+  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.39/7dbde0b50b1c11633fcd23028c658ca472e50f0f.tgz#7dbde0b50b1c11633fcd23028c658ca472e50f0f"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -1500,9 +1500,9 @@ babel-plugin-transform-undefined-to-void@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   version "6.10.0-alpha.f95869d4"
   resolved "http://npm.lwcjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4/175a1a3090e616403f8c819cdcea1aecb66523b2.tgz#175a1a3090e616403f8c819cdcea1aecb66523b2"
 
-babel-preset-compat@0.17.38:
-  version "0.17.38"
-  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.38/fb4d949f6094b40ae030017be643f667a2cfd0cf.tgz#fb4d949f6094b40ae030017be643f667a2cfd0cf"
+babel-preset-compat@0.17.39:
+  version "0.17.39"
+  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.39/f73da8bacb7dea45a2b6a729354639ec83616988.tgz#f73da8bacb7dea45a2b6a729354639ec83616988"
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.0.0-beta.40"
     "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.40"
@@ -1533,7 +1533,7 @@ babel-preset-compat@0.17.38:
     "@babel/plugin-transform-template-literals" "7.0.0-beta.40"
     "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.40"
     "@babel/plugin-transform-unicode-regex" "7.0.0-beta.40"
-    babel-plugin-transform-proxy-compat "0.17.38"
+    babel-plugin-transform-proxy-compat "0.17.39"
 
 babel-preset-env@1.6.1:
   version "1.6.1"
@@ -2357,9 +2357,9 @@ compare-versions@2.0.1:
   version "2.0.1"
   resolved "http://npm.lwcjs.org/compare-versions/-/compare-versions-2.0.1/1edc1f93687fd97a325c59f55e45a07db106aca6.tgz#1edc1f93687fd97a325c59f55e45a07db106aca6"
 
-compat-polyfills@0.17.38:
-  version "0.17.38"
-  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.38/8fcd29acda655b52d0baf6443874e3c4b809aa8d.tgz#8fcd29acda655b52d0baf6443874e3c4b809aa8d"
+compat-polyfills@0.17.39:
+  version "0.17.39"
+  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.39/417ca29cc210009e20ece6ba63bc86859003c8f0.tgz#417ca29cc210009e20ece6ba63bc86859003c8f0"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -7343,14 +7343,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-compat@0.17.38:
-  version "0.17.38"
-  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.38/86e5db3b133e23fe5563813ac6027e11178bfe0b.tgz#86e5db3b133e23fe5563813ac6027e11178bfe0b"
+rollup-plugin-compat@0.17.39:
+  version "0.17.39"
+  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.39/289298951a735538a745df20df79afa9c38e0c9b.tgz#289298951a735538a745df20df79afa9c38e0c9b"
   dependencies:
     "@babel/core" "7.0.0-beta.40"
-    babel-compat "0.17.38"
-    babel-preset-compat "0.17.38"
-    compat-polyfills "0.17.38"
+    babel-compat "0.17.39"
+    babel-preset-compat "0.17.39"
+    compat-polyfills "0.17.39"
     rollup-pluginutils "~2.0.1"
 
 rollup-plugin-inject@^1.4.1:


### PR DESCRIPTION
## Details

Revert `CustomEvent.prototype.preventDefault` polyfill change by upgrading the proxy-compat version to `0.17.39`

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No