### PR TITLE
fix(engine): closes #342 - clean up and docs

### DIFF
--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -1,6 +1,6 @@
 import assert from "./assert";
 import { vmBeingRendered, invokeEventListener, EventListenerContext } from "./invoker";
-import { freeze, isArray, isUndefined, isNull, isFunction, isObject, isString, ArrayPush, assign, create, forEach, StringSlice, StringCharCodeAt, isNumber, isTrue } from "./language";
+import { freeze, isArray, isUndefined, isNull, isFunction, isObject, isString, ArrayPush, assign, create, forEach, StringSlice, StringCharCodeAt, isNumber, isTrue, hasOwnProperty } from "./language";
 import { EmptyArray, SPACE_CHAR, ViewModelReflection, resolveCircularModuleDependency } from "./utils";
 import { renderVM, createVM, appendVM, removeVM, VM, getCustomElementVM, Slotset, allocateInSlot } from "./vm";
 import { ComponentConstructor } from "./component";
@@ -79,11 +79,18 @@ const hook: Hooks = {
     },
     create(oldVNode: VNode, vnode: VNode) {
         const { fallback, mode, ctor } = vnode.data;
-        createVM(vnode.sel as string, vnode.elm as HTMLElement, ctor, {
+        const elm = vnode.elm as HTMLElement;
+        if (hasOwnProperty.call(elm, ViewModelReflection)) {
+            // There is a possibility that a custom element is registered under tagName,
+            // in which case, the initialization is already carry on, and there is nothing else
+            // to do here since this hook is called right after invoking `document.createElement`.
+            return;
+        }
+        createVM(vnode.sel as string, elm, ctor, {
             mode,
             fallback,
         });
-        const vm: VM = (vnode.elm as HTMLElement)[ViewModelReflection];
+        const vm: VM = elm[ViewModelReflection];
         if (process.env.NODE_ENV !== 'production') {
             assert.vm(vm);
             assert.isTrue(isArray(vnode.children), `Invalid vnode for a custom element, it must have children defined.`);

--- a/packages/lwc-engine/src/framework/upgrade.ts
+++ b/packages/lwc-engine/src/framework/upgrade.ts
@@ -106,6 +106,9 @@ export function createElement(sel: string, options: any = {}): HTMLElement {
     // Create element with correct tagName
     const element = document.createElement(tagName);
     if (hasOwnProperty.call(element, ViewModelReflection)) {
+        // There is a possibility that a custom element is registered under tagName,
+        // in which case, the initialization is already carry on, and there is nothing else
+        // to do here.
         return element;
     }
 

--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -2,7 +2,7 @@ import assert from "./assert";
 import { getComponentDef } from "./def";
 import { createComponent, linkComponent, renderComponent, clearReactiveListeners, ComponentConstructor, ErrorCallback, markComponentAsDirty } from "./component";
 import { patchChildren } from "./patch";
-import { ArrayPush, isUndefined, isNull, ArrayUnshift, ArraySlice, create, hasOwnProperty, isTrue, isFalse, isObject, keys } from "./language";
+import { ArrayPush, isUndefined, isNull, ArrayUnshift, ArraySlice, create, isTrue, isFalse, isObject, keys } from "./language";
 import { ViewModelReflection, addCallbackToNextTick, EmptyObject, EmptyArray, usesNativeSymbols } from "./utils";
 import { invokeServiceHook, Services } from "./services";
 import { invokeComponentCallback } from "./invoker";
@@ -173,10 +173,6 @@ export function createVM(tagName: string, elm: HTMLElement, Ctor: ComponentConst
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(elm instanceof HTMLElement, `VM creation requires a DOM element instead of ${elm}.`);
     }
-    if (hasOwnProperty.call(elm, ViewModelReflection)) {
-        return; // already created
-    }
-
     const def = getComponentDef(Ctor);
     const { isRoot, mode } = options;
     const fallback = isTrue(options.fallback) || isFalse(usesNativeShadowRoot);


### PR DESCRIPTION
Adding comments, and moving checks upstream for the cases where the element is registered as a web component, so the VM creation is carry on early on as part of the element creation.

## Does this PR introduce a breaking change?

* No

