### PR TITLE
fix(wire-service): error with invalid adapter id

### DIFF
--- a/packages/lwc-wire-service/src/index.ts
+++ b/packages/lwc-wire-service/src/index.ts
@@ -66,6 +66,12 @@ const wireService = {
             const wireTarget = wireTargets[i];
             const wireDef = wireStaticDef[wireTarget];
             const adapterFactory = adapterFactories.get(wireDef.adapter);
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(wireDef.adapter, `@wire on "${wireTarget}": adapter id must be truthy`);
+                assert.isTrue(adapterFactory, `@wire on "${wireTarget}": unknown adapter id: ${String(wireDef.adapter)}`);
+            }
+
             if (adapterFactory) {
                 const wireEventTarget = new WireEventTarget(cmp, def, context, wireDef, wireTarget);
                 adapterFactory({
@@ -105,8 +111,10 @@ export function registerWireService(registerService: (object) => void) {
  * Registers a wire adapter.
  */
 export function register(adapterId: any, adapterFactory: WireAdapterFactory) {
-    assert.isTrue(adapterId, 'adapter id must be truthy');
-    assert.isTrue(typeof adapterFactory === 'function', 'adapter factory must be a callable');
+    if (process.env.NODE_ENV !== 'production') {
+        assert.isTrue(adapterId, 'adapter id must be truthy');
+        assert.isTrue(typeof adapterFactory === 'function', 'adapter factory must be a callable');
+    }
     adapterFactories.set(adapterId, adapterFactory);
 }
 

--- a/packages/lwc-wire-service/src/property-trap.ts
+++ b/packages/lwc-wire-service/src/property-trap.ts
@@ -16,8 +16,8 @@ import {
 
 /**
  * Invokes the provided change listeners with the resolved component properties.
- * @param configListenerMetadatas list of config listener metadata (config listeners and their context)
- * @param paramValues values for all wire adapter config params
+ * @param configListenerMetadatas List of config listener metadata (config listeners and their context)
+ * @param paramValues Values for all wire adapter config params
  */
 function invokeConfigListeners(configListenerMetadatas: Set<ConfigListenerMetadata>, paramValues: any) {
     configListenerMetadatas.forEach((metadata) => {
@@ -107,7 +107,7 @@ export function findDescriptor(target: any, propName: PropertyKey, protoSet?: an
  * Gets a property descriptor that monitors the provided property for changes
  * @param cmp The component
  * @param prop The name of the property to be monitored
- * @param callback a function to invoke when the prop's value changes
+ * @param callback A function to invoke when the prop's value changes
  * @return A property descriptor
  */
 function getOverrideDescriptor(cmp: Object, prop: string, callback: () => void) {

--- a/packages/lwc-wire-service/src/wiring.ts
+++ b/packages/lwc-wire-service/src/wiring.ts
@@ -98,13 +98,17 @@ export class WireEventTarget {
         switch (type) {
             case CONNECT:
                 const connectedListeners = this._context[CONTEXT_ID][CONTEXT_CONNECTED];
-                assert.isFalse(connectedListeners.includes(listener as NoArgumentListener), 'must not call addEventListener("connect") with the same listener');
+                if (process.env.NODE_ENV !== 'production') {
+                    assert.isFalse(connectedListeners.includes(listener as NoArgumentListener), 'must not call addEventListener("connect") with the same listener');
+                }
                 connectedListeners.push(listener as NoArgumentListener);
                 break;
 
             case DISCONNECT:
                 const disconnectedListeners = this._context[CONTEXT_ID][CONTEXT_DISCONNECTED];
-                assert.isFalse(disconnectedListeners.includes(listener as NoArgumentListener), 'must not call addEventListener("disconnect") with the same listener');
+                if (process.env.NODE_ENV !== 'production') {
+                    assert.isFalse(disconnectedListeners.includes(listener as NoArgumentListener), 'must not call addEventListener("disconnect") with the same listener');
+                }
                 disconnectedListeners.push(listener as NoArgumentListener);
                 break;
 


### PR DESCRIPTION
- In non-prod mode, throw an error when the adapter is invalid: non-truthy or unregistered
- Move existing asserts to be non-prod mode only

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No
