### PR TITLE
refactor(engine): move shadowRoot access into method

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
@@ -1,4 +1,4 @@
-import { Element } from "../html-element";
+import { Element, getHostShadowRoot } from "../html-element";
 import * as api from "../api";
 import { createElement } from '../upgrade';
 
@@ -16,7 +16,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('foo');
         });
 
@@ -32,7 +32,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('foo');
         });
 
@@ -52,7 +52,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('bar baz foo');
         });
 
@@ -72,7 +72,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('');
         });
 
@@ -92,7 +92,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('foo');
         });
 
@@ -112,7 +112,7 @@ describe('class-list', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const childElm = elm.shadowRoot.querySelector('x-child');
+            const childElm = getHostShadowRoot(elm).querySelector('x-child');
             expect(childElm.className).toBe('bar foo');
         });
 

--- a/packages/lwc-engine/src/framework/__tests__/component.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/component.spec.ts
@@ -1,5 +1,5 @@
 import * as target from '../component';
-import { Element } from "../html-element";
+import { Element, getHostShadowRoot } from "../html-element";
 import { createElement } from "../upgrade";
 import { ViewModelReflection } from '../utils';
 
@@ -51,7 +51,7 @@ describe('component', function() {
             const elm = createElement('x-foo', { is: Parent });
             document.body.appendChild(elm);
             expect(elm.lunch).toBe('salad');
-            expect(elm.shadowRoot.querySelector('x-component').breakfast).toBe('pancakes');
+            expect(getHostShadowRoot(elm).querySelector('x-component').breakfast).toBe('pancakes');
         });
 
         it('should allow calling public getters when element is accessed by querySelector', function() {
@@ -358,7 +358,7 @@ describe('component', function() {
                 }
             });
             document.body.appendChild(elm);
-            expect(elm.shadowRoot.querySelector('section').style.cssText).toBe('color: red;');
+            expect(getHostShadowRoot(elm).querySelector('section').style.cssText).toBe('color: red;');
             expect(calledCSSText).toBe(true);
         });
 
@@ -455,7 +455,7 @@ describe('component', function() {
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            const section = elm.shadowRoot.querySelector('section');
+            const section = getHostShadowRoot(elm).querySelector('section');
             section.style.removeProperty = function() {
                 called = true;
             };

--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -1,4 +1,4 @@
-import { Element } from "../html-element";
+import { Element, getHostShadowRoot } from "../html-element";
 import { createElement } from "./../upgrade";
 import { unwrap } from "../membrane";
 
@@ -817,7 +817,9 @@ describe('Shadow Root events', () => {
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
-        elm.shadowRoot.querySelector('div').dispatchEvent(new CustomEvent('foo', { bubbles: true, composed: true }))
+        getHostShadowRoot(elm)
+            .querySelector('div')
+            .dispatchEvent(new CustomEvent('foo', { bubbles: true, composed: true }));
     });
 });
 

--- a/packages/lwc-engine/src/framework/__tests__/template.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/template.spec.ts
@@ -1,6 +1,6 @@
 import * as target from '../template';
 import * as globalApi from '../api';
-import { Element } from "../html-element";
+import { Element, getHostShadowRoot } from "../html-element";
 import { createElement } from '../main';
 import { ViewModelReflection } from '../utils';
 import { Template } from '../template';
@@ -43,9 +43,15 @@ describe('template', () => {
                     ]);
                 });
             });
-            expect(elm.shadowRoot.querySelectorAll('div').length).toBe(2);
-            expect(elm.shadowRoot.querySelectorAll('div')[0].textContent).toBe('a');
-            expect(elm.shadowRoot.querySelectorAll('div')[1].textContent).toBe('b');
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div').length
+            ).toBe(2);
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div')[0].textContent
+            ).toBe('a');
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div')[1].textContent
+            ).toBe('b');
         });
 
         it('should render sets correctly', function() {
@@ -59,9 +65,15 @@ describe('template', () => {
                     ]);
                 });
             });
-            expect(elm.shadowRoot.querySelectorAll('div').length).toBe(2);
-            expect(elm.shadowRoot.querySelectorAll('div')[0].textContent).toBe('a');
-            expect(elm.shadowRoot.querySelectorAll('div')[1].textContent).toBe('b');
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div').length
+            ).toBe(2);
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div')[0].textContent
+            ).toBe('a');
+            expect(
+                getHostShadowRoot(elm).querySelectorAll('div')[1].textContent
+            ).toBe('b');
         });
 
         // this test depends on the memoization

--- a/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
@@ -1,5 +1,5 @@
 import { wrapIframeWindow } from "../iframe";
-import { Element } from "../../html-element";
+import { Element, getHostShadowRoot } from "../../html-element";
 import { createElement } from "../../upgrade";
 
 describe('wrapped iframe window', () => {
@@ -125,7 +125,7 @@ describe('wrapped iframe window', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             const nativeIframeContentWindow = document.querySelector('iframe').contentWindow;
-            const wrappedIframe = elm.shadowRoot.querySelector('iframe'); // will return monkey patched contentWindow
+            const wrappedIframe = getHostShadowRoot(elm).querySelector('iframe'); // will return monkey patched contentWindow
             const contentWindowGetter = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow').get;
             expect(nativeIframeContentWindow === contentWindowGetter.call(wrappedIframe)).toBe(true);
         });

--- a/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
@@ -1,4 +1,4 @@
-import { Element } from "../../html-element";
+import { Element, getHostShadowRoot } from "../../html-element";
 import { h } from "../../api";
 import { createElement } from "../../upgrade";
 import { ViewModelReflection } from "../../utils";
@@ -12,13 +12,13 @@ describe('root', () => {
             class MyComponent extends Element {}
             const elm = createElement('x-foo', { is: MyComponent });
             const vm = elm[ViewModelReflection] as VM;
-            expect(vm.component).toBe(elm.shadowRoot.host);
+            expect(vm.component).toBe(getHostShadowRoot(elm).host);
         });
 
         it('should support this.template.mode', () => {
             class MyComponent extends Element {}
             const elm = createElement('x-foo', { is: MyComponent });
-            expect(elm.shadowRoot.mode).toBe('closed');
+            expect(getHostShadowRoot(elm).mode).toBe('closed');
         });
 
         it('should allow searching for elements from template', () => {
@@ -31,7 +31,7 @@ describe('root', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             return Promise.resolve().then(() => {
-                const nodes = elm.shadowRoot.querySelectorAll('p');
+                const nodes = getHostShadowRoot(elm).querySelectorAll('p');
                 expect(nodes).toHaveLength(1);
             });
         });
@@ -48,7 +48,7 @@ describe('root', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             return Promise.resolve().then(() => {
-                const node = elm.shadowRoot.querySelector('p');
+                const node = getHostShadowRoot(elm).querySelector('p');
                 expect(node.tagName).toBe('P');
             });
         });
@@ -64,7 +64,7 @@ describe('root', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             return Promise.resolve().then(() => {
-                const nodes = elm.shadowRoot.querySelectorAll('p');
+                const nodes = getHostShadowRoot(elm).querySelectorAll('p');
                 expect(nodes).toHaveLength(0);
             });
         });
@@ -80,7 +80,7 @@ describe('root', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             return Promise.resolve().then(() => {
-                const node = elm.shadowRoot.querySelector('p');
+                const node = getHostShadowRoot(elm).querySelector('p');
                 expect(node).toBeNull();
             });
         });
@@ -113,10 +113,14 @@ describe('root', () => {
 
             const elem = createElement('x-shadow-child-nodes', { is: MyComponent });
             document.body.appendChild(elem);
-            const children = elem.shadowRoot.childNodes;
+            const children = getHostShadowRoot(elem).childNodes;
             expect(children).toHaveLength(2);
-            expect(children[0]).toBe(elem.shadowRoot.querySelector('div'));
-            expect(children[1]).toBe(elem.shadowRoot.querySelector('p'));
+            expect(children[0]).toBe(
+                getHostShadowRoot(elem).querySelector('div')
+            );
+            expect(children[1]).toBe(
+                getHostShadowRoot(elem).querySelector('p')
+            );
         });
     });
 });

--- a/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
@@ -1,4 +1,4 @@
-import { Element } from "../../html-element";
+import { Element, getHostShadowRoot } from "../../html-element";
 import { createElement } from "../../upgrade";
 import assertLogger from '../../assert';
 import { register } from "../../services";
@@ -65,7 +65,7 @@ describe('#lightDomQuerySelectorAll()', () => {
 
             const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
             document.body.appendChild(element);
-            const nested = element.shadowRoot.querySelector('x-parent').querySelectorAll('div');
+            const nested = getHostShadowRoot(element).querySelector('x-parent').querySelectorAll('div');
             expect(nested).toHaveLength(2);
             expect(nested[0]).toBe(querySelector.call(element, '.first'));
             expect(nested[1]).toBe(querySelector.call(element, '.second'));
@@ -119,7 +119,7 @@ describe('#lightDomQuerySelectorAll()', () => {
             }
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
-            expect(elm.shadowRoot.querySelector('x-child').querySelectorAll('p')).toHaveLength(0);
+            expect(getHostShadowRoot(elm).querySelector('x-child').querySelectorAll('p')).toHaveLength(0);
         });
 
         it('should not throw an error if no nodes are found', () => {
@@ -134,7 +134,7 @@ describe('#lightDomQuerySelectorAll()', () => {
             const elm = createElement('should-not-throw-an-error-if-no-nodes-are-found', { is: def });
             document.body.appendChild(elm);
             expect(() => {
-                elm.shadowRoot.querySelectorAll('div');
+                getHostShadowRoot(elm).querySelectorAll('div');
             }).not.toThrow();
         });
     });
@@ -195,7 +195,7 @@ describe('#lightDomQuerySelectorAll()', () => {
 
             const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
             document.body.appendChild(element);
-            const nested = element.shadowRoot.querySelector('x-parent').querySelectorAll('div');
+            const nested = getHostShadowRoot(element).querySelector('x-parent').querySelectorAll('div');
             expect(nested).toHaveLength(2);
             expect(nested[0]).toBe(querySelector.call(element, '.first'));
             expect(nested[1]).toBe(querySelector.call(element, '.second'));
@@ -259,7 +259,7 @@ describe('#lightDomQuerySelector()', () => {
 
         const element = createElement('lightdom-queryselector', { is: LightdomQuerySelector });
         document.body.appendChild(element);
-        const div = element.shadowRoot.querySelector('x-parent').querySelector('div');
+        const div = getHostShadowRoot(element).querySelector('x-parent').querySelector('div');
         expect(div).toBe(querySelector.call(element, '.first'));
     });
 
@@ -282,7 +282,7 @@ describe('#lightDomQuerySelector()', () => {
         }
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
-        expect(elm.shadowRoot.querySelector('x-child').querySelector('p')).toBeNull();
+        expect(getHostShadowRoot(elm).querySelector('x-child').querySelector('p')).toBeNull();
     });
 
     it('should not throw an error if element does not exist', () => {
@@ -297,7 +297,7 @@ describe('#lightDomQuerySelector()', () => {
         const elm = createElement('x-foo', { is: def });
         document.body.appendChild(elm);
         expect(() => {
-            elm.shadowRoot.querySelector('div');
+            getHostShadowRoot(elm).querySelector('div');
         }).not.toThrow();
     });
 
@@ -312,7 +312,7 @@ describe('#lightDomQuerySelector()', () => {
         };
         const elm = createElement('x-foo', { is: def });
         document.body.appendChild(elm);
-        expect(elm.shadowRoot.querySelector('div')).toBeNull();
+        expect(getHostShadowRoot(elm).querySelector('div')).toBeNull();
     });
 });
 
@@ -327,7 +327,7 @@ describe('#shadowRootQuerySelector', () => {
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            const ul = elm.shadowRoot.querySelector('ul');
+            const ul = getHostShadowRoot(elm).querySelector('ul');
             expect(ul);
             const li = ul.querySelector('li');
             expect(li);
@@ -358,7 +358,7 @@ describe('#shadowRootQuerySelector', () => {
 
         const elm = createElement('membrane-parent-query-selector-child-custom-element', { is: MyComponent });
         document.body.appendChild(elm);
-        expect(elm.shadowRoot.querySelector('membrane-parent-query-selector-child-custom-element-child').querySelector('div')).toBe(null);
+        expect(getHostShadowRoot(elm).querySelector('membrane-parent-query-selector-child-custom-element-child').querySelector('div')).toBe(null);
     });
 
     it('should querySelectorAll on element from template', () => {
@@ -371,7 +371,7 @@ describe('#shadowRootQuerySelector', () => {
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            const ul = (elm.shadowRoot.querySelectorAll('ul')[0];
+            const ul = getHostShadowRoot(elm).querySelectorAll('ul')[0];
             expect(ul);
             const li = ul.querySelectorAll('li')[0];
             expect(li);
@@ -388,7 +388,7 @@ describe('#shadowRootQuerySelector', () => {
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            const ul = (elm.shadowRoot.querySelector('ul');
+            const ul = getHostShadowRoot(elm).querySelector('ul');
             expect(ul);
             ul.appendChild(document.createElement('li'));
             const li1 = ul.querySelectorAll('li')[0];
@@ -410,7 +410,7 @@ describe('#shadowRootQuerySelector', () => {
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
             expect(() => {
-                elm.shadowRoot.querySelector('doesnotexist');
+                getHostShadowRoot(elm).querySelector('doesnotexist');
             }).not.toThrow();
         });
     });
@@ -426,7 +426,7 @@ describe('#shadowRootQuerySelector', () => {
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('doesnotexist')).toBeNull();
+            expect(getHostShadowRoot(elm).querySelector('doesnotexist')).toBeNull();
         });
     });
 
@@ -444,7 +444,7 @@ describe('#shadowRootQuerySelector', () => {
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
             expect(() => {
-                elm.shadowRoot.querySelectorAll('doesnotexist');
+                getHostShadowRoot(elm).querySelectorAll('doesnotexist');
             }).not.toThrow();
         });
     });
@@ -488,7 +488,9 @@ describe('#shadowRootQuerySelector', () => {
         const elm = createElement('membrane-child-parent-shadow-root-parent', { is: MyComponent });
         document.body.appendChild(elm);
         return Promise.resolve().then(() => {
-            elm.shadowRoot.querySelector('x-child-parent-shadow-root').shadowRoot.querySelector('div').click();
+            getHostShadowRoot(
+                getHostShadowRoot(elm).querySelector('x-child-parent-shadow-root')
+            ).querySelector('div').click();
         });
     });
 });
@@ -569,7 +571,9 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const slot = elm.shadowRoot.querySelector('x-child-node-with-slot').shadowRoot.querySelector('slot');
+        const slot = getHostShadowRoot(
+            getHostShadowRoot(elm).querySelector('x-child-node-with-slot')
+        ).querySelector('slot');
         expect(slot.childNodes).toHaveLength(0);
     });
 
@@ -605,7 +609,9 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const slot = elm.shadowRoot.querySelector('x-child-node-with-slot').shadowRoot.querySelector('slot');
+        const slot = getHostShadowRoot(
+            getHostShadowRoot(elm).querySelector('x-child-node-with-slot')
+        ).querySelector('slot');
         expect(slot.childNodes).toHaveLength(1);
     });
 
@@ -628,10 +634,10 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('div');
+        const child = getHostShadowRoot(elm).querySelector('div');
         const childNodes = child.childNodes;
         expect(childNodes).toHaveLength(1);
-        expect(childNodes[0]).toBe(elm.shadowRoot.querySelector('p'));
+        expect(childNodes[0]).toBe(getHostShadowRoot(elm).querySelector('p'));
     });
 
     it('should return correct elements for custom elements when no children present', () => {
@@ -666,7 +672,7 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-child');
+        const child = getHostShadowRoot(elm).querySelector('x-child');
         const childNodes = child.childNodes;
         expect(childNodes).toHaveLength(0);
     });
@@ -707,7 +713,7 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-child');
+        const child = getHostShadowRoot(elm).querySelector('x-child');
         const childNodes = child.childNodes;
         expect(childNodes).toHaveLength(1);
     });
@@ -746,7 +752,7 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-child');
+        const child = getHostShadowRoot(elm).querySelector('x-child');
         const childNodes = child.childNodes;
         expect(childNodes).toHaveLength(1);
         expect(childNodes[0].nodeType).toBe(3);
@@ -783,7 +789,7 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-child');
+        const child = getHostShadowRoot(elm).querySelector('x-child');
         const childNodes = child.childNodes;
         expect(childNodes).toHaveLength(0);
     });
@@ -827,9 +833,9 @@ describe('#childNodes', () => {
 
         const elm = createElement('x-child-node-parent', { is: Parent });
         document.body.appendChild(elm);
-        const childNodes = elm.shadowRoot.childNodes;
+        const childNodes = getHostShadowRoot(elm).childNodes;
         expect(childNodes).toHaveLength(2);
-        expect(childNodes[0]).toBe(elm.shadowRoot.querySelector('div'));
+        expect(childNodes[0]).toBe(getHostShadowRoot(elm).querySelector('div'));
         expect(childNodes[1].nodeType).toBe(3);
         expect(childNodes[1].textContent).toBe('text');
     });
@@ -854,7 +860,7 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-assigned-slot', { is: MyComponent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-assigned-slot-child');
+        const child = getHostShadowRoot(elm).querySelector('x-assigned-slot-child');
         expect(child.assignedSlot).toBe(null);
     });
 
@@ -875,7 +881,7 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-assigned-slot', { is: MyComponent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('div');
+        const child = getHostShadowRoot(elm).querySelector('div');
         expect(child.assignedSlot).toBe(null);
     });
 
@@ -918,8 +924,10 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-native-slotted-component', { is: MyComponent });
         document.body.appendChild(elm);
-        const slot = elm.shadowRoot.querySelector('x-native-slotted-component-child').shadowRoot.querySelector('slot');
-        const child = elm.shadowRoot.querySelector('div');
+        const slot = getHostShadowRoot(
+            getHostShadowRoot(elm).querySelector('x-native-slotted-component-child')
+        ).querySelector('slot');
+        const child = getHostShadowRoot(elm).querySelector('div');
         expect(child.assignedSlot).toBe(slot);
     });
 
@@ -962,8 +970,10 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-native-slotted-component', { is: MyComponent });
         document.body.appendChild(elm);
-        const slot = elm.shadowRoot.querySelector('x-native-slotted-component-child').shadowRoot.querySelector('slot');
-        const child = elm.shadowRoot.querySelector('x-inside-slot');
+        const slot = getHostShadowRoot(
+            getHostShadowRoot(elm).querySelector('x-native-slotted-component-child')
+        ).querySelector('slot');
+        const child = getHostShadowRoot(elm).querySelector('x-inside-slot');
         expect(child.assignedSlot).toBe(slot);
     });
 
@@ -988,7 +998,7 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-assigned-slot', { is: MyComponent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('div');
+        const child = getHostShadowRoot(elm).querySelector('div');
         expect(child.assignedSlot).toBe(null);
     });
 
@@ -1017,7 +1027,7 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-assigned-slot', { is: MyComponent });
         document.body.appendChild(elm);
-        const child = elm.shadowRoot.querySelector('x-default-slot-custom-element');
+        const child = getHostShadowRoot(elm).querySelector('x-default-slot-custom-element');
         expect(child.assignedSlot).toBe(null);
     });
 
@@ -1058,8 +1068,10 @@ describe('assignedSlot', () => {
 
         const elm = createElement('x-native-slotted-component', { is: MyComponent });
         document.body.appendChild(elm);
-        const slot = elm.shadowRoot.querySelector('x-native-slotted-component-child').shadowRoot.querySelector('slot');
-        const text = elm.shadowRoot.querySelector('x-native-slotted-component-child').childNodes[0];
+        const slot = getHostShadowRoot(
+            getHostShadowRoot(elm).querySelector('x-native-slotted-component-child')
+        ).querySelector('slot');
+        const text = getHostShadowRoot(elm).querySelector('x-native-slotted-component-child').childNodes[0];
         expect(text.assignedSlot).toBe(slot);
     });
 });

--- a/packages/lwc-engine/src/framework/html-element.ts
+++ b/packages/lwc-engine/src/framework/html-element.ts
@@ -29,6 +29,11 @@ function ElementShadowRootGetter(this: HTMLElement): ShadowRoot | null {
     return vm.mode === 'open' ? vm.cmpRoot : null;
 }
 
+export function getHostShadowRoot(elm: HTMLElement): ShadowRoot | null {
+    const vm = getCustomElementVM(elm);
+    return vm.mode === 'open' ? vm.cmpRoot : null;
+}
+
 const fallbackDescriptors = {
     shadowRoot: {
         get: ElementShadowRootGetter,


### PR DESCRIPTION
Move `shadowRoot` access into a method so we can easily switch between native and fallback modes.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No