### PR TITLE
fix(engine): going through cmpRoot to get default aria value

### DIFF
--- a/packages/lwc-engine/src/framework/dom/attributes.ts
+++ b/packages/lwc-engine/src/framework/dom/attributes.ts
@@ -279,7 +279,9 @@ forEach.call(getOwnPropertyNames(GlobalAOMProperties), (propName: string) => {
         const vm = this[ViewModelReflection];
         const value = vm.cmpProps[propName] = isNull(newValue) ? null : newValue + ''; // storing the normalized new value
         if (isNull(value)) {
-            newValue = vm.rootProps[propName];
+            // Go through cmpRoot instead of vm.rootProps
+            // because vm.cmpRoot also handles default values
+            newValue = vm.cmpRoot[propName];
             vm.hostAttrs[attrName] = undefined;
         } else {
             vm.hostAttrs[attrName] = 1;

--- a/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/child/child.html
+++ b/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    Ok
+</template>

--- a/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/child/child.js
+++ b/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/child/child.js
@@ -1,0 +1,5 @@
+import { Element } from 'engine';
+
+export default class Child extends Element {
+
+}

--- a/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.spec.js
+++ b/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.spec.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+describe('Default AOM values on Shadow Root', () => {
+    const URL = 'http://localhost:4567/pass-null-aria-attribute-to-custom-element';
+    let element;
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should correctly set attribute on custom element', function () {
+        const hasAttribute = browser.execute(function () {
+            return document.querySelector('x-child').hasAttribute('aria-label');
+        });
+        assert.equal(hasAttribute.value, false);
+    });
+});

--- a/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.html
+++ b/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child aria-label={getComputedLabel}>Anchor</x-child>
+</template>

--- a/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.js
+++ b/packages/lwc-integration/src/components/accessibility/test-pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element/pass-null-aria-attribute-to-custom-element.js
@@ -1,0 +1,7 @@
+import { Element } from 'engine';
+
+export default class PassingNullAriaAttribute extends Element {
+    get getComputedLabel() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Details
Going through `cmpRoot` instead of `vm.rootProps` directly to re-enable default aria attribute values.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
