### PR TITLE
fix(wire-service): support optional config object on @wire

### DIFF
--- a/packages/lwc-engine/types/engine.d.ts
+++ b/packages/lwc-engine/types/engine.d.ts
@@ -9,7 +9,7 @@ declare module 'engine' {
 
     class HTMLElementTheGoodPart {
         dispatchEvent(evt: ComposableEvent): boolean;
-        addEventListener(type: string, listener?: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;    
+        addEventListener(type: string, listener?: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
         removeEventListener(type: string, listener?: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
         getAttribute(name: string): string | null;
         getBoundingClientRect(): ClientRect;
@@ -19,11 +19,11 @@ declare module 'engine' {
         tabIndex: number
         readonly classList: DOMTokenList;
     }
-    
+
     interface ShadowRootTheGoodPart extends NodeSelector {
         mode: string;
         readonly host: Element;
-    } 
+    }
 
     /**
      * Base class for the Lightning Web Component JavaScript class
@@ -49,7 +49,7 @@ declare module 'engine' {
          * Called when a descendant component throws an error in one of its lifecycle hooks
          */
         errorCallback(error: any, stack: string): void;
-        
+
         readonly root: ShadowRootTheGoodPart;
     }
 
@@ -68,5 +68,5 @@ declare module 'engine' {
      * @param getType imperative accessor for the data source
      * @param config configuration object for the accessor
      */
-    export function wire(getType: (config: any) => any, config: any): PropertyDecorator;
+    export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
 }

--- a/packages/lwc-wire-service/src/__tests__/wiring.spec.ts
+++ b/packages/lwc-wire-service/src/__tests__/wiring.spec.ts
@@ -66,15 +66,25 @@ describe('WireEventTarget', () => {
         });
 
         describe('config event', () => {
+            it('immediately fires when no static or dynamic config', () => {
+                const listener = jest.fn();
+                const mockWireDef: WireDef = {
+                    adapter: {}
+                };
+                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, {} as target.Context, mockWireDef, "test");
+                wireEventTarget.addEventListener(CONFIG, listener);
+                expect(listener).toHaveBeenCalledTimes(1);
+            });
             it('immediately fires when config is statics only', () => {
                 const listener = jest.fn();
-                const mockWireDef = {
+                const mockWireDef: WireDef = {
+                    adapter: {},
                     params: {},
                     static: {
                         test: ["fixed", 'array']
                     }
                 };
-                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, {} as target.Context, mockWireDef as any, "test");
+                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, {} as target.Context, mockWireDef, "test");
                 wireEventTarget.addEventListener(CONFIG, listener);
                 expect(listener).toHaveBeenCalledTimes(1);
             });
@@ -83,7 +93,8 @@ describe('WireEventTarget', () => {
                 wireContext[CONTEXT_UPDATED] = { listeners: {}, values: {} };
                 const mockContext = Object.create(null);
                 mockContext[CONTEXT_ID] = wireContext;
-                const mockWireDef = {
+                const mockWireDef: WireDef = {
+                    adapter: {},
                     params: {
                         key: "prop"
                     }
@@ -91,10 +102,10 @@ describe('WireEventTarget', () => {
                 const mockInstallTrap = jest.fn();
                 const originalInstallTrap = dependency.installTrap;
                 (dependency as any).installTrap = mockInstallTrap;
-                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext, mockWireDef as any, "test");
+                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext, mockWireDef, "test");
                 wireEventTarget.addEventListener(CONFIG, () => { /**/ });
                 expect(mockInstallTrap).toHaveBeenCalled();
-                const wireEventTarget1 = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext, mockWireDef as any, "test1");
+                const wireEventTarget1 = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext, mockWireDef, "test1");
                 wireEventTarget1.addEventListener(CONFIG, () => { /**/ });
                 expect(mockInstallTrap).toHaveBeenCalledTimes(1);
                 (dependency as any).installTrap = originalInstallTrap;
@@ -110,7 +121,8 @@ describe('WireEventTarget', () => {
                 const mockContext2 = Object.create(null);
                 mockContext2[CONTEXT_ID] = wireContext2;
 
-                const mockWireDef = {
+                const mockWireDef: WireDef = {
+                    adapter: {},
                     params: {
                         key: "prop"
                     }
@@ -119,10 +131,10 @@ describe('WireEventTarget', () => {
                 const mockInstallTrap = jest.fn();
                 const originalInstallTrap = dependency.installTrap;
                 (dependency as any).installTrap = mockInstallTrap;
-                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext1, mockWireDef as any, "test");
+                const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext1, mockWireDef, "test");
                 wireEventTarget.addEventListener(CONFIG, () => { /**/ });
                 expect(mockInstallTrap).toHaveBeenCalled();
-                const wireEventTarget1 = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext2, mockWireDef as any, "test");
+                const wireEventTarget1 = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext2, mockWireDef, "test");
                 wireEventTarget1.addEventListener(CONFIG, () => { /**/ });
                 expect(mockInstallTrap).toHaveBeenCalledTimes(2);
                 (dependency as any).installTrap = originalInstallTrap;
@@ -161,8 +173,12 @@ describe('WireEventTarget', () => {
             const mockContext = Object.create(null);
             mockContext[CONTEXT_ID] = Object.create(null);
             mockContext[CONTEXT_ID][CONTEXT_UPDATED] = { listeners: { test: [mockConfigListenerMetadata] } };
-            const mockWireDef = Object.create(null);
-            mockWireDef.params = {test: 'test'};
+            const mockWireDef: WireDef = {
+                adapter: {},
+                params: {
+                    test: 'test'
+                }
+            };
             const wireEventTarget = new target.WireEventTarget({} as Element, {} as ElementDef, mockContext, mockWireDef, "test");
             wireEventTarget.removeEventListener(CONFIG, listener);
             expect(mockContext[CONTEXT_ID][CONTEXT_UPDATED].listeners.test).toHaveLength(0);
@@ -188,7 +204,7 @@ describe('WireEventTarget', () => {
             const mockCmp = {
                 test: (value) => { actual = value; }
             };
-            const wireEventTarget = new target.WireEventTarget(mockCmp as any, {} as ElementDef, {} as target.Context, { method: true } as any, "test");
+            const wireEventTarget = new target.WireEventTarget(mockCmp as any, {} as ElementDef, {} as target.Context, { method: 1 } as WireDef, "test");
             wireEventTarget.dispatchEvent(new target.ValueChangedEvent('value'));
             expect(actual).toBe('value');
         });

--- a/packages/lwc-wire-service/src/engine.ts
+++ b/packages/lwc-wire-service/src/engine.ts
@@ -1,7 +1,7 @@
 // subtypes from the engine
 export { Element, ComposableEvent } from 'engine';
 export interface WireDef {
-    params: {
+    params?: {
         [key: string]: string;
     };
     static?: {

--- a/packages/lwc-wire-service/src/wiring.ts
+++ b/packages/lwc-wire-service/src/wiring.ts
@@ -111,10 +111,10 @@ export class WireEventTarget {
             case CONFIG:
                 const params = this._wireDef.params;
                 const statics = this._wireDef.static;
-                const paramsKeys = Object.keys(params);
+                let paramsKeys: string[];
 
-                // no dynamic params, only static, so fire config once
-                if (paramsKeys.length === 0) {
+                // no dynamic params. fire config once with static params (if present).
+                if (!params || (paramsKeys = Object.keys(params)).length === 0) {
                     const config = statics || {};
                     listener.call(undefined, config);
                     return;


### PR DESCRIPTION
Fixes #181 and #149 

## Details

Config bag is optional resulting in no `static` or `params` fields on the compiled wire definition.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
