### PR TITLE
fix(test-utils): convert to cjs module

### DIFF
--- a/packages/lwc-test-utils/index.js
+++ b/packages/lwc-test-utils/index.js
@@ -9,7 +9,7 @@
  * the shadowRoot property off of
  * @returns {ShadowRoot} The shadow root of the given element
  */
-export function getShadowRoot(element) {
+module.exports.getShadowRoot = function(element) {
     if (!element || !element.$$ShadowRoot$$) {
         const tagName = element && element.tagName && element.tagName.toLowerCase();
         throw new Error(`Attempting to retrieve the shadow root of '${tagName || element}' but no shadowRoot property found`);


### PR DESCRIPTION
## Details

Test util should be a CJS module so it can be directly imported in Jest unit tests.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:
