### PR TITLE
feat(compiler): support default import identifier for wire decorator

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.spec.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/wire-decorator.spec.js
@@ -78,7 +78,7 @@ Test.wire = {
         }
     });
 
-    pluginTest('decorator expects a function identifier as first parameter', `
+    pluginTest('decorator accepts a function identifier as first parameter', `
         import { wire } from 'engine';
         import { getFoo } from 'data-service';
         export default class Test {
@@ -103,7 +103,32 @@ Test.wire = {
         }
     });
 
-    pluginTest('decorator expects an optional config object as second parameter', `
+    pluginTest('decorator accepts a default import function identifier as first parameter', `
+        import { wire } from 'engine';
+        import getFoo from 'foo';
+        export default class Test {
+            @wire(getFoo, {}) wiredProp;
+        }
+    `, {
+        output: {
+            code: `import getFoo from 'foo';
+export default class Test {
+  constructor() {
+    this.wiredProp = void 0;
+  }
+
+}
+Test.wire = {
+  wiredProp: {
+    adapter: getFoo,
+    params: {},
+    static: {}
+  }
+};`
+        }
+    })
+
+    pluginTest('decorator accepts an optional config object as second parameter', `
         import { wire } from 'engine';
         import { getFoo } from 'data-service';
         export default class Test {

--- a/packages/babel-plugin-transform-lwc-class/src/decorators/wire/validate.js
+++ b/packages/babel-plugin-transform-lwc-class/src/decorators/wire/validate.js
@@ -16,7 +16,9 @@ function validateWireParameters(path) {
         );
     }
 
-    if (id.isIdentifier() && !path.scope.getBinding(id.node.name).path.isImportSpecifier()) {
+    if (id.isIdentifier()
+        && !path.scope.getBinding(id.node.name).path.isImportSpecifier()
+        && !path.scope.getBinding(id.node.name).path.isImportDefaultSpecifier()) {
         throw id.buildCodeFrameError(
             `@wire expects a function identifier to be imported as first parameter.`
         );


### PR DESCRIPTION
## Details
apex referential integrity requires default import instead of named import, but current compiler does not support that for wire decorator. This PR addresses that.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No