### PR TITLE
fix(engine): live bindings for value and checked properties 3nd attempt

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/component.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/component.spec.ts
@@ -163,7 +163,7 @@ describe('component', function() {
             expect(context).toBe(elm[ViewModelReflection].component);
         });
 
-        it('should fail to execute setter function when used directly from DOM', function() {
+        it('should call setter function when used directly from DOM', function() {
             class MyChild extends Element {
                 value = 'pancakes';
                 get breakfast() {
@@ -188,12 +188,13 @@ describe('component', function() {
                 }
                 run() {
                     this.template.querySelector('x-child').breakfast = 'eggs';
+                    return this.template.querySelector('x-child').breakfast;
                 }
             }
             MyComponent.publicMethods = ['run'];
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            expect(() => elm.run()).toThrow();
+            expect(elm.run()).toBe('eggs');
         });
 
         it('should execute setter function with correct context when component is root', function() {


### PR DESCRIPTION
## Details

Follow up on #312.

As today, manual mutations in regular HTML element are allowed, while manual mutations on custom elements are not allowed, arguing that the element is controlled by the template, and mutations can only be carry on by it.

With this PR we are relaxing this, and only giving them a warning with more details. This facilitate authors to force pushing new values down to other elements that they own.

## Does this PR introduce a breaking change?

* No
