### PR TITLE
refactor(aom): Fix ariaHasPopup and add ariaColSpan

### DIFF
--- a/packages/lwc-template-compiler/src/parser/constants.ts
+++ b/packages/lwc-template-compiler/src/parser/constants.ts
@@ -69,6 +69,10 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     'usemap': 'useMap',
     'for': 'htmlFor',
 
+    // According to the following list, there are 48 aria attributes (of which 2 are deprecated):
+    // https://www.w3.org/TR/wai-aria-1.1/#x6-6-definitions-of-states-and-properties-all-aria-attributes
+    // This list of 46 non-deprecated aria attributes is consistent with the following proposal:
+    // https://github.com/w3c/aria/pull/708/files#diff-eacf331f0ffc35d4b482f1d15a887d3bR11060
     'aria-activedescendant': 'ariaActiveDescendant',
     'aria-atomic': 'ariaAtomic',
     'aria-autocomplete': 'ariaAutoComplete',
@@ -82,9 +86,11 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     'aria-describedby': 'ariaDescribedBy',
     'aria-details': 'ariaDetails',
     'aria-disabled': 'ariaDisabled',
+//  'aria-dropEffect': 'ariaDropEffect', /* Deprecated in ARIA 1.1 */
     'aria-errormessage': 'ariaErrorMessage',
     'aria-expanded': 'ariaExpanded',
     'aria-flowto': 'ariaFlowTo',
+//  'aria-grabbed': 'ariaGrabbed', /* Deprecated in ARIA 1.1 */
     'aria-haspopup': 'ariaHasPopup',
     'aria-hidden': 'ariaHidden',
     'aria-invalid': 'ariaInvalid',


### PR DESCRIPTION
## Details

This PR might be difficult to review due to the reordering of props. It's probably easier to review by looking at the individual commits.

Correct casing for `ariaHasPopup`:
https://github.com/w3c/aria/pull/708/files#diff-eacf331f0ffc35d4b482f1d15a887d3bR11060

Add missing `ariaColSpan` prop:
https://github.com/w3c/aria/pull/708/files#diff-eacf331f0ffc35d4b482f1d15a887d3bR11051

## Does this PR introduce a breaking change?

* [X] Yes
* [ ] No

If yes, please describe the impact and migration path for existing applications:

Changing `ariaHasPopUp` to `ariaHasPopup` is technically a breaking change but I've confirmed that neither LGC nor core use `ariaHasPopUp`/`aria-haspopup` in an LWC component.