### PR TITLE
fix(jest-preset): remove trailing comma from json

### DIFF
--- a/packages/lwc-jest-preset/jest-preset.json
+++ b/packages/lwc-jest-preset/jest-preset.json
@@ -6,5 +6,5 @@
   "resolver": "lwc-jest-resolver",
   "verbose": true,
   "testMatch": [ "**/__tests__/**/?(*.)(spec|test).js" ],
-  "snapshotSerializers": ["lwc-jest-serializer"],
+  "snapshotSerializers": ["lwc-jest-serializer"]
 }


### PR DESCRIPTION
## Details

Remove trailing comma in JSON to unbreak lwc-jest-preset.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
