### PR TITLE
refactor(engine): closes #355 removing vnode.data.slotset

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
@@ -236,19 +236,22 @@ describe('error boundary component', () => {
                         throw Error('Slot cmp throws in render method');
                     }
                 }
-                function html1($api, $cmp, $slotset) {
-                    return $slotset.x;
+                function html1($api, $cmp, $slotset, $ctx) {
+                    return [$api.s('x', {
+                        key: 0,
+                        attrs: {
+                            name: 'x'
+                        }
+                    }, [], $slotset)];
                 }
+                html1.slots = ["x"];
                 class ChildWithSlot extends Element {
                     render() {
                         return html1;
                     }
                 }
                 function html2($api, $cmp) {
-                    // TODO: There is no way to set 'slot' value onto the template to be matched agains slotset key.
-                    // Not setting it causes the following warning:
-                    // - Ignoring unknown provided slot name "x" in [object:vm ChildWithSlot (7)]. This is probably a typo on the slot attribute.
-                    return [ $api.c('x-child-with-slot', ChildWithSlot, { slotset: { x: [ $api.c('x-slot-cmp', SlotCmp, {})]}}) ];
+                    return [ $api.c('x-child-with-slot', ChildWithSlot, { key: 0 }, [ $api.c('x-slot-cmp', SlotCmp, { attrs: { slot: 'x' } })]) ];
                 }
                 class BoundaryWithSlot extends Element {
                     getError() {

--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -532,11 +532,15 @@ describe('Events on Custom Elements', () => {
 describe('Slotted element events', () => {
     it('should have correct target when event comes from slotted element', () => {
         expect.assertions(1);
-        function childHTML ($api, $cmp, $slotset) {
-            return $slotset.x;
+        function childHTML($api, $cmp, $slotset, $ctx) {
+            return [$api.s('x', {
+                key: 0,
+                attrs: {
+                    name: 'x'
+                }
+            }, [], $slotset)];
         }
-
-        childHTML.slots = ['x'];
+        childHTML.slots = ["x"];
         class Child extends Element {
             render() {
                 return childHTML;
@@ -544,18 +548,15 @@ describe('Slotted element events', () => {
         }
 
         function html($api, $cmp, $slotset) {
-            return [$api.c('x-slotted-event-target-child', Child, {
-                slotset: {
-                    x: [
-                        $api.h('div', {
-                            on: {
-                                click: $api.b($cmp.handleClick),
-                            },
-                            key: 0,
-                        }, [])
-                    ]
-                }
-            })]
+            return [$api.c('x-slotted-event-target-child', Child, {}, [$api.h('div', {
+                on: {
+                    click: $api.b($cmp.handleClick),
+                },
+                attrs: {
+                    slot: 'x'
+                },
+                key: 0,
+            }, [])])];
         }
 
         class SlottedEventTarget extends Element {

--- a/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
@@ -64,9 +64,15 @@ describe('watcher', () => {
 
         it('should rerender the component if any reactive slot changes', () => {
             let counter = 0;
-            function html1($api, $cmp, $slotset) {
-                return $slotset.x || [];
+            function html1($api, $cmp, $slotset, $ctx) {
+                return [$api.s('x', {
+                    key: 0,
+                    attrs: {
+                        name: 'x'
+                    }
+                }, [], $slotset)];
             }
+            html1.slots = ["x"];
             class Child extends Element {
                 render() {
                     counter++;
@@ -75,9 +81,7 @@ describe('watcher', () => {
             }
             function html2($api, $cmp) {
                 const r = $cmp.round;
-                return [$api.c('x-child', Child, {
-                    slotset: r === 0 ? {} : { x: [$api.h('p', { key: 0 }, [])] }
-                })];
+                return [$api.c('x-child', Child, {}, r === 0 ? [] : [$api.h('p', { key: 0, attrs: { slot: 'x' } }, [])])];
             }
             class MyComponent4 extends Element {
                 constructor() {
@@ -94,35 +98,6 @@ describe('watcher', () => {
             elm[ViewModelReflection].component.round += 1;
             Promise.resolve().then(_ => {
                 expect(counter).toBe(2);
-            });
-        });
-
-        it('should not rerender the component if a non-reactive slot changes', () => {
-            let counter = 0;
-            let data;
-            class Child extends Element {
-                render() {
-                    counter++;
-                }
-            }
-            function html($api) {
-                return [$api.c('x-child', Child, data)];
-            }
-            class MyComponent4 extends Element {
-                constructor() {
-                    super();
-                    data = this.data = { slotset: {} };
-                }
-                render() {
-                    return html;
-                }
-            }
-            MyComponent4.track = { data: 1 };
-            const elm = createElement('x-foo', { is: MyComponent4 });
-            document.body.appendChild(elm);
-            data.slotset.x = []; // new array
-            Promise.resolve().then(_ => {
-                expect(counter).toBe(1);
             });
         });
 

--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -2,13 +2,13 @@ import assert from "./assert";
 import { vmBeingRendered } from "./invoker";
 import { freeze, isArray, isUndefined, isNull, isFunction, isObject, isString, ArrayPush, assign, create, forEach, StringSlice, StringCharCodeAt, isNumber, isTrue, hasOwnProperty } from "./language";
 import { EmptyArray, SPACE_CHAR, ViewModelReflection, resolveCircularModuleDependency } from "./utils";
-import { renderVM, createVM, appendVM, removeVM, VM, getCustomElementVM, Slotset, allocateInSlot } from "./vm";
+import { renderVM, createVM, appendVM, removeVM, VM, getCustomElementVM, SlotSet, allocateInSlot } from "./vm";
 import { ComponentConstructor } from "./component";
 import { VNode, VNodeData, VNodes, VElement, VComment, VText, Hooks } from "../3rdparty/snabbdom/types";
 import { getWrappedTemplateListener } from "./events";
 
 export interface RenderAPI {
-    s(slotName: string, data: VNodeData, children: VNodes, slotset: Slotset): VNode;
+    s(slotName: string, data: VNodeData, children: VNodes, slotset: SlotSet): VNode;
     h(tagName: string, data: VNodeData, children: VNodes): VNode;
     c(tagName: string, Ctor: ComponentConstructor, data: VNodeData, children?: VNodes): VNode;
     i(items: any[], factory: () => VNode | VNode): VNodes;
@@ -98,7 +98,7 @@ const hook: Hooks = {
         if (isTrue(vm.fallback)) {
             // slow path
             const children = vnode.children as VNodes;
-            allocateInSlot(vm, children, vnode.data.slotset);
+            allocateInSlot(vm, children);
             // every child vnode is now allocated, and the host should receive none directly, it receives them via the shadow!
             vnode.children = EmptyArray;
         }
@@ -112,7 +112,7 @@ const hook: Hooks = {
         if (isTrue(vm.fallback)) {
             // slow path
             const children = vnode.children as VNodes;
-            allocateInSlot(vm, children, vnode.data.slotset);
+            allocateInSlot(vm, children);
             // every child vnode is now allocated, and the host should receive none directly, it receives them via the shadow!
             vnode.children = EmptyArray;
         }
@@ -210,7 +210,7 @@ export function h(sel: string, data: VNodeData, children: VNodes): VElement {
 }
 
 // [s]lot element node
-export function s(slotName: string, data: VNodeData, children: VNodes, slotset: Slotset | undefined): VElement {
+export function s(slotName: string, data: VNodeData, children: VNodes, slotset: SlotSet | undefined): VElement {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(slotName), `s() 1st argument slotName must be a string.`);
         assert.isTrue(isObject(data), `s() 2nd argument data must be an object.`);
@@ -243,7 +243,7 @@ export function c(sel: string, Ctor: ComponentConstructor, data: VNodeData, chil
             });
         }
     }
-    const { key, slotset, styleMap, style, on, className, classMap, props } = data;
+    const { key, styleMap, style, on, className, classMap, props } = data;
     let { attrs } = data;
 
     // hack to allow component authors to force the usage of the "is" attribute in their components
@@ -258,7 +258,7 @@ export function c(sel: string, Ctor: ComponentConstructor, data: VNodeData, chil
         attrs.is = sel;
     }
 
-    data = { hook, key, slotset, attrs, on, props, ctor: Ctor };
+    data = { hook, key, attrs, on, props, ctor: Ctor };
     data.class = classMap || getMapFromClassName(normalizeStyleString(className));
     data.style = styleMap || normalizeStyleString(style);
     data.token = getCurrentTplToken();

--- a/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
@@ -11,43 +11,49 @@ describe('#lightDomQuerySelectorAll()', () => {
     describe('Invoked from within component', () => {
         it('should allow searching for passed elements', () => {
             function tmpl$1($api, $cmp, $slotset, $ctx) {
-                const {
-                    "$default$": slot0
-                } = $slotset;
-
-                return slot0 || [];
+                return [$api.s('', {
+                    key: 0,
+                    attrs: {
+                        name: ''
+                    }
+                }, [], $slotset)];
             }
-            tmpl$1.slots = ["$default$"];
+            tmpl$1.slots = [""];
 
             class Parent extends Element {
-                selectAllDivs() {
-                    return this.querySelectorAll('div');
-                }
-
                 render() {
                     return tmpl$1;
                 }
 
             }
-            Parent.publicMethods = ["selectAllDivs"];
 
             function tmpl$2($api, $cmp, $slotset, $ctx) {
                 const {
                     t: api_text,
                     h: api_element,
                     c: api_custom_element
-                    } = $api;
+                } = $api;
 
-                    return [api_custom_element("x-parent", Parent, {
+                return [
+                    api_custom_element("x-parent", Parent, {
                         key: 1,
-                        "slotset": {
-                            "$default$": [api_element("div", {
-                                key: 2
-                            }, [api_text("First")]), api_element("div", {
-                                key: 3
-                            }, [api_text("Second")])]
-                        }
-                    })];
+                    }, [
+                        api_element("div", {
+                                key: 2,
+                                classMap: {
+                                    first: true
+                                }
+                            },
+                            [api_text("First")]
+                        ), api_element("div", {
+                                key: 3,
+                                classMap: {
+                                    second: true
+                                }
+                            },
+                            [api_text("Second")]
+                        )
+                    ])];
             }
 
             class LightdomQuerySelector extends Element {
@@ -59,10 +65,10 @@ describe('#lightDomQuerySelectorAll()', () => {
 
             const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
             document.body.appendChild(element);
-            const nested = querySelector.call(element, 'x-parent').selectAllDivs();
+            const nested = element.shadowRoot.querySelector('x-parent').querySelectorAll('div');
             expect(nested.length).toBe(2);
-            expect(nested[0]).toBe(querySelector.call(element, 'x-parent div:nth-child(1)'));
-            expect(nested[1]).toBe(querySelector.call(element, 'x-parent div:nth-child(2)'));
+            expect(nested[0]).toBe(querySelector.call(element, '.first'));
+            expect(nested[1]).toBe(querySelector.call(element, '.second'));
         });
 
         it('should ignore elements passed to its slot', () => {
@@ -136,13 +142,14 @@ describe('#lightDomQuerySelectorAll()', () => {
     describe('Invoked from element instance', () => {
         it('should allow searching for passed elements', () => {
             function tmpl$1($api, $cmp, $slotset, $ctx) {
-                const {
-                    "$default$": slot0
-                } = $slotset;
-
-                return slot0 || [];
+                return [$api.s('', {
+                    key: 0,
+                    attrs: {
+                        name: ''
+                    }
+                }, [], $slotset)];
             }
-            tmpl$1.slots = ["$default$"];
+            tmpl$1.slots = [""];
 
             class Parent extends Element {
                 render() {
@@ -156,37 +163,42 @@ describe('#lightDomQuerySelectorAll()', () => {
                     t: api_text,
                     h: api_element,
                     c: api_custom_element
-                    } = $api;
+                } = $api;
 
-                    return [api_custom_element("x-parent", Parent, {
+                return [
+                    api_custom_element("x-parent", Parent, {
                         key: 1,
-                        "slotset": {
-                            "$default$": [api_element("div", {
-                                key: 2
-                            }, [api_text("First")]), api_element("div", {
-                                key: 3
-                            }, [api_text("Second")])]
-                        }
-                    })];
+                    }, [
+                        api_element("div", {
+                                key: 2,
+                                classMap: {
+                                    first: true
+                                }
+                            },
+                            [api_text("First")]
+                        ), api_element("div", {
+                                key: 3,
+                                classMap: {
+                                    second: true
+                                }
+                            },
+                            [api_text("Second")]
+                        )
+                    ])];
             }
 
             class LightdomQuerySelector extends Element {
-                selectDivs() {
-                    return this.template.querySelector('x-parent').querySelectorAll('div');
-                }
-
                 render() {
                     return tmpl$2;
                 }
             }
-            LightdomQuerySelector.publicMethods = ['selectDivs'];
 
             const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
             document.body.appendChild(element);
-            const nested = element.selectDivs();
+            const nested = element.shadowRoot.querySelector('x-parent').querySelectorAll('div');
             expect(nested.length).toBe(2);
-            expect(nested[0]).toBe(querySelector.call(element, 'x-parent div:nth-child(1)'));
-            expect(nested[1]).toBe(querySelector.call(element, 'x-parent div:nth-child(2)'));
+            expect(nested[0]).toBe(querySelector.call(element, '.first'));
+            expect(nested[1]).toBe(querySelector.call(element, '.second'));
         });
     });
 });
@@ -194,25 +206,21 @@ describe('#lightDomQuerySelectorAll()', () => {
 describe('#lightDomQuerySelector()', () => {
     it('should allow searching for the passed element', () => {
         function tmpl$1($api, $cmp, $slotset, $ctx) {
-            const {
-                "$default$": slot0
-            } = $slotset;
-
-            return slot0 || [];
+            return [$api.s('', {
+                key: 0,
+                attrs: {
+                    name: ''
+                }
+            }, [], $slotset)];
         }
-        tmpl$1.slots = ["$default$"];
+        tmpl$1.slots = [""];
 
         class Parent extends Element {
-            selectFirstDiv() {
-                return this.querySelector('div');
-            }
-
             render() {
                 return tmpl$1;
             }
 
         }
-        Parent.publicMethods = ["selectFirstDiv"];
 
         function tmpl$2($api, $cmp, $slotset, $ctx) {
             const {
@@ -221,16 +229,26 @@ describe('#lightDomQuerySelector()', () => {
                 c: api_custom_element
             } = $api;
 
-            return [api_custom_element("x-parent", Parent, {
-                key: 1,
-                "slotset": {
-                    "$default$": [api_element("div", {
-                        key: 2
-                    }, [api_text("First")]), api_element("div", {
-                        key: 3
-                    }, [api_text("Second")])]
-                }
-            })];
+            return [
+                api_custom_element("x-parent", Parent, {
+                    key: 1,
+                }, [
+                    api_element("div", {
+                            key: 2,
+                            classMap: {
+                                first: true
+                            }
+                        },
+                        [api_text("First")]
+                    ), api_element("div", {
+                            key: 3,
+                            classMap: {
+                                second: true
+                            }
+                        },
+                        [api_text("Second")]
+                    )
+                ])];
         }
 
         class LightdomQuerySelector extends Element {
@@ -241,8 +259,8 @@ describe('#lightDomQuerySelector()', () => {
 
         const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
         document.body.appendChild(element);
-        const div = querySelector.call(element, 'x-parent').selectFirstDiv();
-        expect(div).toBe(querySelector.call(element, 'x-parent div'));
+        const div = element.shadowRoot.querySelector('x-parent').querySelector('div');
+        expect(div).toBe(querySelector.call(element, '.first'));
     });
 
     it('should ignore element from template', () => {
@@ -283,7 +301,7 @@ describe('#lightDomQuerySelector()', () => {
         }).not.toThrow();
     });
 
-    it('should return null if element does not exist', function() {
+    it('should return null if element does not exist', function () {
         function html($api) {
             return [$api.h('p', { key: 0 }, [])];
         }
@@ -318,14 +336,13 @@ describe('#shadowRootQuerySelector', () => {
 
     it('should not reach into child components template when querySelector invoked on child custom element', () => {
         expect.assertions(1);
-        let childTemplate;
         class MyChild extends Element {
             render() {
-                return function ($api) {
+                return function($api) {
                     return [$api.h('div', {
                         key: 0,
                     }, [])];
-                }
+                };
             }
         }
 
@@ -334,20 +351,14 @@ describe('#shadowRootQuerySelector', () => {
         }
 
         class MyComponent extends Element {
-            queryChild() {
-                return this.template.querySelector('membrane-parent-query-selector-child-custom-element-child').querySelector('div');
-            }
-
             render() {
                 return html;
             }
         }
 
-        MyComponent.publicMethods = ['queryChild'];
-
         const elm = createElement('membrane-parent-query-selector-child-custom-element', { is: MyComponent });
         document.body.appendChild(elm);
-        expect(elm.queryChild()).toBe(null);
+        expect(elm.shadowRoot.querySelector('membrane-parent-query-selector-child-custom-element-child').querySelector('div')).toBe(null);
     });
 
     it('should querySelectorAll on element from template', () => {
@@ -447,20 +458,14 @@ describe('#shadowRootQuerySelector', () => {
                 childTemplate = this.template;
             }
 
-            clickDiv() {
-                this.template.querySelector('div').click();
-            }
-
             render() {
-                return function ($api) {
+                return function($api) {
                     return [$api.h('div', {
                         key: 0,
                     }, [])];
-                }
+                };
             }
         }
-
-        MyChild.publicMethods = ['clickDiv'];
 
         function html($api, $cmp) {
             return [$api.c('x-child-parent-shadow-root', MyChild, {
@@ -475,21 +480,15 @@ describe('#shadowRootQuerySelector', () => {
                 expect(evt.target.parentNode).not.toBe(childTemplate);
             }
 
-            clickChildDiv() {
-                this.template.querySelector('x-child-parent-shadow-root').clickDiv();
-            }
-
             render() {
                 return html;
             }
         }
 
-        MyComponent.publicMethods = ['clickChildDiv'];
-
         const elm = createElement('membrane-child-parent-shadow-root-parent', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            elm.clickChildDiv();
+            elm.shadowRoot.querySelector('x-child-parent-shadow-root').shadowRoot.querySelector('div').click();
         });
     });
 });

--- a/packages/lwc-engine/src/framework/template.ts
+++ b/packages/lwc-engine/src/framework/template.ts
@@ -4,18 +4,18 @@ import { isArray, isFunction, isObject, isUndefined, create, ArrayIndexOf, toStr
 import { VNode, VNodes } from "../3rdparty/snabbdom/types";
 import { RenderAPI } from "./api";
 import { Context } from "./context";
-import { Slotset, VM, resetShadowRoot } from "./vm";
+import { SlotSet, VM, resetShadowRoot } from "./vm";
 import { EmptyArray } from "./utils";
 import { Component } from "./component";
 import { removeAttribute, setAttribute } from "./dom/element";
 
 export interface Template {
-    (api: RenderAPI, cmp: object, slotset: Slotset, ctx: Context): undefined | VNodes;
+    (api: RenderAPI, cmp: object, slotset: SlotSet, ctx: Context): undefined | VNodes;
     style?: string;
     token?: string;
 }
 
-const EmptySlots: Slotset = create(null);
+const EmptySlots: SlotSet = create(null);
 
 function validateSlots(vm: VM, html: any) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -20,7 +20,7 @@ export interface HashTable<T> {
     [key: string]: T;
 }
 
-export interface Slotset {
+export interface SlotSet {
     [key: string]: VNodes;
 }
 
@@ -40,7 +40,7 @@ export interface VM {
     // TODO: make this type more restrictive once we know more about it
     rootProps: Record<string, string | null | boolean>;
     cmpState?: HashTable<any>;
-    cmpSlots: Slotset;
+    cmpSlots: SlotSet;
     cmpTrack: HashTable<any>;
     cmpEvents?: Record<string, EventListener[] | undefined>;
     cmpListener?: (event: Event) => void;
@@ -518,23 +518,13 @@ export function getShadowRootVM(root: ShadowRoot): VM {
 }
 
 // slow path routine
-export function allocateInSlot(vm: VM, children: VNodes, compilerSlotSetAllocation: Slotset | undefined) {
+export function allocateInSlot(vm: VM, children: VNodes) {
     if (process.env.NODE_ENV !== 'production') {
         assert.vm(vm);
         assert.invariant(isObject(vm.cmpSlots), `When doing manual allocation, there must be a cmpSlots object available.`);
     }
     const { cmpSlots: oldSlots } = vm;
-    // Backward compatible branch:
-    if (!isUndefined(compilerSlotSetAllocation)) {
-        vm.cmpSlots = compilerSlotSetAllocation;
-        // TODO: remove this block and rely on the engine allocation instead of the compiler
-        // TODO: Issue #133
-        if (oldSlots !== compilerSlotSetAllocation && !vm.isDirty) {
-            markComponentAsDirty(vm);
-        }
-        return;
-    }
-    const cmpSlots = vm.cmpSlots = create(null) as Slotset;
+    const cmpSlots = vm.cmpSlots = create(null) as SlotSet;
     for (let i = 0, len = children.length; i < len; i += 1) {
         const vnode = children[i];
         if (isNull(vnode)) {


### PR DESCRIPTION
## Details

* we had some code in the engine to support compiler slot allocation, this was intended to be removed once the compiler change from https://github.com/salesforce/lwc/pull/348
* After this is merged, the allocation is always carry on by the engine.

## Does this PR introduce a breaking change?

* No

