### PR TITLE
fix(engine): [Backport] add existence check in removeChild

### DIFF
--- a/packages/lwc-engine/src/framework/patch.ts
+++ b/packages/lwc-engine/src/framework/patch.ts
@@ -7,6 +7,7 @@ import classes from "./modules/classes";
 import events from "./modules/events";
 import token from "./modules/token";
 import uid from "./modules/uid";
+import { isNull } from './language';
 
 const {
     createElement,
@@ -49,7 +50,9 @@ export const htmlDomApi: DOMAPI = {
         insertBefore.call(parent, newNode, referenceNode);
     },
     removeChild(node: Node, child: Node) {
-        removeChild.call(node, child);
+        if (!isNull(node)) {
+            removeChild.call(node, child);
+        }
     },
     appendChild(node: Node, child: Node) {
         appendChild.call(node, child);

--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -357,9 +357,6 @@ export function resetShadowRoot(vm: VM) {
         // however, if patching fails it contains partial changes.
         patchChildren(elm, oldCh, EmptyArray);
     } catch (e) {
-        if (process.env.NODE_ENV !== 'production') {
-            assert.logError("Swallow Error: Failed to reset component's shadow with an empty list of children: " + e);
-        }
         // in the event of patch failure force offender removal
         vm.elm.innerHTML = "";
     }


### PR DESCRIPTION
## Details

> Note: This PR is a backport of #285 in `214/patch`.

This PR makes sure guard `removeChild` against `parentNode` to be `null`. We run into this issue when removing from the DOM a component that has thrown during its creation.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No