### PR TITLE
fix: [Backport 214/patch] Prevent properties to leak on intrinsics

### DIFF
--- a/packages/lwc-compiler/package.json
+++ b/packages/lwc-compiler/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.40",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",
     "babel-plugin-transform-lwc-class": "0.19.1",
-    "babel-preset-compat": "0.17.39",
+    "babel-preset-compat": "0.17.40",
     "babel-preset-minify": "0.4.0-alpha.caaefb4c",
     "cssnano": "^3.10.0",
     "lwc-template-compiler": "0.19.1",

--- a/packages/lwc-integration/package.json
+++ b/packages/lwc-integration/package.json
@@ -23,8 +23,8 @@
     "sauce:prod_compat": "MODE=prod_compat yarn build:prod_compat && MODE=prod_compat wdio ./scripts/wdio.sauce.conf.js"
   },
   "devDependencies": {
-    "babel-preset-compat": "0.17.39",
-    "compat-polyfills": "0.17.39",
+    "babel-preset-compat": "0.17.40",
+    "compat-polyfills": "0.17.40",
     "deepmerge": "^1.5.2",
     "dotenv": "^4.0.0",
     "fs-extra": "^4.0.2",
@@ -32,7 +32,7 @@
     "lwc-compiler": "0.19.1",
     "lwc-engine": "0.19.1",
     "minimist": "^1.2.0",
-    "rollup-plugin-compat": "0.17.39",
+    "rollup-plugin-compat": "0.17.40",
     "rollup-plugin-lwc-compiler": "0.19.1",
     "wdio-junit-reporter": "^0.3.1",
     "wdio-mocha-framework": "^0.5.10",

--- a/packages/lwc-integration/src/components/natives/test-array-push-concat-unshift/array-push-concat-unshift.js
+++ b/packages/lwc-integration/src/components/natives/test-array-push-concat-unshift/array-push-concat-unshift.js
@@ -1,6 +1,5 @@
 import { Element, api, track } from 'engine';
 
-
 export default class Issue763 extends Element {
     @api propItems = [{
         title: 'first'

--- a/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.html
+++ b/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.html
@@ -1,0 +1,4 @@
+<template>
+    <p id="object-enumerable-properties">{objectEnumerableProperties}</p>
+    <p id="array-enumerable-properties">{arrayEnumerableProperties}</p>
+</template>

--- a/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.js
+++ b/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.js
@@ -1,0 +1,25 @@
+import { Element } from 'engine';
+
+export default class EnumerablePropertyLeak extends Element {
+    get objectEnumerableProperties() {
+        const properties = [];
+
+        const obj = { x: 'x', y: 'y' };
+        for (let property in obj) {
+            properties.push(property);
+        }
+
+        return properties;
+    }
+
+    get arrayEnumerableProperties() {
+        const properties = [];
+
+        const array = ['x', 'y'];
+        for (let property in array) {
+            properties.push(property);
+        }
+
+        return properties;
+    }
+}

--- a/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.spec.js
+++ b/packages/lwc-integration/src/components/natives/test-enumerable-property-leak/enumerable-property-leak.spec.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+describe('Array prototype methods', () => {
+    const URL = 'http://localhost:4567/enumerable-property-leak';
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should not leak any properties on Object', () => {
+        const el = browser.element('#object-enumerable-properties');
+        assert.strictEqual(el.getText(), 'x,y');
+    });
+
+    it('should not leak any properties on Array', () => {
+        const el = browser.element('#array-enumerable-properties');
+        assert.strictEqual(el.getText(), '0,1');
+    });
+});

--- a/packages/lwc-wire-service/package.json
+++ b/packages/lwc-wire-service/package.json
@@ -27,7 +27,7 @@
     "lwc-engine": "0.19.1",
     "lwc-jest-transformer": "0.17.15",
     "rollup": "~0.56.2",
-    "rollup-plugin-compat": "0.17.39",
+    "rollup-plugin-compat": "0.17.40",
     "rollup-plugin-lwc-compiler": "0.19.1",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0"

--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "^7.1.2",
     "lwc-module-resolver": "0.19.1",
-    "rollup-plugin-compat": "0.17.39",
+    "rollup-plugin-compat": "0.17.40",
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,9 +943,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-compat@0.17.39:
-  version "0.17.39"
-  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.39/a8a0b078f012f2da540cb64aa5d3113c83c39706.tgz#a8a0b078f012f2da540cb64aa5d3113c83c39706"
+babel-compat@0.17.40:
+  version "0.17.40"
+  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.40/1ab255daa93fa8af3dacbbbf37dc81d40feedf79.tgz#1ab255daa93fa8af3dacbbbf37dc81d40feedf79"
 
 babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
@@ -1457,9 +1457,9 @@ babel-plugin-transform-property-literals@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-proxy-compat@0.17.39:
-  version "0.17.39"
-  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.39/7dbde0b50b1c11633fcd23028c658ca472e50f0f.tgz#7dbde0b50b1c11633fcd23028c658ca472e50f0f"
+babel-plugin-transform-proxy-compat@0.17.40:
+  version "0.17.40"
+  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.40/4bdaf70c7d48df6e0f15eddbe95b021314d24454.tgz#4bdaf70c7d48df6e0f15eddbe95b021314d24454"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -1500,9 +1500,9 @@ babel-plugin-transform-undefined-to-void@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   version "6.10.0-alpha.f95869d4"
   resolved "http://npm.lwcjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4/175a1a3090e616403f8c819cdcea1aecb66523b2.tgz#175a1a3090e616403f8c819cdcea1aecb66523b2"
 
-babel-preset-compat@0.17.39:
-  version "0.17.39"
-  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.39/f73da8bacb7dea45a2b6a729354639ec83616988.tgz#f73da8bacb7dea45a2b6a729354639ec83616988"
+babel-preset-compat@0.17.40:
+  version "0.17.40"
+  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.40/51052fcb6746316b45e2944943c65e777fab75bb.tgz#51052fcb6746316b45e2944943c65e777fab75bb"
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.0.0-beta.40"
     "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.40"
@@ -1533,7 +1533,7 @@ babel-preset-compat@0.17.39:
     "@babel/plugin-transform-template-literals" "7.0.0-beta.40"
     "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.40"
     "@babel/plugin-transform-unicode-regex" "7.0.0-beta.40"
-    babel-plugin-transform-proxy-compat "0.17.39"
+    babel-plugin-transform-proxy-compat "0.17.40"
 
 babel-preset-env@1.6.1:
   version "1.6.1"
@@ -2357,9 +2357,9 @@ compare-versions@2.0.1:
   version "2.0.1"
   resolved "http://npm.lwcjs.org/compare-versions/-/compare-versions-2.0.1/1edc1f93687fd97a325c59f55e45a07db106aca6.tgz#1edc1f93687fd97a325c59f55e45a07db106aca6"
 
-compat-polyfills@0.17.39:
-  version "0.17.39"
-  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.39/417ca29cc210009e20ece6ba63bc86859003c8f0.tgz#417ca29cc210009e20ece6ba63bc86859003c8f0"
+compat-polyfills@0.17.40:
+  version "0.17.40"
+  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.40/bd98527ac43ec55a09ee57620a2bcf043f9ba55d.tgz#bd98527ac43ec55a09ee57620a2bcf043f9ba55d"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -7343,14 +7343,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-compat@0.17.39:
-  version "0.17.39"
-  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.39/289298951a735538a745df20df79afa9c38e0c9b.tgz#289298951a735538a745df20df79afa9c38e0c9b"
+rollup-plugin-compat@0.17.40:
+  version "0.17.40"
+  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.40/f725fdf3e569aa99fa822a70277dd8937b147364.tgz#f725fdf3e569aa99fa822a70277dd8937b147364"
   dependencies:
     "@babel/core" "7.0.0-beta.40"
-    babel-compat "0.17.39"
-    babel-preset-compat "0.17.39"
-    compat-polyfills "0.17.39"
+    babel-compat "0.17.40"
+    babel-preset-compat "0.17.40"
+    compat-polyfills "0.17.40"
     rollup-pluginutils "~2.0.1"
 
 rollup-plugin-inject@^1.4.1:


### PR DESCRIPTION
## Details

This PR adds a test to the integration suite to ensure that no enumerable properties leak on the Object and Array prototypes. Backported from #232

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No