### PR TITLE
refactor(engine): exposing `$$ShadowRoot$$` in elements when in test

### DIFF
--- a/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
@@ -85,6 +85,13 @@ describe('root', () => {
             });
         });
 
+        it('should expose the shadow root via $$ShadowRoot$$ when in test mode', () => {
+            class MyComponent extends Element {}
+            const elm = createElement('x-foo', { is: MyComponent });
+            document.body.appendChild(elm);
+            expect(elm.$$ShadowRoot$$).toBeDefined();
+        });
+
     });
 
     describe('childNodes', () => {

--- a/packages/lwc-engine/src/framework/dom/shadow-root.ts
+++ b/packages/lwc-engine/src/framework/dom/shadow-root.ts
@@ -10,8 +10,10 @@ import {
     setAttribute,
     removeAttribute,
 } from './element';
-import { ViewModelReflection, getAttrNameFromPropName } from "../utils";
+import { ViewModelReflection, getAttrNameFromPropName, usesNativeSymbols } from "../utils";
 import { childNodesGetter } from "./node";
+
+export const ShadowRootKey = usesNativeSymbols && process.env.NODE_ENV !== 'test' ? Symbol('ShadowRoot') : '$$ShadowRoot$$';
 
 export const usesNativeShadowRoot = typeof (window as any).ShadowRoot !== "undefined";
 const ShadowRootPrototype = usesNativeShadowRoot ? (window as any).ShadowRoot.prototype : undefined;
@@ -35,6 +37,7 @@ export function attachShadow(elm, options, fallback): ShadowRoot {
         // the component will not work when running in fallback mode.
         defineProperties(sr, DevModeBlackListDescriptorMap);
     }
+    elm[ShadowRootKey] = sr;
     return sr as ShadowRoot;
 }
 


### PR DESCRIPTION
## Details

* we need to expose `$$ShadowRoot$$` property to access the shadowRoot instance so the jest package can use that reliable.
* we cannot expose `shadowRoot` just yet because selenium and others will fail. 

## Does this PR introduce a breaking change?

* No
