### PR TITLE
refactor(engine): fix memory leaks in IE11 (#279)

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
@@ -294,7 +294,7 @@ describe('html-element', () => {
         it('should pierce dispatch event', function() {
             let callCount = 0;
             register({
-                piercing: (component, data, def, context, target, key, value, callback) => {
+                piercing: (target, key, value, callback) => {
                     if (value === EventTarget.prototype.dispatchEvent) {
                         callCount += 1;
                     }
@@ -324,7 +324,7 @@ describe('html-element', () => {
                 count += 1;
             };
             register({
-                piercing: (component, data, def, context, target, key, value, callback) => {
+                piercing: (target, key, value, callback) => {
                     if (value === EventTarget.prototype.dispatchEvent) {
                         callback(pierced);
                     }

--- a/packages/lwc-engine/src/framework/__tests__/piercing.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/piercing.spec.ts
@@ -1,6 +1,6 @@
 import { Element } from "../html-element";
 import { pierce } from '../piercing';
-import { ViewModelReflection } from "../def";
+import { ViewModelReflection } from "../utils";
 import { createElement } from "../upgrade";
 
 describe('piercing', function() {
@@ -18,7 +18,7 @@ describe('piercing', function() {
 
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
-        const replica = pierce(elm[ViewModelReflection], elm);
+        const replica = pierce(elm);
         expect(() => {
             replica.style.position = 'absolute';
             expect(elm.style.position).toBe('absolute');
@@ -43,7 +43,7 @@ describe('piercing', function() {
         const piercedObject = {
             deleteMe: true
         };
-        const replica = pierce(elm[ViewModelReflection], piercedObject);
+        const replica = pierce(piercedObject);
         expect(() => {
             delete replica.deleteMe;
         }).not.toThrow();

--- a/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
@@ -1,6 +1,6 @@
-import { reactiveMembrane } from '../membrane';
 import { unwrap } from '../main';
 import { Element } from "../html-element";
+import { reactiveMembrane } from '../membrane';
 import { createElement } from "../upgrade";
 
 describe('unwrap', () => {

--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -8,6 +8,7 @@ import { ComponentConstructor, markComponentAsDirty } from "./component";
 
 import { VNode, VNodeData, VNodes, VElement, VComment, VText, Hooks } from "../3rdparty/snabbdom/types";
 import { getCustomElementVM } from "./html-element";
+import { pierce } from "./piercing";
 
 export interface RenderAPI {
     h(tagName: string, data: VNodeData, children: VNodes): VNode;
@@ -358,8 +359,8 @@ export function b(fn: EventListener): EventListener {
     }
     const vm: VM = vmBeingRendered;
     return function handler(event: Event) {
-        // TODO: only if the event is `composed` it can be dispatched
-        invokeComponentCallback(vm, fn, [event]);
+        const e = pierce(event);
+        invokeComponentCallback(vm, fn, [e]);
     };
 }
 

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -182,7 +182,7 @@ function handleComponentEvent(vm: VM, event: Event) {
             uninterrupted = false;
             stopImmediatePropagation.call(event);
         };
-        const e = pierce(vm, event);
+        const e = pierce(event);
         for (let i = 0, len = handlers.length; uninterrupted && i < len; i += 1) {
             invokeComponentCallback(vm, handlers[i], [e]);
         }

--- a/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
@@ -1,5 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
+import { Membrane } from "../../membrane";
 import readonly from "../readonly";
 
 describe('readonly.ts', () => {

--- a/packages/lwc-engine/src/framework/html-element.ts
+++ b/packages/lwc-engine/src/framework/html-element.ts
@@ -16,9 +16,8 @@ import {
 import { getPropNameFromAttrName } from "./utils";
 import { isRendering, vmBeingRendered } from "./invoker";
 import { wasNodePassedIntoVM, VM } from "./vm";
-import { pierce, piercingHook } from "./piercing";
+import { pierce, pierceProperty } from "./piercing";
 import { ViewModelReflection } from "./def";
-import { Membrane } from "./membrane";
 import { ArrayReduce, isString, isFunction } from "./language";
 import { observeMutation, notifyMutation } from "./watcher";
 
@@ -138,8 +137,7 @@ class LWCElement implements Component {
         }
 
         // Pierce dispatchEvent so locker service has a chance to overwrite
-        pierce(vm, elm);
-        const dispatchEvent = piercingHook(vm.membrane as Membrane, elm, 'dispatchEvent', elm.dispatchEvent);
+        const dispatchEvent = pierceProperty(elm, 'dispatchEvent');
         return dispatchEvent.call(elm, event);
     }
     addEventListener(type: string, listener: EventListener) {
@@ -246,7 +244,7 @@ class LWCElement implements Component {
         for (let i = 0, len = nodeList.length; i < len; i += 1) {
             if (wasNodePassedIntoVM(vm, nodeList[i])) {
                 // TODO: locker service might need to return a membrane proxy
-                return pierce(vm, nodeList[i]);
+                return pierce(nodeList[i]);
             }
         }
 
@@ -273,7 +271,7 @@ class LWCElement implements Component {
                 assert.logWarning(`this.querySelectorAll() can only return elements that were passed into ${vm.component} via slots. It seems that you are looking for elements from your template declaration, in which case you should use this.root.querySelectorAll() instead.`);
             }
         }
-        return pierce(vm, filteredNodes);
+        return pierce(filteredNodes);
     }
     get tagName(): string {
         const elm = getLinkedElement(this);

--- a/packages/lwc-engine/src/framework/piercing.ts
+++ b/packages/lwc-engine/src/framework/piercing.ts
@@ -1,16 +1,12 @@
 import assert from "./assert";
-import { OwnerKey, VM } from "./vm";
+import { OwnerKey } from "./vm";
 import { Services } from "./services";
-import { getReplica, Membrane, Replicable, ReplicableFunction, MembraneHandler } from "./membrane";
+import { getReplica, Membrane, Replicable, ReplicableFunction } from "./membrane";
+import { isUndefined } from "./language";
 
-export function piercingHook(membrane: Membrane, target: Replicable, key: PropertyKey, value: any): any {
-    const { vm } = membrane.handler as PiercingMembraneHandler;
-    if (process.env.NODE_ENV !== 'production') {
-        assert.vm(vm);
-    }
+function piercingHook(membrane: Membrane, target: Replicable, key: PropertyKey, value: any): any {
     const { piercing } = Services;
     if (piercing) {
-        const { component, data, def, context } = vm;
         let result = value;
         let next = true;
         const callback = (newValue?: any) => {
@@ -18,56 +14,54 @@ export function piercingHook(membrane: Membrane, target: Replicable, key: Proper
             result = newValue;
         };
         for (let i = 0, len = piercing.length; next && i < len; ++i) {
-            piercing[i].call(undefined, component, data, def, context, target, key, value, callback);
+            piercing[i].call(undefined, target, key, value, callback);
         }
         return result === value ? getReplica(membrane, result) : result;
     }
 }
 
-export class PiercingMembraneHandler implements MembraneHandler {
-    vm: VM;
-    constructor(vm: VM) {
-        if (process.env.NODE_ENV !== 'production') {
-            assert.vm(vm);
-        }
-        this.vm = vm;
-    }
-    get(membrane: Membrane, target: Replicable, key: PropertyKey): any {
-        if (key === OwnerKey) {
-            return undefined;
-        }
-        const value = target[key];
-        return piercingHook(membrane, target, key, value);
-    }
-    set(membrane: Membrane, target: Replicable, key: string, newValue: any): boolean {
-        target[key] = newValue;
-        return true;
-    }
-    deleteProperty(membrane: Membrane, target: Replicable, key: PropertyKey): boolean {
-        delete target[key];
-        return true;
-    }
-    apply(membrane: Membrane, targetFn: ReplicableFunction, thisArg: any, argumentsList: any[]): any {
-        return getReplica(membrane, targetFn.apply(thisArg, argumentsList));
-    }
-    construct(membrane: Membrane, targetFn: ReplicableFunction, argumentsList: any[], newTarget: any): any {
-        if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(newTarget, `construct handler expects a 3rd argument with a newly created object that will be ignored in favor of the wrapped constructor.`);
-        }
-        return getReplica(membrane, new targetFn(...argumentsList));
-    }
+let piercingMembrane: Membrane;
+
+function createPiercingMembrane() {
+    return new Membrane({
+        get(membrane: Membrane, target: Replicable, key: PropertyKey): any {
+            if (key === OwnerKey) {
+                return undefined;
+            }
+            const value = target[key];
+            return piercingHook(membrane, target, key, value);
+        },
+        set(membrane: Membrane, target: Replicable, key: string, newValue: any): boolean {
+            target[key] = newValue;
+            return true;
+        },
+        deleteProperty(membrane: Membrane, target: Replicable, key: PropertyKey): boolean {
+            delete target[key];
+            return true;
+        },
+        apply(membrane: Membrane, targetFn: ReplicableFunction, thisArg: any, argumentsList: any[]): any {
+            return getReplica(membrane, targetFn.apply(thisArg, argumentsList));
+        },
+        construct(membrane: Membrane, targetFn: ReplicableFunction, argumentsList: any[], newTarget: any): any {
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(newTarget, `construct handler expects a 3rd argument with a newly created object that will be ignored in favor of the wrapped constructor.`);
+            }
+            return getReplica(membrane, new targetFn(...argumentsList));
+        },
+    });
 }
 
-export function pierce(vm: VM, value: Replicable | any): any {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.vm(vm);
+export function pierce(value: Replicable | any): any {
+    if (isUndefined(piercingMembrane)) {
+        piercingMembrane = createPiercingMembrane();
     }
+    return getReplica(piercingMembrane, value);
+}
 
-    let { membrane } = vm;
-    if (!membrane) {
-        const handler = new PiercingMembraneHandler(vm);
-        membrane = new Membrane(handler);
-        vm.membrane = membrane;
+// TODO: this is only really needed by locker, eventually we can remove this
+export function pierceProperty(target: Replicable | any, key: PropertyKey): any {
+    if (isUndefined(piercingMembrane)) {
+        piercingMembrane = createPiercingMembrane();
     }
-    return getReplica(membrane, value);
+    return piercingHook(piercingMembrane, target, key, target[key]);
 }

--- a/packages/lwc-engine/src/framework/root.ts
+++ b/packages/lwc-engine/src/framework/root.ts
@@ -1,15 +1,13 @@
 import assert from "./assert";
-import { ViewModelReflection, ComponentDef } from "./def";
+import { ViewModelReflection } from "./def";
 import { isUndefined, ArrayFilter, defineProperty, isNull, defineProperties, create, getOwnPropertyNames, forEach, hasOwnProperty } from "./language";
 import { isBeingConstructed, getCustomElementComponent } from "./component";
 import { OwnerKey, isNodeOwnedByVM, VM } from "./vm";
 import { register } from "./services";
-import { pierce, piercingHook } from "./piercing";
-import { Context } from "./context";
+import { pierce } from "./piercing";
 import { Component } from "./component";
-import { VNodeData } from "../3rdparty/snabbdom/types";
 import { getCustomElementVM } from "./html-element";
-import { Replicable, Membrane } from "./membrane";
+import { Replicable } from "./membrane";
 
 import { TargetSlot } from './membrane';
 import {
@@ -67,7 +65,7 @@ const RootDescriptors: PropertyDescriptorMap = create(null);
 // to ShadowRoot prototype to polyfill AOM capabilities.
 forEach.call(getOwnPropertyNames(GlobalAOMProperties), (propName: string) => RootDescriptors[propName] = createAccessibilityDescriptorForShadowRoot(propName, getAttrNameFromPropName(propName), GlobalAOMProperties[propName]));
 
-export function shadowRootQuerySelector(shadowRoot: ShadowRoot, selector: string): HTMLElement | null {
+export function shadowRootQuerySelector(shadowRoot: ShadowRoot, selector: string): Element | null {
     const vm = getCustomElementVM(shadowRoot);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -75,9 +73,7 @@ export function shadowRootQuerySelector(shadowRoot: ShadowRoot, selector: string
     }
 
     const elm = getLinkedElement(shadowRoot);
-    pierce(vm, elm);
-    const piercedQuerySelector = piercingHook(vm.membrane as Membrane, elm, 'querySelector', elm.querySelector);
-    return piercedQuerySelector.call(elm, selector);
+    return getFirstMatch(vm, elm, selector);
 }
 
 export function shadowRootQuerySelectorAll(shadowRoot: ShadowRoot, selector: string): HTMLElement[] {
@@ -86,9 +82,7 @@ export function shadowRootQuerySelectorAll(shadowRoot: ShadowRoot, selector: str
         assert.isFalse(isBeingConstructed(vm), `this.root.querySelectorAll() cannot be called during the construction of the custom element for ${vm} because no content has been rendered yet.`);
     }
     const elm = getLinkedElement(shadowRoot);
-    pierce(vm, elm);
-    const piercedQuerySelectorAll = piercingHook(vm.membrane as Membrane, elm, 'querySelectorAll', elm.querySelectorAll);
-    return piercedQuerySelectorAll.call(elm, selector);
+    return getAllMatches(vm, elm, selector);
 }
 
 export class Root implements ShadowRoot {
@@ -112,14 +106,14 @@ export class Root implements ShadowRoot {
         throw new Error();
     }
     querySelector(selector: string): HTMLElement | null {
-        const node = shadowRootQuerySelector(this, selector);
+        const node = shadowRootQuerySelector(this as ShadowRoot, selector);
         if (process.env.NODE_ENV !== 'production') {
-            const component = getCustomElementComponent(this);
+            const component = getCustomElementComponent(this as ShadowRoot);
             if (isNull(node) && component.querySelector(selector)) {
                 assert.logWarning(`this.root.querySelector() can only return elements from the template declaration of ${component}. It seems that you are looking for elements that were passed via slots, in which case you should use this.querySelector() instead.`);
             }
         }
-        return node;
+        return node as HTMLElement;
     }
     querySelectorAll(selector: string): HTMLElement[] {
         const nodeList = shadowRootQuerySelectorAll(this, selector);
@@ -138,21 +132,42 @@ export class Root implements ShadowRoot {
 }
 defineProperties(Root.prototype, RootDescriptors);
 
-function getFirstMatch(vm: VM, elm: Element, selector: string): Node | null {
+function getFirstMatch(vm: VM, elm: Element, selector: string): Element | null {
     const nodeList = querySelectorAll.call(elm, selector);
     // search for all, and find the first node that is owned by the VM in question.
     for (let i = 0, len = nodeList.length; i < len; i += 1) {
         if (isNodeOwnedByVM(vm, nodeList[i])) {
-            return pierce(vm, nodeList[i]);
+            return pierce(nodeList[i]);
         }
     }
     return null;
 }
 
-function getAllMatches(vm: VM, elm: Element, selector: string): NodeList {
+function getAllMatches(vm: VM, elm: Element, selector: string): HTMLElement[] {
     const nodeList = querySelectorAll.call(elm, selector);
     const filteredNodes = ArrayFilter.call(nodeList, (node: Node): boolean => isNodeOwnedByVM(vm, node));
-    return pierce(vm , filteredNodes);
+    return pierce(filteredNodes);
+}
+
+function getElementOwnerVM(elm: Element): VM | undefined {
+    if (!(elm instanceof Node)) {
+        return;
+    }
+    let node: Node | null = elm;
+    let ownerKey;
+    // search for the first element with owner identity (just in case of manually inserted elements)
+    while (!isNull(node) && isUndefined((ownerKey = node[OwnerKey]))) {
+        node = node.parentNode;
+    }
+    if (isUndefined(ownerKey) || isNull(node)) {
+        return;
+    }
+    let vm: VM | undefined;
+    // search for a custom element with a VM that owns the first element with owner identity attached to it
+    while (!isNull(node) && (isUndefined(vm = node[ViewModelReflection]) || (vm as VM).uid !== ownerKey)) {
+        node = node.parentNode;
+    }
+    return isNull(node) ? undefined : vm;
 }
 
 function isParentNodeKeyword(key: PropertyKey): boolean {
@@ -213,35 +228,39 @@ export function wrapIframeWindow(win: Window) {
 
 // Registering a service to enforce the shadowDOM semantics via the Raptor membrane implementation
 register({
-    piercing(component: Component, data: VNodeData, def: ComponentDef, context: Context, target: Replicable, key: PropertyKey, value: any, callback: (value?: any) => void) {
-        const vm: VM = component[ViewModelReflection];
-        const { elm } = vm;
+    piercing(target: Replicable, key: PropertyKey, value: any, callback: (value?: any) => void) {
         if (value) {
             if (isIframeContentWindow(key as PropertyKey, value)) {
                 callback(wrapIframeWindow(value));
             }
             if (value === querySelector) {
-                // TODO: it is possible that they invoke the querySelector() function via call or apply to set a new context, what should
-                // we do in that case? Right now this is essentially a bound function, but the original is not.
-                return callback((selector: string): Node | null => getFirstMatch(vm, target as Element, selector));
+                return callback((selector: string): Node | null => {
+                    const vm = getElementOwnerVM(target as Element);
+                    return isUndefined(vm) ? null : getFirstMatch(vm, target as Element, selector);
+                });
             }
             if (value === querySelectorAll) {
-                // TODO: it is possible that they invoke the querySelectorAll() function via call or apply to set a new context, what should
-                // we do in that case? Right now this is essentially a bound function, but the original is not.
-                return callback((selector: string): NodeList => getAllMatches(vm, target as Element, selector));
+                return callback((selector: string): Element[] => {
+                    const vm = getElementOwnerVM(target as Element);
+                    return isUndefined(vm) ? [] : getAllMatches(vm, target as Element, selector);
+                });
             }
             if (isParentNodeKeyword(key)) {
-                if (value === elm) {
+                const vm = getElementOwnerVM(target as Element);
+                if (!isUndefined(vm) && value === vm.elm) {
                     // walking up via parent chain might end up in the shadow root element
-                    return callback(component.root);
-                } else if (target[OwnerKey] !== value[OwnerKey]) {
+                    return callback((vm.component as Component).root);
+                } else if (target instanceof Element && value instanceof Element && target[OwnerKey] !== value[OwnerKey]) {
                     // cutting out access to something outside of the shadow of the current target (usually slots)
-                    return callback();
+                    return callback(); // TODO: this should probably be `null`
                 }
             }
-            if (value === elm) {
-                // prevent access to the original Host element
-                return callback(component);
+            if (value instanceof HTMLElement) {
+                const vm = value[ViewModelReflection];
+                if (!isUndefined(vm) && value === vm.elm) {
+                    // prevent access to the original Host element
+                    return callback(vm.component);
+                }
             }
         }
     }

--- a/packages/lwc-engine/src/framework/services.ts
+++ b/packages/lwc-engine/src/framework/services.ts
@@ -3,13 +3,12 @@ import { isUndefined, isObject, isArray, create, ArrayPush } from "./language";
 
 import { Replicable } from "./membrane";
 import { Context } from "./context";
-import { Component } from "./component";
 import { VNodeData } from "../3rdparty/snabbdom/types";
 import { ComponentDef } from "./def";
 import { VM } from "./vm";
 
 export type ServiceCallback = (component: object, data: VNodeData, def: ComponentDef, context: Context) => void;
-export type MembranePiercingCallback = (component: Component, data: VNodeData, def: ComponentDef, context: Context, target: Replicable, key: PropertyKey, value: any, callback: (newValue?: any) => void) => void;
+export type MembranePiercingCallback = (target: Replicable, key: PropertyKey, value: any, callback: (newValue?: any) => void) => void;
 export interface ServiceDef {
     wiring?: ServiceCallback;
     connected?: ServiceCallback;

--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -11,7 +11,6 @@ import { invokeComponentCallback } from "./invoker";
 import { VNode, VNodeData, VNodes } from "../3rdparty/snabbdom/types";
 import { Template } from "./template";
 import { ComponentDef } from "./def";
-import { Membrane } from "./membrane";
 import { Component } from "./component";
 import { Context } from "./context";
 import { ShadowRoot } from "./root";
@@ -52,7 +51,6 @@ export interface VM {
     isDirty: boolean;
     isRoot: boolean;
     component?: Component;
-    membrane?: Membrane;
     deps: VM[][];
     hostAttrs: Record<string, number | undefined>;
     toString(): string;


### PR DESCRIPTION
* refactor(engine): fix memory leaks in IE11

(cherry picked from commit d6c57348abc10510a4594636d129329395317d60)


## Details

This is a backport of #279

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

