### PR TITLE
fix(engine): isBeingConstructed flag is not get out of sync

### DIFF
--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -43,24 +43,12 @@ export interface ComponentConstructor {
     readonly __circular__?: any;
 }
 
-export let vmBeingConstructed: VM | null = null;
-export function isBeingConstructed(vm: VM): boolean {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.vm(vm);
-    }
-    return vmBeingConstructed === vm;
-}
-
 export function createComponent(vm: VM, Ctor: ComponentConstructor) {
     if (process.env.NODE_ENV !== 'production') {
         assert.vm(vm);
     }
     // create the component instance
-    const vmBeingConstructedInception = vmBeingConstructed;
-    vmBeingConstructed = vm;
-
     const component = invokeComponentConstructor(vm, Ctor);
-    vmBeingConstructed = vmBeingConstructedInception;
 
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm.component === component, `Invalid construction for ${vm}, maybe you are missing the call to super() on classes extending Element.`);

--- a/packages/lwc-engine/src/framework/decorators/api.ts
+++ b/packages/lwc-engine/src/framework/decorators/api.ts
@@ -1,8 +1,8 @@
 import assert from "../assert";
 import { defineProperty, isObject, isNull, isTrue } from "../language";
-import { isRendering, vmBeingRendered } from "../invoker";
+import { isRendering, vmBeingRendered, isBeingConstructed } from "../invoker";
 import { observeMutation, notifyMutation } from "../watcher";
-import { isBeingConstructed, Component } from "../component";
+import { Component } from "../component";
 import { VM } from "../vm";
 import { getCustomElementVM } from "../html-element";
 import { isUndefined, isFunction } from "../language";

--- a/packages/lwc-engine/src/framework/html-element.ts
+++ b/packages/lwc-engine/src/framework/html-element.ts
@@ -1,6 +1,6 @@
 import assert from "./assert";
 import { Root, shadowRootQuerySelector, shadowRootQuerySelectorAll, ShadowRoot } from "./root";
-import { vmBeingConstructed, isBeingConstructed, Component } from "./component";
+import { Component } from "./component";
 import { isObject, ArrayFilter, freeze, seal, defineProperty, defineProperties, getOwnPropertyNames, isUndefined, ArraySlice, isNull, forEach } from "./language";
 import {
     getGlobalHTMLPropertiesInfo,
@@ -15,7 +15,7 @@ import {
     CustomEvent,
 } from "./dom";
 import { getPropNameFromAttrName } from "./utils";
-import { isRendering, vmBeingRendered } from "./invoker";
+import { vmBeingConstructed, isBeingConstructed, isRendering, vmBeingRendered } from "./invoker";
 import { wasNodePassedIntoVM, VM } from "./vm";
 import { pierce, piercingHook } from "./piercing";
 import { ViewModelReflection } from "./def";

--- a/packages/lwc-engine/src/framework/invoker.ts
+++ b/packages/lwc-engine/src/framework/invoker.ts
@@ -13,6 +13,14 @@ import { startMeasure, endMeasure } from "./performance-timing";
 export let isRendering: boolean = false;
 export let vmBeingRendered: VM|null = null;
 
+export let vmBeingConstructed: VM | null = null;
+export function isBeingConstructed(vm: VM): boolean {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.vm(vm);
+    }
+    return vmBeingConstructed === vm;
+}
+
 export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, args?: any[]): any {
     const { context, component } = vm;
     const ctx = currentContext;
@@ -61,6 +69,8 @@ export function invokeComponentConstructor(vm: VM, Ctor: ComponentConstructor): 
     const { context } = vm;
     const ctx = currentContext;
     establishContext(context);
+    const vmBeingConstructedInception = vmBeingConstructed;
+    vmBeingConstructed = vm;
 
     if (process.env.NODE_ENV !== 'production') {
         startMeasure(vm, 'constructor');
@@ -78,6 +88,7 @@ export function invokeComponentConstructor(vm: VM, Ctor: ComponentConstructor): 
         }
 
         establishContext(ctx);
+        vmBeingConstructed = vmBeingConstructedInception;
         if (error) {
             error.wcStack = getComponentStack(vm);
             // rethrowing the original error annotated after restoring the context

--- a/packages/lwc-engine/src/framework/root.ts
+++ b/packages/lwc-engine/src/framework/root.ts
@@ -1,7 +1,7 @@
 import assert from "./assert";
 import { ViewModelReflection, ComponentDef } from "./def";
 import { isUndefined, ArrayFilter, defineProperty, isNull, defineProperties, create, getOwnPropertyNames, forEach, hasOwnProperty, ArrayIndexOf, ArraySplice, ArrayPush, isFunction, isFalse } from "./language";
-import { isBeingConstructed, getCustomElementComponent } from "./component";
+import { getCustomElementComponent } from "./component";
 import { OwnerKey, isNodeOwnedByVM, VM } from "./vm";
 import { register } from "./services";
 import { pierce, piercingHook } from "./piercing";
@@ -25,7 +25,7 @@ import {
     removeEventListener,
 } from './dom';
 import { getAttrNameFromPropName } from "./utils";
-import { invokeRootCallback, isRendering, vmBeingRendered } from "./invoker";
+import { invokeRootCallback, isRendering, vmBeingRendered, isBeingConstructed } from "./invoker";
 
 function getLinkedElement(root: ShadowRoot): HTMLElement {
     return getCustomElementVM(root).elm;


### PR DESCRIPTION
## Details

the flag to track the construction process was not restored correctly when the constructor throws and there is no boundary to recovery from such failure. this PR fixes that so it can never be out of sync, using the same trick that we use for `isRendering`.

## Does this PR introduce a breaking change?

* No