### PR TITLE
chore: Bump version of proxy-compat to 0.17.43

### DIFF
--- a/packages/lwc-compiler/package.json
+++ b/packages/lwc-compiler/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.40",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",
     "babel-plugin-transform-lwc-class": "0.20.0",
-    "babel-preset-compat": "0.17.42",
+    "babel-preset-compat": "0.17.43",
     "babel-preset-minify": "0.4.0-alpha.caaefb4c",
     "cssnano": "^3.10.0",
     "lwc-template-compiler": "0.20.0",

--- a/packages/lwc-integration/package.json
+++ b/packages/lwc-integration/package.json
@@ -23,8 +23,8 @@
     "sauce:prod_compat": "MODE=prod_compat yarn build:prod_compat && MODE=prod_compat wdio ./scripts/wdio.sauce.conf.js"
   },
   "devDependencies": {
-    "babel-preset-compat": "0.17.42",
-    "compat-polyfills": "0.17.42",
+    "babel-preset-compat": "0.17.43",
+    "compat-polyfills": "0.17.43",
     "deepmerge": "^1.5.2",
     "dotenv": "^4.0.0",
     "fs-extra": "^4.0.2",
@@ -32,7 +32,7 @@
     "lwc-compiler": "0.20.0",
     "lwc-engine": "0.20.0",
     "minimist": "^1.2.0",
-    "rollup-plugin-compat": "0.17.42",
+    "rollup-plugin-compat": "0.17.43",
     "rollup-plugin-lwc-compiler": "0.20.0",
     "wdio-junit-reporter": "^0.3.1",
     "wdio-mocha-framework": "^0.5.10",

--- a/packages/lwc-wire-service/package.json
+++ b/packages/lwc-wire-service/package.json
@@ -27,7 +27,7 @@
     "lwc-engine": "0.20.0",
     "lwc-jest-transformer": "0.17.15",
     "rollup": "~0.56.2",
-    "rollup-plugin-compat": "0.17.42",
+    "rollup-plugin-compat": "0.17.43",
     "rollup-plugin-lwc-compiler": "0.20.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0"

--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "^7.1.2",
     "lwc-module-resolver": "0.20.0",
-    "rollup-plugin-compat": "0.17.42",
+    "rollup-plugin-compat": "0.17.43",
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,9 +966,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-compat@0.17.42:
-  version "0.17.42"
-  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.42/7d1e9edaa4b6d7e3a24af7642f493b44ad4562d0.tgz#7d1e9edaa4b6d7e3a24af7642f493b44ad4562d0"
+babel-compat@0.17.43:
+  version "0.17.43"
+  resolved "http://npm.lwcjs.org/babel-compat/-/babel-compat-0.17.43/1482a5b6105846c2aa1abd40bd0f9aeeabbd173e.tgz#1482a5b6105846c2aa1abd40bd0f9aeeabbd173e"
 
 babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
@@ -1480,9 +1480,9 @@ babel-plugin-transform-property-literals@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-proxy-compat@0.17.42:
-  version "0.17.42"
-  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.42/d62a5609d4237bf8abf8df054cd8fe345af4bc5b.tgz#d62a5609d4237bf8abf8df054cd8fe345af4bc5b"
+babel-plugin-transform-proxy-compat@0.17.43:
+  version "0.17.43"
+  resolved "http://npm.lwcjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.17.43/090c10a9c1e619ed95cbf0b990ba2a68144f205c.tgz#090c10a9c1e619ed95cbf0b990ba2a68144f205c"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -1523,9 +1523,9 @@ babel-plugin-transform-undefined-to-void@^6.10.0-alpha.caaefb4c, babel-plugin-tr
   version "6.10.0-alpha.f95869d4"
   resolved "http://npm.lwcjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4/175a1a3090e616403f8c819cdcea1aecb66523b2.tgz#175a1a3090e616403f8c819cdcea1aecb66523b2"
 
-babel-preset-compat@0.17.42:
-  version "0.17.42"
-  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.42/5d2cbe9d9467921c08d34636c29def0401e75538.tgz#5d2cbe9d9467921c08d34636c29def0401e75538"
+babel-preset-compat@0.17.43:
+  version "0.17.43"
+  resolved "http://npm.lwcjs.org/babel-preset-compat/-/babel-preset-compat-0.17.43/9aff3e16b1b07dd928ecc16111afcbe84e28539b.tgz#9aff3e16b1b07dd928ecc16111afcbe84e28539b"
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.0.0-beta.40"
     "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.40"
@@ -1556,7 +1556,7 @@ babel-preset-compat@0.17.42:
     "@babel/plugin-transform-template-literals" "7.0.0-beta.40"
     "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.40"
     "@babel/plugin-transform-unicode-regex" "7.0.0-beta.40"
-    babel-plugin-transform-proxy-compat "0.17.42"
+    babel-plugin-transform-proxy-compat "0.17.43"
 
 babel-preset-env@1.6.1:
   version "1.6.1"
@@ -2408,9 +2408,9 @@ compare-versions@2.0.1:
   version "2.0.1"
   resolved "http://npm.lwcjs.org/compare-versions/-/compare-versions-2.0.1/1edc1f93687fd97a325c59f55e45a07db106aca6.tgz#1edc1f93687fd97a325c59f55e45a07db106aca6"
 
-compat-polyfills@0.17.42:
-  version "0.17.42"
-  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.42/9328dab73004fa26aeaeae5c3b261b90e7182d2d.tgz#9328dab73004fa26aeaeae5c3b261b90e7182d2d"
+compat-polyfills@0.17.43:
+  version "0.17.43"
+  resolved "http://npm.lwcjs.org/compat-polyfills/-/compat-polyfills-0.17.43/2d92dc41c0bb8e0834c4246774a318b0027e1c58.tgz#2d92dc41c0bb8e0834c4246774a318b0027e1c58"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -7490,14 +7490,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-compat@0.17.42:
-  version "0.17.42"
-  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.42/6522db11a3555dbcfbf11f218cf2f87562602833.tgz#6522db11a3555dbcfbf11f218cf2f87562602833"
+rollup-plugin-compat@0.17.43:
+  version "0.17.43"
+  resolved "http://npm.lwcjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.17.43/63b4796016c16f2ef2e2a159e33a1068f6710729.tgz#63b4796016c16f2ef2e2a159e33a1068f6710729"
   dependencies:
     "@babel/core" "7.0.0-beta.40"
-    babel-compat "0.17.42"
-    babel-preset-compat "0.17.42"
-    compat-polyfills "0.17.42"
+    babel-compat "0.17.43"
+    babel-preset-compat "0.17.43"
+    compat-polyfills "0.17.43"
     rollup-pluginutils "~2.0.1"
 
 rollup-plugin-inject@^1.4.1:


### PR DESCRIPTION
## Details

* Performance improvement added to `Object.prototype.hasOwnProperty`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No