### PR TITLE
fix(engine): define setter along with getter in global html attr

### DIFF
--- a/packages/lwc-engine/src/framework/html-element.ts
+++ b/packages/lwc-engine/src/framework/html-element.ts
@@ -351,7 +351,6 @@ if (process.env.NODE_ENV !== 'production') {
             enumerable: false,
         });
     });
-
 }
 
 freeze(LWCElement);


### PR DESCRIPTION
## Details

Some global HTML attributes are not implemented in jsdom, which leads to test failures. In non-prod mode, for the global HTML attributes that aren't defined on `LWCElement.prototype`, we define a getter to log debug info. Defining a getter without a setter is dangerous. We must also define a setter to avoid errors when this attribute is set to avoid errors such as:

`TypeError: Cannot set property draggable of [object Object] which has only a getter`

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No