### PR TITLE
chore: Increment timeout for perf benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,8 @@ jobs:
           name: Preformance Test
           working_directory: packages/benchmark
           command: yarn start --externalStorage=@best/store-aws --runner remote
+          no_output_timeout: 30m
+
 
       - store_artifacts:
           path: ~/lwc/packages/benchmark/__benchmark_results__/


### PR DESCRIPTION
## Details
Increment timeout on benchmarks to 30m

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No