### PR TITLE
ci: run integration tests in all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,16 +140,10 @@ workflows:
       - integration_test_compat:
           requires:
             - build_and_test
-          filters:
-            branches:
-              only: /\w+\/.*/
 
       - integration_test:
           requires:
             - build_and_test
-          filters:
-            branches:
-              ignore: master
 
       - perf_and_compare:
           requires:


### PR DESCRIPTION
## Details

Currently, we don't run any integration tests against master and require a `/` in the branch name for other CI jobs. We definitely want to be running tests against master, and the slash causes release branches like `0.20.6` to be ignored. 

So remove both filters. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:


## Reminders ( please delete this section before submitting )
-------------------------------------------------------------

### The PR fulfills these requirements:
* Tests for the changes have been added (for bug fixes / features)
* Docs have been added / updated (for bug fixes / features)

### PR Title
LWC PR title follows [conventional commit](../CONTRIBUTING.md#create-a-pull-request) format and is automatically validated by our CI.
```shell
ex:
commit-type(optional scope): commit description. ( NOTE: space between column and the message )

Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, proposal.
Scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
```
