### PR TITLE
chore(lwc-compiler): add missing filename to transformers

### DIFF
--- a/packages/lwc-compiler/src/bundler/__tests__/bundler.spec.ts
+++ b/packages/lwc-compiler/src/bundler/__tests__/bundler.spec.ts
@@ -1,12 +1,11 @@
-import { bundle } from "../bundler";
-import { pretify } from "../../__tests__/utils";
+import { bundle } from '../bundler';
 
 describe('bundler', () => {
     test('throws when invoked without configurations', async () => {
-        try {
-            const { diagnostics, code, metadata } = await bundle();
-        } catch (error) {
-            expect(error.message).toBe("Expected options object, received \"undefined\".");
-        }
+        await expect(bundle()).rejects.toMatchObject({
+            message: expect.stringContaining(
+                'Expected options object, received "undefined".',
+            ),
+        });
     });
 });

--- a/packages/lwc-compiler/src/transformers/__tests__/transform.spec.ts
+++ b/packages/lwc-compiler/src/transformers/__tests__/transform.spec.ts
@@ -80,24 +80,19 @@ describe('Javascript transform', () => {
     });
 
     it('should throw when processing an invalid javascript file', async () => {
-        expect.assertions(1);
-        try {
-            await transform(`const`, 'foo.js', {
+        await expect(
+            transform(`const`, 'foo.js', {
                 namespace: 'x',
                 name: 'foo',
-            });
-        } catch (error) {
-            // TODO: Figure out how to disable error message code snippet for failing token.
-            expect(
-                error.message.indexOf('foo.js: Unexpected token (1:5)'),
-            ).toBeGreaterThanOrEqual(0);
-        }
+            })
+        ).rejects.toMatchObject({
+            message: expect.stringContaining('foo.js: Unexpected token (1:5)')
+        });
     });
 
     it('should throw if invalid resolveProxyCompat value is specified in compat mode', async () => {
-        expect.assertions(1);
-        try {
-            const result = await transform(`debugger`, 'foo.js', {
+        await expect(
+            transform(`debugger`, 'foo.js', {
                 namespace: 'x',
                 name: 'foo',
                 outputConfig: {
@@ -106,12 +101,12 @@ describe('Javascript transform', () => {
                         badkey: 'hello',
                     },
                 },
-            });
-        } catch (error) {
-            expect(error.message).toBe(
-                'Unexpected resolveProxyCompat option, expected property "module", "global" or "independent"',
-            );
-        }
+            })
+        ).rejects.toMatchObject({
+            message: expect.stringContaining(
+                'Unexpected resolveProxyCompat option, expected property "module", "global" or "independent"'
+            )
+        });
     });
 
     it('allows dynamic imports', async () => {
@@ -172,32 +167,27 @@ describe('HTML transform', () => {
     });
 
     it('should throw when processing an invalid HTML file', async () => {
-        expect.assertions(1);
-        try {
-            await transform(`<html`, 'foo.html', {
+        await expect(
+            transform(`<html`, 'foo.html', {
                 namespace: 'x',
                 name: 'foo',
-            });
-        } catch (error) {
-            // TODO: Figure out how to disable error message code snippet for failing token.
-            expect(
-                error.message.indexOf('Invalid HTML syntax: eof-in-tag.'),
-            ).toBe(0);
-        }
+            })
+        ).rejects.toMatchObject({
+            message: expect.stringContaining('foo.html: Invalid HTML syntax: eof-in-tag.')
+        });
     });
 });
 
 describe('CSS transform', () => {
     it('should throw when processing an invalid CSS file', async () => {
-        expect.assertions(1);
-        try {
-            await transform(`<`, 'foo.css', {
+        await expect(
+            transform(`<`, 'foo.css', {
                 namespace: 'x',
                 name: 'foo',
-            });
-        } catch (error) {
-            expect(error.message).toBe('<css input>:1:1: Unknown word');
-        }
+            })
+        ).rejects.toMatchObject({
+            message: expect.stringContaining('foo.css:1:1: Unknown word')
+        });
     });
 
     it('should apply transformation for stylesheet file', async () => {

--- a/packages/lwc-compiler/src/transformers/style.ts
+++ b/packages/lwc-compiler/src/transformers/style.ts
@@ -49,7 +49,7 @@ function replaceToken(src: string): string {
 
 export default async function transformStyle(
     src: string,
-    _filename: string,
+    filename: string,
     { stylesheetConfig, outputConfig }: NormalizedCompilerOptions
 ): Promise<FileTransformerResult> {
     const { minify } = outputConfig;
@@ -75,7 +75,7 @@ export default async function transformStyle(
     }
 
     const res = await postcss(plugins).process(src, {
-        from: undefined,
+        from: filename,
     });
 
     let code: string = '';

--- a/packages/lwc-compiler/src/transformers/template.ts
+++ b/packages/lwc-compiler/src/transformers/template.ts
@@ -67,7 +67,7 @@ const transform: FileTransformer = function(
 
     const fatalError = warnings.find(warning => warning.level === "error");
     if (fatalError) {
-        throw new Error(fatalError.message);
+        throw new Error(`${filename}: ${fatalError.message}`);
     }
 
     return {


### PR DESCRIPTION
## Details

This PR adds the filename to errors thrown by the HTML and CSS transform. This would make the debugging of jest transform easier.

<img width="828" alt="screen shot 2018-07-03 at 7 42 37 am" src="https://user-images.githubusercontent.com/2567083/42226839-d27a8706-7e94-11e8-8483-2244a3b954ae.png">

Fix #459

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No