### PR TITLE
chore(engine): Reduce test coupling with engine internals

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/api.spec.ts
@@ -1,7 +1,5 @@
 import * as api from '../api';
-import { Element } from "../html-element";
-import { createElement } from '../main';
-import { RenderAPI } from '../api';
+import { createElement, Element } from '../main';
 import { querySelector } from "../dom/element";
 
 describe('api', () => {
@@ -101,9 +99,10 @@ describe('api', () => {
             }
             const elm = createElement('x-foo', { is: Foo });
             document.body.appendChild(elm);
-            const span = querySelector.call(elm, 'button') as Element;
-            expect(span.tagName).toEqual('BUTTON');
-            expect(span.getAttribute('is')).toEqual('x-bar');
+
+            const button = elm.shadowRoot.querySelector('button') as Element;
+            expect(button.tagName).toEqual('BUTTON');
+            expect(button.getAttribute('is')).toEqual('x-bar');
         });
 
         it('should throw if the forceTagName value is a reserved standard element name', () => {

--- a/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../html-element";
-import * as api from "../api";
-import { createElement } from '../upgrade';
+import { createElement, Element } from '../main';
 
 describe('class-list', () => {
     describe('integration', () => {

--- a/packages/lwc-engine/src/framework/__tests__/component.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/component.spec.ts
@@ -1,19 +1,7 @@
-import * as target from '../component';
-import { Element } from "../html-element";
-import { createElement } from "../upgrade";
 import { ViewModelReflection } from '../utils';
+import { createElement, Element } from "../main";
 
 describe('component', function() {
-    describe('#createComponent()', () => {
-        it('should throw for non-object values', () => {
-            expect(() => target.createComponent(undefined)).toThrow();
-            expect(() => target.createComponent("")).toThrow();
-            expect(() => target.createComponent(NaN)).toThrow();
-            expect(() => target.createComponent(function() {})).toThrow();
-            expect(() => target.createComponent(1)).toThrow();
-        });
-    });
-
     describe('public computed props', () => {
         it('should allow public getters', function() {
             class MyComponent extends Element  {

--- a/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../html-element";
-import { createElement } from "../upgrade";
-import { querySelector, querySelectorAll } from "../dom/element";
+import { createElement, Element } from '../main';
 
 function createBoundaryComponent(elementsToRender) {
     function html($api, $cmp) {
@@ -79,7 +77,7 @@ describe('error boundary component', () => {
                 const boundaryHostElm = createElement('x-parent', {is: BoundryHost});
 
                 document.body.appendChild(boundaryHostElm);
-                expect(querySelectorAll.call(boundaryHostElm, 'x-boundary-sibling').length).toBe(1);
+                expect(boundaryHostElm.shadowRoot.querySelectorAll('x-boundary-sibling').length).toBe(1);
             }),
 
             it('should unmount enitre subtree up to boundary component if child throws inside constructor', () => {
@@ -105,8 +103,8 @@ describe('error boundary component', () => {
                 const elm = createElement('x-boundary', { is: Boundary });
                 document.body.appendChild(elm);
 
-                expect(querySelector.call(elm, 'x-second-level-child')).toBeNull();
-                expect(querySelector.call(elm, 'x-first-level-child')).toBeNull();
+                expect(elm.shadowRoot.querySelector('x-second-level-child')).toBeNull();
+                expect(elm.shadowRoot.querySelector('x-first-level-child')).toBeNull();
             }),
 
             it('should throw if error occurs in error boundary constructor', () => {
@@ -128,12 +126,14 @@ describe('error boundary component', () => {
                         return html;
                     }
                 }
-                expect( () => {
+
+                expect(() => {
                     const elm = createElement('x-boundary', { is: Boundary });
                     document.body.appendChild(elm);
+
+                    expect(elm.shadowRoot.querySelector('x-first-level-child')).toBeNull();
+                    expect(elm.shadowRoot.querySelector('x-first-level-child-sibling')).toBeNull();
                 }).toThrow();
-                expect(document.body.querySelector('x-first-level-child')).toBeNull();
-                expect(document.body.querySelector('x-first-level-child-sibling')).toBeNull();
             });
         }),
 
@@ -201,7 +201,7 @@ describe('error boundary component', () => {
                 const boundaryHostElm = createElement('x-parent', {is: BoundryHost});
                 document.body.appendChild(boundaryHostElm);
 
-                expect(querySelectorAll.call(boundaryHostElm, 'x-boundary-sibling').length).toBe(1);
+                expect(boundaryHostElm.shadowRoot.querySelectorAll('x-boundary-sibling').length).toBe(1);
             }),
 
             it('should unmount child and its subtree if boundary child throws inside render', () => {
@@ -226,8 +226,8 @@ describe('error boundary component', () => {
                 const elm = createElement('x-boundary', { is: Boundary });
                 document.body.appendChild(elm);
 
-                expect(querySelector.call(elm, 'x-first-level-child')).toBeNull();
-                expect(querySelector.call(elm, 'x-second-level-child')).toBeNull();
+                expect(elm.shadowRoot.querySelector('x-first-level-child')).toBeNull();
+                expect(elm.shadowRoot.querySelector('x-second-level-child')).toBeNull();
             }),
 
             it ('should call errorCallback if slot throws an error inside render', () => {
@@ -345,7 +345,7 @@ describe('error boundary component', () => {
                 document.body.appendChild(hostBoundaryElm);
 
                 expect(hostBoundaryElm.getError()).toBe('Child Boundary ErrorCallback Throw');
-                expect(querySelectorAll.call(hostBoundaryElm, 'child-error-boundary').length).toBe(0);
+                expect(hostBoundaryElm.shadowRoot.querySelectorAll('child-error-boundary').length).toBe(0);
             });
 
             it('should unmount error boundary child if it throws inside renderedCallback', () => {
@@ -440,7 +440,7 @@ describe('error boundary component', () => {
                 const boundaryHostElm = createElement('x-parent', {is: BoundryHost});
                 document.body.appendChild(boundaryHostElm);
 
-                expect(querySelectorAll.call(boundaryHostElm, 'x-boundary-sibling').length).toBe(1);
+                expect(boundaryHostElm.shadowRoot.querySelectorAll('x-boundary-sibling').length).toBe(1);
             }),
 
             it('should unmount boundary child and its subtree if child throws inside renderedCallback', () => {
@@ -536,7 +536,7 @@ describe('error boundary component', () => {
                 const boundaryHostElm = createElement('x-parent', {is: BoundryHost});
                 document.body.appendChild(boundaryHostElm);
 
-                expect(querySelectorAll.call(boundaryHostElm, 'x-boundary-sibling').length).toBe(1);
+                expect(boundaryHostElm.shadowRoot.querySelectorAll('x-boundary-sibling').length).toBe(1);
             }),
 
             it('should unmount boundary child and its subtree if boundary child throws inside connectedCallback', () => {

--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../html-element";
-import { createElement } from "./../upgrade";
-import { unwrap } from "../membrane";
+import { createElement, Element } from "../main";
 
 describe('Composed events', () => {
     it('should be able to consume events from within template', () => {

--- a/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
@@ -1,12 +1,6 @@
-import { Element } from "../html-element";
-import { createElement } from "../upgrade";
+import { createElement, Element, unwrap } from "../main";
 import assertLogger from '../assert';
-import { register } from "../services";
 import { ViewModelReflection } from "../utils";
-import { VNode } from "../../3rdparty/snabbdom/types";
-import { Component } from "../component";
-import { unwrap } from "../main";
-import { querySelector } from "../dom/element";
 
 describe('html-element', () => {
     describe('#setAttributeNS()', () => {
@@ -27,8 +21,9 @@ describe('html-element', () => {
             }
             const element = createElement('should-set-attribute-on-host-element-when-element-is-nested-in-template', { is: Parent });
             document.body.appendChild(element);
-            const child = querySelector.call(element, 'x-child');
+            const child = element.shadowRoot.querySelector('x-child');
             child.setFoo();
+
             expect(child.hasAttributeNS('x', 'foo')).toBe(true);
             expect(child.getAttributeNS('x', 'foo')).toBe('bar');
         });
@@ -77,8 +72,9 @@ describe('html-element', () => {
             }
             const element = createElement('should-set-attribute-on-host-element-when-element-is-nested-in-template', { is: Parent });
             document.body.appendChild(element);
-            const child = querySelector.call(element, 'x-child');
+            const child = element.shadowRoot.querySelector('x-child');
             child.setFoo();
+
             expect(child.hasAttribute('foo')).toBe(true);
             expect(child.getAttribute('foo')).toBe('bar');
         });
@@ -131,8 +127,9 @@ describe('html-element', () => {
             }
             const element = createElement('remove-namespaced-attribute-on-host-element', { is: Parent });
             document.body.appendChild(element);
-            const child = querySelector.call(element, 'x-child');
+            const child = element.shadowRoot.querySelector('x-child');
             child.removeTitle();
+
             expect(child.hasAttributeNS('x', 'title')).toBe(false);
         });
 
@@ -172,8 +169,9 @@ describe('html-element', () => {
             }
             const element = createElement('element-is-nested-in-template', { is: Parent });
             document.body.appendChild(element);
-            const child = querySelector.call(element, 'x-child');
+            const child = element.shadowRoot.querySelector('x-child');
             child.removeTitle();
+
             expect(child.hasAttribute('title')).toBe(false);
         });
 
@@ -623,8 +621,9 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 childElm.setAttribute('title', "value from parent");
+
                 expect(assertLogger.logError).toBeCalled();
                 assertLogger.logError.mockRestore();
             });
@@ -647,8 +646,9 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 childElm.removeAttribute('title');
+
                 expect(assertLogger.logError).toBeCalled();
                 assertLogger.logError.mockRestore();
             });
@@ -703,7 +703,7 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 expect(childElm.getAttribute('title')).toBe('child title');
             });
         });
@@ -1434,7 +1434,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.id).toBe('en');
+                        expect(element.shadowRoot.querySelector('div').id).toBe('en');
                     });
             });
 
@@ -1558,7 +1558,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.id).toBe('true');
+                        expect(element.shadowRoot.querySelector('div').id).toBe('true');
                     });
             });
 
@@ -1682,7 +1682,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.id).toBe('ltr');
+                        expect(element.shadowRoot.querySelector('div').id).toBe('ltr');
                     });
             });
 
@@ -1806,7 +1806,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.title).toBe('id');
+                        expect(element.shadowRoot.querySelector('div').title).toBe('id');
                     });
             });
 
@@ -1930,7 +1930,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.title).toBe('accessKey');
+                        expect(element.shadowRoot.querySelector('div').title).toBe('accessKey');
                     });
             });
 
@@ -2054,7 +2054,7 @@ describe('html-element', () => {
                 return Promise.resolve()
                     .then(() => {
                         expect(renderCount).toBe(2);
-                        expect(querySelector.call(element, 'div')!.id).toBe('title');
+                        expect(element.shadowRoot.querySelector('div').id).toBe('title');
                     });
             });
 
@@ -2116,7 +2116,7 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 childElm.setAttribute('title', "value from parent");
                 expect(assertLogger.logError).toBeCalled();
                 assertLogger.logError.mockRestore();
@@ -2139,7 +2139,7 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 childElm.removeAttribute('title');
                 expect(assertLogger.logError).toBeCalled();
                 assertLogger.logError.mockRestore();
@@ -2195,7 +2195,7 @@ describe('html-element', () => {
             document.body.appendChild(parentElm);
 
             return Promise.resolve().then( () => {
-                const childElm = querySelector.call(parentElm, 'x-child');
+                const childElm = parentElm.shadowRoot.querySelector('x-child');
                 expect(childElm.getAttribute('title')).toBe('child title');
             })
         })

--- a/packages/lwc-engine/src/framework/__tests__/invoker.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/invoker.spec.ts
@@ -1,5 +1,4 @@
-import { createElement } from "../main";
-import { Element } from "../html-element";
+import { createElement, Element } from '../main';
 
 describe('invoker', () => {
 

--- a/packages/lwc-engine/src/framework/__tests__/patch.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/patch.spec.ts
@@ -1,11 +1,7 @@
-import { Element } from "../html-element";
-import { createElement } from "../main";
-import { querySelector } from "../dom/element";
+import { createElement, Element } from '../main';
 
 describe('patch', () => {
-
     describe('#patch()', () => {
-
         it('should call connectedCallback syncronously', () => {
             let flag = false;
             class MyComponent extends Element {
@@ -266,7 +262,7 @@ describe('patch', () => {
                 return Promise.resolve();
             })
             .then(() => {
-                expect(querySelector.call(element, 'span').textContent).toBe('second');
+                expect(element.shadowRoot.querySelector('span').textContent).toBe('second');
             });
         });
 

--- a/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
@@ -1,7 +1,5 @@
-import { unwrap } from '../main';
-import { Element } from "../html-element";
+import { unwrap, createElement, Element } from '../main';
 import { reactiveMembrane } from '../membrane';
-import { createElement } from "../upgrade";
 
 describe('unwrap', () => {
     it('should return value when not a proxy', () => {

--- a/packages/lwc-engine/src/framework/__tests__/services.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/services.spec.ts
@@ -1,6 +1,5 @@
 import * as target from '../services';
-import { Element } from "../html-element";
-import { createElement } from '../upgrade';
+import { createElement, Element } from '../main';
 
 function resetServices() {
     Object.keys(target.Services).forEach((name) => {
@@ -9,9 +8,7 @@ function resetServices() {
 }
 
 describe('services', () => {
-
     describe('register()', () => {
-
         beforeEach(function() {
             resetServices();
         });

--- a/packages/lwc-engine/src/framework/__tests__/template.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/template.spec.ts
@@ -1,10 +1,8 @@
 import * as target from '../template';
 import * as globalApi from '../api';
-import { Element } from "../html-element";
-import { createElement } from '../main';
+import { createElement, Element } from '../main';
 import { ViewModelReflection } from '../utils';
 import { Template } from '../template';
-import { querySelector } from '../dom/element';
 
 function createCustomComponent(html: Template, slotset?) {
     class MyComponent extends Element {
@@ -461,7 +459,7 @@ describe('template', () => {
             const element = createElement('x-attr-cmp', { is: MyComponent });
             document.body.appendChild(element);
 
-            expect(querySelector.call(element, 'div').getAttribute('title')).toBe('foo');
+            expect(element.shadowRoot.querySelector('div').getAttribute('title')).toBe('foo');
         });
 
         it('should remove attribute when value is null', () => {
@@ -493,10 +491,10 @@ describe('template', () => {
             const element = createElement('x-attr-cmp', { is: MyComponent });
             document.body.appendChild(element);
 
-            expect(querySelector.call(element, 'div').getAttribute('title')).toBe('initial');
+            expect(element.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial');
             element.setInner(null);
             return Promise.resolve().then(() => {
-                expect(querySelector.call(element, 'div').hasAttribute('title')).toBe(false);
+                expect(element.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
             });
         });
     });

--- a/packages/lwc-engine/src/framework/__tests__/upgrade.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/upgrade.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../html-element";
-import { createElement } from "../upgrade";
-import { ComponentConstructor } from "../component";
+import { createElement, Element } from '../main';
 
 describe('upgrade', () => {
     describe('#createElement()', () => {

--- a/packages/lwc-engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/vm.spec.ts
@@ -1,6 +1,4 @@
-// import * as target from '../watcher';
-import { Element } from "../html-element";
-import { createElement } from "../upgrade";
+import { createElement, Element } from "../main";
 import { ViewModelReflection } from "../utils";
 import { VM } from "../vm";
 

--- a/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
@@ -1,11 +1,7 @@
-import { Element } from "../html-element";
-import { createElement } from '../main';
-import { ViewModelReflection } from "../utils";
+import { createElement, Element } from '../main';
 
 describe('watcher', () => {
-
     describe('integration', () => {
-
         it('should not rerender the component if nothing changes', () => {
             let counter = 0;
             class MyComponent1 extends Element {
@@ -88,14 +84,19 @@ describe('watcher', () => {
                     super();
                     this.round = 0;
                 }
+                updateRound() {
+                    return this.round += 1;
+                }
                 render() {
                     return html2;
                 }
             }
             MyComponent4.track = { round: 1 };
+            MyComponent4.publicMethods = [ 'updateRound' ];
             const elm = createElement('x-foo', { is: MyComponent4 });
             document.body.appendChild(elm);
-            elm[ViewModelReflection].component.round += 1;
+
+            elm.updateRound();
             Promise.resolve().then(_ => {
                 expect(counter).toBe(2);
             });

--- a/packages/lwc-engine/src/framework/decorators/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/api.spec.ts
@@ -1,7 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import api from "../api";
-import { querySelector } from "../../dom/element";
+import { createElement, Element } from "../../main";
 
 describe('decorators/api.ts', () => {
     describe('@api x', () => {
@@ -40,7 +37,7 @@ describe('decorators/api.ts', () => {
             const elm = createElement('x-foo', { is: Parent });
             document.body.appendChild(elm);
             expect(elm.parentGetter).toBe('parentgetter');
-            expect(querySelector.call(elm, 'x-component').breakfast).toBe('pancakes');
+            expect(elm.shadowRoot.querySelector('x-component').breakfast).toBe('pancakes');
         });
 
         it('should not be consider properties reactive if not used in render', function() {
@@ -149,7 +146,7 @@ describe('decorators/api.ts', () => {
             const elm = createElement('x-foo', { is: Parent });
             document.body.appendChild(elm);
             expect(elm.parentGetter).toBe('parentgetter');
-            expect(querySelector.call(elm, 'x-component').breakfast).toBe('pancakes');
+            expect(elm.shadowRoot.querySelector('x-component').breakfast).toBe('pancakes');
         });
 
         it('should not be consider getter and setters reactive', function() {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/decorate.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/decorate.spec.ts
@@ -1,4 +1,4 @@
-import decorate from "../decorate";
+import { decorate } from "../../main";
 
 describe('decorate.ts', () => {
     describe('decorate() api', () => {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/readonly.spec.ts
@@ -1,5 +1,4 @@
-import { Membrane } from "../../membrane";
-import readonly from "../readonly";
+import { readonly } from "../../main";
 
 describe('readonly.ts', () => {
     describe('readonly()', () => {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
@@ -1,7 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import track from "../track";
-import readonly from "../readonly";
+import { createElement, Element, track, readonly } from "../../main";
 
 describe('track.ts', () => {
     describe('integration', () => {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import wire from "../wire";
+import { createElement, Element, wire } from "../../main";
 
 describe('wire.ts', () => {
     describe('integration', () => {

--- a/packages/lwc-engine/src/framework/dom/__tests__/dom.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/dom.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import { querySelector } from "../element";
+import { createElement, Element } from "../../main";
 import { getRootNode } from "../node";
 
 describe('dom', () => {
@@ -43,7 +41,7 @@ describe('dom', () => {
 
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
-            const child = querySelector.call(elm, 'x-child');
+            const child = elm.shadowRoot.querySelector('x-child');
             const match = getRootNode.call(child, { composed: true });
             // We can't assert against document directly, because
             // for some reasons, jest is locking up with document here
@@ -100,7 +98,7 @@ describe('dom', () => {
 
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
-            const child = querySelector.call(elm, 'x-child');
+            const child = elm.shadowRoot.querySelector('x-child');
             const match = getRootNode.call(child, { composed: false });
             // We can't assert against document directly, because
             // for some reasons, jest is locking up with document here
@@ -187,7 +185,7 @@ describe('dom', () => {
 
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
-            const child = querySelector.call(elm, 'x-foo');
+            const child = elm.shadowRoot.querySelector('x-foo');
             child.trigger();
         });
     });

--- a/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
@@ -1,6 +1,5 @@
 import { wrapIframeWindow } from "../iframe";
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
+import { createElement, Element } from "../../main";
 
 describe('wrapped iframe window', () => {
     describe('methods', function () {

--- a/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
@@ -1,9 +1,7 @@
-import { Element } from "../../html-element";
+import { createElement, Element } from "../../main";
 import { h } from "../../api";
-import { createElement } from "../../upgrade";
 import { ViewModelReflection } from "../../utils";
 import { VM } from "../../vm";
-import { Component } from "../../component";
 
 describe('root', () => {
     describe('integration', () => {

--- a/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
@@ -1,10 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import assertLogger from '../../assert';
-import { register } from "../../services";
-import { VNode } from "../../../3rdparty/snabbdom/types";
-import { Component } from "../../component";
-import { unwrap } from "../../main";
+import { createElement, Element } from "../../main";
 import { querySelector } from "../element";
 
 describe('#lightDomQuerySelectorAll()', () => {

--- a/packages/lwc-engine/src/framework/modules/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/events.spec.ts
@@ -1,17 +1,13 @@
-import { h, c, t, RenderAPI } from "../../api";
-import { Element } from "../../html-element";
-import { VNode } from "../../../3rdparty/snabbdom/types";
-import { createElement } from "../../upgrade";
-import { Component } from "../../component";
+import { createElement, Element } from "../../main";
 
 describe('module/events', () => {
 
     it('attaches click event handler to element', function() {
-        let result: Event[] = [], cmp: Component;
-        function html($api: RenderAPI) {
+        let result: Event[] = [], cmp;
+        function html($api) {
             return [
                 $api.h('div', {key: 1, on: {click(ev: Event) { result.push(ev); }}}, [
-                    $api.h('a', { key: 0 }, [t('Click my parent')]),
+                    $api.h('a', { key: 0 }, [$api.t('Click my parent')]),
                 ])
             ];
         }
@@ -31,21 +27,21 @@ describe('module/events', () => {
     });
 
     it('does not attach new listener', function() {
-        let result: Number[] = [], component: Component, second = false;
-        function html($api: RenderAPI, $cmp: Component) {
+        let result: Number[] = [], component, second = false;
+        function html($api, $cmp) {
             const c = $cmp.counter;
             // using the same key
             if (c === 0) {
                 return [
                     $api.h('div', {key: 1, on: {click: $api.b($cmp.clickOne)}}, [
-                        $api.h('a', {key: 0}, [t('Click my parent')]),
+                        $api.h('a', {key: 0}, [$api.t('Click my parent')]),
                     ])
                 ];
             } else if (c === 1) {
                 second = true;
                 return [
                     $api.h('div', {key: 1, on:  {click: $api.b($cmp.clickTwo)}}, [
-                        $api.h('a', {key: 0}, [t('Click my parent')]),
+                        $api.h('a', {key: 0}, [$api.t('Click my parent')]),
                     ])
                 ];
             }
@@ -75,21 +71,21 @@ describe('module/events', () => {
     });
 
     it('should reuse the listener', function() {
-        let result: Number[] = [], component: Component, second = false;
-        function html($api: RenderAPI, $cmp: Component) {
+        let result: Number[] = [], component, second = false;
+        function html($api, $cmp) {
             const c = $cmp.counter;
             // using different keys
             if (c === 0) {
                 return [
                     $api.h('p', { key: 1, on: {click: $api.b($cmp.clicked)}}, [
-                        $api.h('a', { key: 0 }, [t('Click my parent')]),
+                        $api.h('a', { key: 0 }, [$api.t('Click my parent')]),
                     ])
                 ];
             } else if (c === 1) {
                 second = true;
                 return [
                     $api.h('div', { key: 2, on:  {click: $api.b($cmp.clicked)}}, [
-                        $api.h('a', { key: 3 }, [t('Click my parent')]),
+                        $api.h('a', { key: 3 }, [$api.t('Click my parent')]),
                     ])
                 ];
             }
@@ -118,11 +114,11 @@ describe('module/events', () => {
     });
 
     it('must not expose the virtual node to the event handler', function() {
-        let result: any[] = [], cmp: Component;
-        function html($api: RenderAPI, $cmp: Component) {
+        let result: any[] = [], cmp;
+        function html($api, $cmp) {
             return [
                 $api.h('div', {key: 0, on: {click: $api.b($cmp.clicked)}}, [
-                    $api.h('a', {key: 1}, [t('Click my parent')]),
+                    $api.h('a', {key: 1}, [$api.t('Click my parent')]),
                 ])
             ];
         }
@@ -148,9 +144,9 @@ describe('module/events', () => {
     });
 
     it('attaches click event handler to custom element', function() {
-        let result: Event[] = [], cmp: Component;
+        let result: Event[] = [], cmp;
         class MyChild extends Element {}
-        function html($api: RenderAPI) {
+        function html($api) {
             return [
                 $api.c('x-child', MyChild, {on: {click(ev: Event) { result.push(ev); }}})
             ];
@@ -171,9 +167,9 @@ describe('module/events', () => {
     });
 
     it('attaches custom event handler to custom element', function() {
-        let result: Event[] = [], cmp: Component;
+        let result: Event[] = [], cmp;
         class MyChild extends Element {}
-        function html($api: RenderAPI) {
+        function html($api) {
             return [
                 $api.c('x-child', MyChild, {on: {test(ev: Event) { result.push(ev); }}})
             ];

--- a/packages/lwc-engine/src/framework/modules/__tests__/styles.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/styles.spec.ts
@@ -1,6 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import { Template } from "../../template";
+import { createElement, Element } from "../../main";
 
 describe('modules/styles', () => {
     it('should add style to the element', () => {

--- a/packages/lwc-engine/src/framework/modules/__tests__/token.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/token.spec.ts
@@ -1,7 +1,4 @@
-import { Element } from "../../html-element";
-import { createElement } from "../../upgrade";
-import { Template } from "../../template";
-import { querySelectorAll } from "../../dom/element";
+import { createElement, Element } from "../../main";
 
 describe('modules/token', () => {
     it('adds token to all the children elements', () => {
@@ -19,7 +16,7 @@ describe('modules/token', () => {
         const cmp = createElement('x-cmp', { is: Component });
         document.body.appendChild(cmp);
 
-        expect(querySelectorAll.call(cmp, '[test]')).toHaveLength(1);
+        expect(cmp.shadowRoot.querySelectorAll('[test]')).toHaveLength(1);
     });
 
     it('removes children element tokens if the template has no token', () => {
@@ -45,24 +42,24 @@ describe('modules/token', () => {
         const cmp = createElement('x-cmp', { is: Component });
         document.body.appendChild(cmp);
 
-        expect(querySelectorAll.call(cmp, 'section')).toHaveLength(1);
-        expect(querySelectorAll.call(cmp, '[test]')).toHaveLength(1);
+        expect(cmp.shadowRoot.querySelectorAll('section')).toHaveLength(1);
+        expect(cmp.shadowRoot.querySelectorAll('[test]')).toHaveLength(1);
 
         cmp.tmpl = unstyledTmpl;
 
         return Promise.resolve().then(() => {
-            expect(querySelectorAll.call(cmp, 'section')).toHaveLength(1);
-            expect(querySelectorAll.call(cmp, '[test]')).toHaveLength(0);
+            expect(cmp.shadowRoot.querySelectorAll('section')).toHaveLength(1);
+            expect(cmp.shadowRoot.querySelectorAll('[test]')).toHaveLength(0);
         });
     });
 
     it('replace children element tokens when swapping template', () => {
-        const styledTmplA: Template = $api => [
+        const styledTmplA = $api => [
             $api.h('section', { key: 0 }, [ $api.t('test') ]),
         ];
         styledTmplA.token = 'testA';
 
-        const styledTmplB: Template = $api => [
+        const styledTmplB = $api => [
             $api.h('section', { key: 0 }, [ $api.t('test') ]),
         ];
         styledTmplB.token = 'testB';
@@ -80,14 +77,14 @@ describe('modules/token', () => {
         const cmp = createElement('x-cmp', { is: Component });
         document.body.appendChild(cmp);
 
-        expect(querySelectorAll.call(cmp, '[testA]')).toHaveLength(1);
-        expect(querySelectorAll.call(cmp, '[testB]')).toHaveLength(0);
+        expect(cmp.shadowRoot.querySelectorAll('[testA]')).toHaveLength(1);
+        expect(cmp.shadowRoot.querySelectorAll('[testB]')).toHaveLength(0);
 
         cmp.tmpl = styledTmplB;
 
         return Promise.resolve().then(() => {
-            expect(querySelectorAll.call(cmp, '[testA]')).toHaveLength(0);
-            expect(querySelectorAll.call(cmp, '[testB]')).toHaveLength(1);
+            expect(cmp.shadowRoot.querySelectorAll('[testA]')).toHaveLength(0);
+            expect(cmp.shadowRoot.querySelectorAll('[testB]')).toHaveLength(1);
         });
     });
 });


### PR DESCRIPTION
## Details

Reduce coupling between engine internals and unit tests:
* Use `shadowRoot.querySelector` instead of the native `querySelector` retrieved from `src/framework/dom/element.ts` in all the relevant tests.
* Instead of importing the engine public APIs from the files they get defined (`html-element.ts`, `upgrade.ts`, ...), all the public APIs are now imported from `main.ts`.

This would ease the refactorability of the engine in the long run.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
