### PR TITLE
test(engine): add basic querySelector tests

### DIFF
--- a/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.html
+++ b/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.html
@@ -1,0 +1,8 @@
+<template>
+    <x-child>
+        <p>first slotted content</p>
+        <p>second slotted content</p>
+    </x-child>
+    <div id="query-selector">querySelector: {querySelectorMessage}</div>
+    <div id="query-selector-all">querySelectorAll: {querySelectorAllMessage}</div>
+</template>

--- a/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.js
+++ b/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.js
@@ -1,0 +1,14 @@
+import { Element, api, track } from 'engine';
+
+export default class QuerySelector extends Element {
+    @track querySelectorMessage;
+    @track querySelectorAllMessage;
+
+    renderedCallback() {
+        const child = this.template.querySelector('x-child');
+        this.querySelectorMessage = child.querySelector('p').textContent;
+        this.querySelectorAllMessage = child.querySelectorAll('p').reduce((str, el) => {
+            return `${str} ${el.textContent}`;
+        }, '');
+    }
+}

--- a/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.spec.js
+++ b/packages/lwc-integration/src/components/dom/test-basic-queryselector/basic-queryselector/basic-queryselector.spec.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const URL = 'http://localhost:4567/basic-queryselector';
+browser.url(URL);
+
+describe('querySelector', () => {
+    it.skip('should return an element from the light dom', () => {
+        assert.deepEqual(
+            browser.element('#query-selector').getText(),
+            'querySelector: first slotted content'
+        );
+    });
+});
+
+describe('querySelectorAll', () => {
+    it.skip('should return elements from the light dom', () => {
+        assert.deepEqual(
+            browser.element('#query-selector-all').getText(),
+            'querySelectorAll: first slotted content second slotted content'
+        );
+    });
+});

--- a/packages/lwc-integration/src/components/dom/test-basic-queryselector/child/child.html
+++ b/packages/lwc-integration/src/components/dom/test-basic-queryselector/child/child.html
@@ -1,0 +1,4 @@
+<template>
+    <p>child shadow dom content</p>
+    <slot></slot>
+</template>

--- a/packages/lwc-integration/src/components/dom/test-basic-queryselector/child/child.js
+++ b/packages/lwc-integration/src/components/dom/test-basic-queryselector/child/child.js
@@ -1,0 +1,4 @@
+import { Element } from 'engine';
+
+export default class Child extends Element {
+}


### PR DESCRIPTION
## Details

Just adding some coverage. Tests currently fail in compat mode.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
