### PR TITLE
fix(engine): live bindings for value and checked properties

### DIFF
--- a/packages/lwc-engine/src/framework/modules/__tests__/props.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/props.spec.ts
@@ -3,24 +3,58 @@ import target from '../props';
 
 describe('module/props', () => {
 
-    it('should not set the input element value when the new value matches (reconcilation)', () => {
+    it('should not set the input element title when the new value matches (reconcilation)', () => {
         const elm = {};
-        let read = false;
-        Object.defineProperty(elm, 'value', {
+        let read = 0;
+        Object.defineProperty(elm, 'title', {
             get: () => {
-                read = true;
-                return "new value";
+                read += 1;
+                return "new title";
             },
-            set: () => { throw new Error('setter for input.value was called accidentaly'); },
+            set: () => { throw new Error('setter for input.title was called accidentaly'); },
             configurable: false,
             enumerable: true,
         });
-        const oldVnode = { data: { props: { value: "old value" } } };
-        const newVnode = { data: { props: { value: "new value" } }, elm };
+        const oldVnode = { data: { props: { title: "old title" } } };
+        const newVnode = { data: { props: { title: "old title" } }, elm };
 
         target.update(oldVnode, newVnode);
-        expect(read).toBe(true);
+        expect(read).toBe(0);
+        expect(elm.title).toBe("new title");
+    });
+
+    it('should set the input element value when the new value matches if it is not match the elm.value (especial reconcilation)', () => {
+        const elm = {};
+        Object.defineProperty(elm, 'value', {
+            value: "old value",
+            enumerable: true,
+            writable: true,
+        });
+        const oldVnode = { data: { props: { value: "new value" } } };
+        const newVnode = { data: { props: { value: "new value" } }, elm };
+
+        expect(elm.value).toBe('old value');
+        // value PropertyKey is considered especial, and even if the old tracked value is equal to the new tracked value
+        // we still check against the element's corresponding value to be sure.
+        target.update(oldVnode, newVnode);
         expect(elm.value).toBe("new value");
+    });
+
+    it('should set the input element checked when the new checked matches if it is not match the elm.checked (especial reconcilation)', () => {
+        const elm = {};
+        Object.defineProperty(elm, 'checked', {
+            value: "old checked",
+            enumerable: true,
+            writable: true,
+        });
+        const oldVnode = { data: { props: { checked: "new checked" } } };
+        const newVnode = { data: { props: { checked: "new checked" } }, elm };
+
+        expect(elm.checked).toBe('old checked');
+        // checked PropertyKey is considered especial, and even if the old tracked value is equal to the new tracked value
+        // we still check against the element's corresponding value to be sure.
+        target.update(oldVnode, newVnode);
+        expect(elm.checked).toBe("new checked");
     });
 
     it('should set the input element value when the new value does not match (reconcilation)', () => {


### PR DESCRIPTION
## Details

`value` and `checked` properties are considered especial during the diffing algo. If we found them, we need to check the actual live value to compare it with the upcoming value instead of just comparing it to the old value from previous rehydration.

## Does this PR introduce a breaking change?

* No

