### PR TITLE
refactor(engine): renaming element to lightning element

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/api.spec.ts
@@ -1,13 +1,13 @@
 import * as api from '../api';
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { getHostShadowRoot } from '../html-element';
 
 describe('api', () => {
     describe('#c()', () => {
-        class Foo extends Element {}
+        class Foo extends LightningElement {}
 
         it('should call the Ctor factory for circular dependencies', () => {
-            const factory = function() { return class extends Element {
+            const factory = function() { return class extends LightningElement {
                 static forceTagName = 'input';
             }; };
             factory.__circular__ = true;
@@ -69,7 +69,7 @@ describe('api', () => {
         });
 
         it('should support forceTagName static definition to force tagname on root node', () => {
-            class Bar extends Element {
+            class Bar extends LightningElement {
                 static forceTagName = 'input';
             }
             const element = createElement('x-foo', { is: Bar });
@@ -80,7 +80,7 @@ describe('api', () => {
         });
 
         it('should not include is attribute when forceTagName is not present on root', () => {
-            class Bar extends Element {}
+            class Bar extends LightningElement {}
             const element = createElement('x-foo', { is: Bar });
             expect(element.hasAttribute('is')).toBe(false);
         });
@@ -89,12 +89,12 @@ describe('api', () => {
             function html($api) {
                 return [$api.c('button', Bar, { attrs: { is: "x-bar" } })];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 render() {
                     return html;
                 }
             }
-            class Bar extends Element {
+            class Bar extends LightningElement {
                 static forceTagName = 'input';
             }
             const elm = createElement('x-foo', { is: Foo });
@@ -106,7 +106,7 @@ describe('api', () => {
         });
 
         it('should throw if the forceTagName value is a reserved standard element name', () => {
-            class Bar extends Element {
+            class Bar extends LightningElement {
                 static forceTagName = 'div';
             }
 
@@ -118,7 +118,7 @@ describe('api', () => {
         });
 
         it('should throw if the forceTagName is a custom element name', () => {
-            class Bar extends Element {
+            class Bar extends LightningElement {
                 static forceTagName = 'x-bar';
             }
 
@@ -262,7 +262,7 @@ describe('api', () => {
             function html($api) {
                 return [$api.t('miami')];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 render() {
                     return html;
                 }
@@ -279,7 +279,7 @@ describe('api', () => {
             function html($api) {
                 return [$api.p('miami')];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 render() {
                     return html;
                 }
@@ -307,7 +307,7 @@ describe('api', () => {
                 k2 = $api.k(345, "678");
                 return [];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 render() {
                     return html;
                 }
@@ -322,7 +322,7 @@ describe('api', () => {
                 const k1 = $api.k(678, {});
                 return [];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 render() {
                     return html;
                 }

--- a/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/class-list.spec.ts
@@ -1,14 +1,14 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { getHostShadowRoot } from '../html-element';
 
 describe('class-list', () => {
     describe('integration', () => {
         it('should support outer className', () => {
-            class ChildComponent extends Element {}
+            class ChildComponent extends LightningElement {}
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { className: 'foo' })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -20,11 +20,11 @@ describe('class-list', () => {
         });
 
         it('should support outer classMap', () => {
-            class ChildComponent extends Element {}
+            class ChildComponent extends LightningElement {}
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { classMap: { foo: 1 } })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -36,7 +36,7 @@ describe('class-list', () => {
         });
 
         it('should combine data.className first and then inner classes', () => {
-            class ChildComponent extends Element {
+            class ChildComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
                 }
@@ -44,7 +44,7 @@ describe('class-list', () => {
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { className: 'bar  baz' })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -56,7 +56,7 @@ describe('class-list', () => {
         });
 
         it('should allow deleting outer classes from within', () => {
-            class ChildComponent extends Element {
+            class ChildComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.remove('foo');
                 }
@@ -64,7 +64,7 @@ describe('class-list', () => {
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { className: 'foo' })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -76,7 +76,7 @@ describe('class-list', () => {
         });
 
         it('should dedupe all classes', () => {
-            class ChildComponent extends Element {
+            class ChildComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
                 }
@@ -84,7 +84,7 @@ describe('class-list', () => {
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { className: 'foo   foo' })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -96,7 +96,7 @@ describe('class-list', () => {
         });
 
         it('should combine outer classMap and inner classes', () => {
-            class ChildComponent extends Element {
+            class ChildComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
                 }
@@ -104,7 +104,7 @@ describe('class-list', () => {
             function html($api) {
                 return [$api.c('x-child', ChildComponent, { classMap: { bar: 1 } })];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -116,7 +116,7 @@ describe('class-list', () => {
         });
 
         it('should support toggle', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
                     this.classList.toggle('foo');
@@ -129,7 +129,7 @@ describe('class-list', () => {
         });
 
         it('should support toggle with force', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.toggle('foo', true);
                     this.classList.toggle('bar', false);
@@ -142,7 +142,7 @@ describe('class-list', () => {
 
         it('should support contains', () => {
             expect.assertions(2);
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
 
@@ -157,7 +157,7 @@ describe('class-list', () => {
         it('should support item', () => {
             expect.assertions(2);
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
 
@@ -170,7 +170,7 @@ describe('class-list', () => {
         });
 
         it('should update on the next tick when dirty', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = { x: 1 };
                 initClassNames() {
                     this.classList.add('foo');
@@ -206,7 +206,7 @@ describe('class-list', () => {
         });
 
         it('should support adding new values to classList via connectedCallback', () => {
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 initClassNames() {
                     this.classList.add('classFromInit');
                 }
@@ -225,7 +225,7 @@ describe('class-list', () => {
         });
 
         it('should support removing values from classList via connectedCallback', () => {
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 initClassNames() {
                     this.classList.add('theOnlyClassThatShouldRemain');
                     this.classList.add('classToRemoveDuringConnectedCb');

--- a/packages/lwc-engine/src/framework/__tests__/component.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/component.spec.ts
@@ -1,10 +1,10 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { getHostShadowRoot } from '../html-element';
 
 describe('component', function() {
     describe('public computed props', () => {
         it('should allow public getters', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 value = 'pancakes';
                 get breakfast() {
                     return this.value;
@@ -19,7 +19,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-component', MyComponent, {})];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 value = 'salad';
                 get lunch() {
                     return this.value;
@@ -46,7 +46,7 @@ describe('component', function() {
             const count = 0;
             let value;
             const propVal = { foo: 'bar' };
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 m = propVal;
             }
             MyChild.publicProps = {
@@ -57,7 +57,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 callChildM() {
                     value = this.template.querySelector('x-child').m;
                 }
@@ -75,7 +75,7 @@ describe('component', function() {
         });
 
         it('should not allow public getters to be set by owner', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get x() {
                     return 1;
                 }
@@ -96,7 +96,7 @@ describe('component', function() {
             function html($api, $cmp, $slotset, $ctx) {
                 return [$api.h('div', { key: 0 }, [$api.d($cmp.validity)])];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 state = { value: 0 };
 
                 get validity() {
@@ -132,7 +132,7 @@ describe('component', function() {
             let component;
             let context;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     component = this;
@@ -157,7 +157,7 @@ describe('component', function() {
         });
 
         it('should call setter function when used directly from DOM', function() {
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 value = 'pancakes';
                 get breakfast() {
                     return this.value;
@@ -175,7 +175,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 render() {
                     return html;
                 }
@@ -195,7 +195,7 @@ describe('component', function() {
             let context;
             let component;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     component = this;
@@ -231,7 +231,7 @@ describe('component', function() {
             let component;
             let context;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 value = 'pancakes';
 
                 constructor() {
@@ -268,7 +268,7 @@ describe('component', function() {
             let component;
             let context;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 value;
                 breakfast = 'pancakes';
 
@@ -301,7 +301,7 @@ describe('component', function() {
         });
 
         it('should throw when configured prop is missing getter', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 set breakfast(value) {}
             }
 
@@ -317,7 +317,7 @@ describe('component', function() {
         });
 
         it('should throw when configured prop is missing setter', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
             }
 
             MyComponent.publicProps = {
@@ -345,7 +345,7 @@ describe('component', function() {
                     []
                 )];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 state = {
                     customStyle: 'color: red'
                 };
@@ -383,7 +383,7 @@ describe('component', function() {
                     []
                 )];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 state = {
                     customStyle: undefined
                 };
@@ -422,7 +422,7 @@ describe('component', function() {
                     []
                 )];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 state = {
                     customStyle: null
                 };
@@ -448,7 +448,7 @@ describe('component', function() {
                     []
                 )];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 customStyle: {
                     color: 'red'
                 };
@@ -488,7 +488,7 @@ describe('component', function() {
         it('should not invoke function when accessing public method', function() {
             let callCount = 0;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 m() {
                     callCount += 1;
                 }
@@ -503,7 +503,7 @@ describe('component', function() {
         it('should invoke function only once', function() {
             let callCount = 0;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 m() {
                     callCount += 1;
                 }
@@ -520,7 +520,7 @@ describe('component', function() {
             let context;
             let args;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     component = this;
@@ -541,7 +541,7 @@ describe('component', function() {
         });
 
         it('should express function identity with strict equality', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 m() {
                 }
             }
@@ -553,7 +553,7 @@ describe('component', function() {
 
         it('should allow calling methods when element is referenced with querySelector', function() {
             let count = 0;
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 m() {
                     count += 1;
                 }
@@ -562,7 +562,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 callChildM() {
                     this.template.querySelector('x-child').m();
                 }
@@ -582,7 +582,7 @@ describe('component', function() {
 
         it('should allow calling getAttribute on child when referenced with querySelector', function() {
             let count = 0;
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 m() {
                     count += 1;
                 }
@@ -591,7 +591,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 getChildAttribute() {
                     this.template.querySelector('x-child').getAttribute('title');
                 }
@@ -610,7 +610,7 @@ describe('component', function() {
 
         it('should allow calling setAttribute on child when referenced with querySelector', function() {
             let count = 0;
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 m() {
                     count += 1;
                 }
@@ -619,7 +619,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 setChildAttribute() {
                     this.template.querySelector('x-child').setAttribute('title', 'foo');
                 }
@@ -638,7 +638,7 @@ describe('component', function() {
 
         it('should allow calling removeAttribute on child when referenced with querySelector', function() {
             let count = 0;
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 m() {
                     count += 1;
                 }
@@ -647,7 +647,7 @@ describe('component', function() {
             function html($api) {
                 return [$api.c('x-child', MyChild, {})];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 removeChildAttribute() {
                     this.template.querySelector('x-child').removeAttribute('title');
                 }

--- a/packages/lwc-engine/src/framework/__tests__/def.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/def.spec.ts
@@ -1,17 +1,17 @@
-import { Element } from '../main';
+import { LightningElement } from '../main';
 import { getComponentDef } from '../def';
 
 describe('def', () => {
     describe('#getComponentDef()', () => {
         it('should understand empty constructors', () => {
-            const def = class MyComponent extends Element {};
+            const def = class MyComponent extends LightningElement {};
             expect(() => {
                 getComponentDef(def);
             }).not.toThrow();
         });
 
         it('should prevent mutations of important keys but should allow expondos for memoization and polyfills', () => {
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const def = getComponentDef(MyComponent);
             expect(() => {
                 def.name = 'something else';
@@ -27,7 +27,7 @@ describe('def', () => {
         });
 
         it('should understand static publicMethods', () => {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 foo() {}
                 bar() {}
             }
@@ -36,14 +36,14 @@ describe('def', () => {
         });
 
         it('should understand static wire', () => {
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             MyComponent.wire = { x: { type: 'record' } };
             expect(getComponentDef(MyComponent).wire).toEqual({ x: { type: 'record' } });
         });
 
         it('should infer config and type from public props without explicitly specifying them', () => {
             function foo() {}
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             Object.defineProperties(MyComponent.prototype, {
                 foo: { get: foo, configurable: true }
             });
@@ -68,7 +68,7 @@ describe('def', () => {
 
         it('should provide default html props', () => {
             function foo() {}
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             expect(Object.keys(getComponentDef(MyComponent).props).reduce((reducer, propName) => {
                 reducer[propName] = null;
                 return reducer;
@@ -132,7 +132,7 @@ describe('def', () => {
 
         it('should provide definition for each individual html prop', () => {
             function foo() {}
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             const { props } = getComponentDef(MyComponent);
             // aria multi-capital
             expect(props.ariaActiveDescendant).toEqual({
@@ -161,7 +161,7 @@ describe('def', () => {
 
         it('should inherit props correctly', function() {
             function x() {}
-            class MySuperComponent extends Element {}
+            class MySuperComponent extends LightningElement {}
             Object.defineProperties(MySuperComponent.prototype, {
                 x: { get: x, configurable: true }
             });
@@ -221,7 +221,7 @@ describe('def', () => {
 
         it('should throw if setter is declared without a getter', function() {
             function x() {}
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             Object.defineProperties(MyComponent.prototype, {
                 x: { set: x, configurable: true }
             });
@@ -238,7 +238,7 @@ describe('def', () => {
         });
 
         it('should inherit methods correctly', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 foo() {}
                 bar() {}
             }
@@ -261,7 +261,7 @@ describe('def', () => {
         });
 
         it('should inherit static wire properly', () => {
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             MyComponent.wire = { x: { type: 'record' } };
             class MySubComponent extends MyComponent {}
             MySubComponent.wire = { y: { type: 'record' } };
@@ -276,7 +276,7 @@ describe('def', () => {
         });
 
         it('should inherit static wire properly when parent defines same property', () => {
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             MyComponent.wire = { x: { type: 'record' } };
             class MySubComponent extends MyComponent {}
             MySubComponent.wire = { x: { type: 'subrecord' } };
@@ -288,7 +288,7 @@ describe('def', () => {
         });
 
         it('should handle publicProps with empty object', function() {
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             MyComponent.publicProps = {
                 foo: {}
             };
@@ -300,7 +300,7 @@ describe('def', () => {
         });
 
         it('should support html properties with exceptional transformation', function() {
-            class MyComponent extends Element  {}
+            class MyComponent extends LightningElement  {}
             MyComponent.publicProps = {
                 readOnly: {}
             };

--- a/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/error-boundary.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { querySelector, querySelectorAll } from "../dom/element";
 
 function createBoundaryComponent(elementsToRender) {
@@ -11,7 +11,7 @@ function createBoundaryComponent(elementsToRender) {
             });
         }
     }
-    class Boundary extends Element {
+    class Boundary extends LightningElement {
         getError() {
             return this.error;
         }
@@ -35,7 +35,7 @@ describe('error boundary component', () => {
 
         describe('constructor', () => {
             it('should call errorCallback when boundary child throws inside constructor', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     constructor() {
                         super();
                         throw new Error("Child Constructor Throw");
@@ -53,13 +53,13 @@ describe('error boundary component', () => {
             }),
 
             it('should not affect error boundary siblings when boundary child throws inside constructor', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     constructor() {
                         super();
                         throw new Error("Child Constructor Throw");
                     }
                 }
-                class BoundarySibling extends Element {}
+                class BoundarySibling extends LightningElement {}
                 const Boundary = createBoundaryComponent([{
                     name: 'x-child',
                     ctor: BoundaryChild
@@ -70,7 +70,7 @@ describe('error boundary component', () => {
                         $api.c('x-boundary-sibling', BoundarySibling, {}),
                     ];
                 }
-                class BoundryHost extends Element {
+                class BoundryHost extends LightningElement {
                     render() {
                         return html;
                     }
@@ -82,11 +82,11 @@ describe('error boundary component', () => {
             }),
 
             it('should unmount enitre subtree up to boundary component if child throws inside constructor', () => {
-                class SecondLevelChild extends Element {}
+                class SecondLevelChild extends LightningElement {}
                 function html($api, $cmp) {
                     return [ $api.c('x-second-level-child', SecondLevelChild, {})];
                 }
-                class FirstLevelChild extends Element {
+                class FirstLevelChild extends LightningElement {
                     constructor() {
                         super();
                         throw new Error("Child Constructor Throw");
@@ -109,15 +109,15 @@ describe('error boundary component', () => {
             }),
 
             it('should throw if error occurs in error boundary constructor', () => {
-                class FirstLevelChild extends Element {}
-                class FirstLevelChildSibling extends Element {}
+                class FirstLevelChild extends LightningElement {}
+                class FirstLevelChildSibling extends LightningElement {}
                 function html($api, $cmp) {
                     return [
                         $api.c('x-first-level-child-sibling', FirstLevelChildSibling, {}),
                         $api.c('x-first-level-child', FirstLevelChild, {})
                     ];
                 }
-                class Boundary extends Element {
+                class Boundary extends LightningElement {
                     constructor() {
                         super();
                         throw new Error();
@@ -138,7 +138,7 @@ describe('error boundary component', () => {
 
         describe('render', () => {
             it('should call errorCallback when boundary child throws inside render', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     render() {
                         throw new Error("Child Render Throw");
                     }
@@ -154,7 +154,7 @@ describe('error boundary component', () => {
             }),
 
             it('should throw when error boundary throws inside render method', () => {
-                class Boundary extends Element {
+                class Boundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -176,12 +176,12 @@ describe('error boundary component', () => {
             }),
 
             it('should not affect error boundary siblings when boundary child throws inside render', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     render() {
                         throw new Error("Child Constructor Throw");
                     }
                 }
-                class BoundarySibling extends Element {}
+                class BoundarySibling extends LightningElement {}
                 const Boundary = createBoundaryComponent([{
                     name: 'x-child',
                     ctor: BoundaryChild
@@ -192,7 +192,7 @@ describe('error boundary component', () => {
                         $api.c('x-boundary-sibling', BoundarySibling, {}),
                     ];
                 }
-                class BoundryHost extends Element {
+                class BoundryHost extends LightningElement {
                     render() {
                         return html;
                     }
@@ -204,7 +204,7 @@ describe('error boundary component', () => {
             }),
 
             it('should unmount child and its subtree if boundary child throws inside render', () => {
-                class SecondLevelChild extends Element {
+                class SecondLevelChild extends LightningElement {
                     render() {
                         throw new Error("Child Render Throw");
                     }
@@ -212,7 +212,7 @@ describe('error boundary component', () => {
                 function html($api, $cmp) {
                     return [ $api.c('x-second-level-child', SecondLevelChild, {})];
                 }
-                class FirstLevelChild extends Element {
+                class FirstLevelChild extends LightningElement {
                     render() {
                         return html;
                     }
@@ -230,7 +230,7 @@ describe('error boundary component', () => {
             }),
 
             it ('should call errorCallback if slot throws an error inside render', () => {
-                class SlotCmp extends Element {
+                class SlotCmp extends LightningElement {
                     render() {
                         throw Error('Slot cmp throws in render method');
                     }
@@ -244,7 +244,7 @@ describe('error boundary component', () => {
                     }, [], $slotset)];
                 }
                 html1.slots = ["x"];
-                class ChildWithSlot extends Element {
+                class ChildWithSlot extends LightningElement {
                     render() {
                         return html1;
                     }
@@ -252,7 +252,7 @@ describe('error boundary component', () => {
                 function html2($api, $cmp) {
                     return [ $api.c('x-child-with-slot', ChildWithSlot, { key: 0 }, [ $api.c('x-slot-cmp', SlotCmp, { attrs: { slot: 'x' } })]) ];
                 }
-                class BoundaryWithSlot extends Element {
+                class BoundaryWithSlot extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -275,7 +275,7 @@ describe('error boundary component', () => {
 
         describe('renderedCallback', () => {
             it('should call errorCallback when boundary child throws inside renderedCallback', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     renderedCallback() {
                         throw new Error("Child RenderedCallback Throw");
                     }
@@ -291,7 +291,7 @@ describe('error boundary component', () => {
             }),
 
             it('should throw an error when error boundary throws inside renderedCallback', () => {
-                class Boundary extends Element {
+                class Boundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -313,7 +313,7 @@ describe('error boundary component', () => {
             }),
 
             it('should unomunt child error boundary component if it throws inside errorCallback', () => {
-                class ChildBoundaryContent extends Element {
+                class ChildBoundaryContent extends LightningElement {
                     renderedCallback() {
                         throw new Error("Child RenderedCallback Throw");
                     }
@@ -321,7 +321,7 @@ describe('error boundary component', () => {
                 function html($api, $cmp) {
                     return [$api.c('child-boundary-content', ChildBoundaryContent, {})];
                 }
-                class ChildErrorBoundary extends Element {
+                class ChildErrorBoundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -348,7 +348,7 @@ describe('error boundary component', () => {
             });
 
             it('should unmount error boundary child if it throws inside renderedCallback', () => {
-                class ChildErrorBoundary extends Element {
+                class ChildErrorBoundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -375,7 +375,7 @@ describe('error boundary component', () => {
             }),
 
             it('should invoke parent boundary if child`s immediate boundary fails inside renderedCallback', () => {
-                class ChildBoundaryContent extends Element {
+                class ChildBoundaryContent extends LightningElement {
                     renderedCallback() {
                         throw new Error("Child RenderedCallback Throw");
                     }
@@ -383,7 +383,7 @@ describe('error boundary component', () => {
                 function html($api, $cmp) {
                     return [$api.c('child-boundary-content', ChildBoundaryContent, {})];
                 }
-                class ChildErrorBoundary extends Element {
+                class ChildErrorBoundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -414,12 +414,12 @@ describe('error boundary component', () => {
             }),
 
             it('should not affect error boundary siblings when boundary child throws inside renderedCallback', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     renderedCallback() {
                         throw new Error("Child RenderedCallback Throw");
                     }
                 }
-                class BoundarySibling extends Element {}
+                class BoundarySibling extends LightningElement {}
 
                 const Boundary = createBoundaryComponent([{
                     name: 'x-child',
@@ -431,7 +431,7 @@ describe('error boundary component', () => {
                         $api.c('x-boundary-sibling', BoundarySibling, {}),
                     ];
                 }
-                class BoundryHost extends Element {
+                class BoundryHost extends LightningElement {
                     render() {
                         return html;
                     }
@@ -443,7 +443,7 @@ describe('error boundary component', () => {
             }),
 
             it('should unmount boundary child and its subtree if child throws inside renderedCallback', () => {
-                class SecondLevelChild extends Element {
+                class SecondLevelChild extends LightningElement {
                     renderedCallback() {
                         throw new Error("Child RenderedCallback Throw");
                     }
@@ -451,7 +451,7 @@ describe('error boundary component', () => {
                 function html($api, $cmp) {
                     return [$api.c('x-second-level-child', SecondLevelChild, {})];
                 }
-                class FirstLevelChild extends Element {
+                class FirstLevelChild extends LightningElement {
                     render() {
                         return html;
                     }
@@ -471,7 +471,7 @@ describe('error boundary component', () => {
 
         describe('connectedCallback', () => {
             it('should call errorCallback when boundary child throws inside connectedCallback', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     connectedCallback() {
                         throw new Error("Child ConnectedCallback Throw");
                     }
@@ -488,7 +488,7 @@ describe('error boundary component', () => {
             }),
 
             it('should throw an error when error boundary throws inside connectedCallback', () => {
-                class Boundary extends Element {
+                class Boundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -510,12 +510,12 @@ describe('error boundary component', () => {
             }),
 
             it('should not affect error boundary siblings when boundary child throws inside connectedCallback', () => {
-                class BoundaryChild extends Element {
+                class BoundaryChild extends LightningElement {
                     connectedCallback() {
                         throw new Error("Child ConnectedCallback Throw");
                     }
                 }
-                class BoundarySibling extends Element {}
+                class BoundarySibling extends LightningElement {}
 
                 const Boundary = createBoundaryComponent([{
                     name: 'x-child',
@@ -527,7 +527,7 @@ describe('error boundary component', () => {
                         $api.c('x-boundary-sibling', BoundarySibling, {}),
                     ];
                 }
-                class BoundryHost extends Element {
+                class BoundryHost extends LightningElement {
                     render() {
                         return html;
                     }
@@ -539,7 +539,7 @@ describe('error boundary component', () => {
             }),
 
             it('should unmount boundary child and its subtree if boundary child throws inside connectedCallback', () => {
-                class SecondLevelChild extends Element {
+                class SecondLevelChild extends LightningElement {
                     connectedCallback() {
                         throw new Error("Child ConnectedCallback Throw");
                     }
@@ -547,7 +547,7 @@ describe('error boundary component', () => {
                 function html($api, $cmp) {
                     return [ $api.c('x-second-level-child', SecondLevelChild, {})];
                 }
-                class FirstLevelChild extends Element {
+                class FirstLevelChild extends LightningElement {
                     render() {
                         return html;
                     }
@@ -567,12 +567,12 @@ describe('error boundary component', () => {
 
         describe('error boundary failures in rendering alternative view', () => {
             it('should throw if error boundary fails to render alternative view', () => {
-                class PostErrorChildOffender extends Element {
+                class PostErrorChildOffender extends LightningElement {
                     render() {
                         throw new Error("Post-Failure Child Content Throws in Render");
                     }
                 }
-                class PreErrorChildContent extends Element {
+                class PreErrorChildContent extends LightningElement {
                     render() {
                         throw new Error("Pre-Failure Child Content Throws in Render");
                     }
@@ -584,7 +584,7 @@ describe('error boundary component', () => {
                         return [ $api.c('pre-error-child-content', PreErrorChildContent, {})];
                     }
                 }
-                class AltViewErrorBoundary extends Element {
+                class AltViewErrorBoundary extends LightningElement {
                     getError() {
                         return this.error;
                     }
@@ -606,12 +606,12 @@ describe('error boundary component', () => {
             }),
 
             it('should rethrow error to the parent error boundary when child boundary fails to render alternative view', () => {
-                class PostErrorChildOffender extends Element {
+                class PostErrorChildOffender extends LightningElement {
                     render() {
                         throw new Error("Post-Failure Child Content Throws in Render");
                     }
                 }
-                class PreErrorChildContent extends Element {
+                class PreErrorChildContent extends LightningElement {
                     render() {
                         throw new Error("Pre-Failure Child Content Throws in Render");
                     }
@@ -623,7 +623,7 @@ describe('error boundary component', () => {
                         return [ $api.c('pre-error-child-content', PreErrorChildContent, {})];
                     }
                 }
-                class AltViewErrorBoundary extends Element {
+                class AltViewErrorBoundary extends LightningElement {
                     getError() {
                         return this.error;
                     }

--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -1,17 +1,17 @@
-import { createElement, Element, unwrap } from '../main';
-import { getHostShadowRoot } from '../html-element';
+import { createElement, unwrap } from '../main';
+import { getHostShadowRoot, LightningElement } from '../html-element';
 
 describe('Composed events', () => {
     it('should be able to consume events from within template', () => {
         let count = 0;
-        class Child extends Element {
+        class Child extends LightningElement {
             triggerFoo() {
                 this.dispatchEvent(new CustomEvent('foo'));
             }
         }
         Child.publicMethods = ['triggerFoo'];
 
-        class ComposedEvents extends Element {
+        class ComposedEvents extends LightningElement {
             triggerChildFoo() {
                 this.template.querySelector('x-custom-event-child').triggerFoo();
             }
@@ -56,7 +56,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -80,7 +80,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -105,7 +105,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -130,7 +130,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -154,7 +154,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -177,7 +177,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
         let cmp;
-        class Foo extends Element {
+        class Foo extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -200,7 +200,7 @@ describe('Events on Custom Elements', () => {
         function html($api) {
             return [$api.h('div', { key: 0}, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 this.template.addEventListener('c-event', function() {
@@ -227,7 +227,7 @@ describe('Events on Custom Elements', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('c-event', function() {
                     count += 1;
@@ -254,7 +254,7 @@ describe('Events on Custom Elements', () => {
         function html1($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyChild extends Element {
+        class MyChild extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('c-event', function() {
                     count += 1;
@@ -272,7 +272,7 @@ describe('Events on Custom Elements', () => {
         function html2($api) {
             return [$api.c('x-child', MyChild, {})];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html2;
             }
@@ -294,7 +294,7 @@ describe('Events on Custom Elements', () => {
         function html1($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyChild extends Element {
+        class MyChild extends LightningElement {
             constructor() {
                 super();
                 this.template.addEventListener('c-event', function() {
@@ -313,7 +313,7 @@ describe('Events on Custom Elements', () => {
         function html2($api) {
             return [$api.c('x-child', MyChild, {})];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html2;
             }
@@ -332,7 +332,7 @@ describe('Events on Custom Elements', () => {
 
     it('should add event listeners on component instance', () => {
         const clickSpy = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', clickSpy);
             }
@@ -346,7 +346,7 @@ describe('Events on Custom Elements', () => {
 
     it('should remove event listeners from component instance', () => {
         const clickSpy = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', clickSpy);
             }
@@ -369,7 +369,7 @@ describe('Events on Custom Elements', () => {
     it('should call event handler with undefined context', () => {
         expect.assertions(1);
         let clickSpy;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', function () {
                     expect(this).toBe(undefined);
@@ -388,7 +388,7 @@ describe('Events on Custom Elements', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 const cmp = this;
                 this.addEventListener('click', clickSpy);
@@ -419,7 +419,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', function () {
                     expect(this).toBe(undefined);
@@ -450,7 +450,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', function (evt) {
                     expect(unwrap(evt.target)).toBe(elm);
@@ -474,7 +474,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', function (evt) {
                     expect(unwrap(evt.target)).toBe(elm);
@@ -505,7 +505,7 @@ describe('Events on Custom Elements', () => {
             return [$api.h('div', { key: 0 }, [])];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', (evt) => {
                     const div = this.template.querySelector('div');
@@ -540,7 +540,7 @@ describe('Slotted element events', () => {
             }, [], $slotset)];
         }
         childHTML.slots = ["x"];
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return childHTML;
             }
@@ -558,7 +558,7 @@ describe('Slotted element events', () => {
             }, [])])];
         }
 
-        class SlottedEventTarget extends Element {
+        class SlottedEventTarget extends LightningElement {
             handleClick(evt) {
                 expect(evt.target.tagName.toLowerCase()).toBe('div');
             }
@@ -585,7 +585,7 @@ describe('Component events', () => {
     it('should have correct target when component event gets dispatched within event handler', () => {
         expect.assertions(1);
         let clickSpy;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', (evt) => {
                     this.dispatchEvent(new CustomEvent('foo'));
@@ -606,7 +606,7 @@ describe('Shadow Root events', () => {
     it('should call event handler with correct target', () => {
         expect.assertions(1);
         let clickSpy;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', (evt) => {
                     expect(evt.target).toBe(this.template.querySelector('div'));
@@ -635,7 +635,7 @@ describe('Shadow Root events', () => {
     it('should call event handler with undefined context', () => {
         expect.assertions(1);
         let clickSpy;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', function () {
                     expect(this).toBe(undefined);
@@ -663,7 +663,7 @@ describe('Shadow Root events', () => {
 
     it('should call template event handlers before component event handlers', () => {
         const calls = [];
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', () => calls.push('component'));
                 this.template.addEventListener('click', () => calls.push('template'));
@@ -692,7 +692,7 @@ describe('Shadow Root events', () => {
     it('should have correct event target when event originates from child component shadow dom', () => {
         expect.assertions(2);
         let childTemplate;
-        class MyChild extends Element {
+        class MyChild extends LightningElement {
             constructor() {
                 super();
                 childTemplate = this.template;
@@ -721,7 +721,7 @@ describe('Shadow Root events', () => {
             })];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             handleClick(evt) {
                 expect(evt.target.tagName.toLowerCase()).toBe('correct-nested-root-event-target-child');
                 expect(evt.target).toBe(this.template.querySelector('correct-nested-root-event-target-child'));
@@ -748,9 +748,9 @@ describe('Shadow Root events', () => {
     it('should retarget properly event listener attached on non-root components', () => {
         expect.assertions(2);
 
-        class GrandChild extends Element {}
+        class GrandChild extends LightningElement {}
 
-        class Child extends Element {
+        class Child extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', evt => {
                     expect(evt.target.tagName).toBe('X-GRAND-CHILD');
@@ -767,7 +767,7 @@ describe('Shadow Root events', () => {
             }
         }
 
-        class Root extends Element {
+        class Root extends LightningElement {
             render() {
                 return $api => {
                     return [
@@ -796,7 +796,7 @@ describe('Shadow Root events', () => {
                 }, [])];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 this.template.addEventListener('foo', (evt) => {
@@ -825,7 +825,7 @@ describe('Shadow Root events', () => {
 describe('Removing events from shadowroot', () => {
     it('should remove event correctly', () => {
         const onClick = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', onClick);
             }
@@ -859,7 +859,7 @@ describe('Removing events from shadowroot', () => {
     it('should only remove shadow root events', () => {
         const onClick = jest.fn();
         const cmpClick = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', cmpClick);
                 this.template.addEventListener('click', onClick);
@@ -896,7 +896,7 @@ describe('Removing events from shadowroot', () => {
 describe('Removing events from cmp', () => {
     it('should remove event correctly', () => {
         const onClick = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', onClick);
             }
@@ -930,7 +930,7 @@ describe('Removing events from cmp', () => {
     it('should only remove shadow root events', () => {
         const onClick = jest.fn();
         const cmpClick = jest.fn();
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 this.addEventListener('click', cmpClick);
                 this.template.addEventListener('click', onClick);

--- a/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
@@ -1,18 +1,18 @@
-import { createElement, Element, register, unwrap } from '../main';
-import { getHostShadowRoot } from '../html-element';
+import { createElement, register, unwrap } from '../main';
+import { getHostShadowRoot, LightningElement } from '../html-element';
 import assertLogger from '../assert';
 
 describe('html-element', () => {
     describe('#setAttributeNS()', () => {
         it('should set attribute on host element when element is nested in template', () => {
-            class Child extends Element {
+            class Child extends LightningElement {
                 setFoo() {
                     this.setAttributeNS('x', 'foo', 'bar');
                 }
             }
             Child.publicMethods = ['setFoo'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return ($api) => {
                         return [$api.c('x-child', Child, {})]
@@ -29,7 +29,7 @@ describe('html-element', () => {
         });
 
         it('should set attribute on host element', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 setFoo() {
                     this.setAttributeNS('x', 'foo', 'bar');
                 }
@@ -42,7 +42,7 @@ describe('html-element', () => {
         });
 
         it('should throw an error if attempting to call setAttributeNS during construction', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -56,14 +56,14 @@ describe('html-element', () => {
 
     describe('#setAttribute()', () => {
         it('should set attribute on host element when element is nested in template', () => {
-            class Child extends Element {
+            class Child extends LightningElement {
                 setFoo() {
                     this.setAttribute('foo', 'bar');
                 }
             }
             Child.publicMethods = ['setFoo'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return ($api) => {
                         return [$api.c('x-child', Child, {})]
@@ -81,7 +81,7 @@ describe('html-element', () => {
         });
 
         it('should set attribute on host element', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 setFoo() {
                     this.setAttribute('foo', 'bar');
                 }
@@ -94,7 +94,7 @@ describe('html-element', () => {
         });
 
         it('should throw an error if attempting to call setAttribute during construction', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -108,14 +108,14 @@ describe('html-element', () => {
 
     describe('#removeAttributeNS()', () => {
         it('should remove namespaced attribute on host element when element is nested in template', () => {
-            class Child extends Element {
+            class Child extends LightningElement {
                 removeTitle() {
                     this.removeAttributeNS('x', 'title');
                 }
             }
             Child.publicMethods = ['removeTitle'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return ($api) => {
                         return [$api.c('x-child', Child, {
@@ -134,7 +134,7 @@ describe('html-element', () => {
         });
 
         it('should remove attribute on host element', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 removeTitle() {
                     this.removeAttributeNS('x', 'title');
                 }
@@ -149,14 +149,14 @@ describe('html-element', () => {
 
     describe('#removeAttribute()', () => {
         it('should remove attribute on host element when element is nested in template', () => {
-            class Child extends Element {
+            class Child extends LightningElement {
                 removeTitle() {
                     this.removeAttribute('title');
                 }
             }
             Child.publicMethods = ['removeTitle'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return ($api) => {
                         return [$api.c('x-child', Child, {
@@ -175,7 +175,7 @@ describe('html-element', () => {
         });
 
         it('should remove attribute on host element', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 removeTitle() {
                     this.removeAttribute('title');
                 }
@@ -190,7 +190,7 @@ describe('html-element', () => {
 
     describe('#getBoundingClientRect()', () => {
         it('should throw during construction', () => {
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -205,7 +205,7 @@ describe('html-element', () => {
 
     describe('#classList()', () => {
         it('should throw when adding classList during construction', () => {
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.classList.add('foo');
@@ -216,7 +216,7 @@ describe('html-element', () => {
 
         it('should have a valid classList during connectedCallback', () => {
             expect.assertions(2);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.classList.add('foo');
                     expect(this.classList.contains('foo')).toBe(true);
@@ -230,7 +230,7 @@ describe('html-element', () => {
 
     describe('#getAttributeNS()', () => {
         it('should return correct attribute value', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 getXTitle() {
                     return this.getAttributeNS('x', 'title');
                 }
@@ -245,7 +245,7 @@ describe('html-element', () => {
     describe('#getAttribute()', () => {
         it('should throw when no attribute name is provided', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => this.getAttribute()).toThrow();
@@ -255,7 +255,7 @@ describe('html-element', () => {
         });
         it('should not throw when attribute name matches a declared public property', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => this.getAttribute('foo')).not.toThrow();
@@ -266,7 +266,7 @@ describe('html-element', () => {
         });
         it('should be null for non-valid attribute names', () => {
             expect.assertions(3);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.getAttribute(null)).toBeNull();
@@ -278,7 +278,7 @@ describe('html-element', () => {
         });
         it('should be null for non-existing attributes', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.getAttribute("foo-bar-baz")).toBeNull();
@@ -292,7 +292,7 @@ describe('html-element', () => {
     describe('#dispatchEvent', function() {
         it('should throw when event is dispatched during construction', function() {
             expect.assertions(1);
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -307,7 +307,7 @@ describe('html-element', () => {
         it('should log warning when element is not connected', function() {
             jest.spyOn(assertLogger, 'logWarning');
 
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 dispatch(evt) {
                     this.dispatchEvent(evt);
                 }
@@ -324,7 +324,7 @@ describe('html-element', () => {
         it('should not log warning when element is connected', function() {
             jest.spyOn(assertLogger, 'logWarning');
 
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 dispatch(evt) {
                     this.dispatchEvent(evt);
                 }
@@ -343,7 +343,7 @@ describe('html-element', () => {
         it('should log warning when event name contains non-alphanumeric lowercase characters', function() {
             jest.spyOn(assertLogger, 'logWarning');
 
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 connectedCallback() {
                     this.dispatchEvent(new CustomEvent('foo1-$'));
                 }
@@ -359,7 +359,7 @@ describe('html-element', () => {
         it('should log warning when event name does not start with alphabetic lowercase characters', function() {
             jest.spyOn(assertLogger, 'logWarning');
 
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 connectedCallback() {
                     this.dispatchEvent(new CustomEvent('123'));
                 }
@@ -374,7 +374,7 @@ describe('html-element', () => {
         it('should not log warning for alphanumeric lowercase event name', function() {
             jest.spyOn(assertLogger, 'logWarning');
 
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 connectedCallback() {
                     this.dispatchEvent(new CustomEvent('foo1234abc'));
                 }
@@ -393,7 +393,7 @@ describe('html-element', () => {
                 return [$api.h('div', { key: 1 }, [])];
             };
             let elm;
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 constructor() {
                     super();
                     this.template.addEventListener('click', (e) => {
@@ -420,7 +420,7 @@ describe('html-element', () => {
             function html($api, $cmp) {
                 return [$api.h('div', { key: 1, on: { click: $api.b($cmp.handleClick)} }, [])];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 handleClick(e: Event) {
                     expect(e.target).toBe(this.template.querySelector('div'));
                     expect(e.currentTarget).toBe(this.template.querySelector('div'));
@@ -444,7 +444,7 @@ describe('html-element', () => {
                 return [$api.h('div', { key: 1 }, [])];
             }
             let elm;
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 constructor() {
                     super();
                     this.template.addEventListener('xyz', (e) => {
@@ -479,7 +479,7 @@ describe('html-element', () => {
             function html($api, $cmp) {
                 return [$api.h('div', { key: 1, on: { xyz: $api.b($cmp.handleXyz)} }, [])];
             }
-            class Foo extends Element {
+            class Foo extends LightningElement {
                 handleXyz(e: Event) {
                     expect(e.target).toBe(this.template.querySelector('div'));
                     expect(e.currentTarget).toBe(this.template.querySelector('div'));
@@ -509,7 +509,7 @@ describe('html-element', () => {
     describe('#tagName', () => {
         it('should have a valid value during construction', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.tagName).toBe('X-FOO');
@@ -522,7 +522,7 @@ describe('html-element', () => {
     describe('#tracked', () => {
         it('should not warn if component has untracked state property', function() {
             jest.spyOn(assertLogger, 'logWarning');
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = {};
             }
             const element = createElement('x-foo', { is: MyComponent });
@@ -531,7 +531,7 @@ describe('html-element', () => {
         });
         it('should not warn if component has tracked state property', function() {
             jest.spyOn(assertLogger, 'logWarning');
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = {};
             }
             MyComponent.track = { state: 1 };
@@ -542,7 +542,7 @@ describe('html-element', () => {
         it('should be mutable during construction', () => {
             let state;
             const o = { foo: 1, bar: 2, baz: 1 };
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 state = {
                     foo: undefined,
                     bar: undefined,
@@ -568,7 +568,7 @@ describe('html-element', () => {
         it('should accept member properties', () => {
             let state;
             const o = { foo: 1 };
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 state = { x: 1, y: o };
                 constructor() {
                     super();
@@ -582,7 +582,7 @@ describe('html-element', () => {
         });
         it('should not throw an error when assigning observable object', function() {
             expect.assertions(1);
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -598,7 +598,7 @@ describe('html-element', () => {
     describe('global HTML Properties', () => {
         it('should always return null', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.getAttribute('title')).toBeNull();
@@ -609,7 +609,7 @@ describe('html-element', () => {
 
         it('should set user specified value during setAttribute call', () => {
             let userDefinedTabIndexValue = -1;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 renderedCallback() {
                     userDefinedTabIndexValue = this.getAttribute("tabindex");
                 }
@@ -631,12 +631,12 @@ describe('html-element', () => {
                     $api.c('x-child', Child, { attrs: { title: 'child title' }})
                 ];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return html;
                 }
             }
-            class Child extends Element {}
+            class Child extends LightningElement {}
             const parentElm = createElement('x-parent', { is: Parent });
             document.body.appendChild(parentElm);
 
@@ -654,12 +654,12 @@ describe('html-element', () => {
                     $api.c('x-child', Child, { attrs: { title: 'child title' }})
                 ];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return html;
                 }
             }
-            class Child extends Element {}
+            class Child extends LightningElement {}
             const parentElm = createElement('x-parent', { is: Parent });
             document.body.appendChild(parentElm);
 
@@ -672,7 +672,7 @@ describe('html-element', () => {
 
         it('should log error message when attribute is set via elm.setAttribute if reflective property is defined', () => {
             jest.spyOn(assertLogger, 'logError');
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', {is: MyComponent});
             elm.setAttribute('tabindex', '0');
             document.body.appendChild(elm);
@@ -684,7 +684,7 @@ describe('html-element', () => {
         });
 
         it('should delete existing attribute prior rendering', () => {
-            const def = class MyComponent extends Element {};
+            const def = class MyComponent extends LightningElement {};
             const elm = createElement('x-foo', { is: def });
             elm.setAttribute('title', 'parent title');
             elm.removeAttribute('title');
@@ -702,13 +702,13 @@ describe('html-element', () => {
                     $api.c('x-child', Child, { attrs: { title: 'child title' }})
                 ];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return html;
                 }
             }
 
-            class Child extends Element {
+            class Child extends LightningElement {
                 renderedCallback() {
                     childTitle = this.getAttribute('title');
                 }
@@ -726,7 +726,7 @@ describe('html-element', () => {
     describe('#toString()', () => {
         it('should produce a nice tag', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.toString()).toBe('<x-foo>');
@@ -740,7 +740,7 @@ describe('html-element', () => {
         it('should allow custom instance getter and setter', () => {
             let cmp, a, ctx;
 
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     cmp = this;
@@ -772,7 +772,7 @@ describe('html-element', () => {
         it('should have a valid value during connectedCallback', function() {
             expect.assertions(1);
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     expect(this.tabIndex).toBe(3);
                 }
@@ -784,7 +784,7 @@ describe('html-element', () => {
         });
 
         it('should have a valid value after initial render', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 getTabIndex() {
                     return this.tabIndex;
                 }
@@ -799,7 +799,7 @@ describe('html-element', () => {
         });
 
         it('should set tabindex correctly', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.tabIndex = 2;
                 }
@@ -820,7 +820,7 @@ describe('html-element', () => {
 
         it('should not trigger render cycle', function() {
             let callCount = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.tabIndex = 2;
                 }
@@ -840,7 +840,7 @@ describe('html-element', () => {
         });
 
         it('should allow parent component to overwrite internally set tabIndex', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     this.tabIndex = 2;
                 }
@@ -863,7 +863,7 @@ describe('html-element', () => {
 
         it('should throw if setting tabIndex during render', function() {
             expect.assertions(1);
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     expect(() => {
                         this.tabIndex = 2;
@@ -878,7 +878,7 @@ describe('html-element', () => {
 
         it('should throw if setting tabIndex during construction', function() {
             expect.assertions(1);
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(() => {
@@ -893,7 +893,7 @@ describe('html-element', () => {
     describe('life-cycles', function() {
         it('should guarantee that the element is rendered when inserted in the DOM', function() {
             let rendered = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     rendered++;
                     return () => [];
@@ -907,7 +907,7 @@ describe('html-element', () => {
 
         it('should guarantee that the connectedCallback is invoked sync after the element is inserted in the DOM', function() {
             let called = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return () => [];
                 }
@@ -923,7 +923,7 @@ describe('html-element', () => {
 
         it('should guarantee that the connectedCallback is invoked before render after the element is inserted in the DOM', function() {
             const ops: string[] = [];
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     ops.push('render');
                     return () => [];
@@ -939,7 +939,7 @@ describe('html-element', () => {
 
         it('should guarantee that the disconnectedCallback is invoked sync after the element is removed from the DOM', function() {
             let called = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return () => [];
                 }
@@ -956,7 +956,7 @@ describe('html-element', () => {
 
         it('should not render even if there is a mutation if the element is not in the DOM yet', function() {
             let rendered = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     rendered++;
                     this.x; // reactive
@@ -973,7 +973,7 @@ describe('html-element', () => {
 
         it('should not render if the element was removed from the DOM', function() {
             let rendered = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     rendered++;
                     this.x; // reactive
@@ -995,7 +995,7 @@ describe('html-element', () => {
             let rendered = 0;
             let connected = 0;
             let disconnected = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     rendered++;
                     return () => [];
@@ -1020,7 +1020,7 @@ describe('html-element', () => {
         });
 
         it('should not throw error when accessing a non-observable property from tracked property when not rendering', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = {};
                 set foo(value) {
                     this.state.foo = value;
@@ -1047,7 +1047,7 @@ describe('html-element', () => {
 
         it('should not log a warning when setting tracked value to null', function() {
             jest.spyOn(assertLogger, 'logWarning');
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = {};
                 connectedCallback() {
                     this.state.foo = null;
@@ -1063,7 +1063,7 @@ describe('html-element', () => {
 
         it('should not log a warning when initializing api value to null', function() {
             jest.spyOn(assertLogger, 'logWarning');
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 foo = null;
             }
             MyComponent.publicProps = {
@@ -1080,7 +1080,7 @@ describe('html-element', () => {
 
     describe('Inheritance', () => {
         it('should inherit public getters and setters correctly', () => {
-            class MyParent extends Element {
+            class MyParent extends LightningElement {
                 get foo() {}
                 set foo(value) {}
             }
@@ -1099,7 +1099,7 @@ describe('html-element', () => {
 
         it('should call correct inherited public setter', () => {
             let count = 0;
-            class MyParent extends Element {
+            class MyParent extends LightningElement {
                 get foo() {}
                 set foo(value) {
                     count += 1;
@@ -1123,7 +1123,7 @@ describe('html-element', () => {
     describe('Aria Properties', () => {
         describe('#role', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-aria-role', { is: MyComponent });
@@ -1132,7 +1132,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-role', { is: MyComponent });
@@ -1141,7 +1141,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value when nothing has been set', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-role', { is: MyComponent });
@@ -1149,7 +1149,7 @@ describe('html-element', () => {
             });
 
             it('should return null even if the shadow root value is set', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.role = 'tab';
                     }
@@ -1163,7 +1163,7 @@ describe('html-element', () => {
 
             it('should call setter when defined', () => {
                 let called = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get role() {}
                     set role(value) {
                         called += 1;
@@ -1181,7 +1181,7 @@ describe('html-element', () => {
             });
 
             it('should not overwrite role attribute when setter does nothing', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.role = 'tab';
                     }
@@ -1200,7 +1200,7 @@ describe('html-element', () => {
             });
 
             it('should reflect role from root when element value is set to null', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.role = 'tab';
                     }
@@ -1217,7 +1217,7 @@ describe('html-element', () => {
             });
 
             it('should remove role attribute from element when root and value is null', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.role = 'tab';
                     }
@@ -1240,7 +1240,7 @@ describe('html-element', () => {
 
             describe('AOM shim', () => {
                 it('getAttribute reflect default value when aria-checked has been removed', () => {
-                    class MyComponent extends Element {
+                    class MyComponent extends LightningElement {
                         connectedCallback() {
                             this.template.role = 'tab'
                         }
@@ -1256,7 +1256,7 @@ describe('html-element', () => {
 
         describe('#ariaChecked', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-aria-checked', { is: MyComponent });
@@ -1265,7 +1265,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-checked', { is: MyComponent });
@@ -1274,7 +1274,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value when nothing has been set', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-checked', { is: MyComponent });
@@ -1282,7 +1282,7 @@ describe('html-element', () => {
             });
 
             it('should return null even if the shadow root value is set', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.ariaChecked = 'true';
                     }
@@ -1296,7 +1296,7 @@ describe('html-element', () => {
 
             describe('AOM shim', () => {
                 it('internal getAttribute reflect default value when aria-checked has been removed', () => {
-                    class MyComponent extends Element {
+                    class MyComponent extends LightningElement {
                         connectedCallback() {
                             this.template.ariaChecked = 'true';
                             this.setAttribute('aria-checked', 'false');
@@ -1309,7 +1309,7 @@ describe('html-element', () => {
                 });
 
                 it('external getAttribute reflect default value when aria-checked has been removed', () => {
-                    class MyComponent extends Element {
+                    class MyComponent extends LightningElement {
                         connectedCallback() {
                             this.template.ariaChecked = 'true';
                         }
@@ -1325,7 +1325,7 @@ describe('html-element', () => {
 
         describe('#ariaLabel', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-aria-label', { is: MyComponent });
@@ -1334,7 +1334,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-label', { is: MyComponent });
@@ -1343,7 +1343,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value when nothing has been set', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-aria-label', { is: MyComponent });
@@ -1351,7 +1351,7 @@ describe('html-element', () => {
             });
 
             it('should return null value when not value is set, shadow root value should not leak out', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     connectedCallback() {
                         this.template.ariaLabel = 'foo';
                     }
@@ -1368,7 +1368,7 @@ describe('html-element', () => {
     describe('global HTML Properties', () => {
         describe('#lang', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-lang', { is: MyComponent });
@@ -1377,7 +1377,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-lang', { is: MyComponent });
@@ -1387,7 +1387,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set lang(value) {
                         count += 1;
                     }
@@ -1405,7 +1405,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set lang(value) {
 
                     }
@@ -1433,7 +1433,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get lang() {
                         count += 1;
                         return 'en';
@@ -1451,7 +1451,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -1477,7 +1477,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.lang = 'en';
@@ -1492,7 +1492,7 @@ describe('html-element', () => {
 
         describe('#hidden', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-hidden', { is: MyComponent });
@@ -1501,7 +1501,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-hidden', { is: MyComponent });
@@ -1511,7 +1511,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set hidden(value) {
                         count += 1;
                     }
@@ -1529,7 +1529,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set hidden(value) {
 
                     }
@@ -1557,7 +1557,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get hidden() {
                         count += 1;
                         return 'hidden';
@@ -1575,7 +1575,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -1601,7 +1601,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.hidden = true;
@@ -1616,7 +1616,7 @@ describe('html-element', () => {
 
         describe('#dir', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-dir', { is: MyComponent });
@@ -1625,7 +1625,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-dir', { is: MyComponent });
@@ -1635,7 +1635,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set dir(value) {
                         count += 1;
                     }
@@ -1653,7 +1653,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set dir(value) {
 
                     }
@@ -1681,7 +1681,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get dir() {
                         count += 1;
                         return 'ltr';
@@ -1699,7 +1699,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -1725,7 +1725,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.dir = 'ltr';
@@ -1740,7 +1740,7 @@ describe('html-element', () => {
 
         describe('#id', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-id', { is: MyComponent });
@@ -1749,7 +1749,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-id', { is: MyComponent });
@@ -1759,7 +1759,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set id(value) {
                         count += 1;
                     }
@@ -1777,7 +1777,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set id(value) {
 
                     }
@@ -1805,7 +1805,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get id() {
                         count += 1;
                         return 'id';
@@ -1823,7 +1823,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -1849,7 +1849,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.id = 'id';
@@ -1864,7 +1864,7 @@ describe('html-element', () => {
 
         describe('#accessKey', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-accessKey', { is: MyComponent });
@@ -1873,7 +1873,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-accessKey', { is: MyComponent });
@@ -1883,7 +1883,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set accessKey(value) {
                         count += 1;
                     }
@@ -1901,7 +1901,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set accessKey(value) {
 
                     }
@@ -1929,7 +1929,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get accessKey() {
                         count += 1;
                         return 'accessKey';
@@ -1947,7 +1947,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -1973,7 +1973,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.accessKey = 'accessKey';
@@ -1988,7 +1988,7 @@ describe('html-element', () => {
 
         describe('#title', () => {
             it('should reflect attribute by default', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-reflect-title', { is: MyComponent });
@@ -1997,7 +1997,7 @@ describe('html-element', () => {
             });
 
             it('should return correct value from getter', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
 
                 }
                 const element = createElement('prop-getter-title', { is: MyComponent });
@@ -2007,7 +2007,7 @@ describe('html-element', () => {
 
             it('should call setter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set title(value) {
                         count += 1;
                     }
@@ -2025,7 +2025,7 @@ describe('html-element', () => {
 
             it('should not be reactive when defining own setter', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     set title(value) {
 
                     }
@@ -2053,7 +2053,7 @@ describe('html-element', () => {
 
             it('should call getter defined in component', () => {
                 let count = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     get title() {
                         count += 1;
                         return 'title';
@@ -2071,7 +2071,7 @@ describe('html-element', () => {
 
             it('should be reactive by default', () => {
                 let renderCount = 0;
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     render() {
                         return ($api, $cmp) => {
                             renderCount += 1;
@@ -2097,7 +2097,7 @@ describe('html-element', () => {
             });
 
             it('should throw an error when setting default value in constructor', () => {
-                class MyComponent extends Element {
+                class MyComponent extends LightningElement {
                     constructor() {
                         super();
                         this.title = 'title';
@@ -2112,7 +2112,7 @@ describe('html-element', () => {
 
         it('should always return null', () => {
             expect.assertions(1);
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect(this.getAttribute('title')).toBeNull();
@@ -2123,7 +2123,7 @@ describe('html-element', () => {
 
         it('should set user specified value during setAttribute call', () => {
             let userDefinedTabIndexValue = -1;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 renderedCallback() {
                     userDefinedTabIndexValue = this.getAttribute("tabindex");
                 }
@@ -2140,7 +2140,7 @@ describe('html-element', () => {
 
         it('should log console error when user land code changes attribute via querySelector', () => {
             jest.spyOn(assertLogger, 'logError');
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return function($api, $cmp) {
                         return [
@@ -2149,7 +2149,7 @@ describe('html-element', () => {
                     }
                 }
             }
-            class Child extends Element {}
+            class Child extends LightningElement {}
             const parentElm = createElement('x-parent', { is: Parent });
             document.body.appendChild(parentElm);
 
@@ -2162,7 +2162,7 @@ describe('html-element', () => {
 
         it('should log console error when user land code removes attribute via querySelector', () => {
             jest.spyOn(assertLogger, 'logError');
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return function($api, $cmp) {
                         return [
@@ -2171,7 +2171,7 @@ describe('html-element', () => {
                     }
                 }
             }
-            class Child extends Element {}
+            class Child extends LightningElement {}
             const parentElm = createElement('x-parent', { is: Parent });
             document.body.appendChild(parentElm);
 
@@ -2183,7 +2183,7 @@ describe('html-element', () => {
 
         it('should not log error message when arbitrary attribute is set via elm.setAttribute', () => {
             jest.spyOn(assertLogger, 'logError');
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', {is: MyComponent});
             elm.setAttribute('foo', 'something');
             document.body.appendChild(elm);
@@ -2195,7 +2195,7 @@ describe('html-element', () => {
         })
 
         it('should delete existing attribute prior rendering', () => {
-            const def = class MyComponent extends Element {}
+            const def = class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', { is: def });
             elm.setAttribute('title', 'parent title');
             elm.removeAttribute('title');
@@ -2209,7 +2209,7 @@ describe('html-element', () => {
         it('should correctly set child attribute ', () => {
             let childTitle = null;
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return function($api, $cmp) {
                         return [
@@ -2219,7 +2219,7 @@ describe('html-element', () => {
                 }
             }
 
-            class Child extends Element {
+            class Child extends LightningElement {
                 renderedCallback() {
                     childTitle = this.getAttribute('title');
                 }

--- a/packages/lwc-engine/src/framework/__tests__/invoker.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/invoker.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 
 describe('invoker', () => {
 
@@ -10,7 +10,7 @@ describe('invoker', () => {
 
         it('should support undefined result from render()', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     counter++;
                     return;
@@ -22,7 +22,7 @@ describe('invoker', () => {
         });
 
         it('should throw if render() returns something that is not a function or a promise or undefined', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return 1;
                 }
@@ -38,7 +38,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     counter++;
                     expect(this.template.querySelectorAll('p').length).toBe(0);
@@ -55,7 +55,7 @@ describe('invoker', () => {
 
         it('should invoke connectedCallback() in a child after connectedCallback() on parent', () => {
             const stack = [];
-            class Child extends Element {
+            class Child extends LightningElement {
                 connectedCallback() {
                     stack.push('child');
                 }
@@ -63,7 +63,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.c('x-child', Child, {})];
             }
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     stack.push('parent');
                 }
@@ -78,7 +78,7 @@ describe('invoker', () => {
 
         it('should invoke disconnectedCallback() in a child after disconnectedCallback() on parent', () => {
             const stack = [];
-            class Child extends Element {
+            class Child extends LightningElement {
                 disconnectedCallback() {
                     stack.push('child');
                 }
@@ -86,7 +86,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.c('x-child', Child, {})];
             }
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 disconnectedCallback() {
                     stack.push('parent');
                 }
@@ -106,7 +106,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 disconnectedCallback() {
                     counter++;
                     expect(elm.parentNode).toBe(null);
@@ -130,7 +130,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 renderedCallback() {
                     counter++;
                     expect(this.template.querySelectorAll('p').length).toBe(1);
@@ -147,7 +147,7 @@ describe('invoker', () => {
 
         it('should invoke parent renderedCallback() sync after every change after all child renderedCallback', () => {
             const cycle = [];
-            class Child extends Element {
+            class Child extends LightningElement {
                 renderedCallback() {
                     cycle.push('child');
                 }
@@ -155,7 +155,7 @@ describe('invoker', () => {
             function html($api) {
                 return [$api.c('x-child', Child, {})];
             }
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 renderedCallback() {
                     cycle.push('parent');
                 }
@@ -180,7 +180,7 @@ describe('invoker', () => {
                     }, [])
                 ];
             }
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 renderedCallback() {
                     lifecycle.push('rendered');
                 }
@@ -206,7 +206,7 @@ describe('invoker', () => {
 
         it('should invoke renderedCallback() sync after connectedCallback and render', () => {
             const lifecycle: string[] = [];
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 renderedCallback() {
                     lifecycle.push('rendered');
                 }
@@ -224,7 +224,7 @@ describe('invoker', () => {
 
         it('should decorate error thrown with component stack information', () => {
             expect.hasAssertions();
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     (undefined).foo;
                 }
@@ -239,7 +239,7 @@ describe('invoker', () => {
 
         it('should decorate error thrown with component stack information even when nested', () => {
             expect.hasAssertions();
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 connectedCallback() {
                     (undefined).foo;
                 }
@@ -249,7 +249,7 @@ describe('invoker', () => {
                     "section", { key: 0 }, [$api.c("x-bar", MyComponent2, {})]
                 )];
             }
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 render() {
                     return html;
                 }
@@ -266,7 +266,7 @@ describe('invoker', () => {
         it('can remove listener in disconnectedCallback()', () => {
             let removed;
             function fn() {}
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     this.template.addEventListener('click', fn);
                 }

--- a/packages/lwc-engine/src/framework/__tests__/issue-180.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/issue-180.spec.ts
@@ -1,9 +1,9 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 
 describe('issue #180', () => {
 
     it('should support data-foo attribute', () => {
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             connectedCallback() {
                 expect(this.getAttribute('data-foo')).toBe("miami");
             }
@@ -15,7 +15,7 @@ describe('issue #180', () => {
     });
 
     it('should not allow dataFoo public api property', () => {
-        class MyComponent extends Element {}
+        class MyComponent extends LightningElement {}
         MyComponent.publicProps = { dataFoo: { config: 1 } };
         expect(() => {
             createElement('x-foo', { is: MyComponent });

--- a/packages/lwc-engine/src/framework/__tests__/patch.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/patch.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { getHostShadowRoot } from '../html-element';
 
 describe('patch', () => {
@@ -7,7 +7,7 @@ describe('patch', () => {
 
         it('should call connectedCallback syncronously', () => {
             let flag = false;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     flag = true;
                 }
@@ -19,7 +19,7 @@ describe('patch', () => {
 
         it('should call disconnectedCallback syncronously', () => {
             let flag = false;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 disconnectedCallback() {
                     flag = true;
                 }
@@ -32,7 +32,7 @@ describe('patch', () => {
 
         it('should call renderedCallback syncronously', () => {
             let flag = false;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 renderedCallback() {
                     flag = true;
                 }
@@ -48,7 +48,7 @@ describe('patch', () => {
                 calls.push('root:render');
                 return [$api.c('x-child', Child, {})];
             }
-            class Root extends Element {
+            class Root extends LightningElement {
                 constructor() {
                     super();
                     calls.push('root:constructor');
@@ -64,7 +64,7 @@ describe('patch', () => {
                 }
             }
 
-            class Child extends Element {
+            class Child extends LightningElement {
                 constructor() {
                     super();
                     calls.push('child:constructor');
@@ -104,7 +104,7 @@ describe('patch', () => {
                     [$cmp.state.show ? $api.c('x-child', Child, {}) : null]
                 )];
             }
-            class Root extends Element {
+            class Root extends LightningElement {
                 state = {
                     show: false
                 };
@@ -124,7 +124,7 @@ describe('patch', () => {
             Root.publicMethods = ['show', 'hide'];
             Root.track = { state: 1 };
 
-            class Child extends Element {
+            class Child extends LightningElement {
                 constructor() {
                     super();
                     calls.push('child:constructor');
@@ -175,7 +175,7 @@ describe('patch', () => {
                     ? [$api.c('x-child', Child, {})]
                     : [];
             }
-            class Root extends Element {
+            class Root extends LightningElement {
                 state = {
                     show: false
                 };
@@ -192,7 +192,7 @@ describe('patch', () => {
             Root.publicMethods = ['show'];
             Root.track = { state: 1 };
 
-            class Child extends Element {
+            class Child extends LightningElement {
                 constructor() {
                     super();
                     calls.push('child:constructor');
@@ -230,7 +230,7 @@ describe('patch', () => {
             function html($api, $cmp) {
                 return [$api.h('span', { key: 0 }, [$api.t($cmp.state.foo)])];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 state = {
                     foo: 'bar'
                 };
@@ -271,7 +271,7 @@ describe('patch', () => {
 
         it('should preserve the creation order and the hook order', () => {
             let chars = '^';
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     chars += 'connected-1:';
                 }
@@ -279,7 +279,7 @@ describe('patch', () => {
                     chars += 'rendered-1:';
                 }
             }
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 connectedCallback() {
                     chars += 'connected-2:';
                 }
@@ -296,7 +296,7 @@ describe('patch', () => {
 
         it('should disconnect when mounting a different element', () => {
             let chars = '^';
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 connectedCallback() {
                     chars += 'connected:';
                 }

--- a/packages/lwc-engine/src/framework/__tests__/performance-timing.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/performance-timing.spec.ts
@@ -89,29 +89,31 @@ class FlameChart {
 }
 
 describe('performance-timing', () => {
-    let engine: any;
+    let createElement: any;
+    let LightningElement: any;
     let flamechart: FlameChart;
 
     beforeEach(() => {
         // Make sure to reset module cache between each test to ensure to reset the uid.
         jest.resetModules();
-        engine = require('../main.ts');
+        createElement = require('../main.ts').createElement;
+        LightningElement = require('../main.ts').LightningElement;
 
         flamechart = new FlameChart();
         flamechart.injectPolyfill();
     });
 
     it('captures component constructor', () => {
-        class Foo extends engine.Element {}
+        class Foo extends LightningElement {}
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
         expect(flamechart.toString()).toMatchSnapshot();
     });
 
     it('captures all lifecycle hooks', () => {
-        class Foo extends engine.Element {
+        class Foo extends LightningElement {
             // tslint:disable-next-line:no-empty
             connectedCallback() {}
 
@@ -122,7 +124,7 @@ describe('performance-timing', () => {
             disconnectedCallback() {}
         }
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
         document.body.removeChild(elm);
 
@@ -130,7 +132,7 @@ describe('performance-timing', () => {
     });
 
     it('captures nested component tree', () => {
-        class Bar extends engine.Element {
+        class Bar extends LightningElement {
             render() {
                 return ($api: any) => [
                     $api.h('span', { key: 0 }, [])
@@ -138,7 +140,7 @@ describe('performance-timing', () => {
             }
         }
 
-        class Foo extends engine.Element {
+        class Foo extends LightningElement {
             render() {
                 return ($api: any) => [
                     $api.c('x-bar', Bar, {}),
@@ -147,20 +149,20 @@ describe('performance-timing', () => {
             }
         }
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
         expect(flamechart.toString()).toMatchSnapshot();
     });
 
     it('recovers from errors', () => {
-        class Foo extends engine.Element {
+        class Foo extends LightningElement {
             render() {
                 throw new Error('Nooo!');
             }
         }
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
 
         try {
             document.body.appendChild(elm);
@@ -172,13 +174,13 @@ describe('performance-timing', () => {
     });
 
     it('captures error callback', () => {
-        class Bar extends engine.Element {
+        class Bar extends LightningElement {
             render() {
                 throw new Error('Noo!');
             }
         }
 
-        class Foo extends engine.Element {
+        class Foo extends LightningElement {
             render() {
                 return ($api: any) => [
                     $api.c('x-bar', Bar, {}),
@@ -189,7 +191,7 @@ describe('performance-timing', () => {
             errorCallback() {}
         }
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
         expect(flamechart.toString()).toMatchSnapshot();
@@ -199,7 +201,7 @@ describe('performance-timing', () => {
         let bar: Bar;
         let baz: Baz;
 
-        class Bar extends engine.Element {
+        class Bar extends LightningElement {
             state: boolean = false;
 
             connectedCallback() {
@@ -217,7 +219,7 @@ describe('performance-timing', () => {
             };
         }
 
-        class Baz extends engine.Element {
+        class Baz extends LightningElement {
             state: boolean = false;
 
             connectedCallback() {
@@ -235,7 +237,7 @@ describe('performance-timing', () => {
             };
         }
 
-        class Foo extends engine.Element {
+        class Foo extends LightningElement {
             render() {
                 return ($api: any) => {
                     return [
@@ -246,7 +248,7 @@ describe('performance-timing', () => {
             }
         }
 
-        const elm = engine.createElement('x-foo', { is: Foo });
+        const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
         flamechart.reset();

--- a/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/reactive.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element, unwrap } from '../main';
+import { createElement, LightningElement, unwrap } from '../main';
 import { reactiveMembrane } from '../membrane';
 
 describe('unwrap', () => {
@@ -17,7 +17,7 @@ describe('unwrap', () => {
         const renderHandler = ($api) => {
             return [$api.h('div', { key: 0 }, [])]
         }
-        class CustomEl extends Element {
+        class CustomEl extends LightningElement {
             query() {
                 return this.template.querySelector('div');
             }

--- a/packages/lwc-engine/src/framework/__tests__/services.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/services.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from "../main";
+import { createElement, LightningElement } from "../main";
 import * as target from '../services';
 
 function resetServices() {
@@ -64,7 +64,7 @@ describe('services', () => {
                     d++;
                 }
             });
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             document.body.removeChild(elm);
@@ -91,7 +91,7 @@ describe('services', () => {
             function html() {
                 return [];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 connectedCallback() {
                     lifecycleLog.push('component connected callback');
                 }

--- a/packages/lwc-engine/src/framework/__tests__/template.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/template.spec.ts
@@ -1,8 +1,8 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { getHostShadowRoot } from '../html-element';
 
 function createCustomComponent(html) {
-    class MyComponent extends Element {
+    class MyComponent extends LightningElement {
         render() {
             return html;
         }
@@ -106,7 +106,7 @@ describe('template', () => {
                 $cmp.y;
                 return [];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 get x() {
                     counter += 1;
                     this.y; // accessing another getter
@@ -131,7 +131,7 @@ describe('template', () => {
                 return [];
             }
             template.ids = ['x'];
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 x = 1;
                 render() {
                     return template;
@@ -154,7 +154,7 @@ describe('template', () => {
                 value = memoizer.m0;
                 return [];
             }
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 render() {
                     counter++;
                     if (counter === 1) {
@@ -179,7 +179,7 @@ describe('template', () => {
             function html($api) {
                 return [$api.t('some text')];
             }
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 render() {
                     return html;
                 }
@@ -192,7 +192,7 @@ describe('template', () => {
         it('should profixied default objects', () => {
             const x = [1, 2, 3];
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.x = x;
@@ -215,7 +215,7 @@ describe('template', () => {
 
         it('should proxify property objects', () => {
             const x = [1, 2, 3];
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             MyComponent.publicProps = {
                 x: {
                     config: 0
@@ -233,7 +233,7 @@ describe('template', () => {
                 y = $cmp.x;
                 return [];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     x = this.x;
@@ -293,7 +293,7 @@ describe('template', () => {
                 }, [])]
             }
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 get getStyle() {
                     return '';
                 }
@@ -315,7 +315,7 @@ describe('template', () => {
             const styledTmpl = () => [];
             styledTmpl.hostToken = 'token-host';
 
-            class Component extends Element {
+            class Component extends LightningElement {
                 render() {
                     return styledTmpl;
                 }
@@ -340,7 +340,7 @@ describe('template', () => {
             ];
             styledTmpl.shadowToken = 'token';
 
-            class Component extends Element {
+            class Component extends LightningElement {
                 render() {
                     return styledTmpl;
                 }
@@ -359,7 +359,7 @@ describe('template', () => {
 
             const unstyledTmpl = () => [];
 
-            class Component extends Element {
+            class Component extends LightningElement {
                 tmpl = styledTmpl;
                 render() {
                     return this.tmpl;
@@ -388,7 +388,7 @@ describe('template', () => {
             const styledTmplB = () => [];
             styledTmplB.hostToken = 'tokenB-host';
 
-            class Component extends Element {
+            class Component extends LightningElement {
                 tmpl = styledTmplA;
                 render() {
                     return this.tmpl;
@@ -421,7 +421,7 @@ describe('template', () => {
             }
             let div: HTMLElement;
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.x = 0;
@@ -456,7 +456,7 @@ describe('template', () => {
             }
             let div: HTMLElement;
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.x = 0;
@@ -493,7 +493,7 @@ describe('template', () => {
                 }, [])]
             }
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -517,7 +517,7 @@ describe('template', () => {
                 }, [])]
             }
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 _inner = 'initial',
                 setInner(value) {
                     this._inner = value;

--- a/packages/lwc-engine/src/framework/__tests__/upgrade.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/upgrade.spec.ts
@@ -1,9 +1,9 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 
 describe('upgrade', () => {
     describe('#createElement()', () => {
         it('should support constructors with circular dependencies', () => {
-            const factory = () => class extends Element { };
+            const factory = () => class extends LightningElement { };
             factory.__circular__ = true;
 
             expect(
@@ -17,7 +17,7 @@ describe('upgrade', () => {
                 x: any,
                 y: any;
             };
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 x: any;
                 y: any;
                 constructor() {
@@ -39,7 +39,7 @@ describe('upgrade', () => {
         });
 
         it('should proxify any value before setting a property', () => {
-            const def = class MyComponent extends Element {};
+            const def = class MyComponent extends LightningElement {};
             def.publicProps = { x: 1 };
             const elm = createElement('x-foo', { is: def });
             const o = { foo: 1 };

--- a/packages/lwc-engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/vm.spec.ts
@@ -1,23 +1,23 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 import { ViewModelReflection } from "../utils";
 
 describe('vm', () => {
     describe('insertion index', () => {
         it('should assign idx=0 (insertion index) during construction', () => {
-            class MyComponent1 extends Element {}
+            class MyComponent1 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent1 });
             expect(elm[ViewModelReflection].idx).toBe(0);
         });
 
         it('should assign idx>0 after insertion', () => {
-            class MyComponent2 extends Element {}
+            class MyComponent2 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent2 });
             document.body.appendChild(elm);
             expect(elm[ViewModelReflection].idx).toBeGreaterThan(0);
         });
 
         it('should assign idx=0 after removal', () => {
-            class MyComponent3 extends Element {}
+            class MyComponent3 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent3 });
             document.body.appendChild(elm);
             document.body.removeChild(elm);
@@ -26,7 +26,7 @@ describe('vm', () => {
 
         it('should assign bigger idx to children', () => {
             let vm1: VM, vm2: VM;
-            class ChildComponent4 extends Element {
+            class ChildComponent4 extends LightningElement {
                 constructor() {
                     super();
                     vm2 = this[ViewModelReflection];
@@ -35,7 +35,7 @@ describe('vm', () => {
             function html($api) {
                 return [$api.c('x-bar', ChildComponent4, {})];
             }
-            class MyComponent4 extends Element {
+            class MyComponent4 extends LightningElement {
                 constructor() {
                     super();
                     vm1 = this[ViewModelReflection];
@@ -54,7 +54,7 @@ describe('vm', () => {
         it('should assign bigger idx on reinsertion, including children idx', () => {
             let vm1: VM, vm2: VM;
             let counter = 0;
-            class ChildComponent5 extends Element {
+            class ChildComponent5 extends LightningElement {
                 constructor() {
                     super();
                     vm2 = this[ViewModelReflection];
@@ -66,7 +66,7 @@ describe('vm', () => {
             function html($api) {
                 return [$api.c('x-bar', ChildComponent5, {})];
             }
-            class MyComponent5 extends Element {
+            class MyComponent5 extends LightningElement {
                 constructor() {
                     super();
                     vm1 = this[ViewModelReflection];

--- a/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/watcher.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../main';
+import { createElement, LightningElement } from '../main';
 
 describe('watcher', () => {
 
@@ -6,7 +6,7 @@ describe('watcher', () => {
 
         it('should not rerender the component if nothing changes', () => {
             let counter = 0;
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 render() {
                     counter++;
                 }
@@ -22,7 +22,7 @@ describe('watcher', () => {
                 $cmp.x;
                 return [];
             }
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 render() {
                     counter++;
                     // TODO: if x is used in render (outside of html), and it is not used inside the compiled template
@@ -45,7 +45,7 @@ describe('watcher', () => {
 
         it('should not rerender the component if a non-reactive prop changes', () => {
             let counter = 0;
-            class MyComponent3 extends Element {
+            class MyComponent3 extends LightningElement {
                 render() {
                     counter++;
                 }
@@ -71,7 +71,7 @@ describe('watcher', () => {
                 }, [], $slotset)];
             }
             html1.slots = ["x"];
-            class Child extends Element {
+            class Child extends LightningElement {
                 render() {
                     counter++;
                     return html1;
@@ -81,7 +81,7 @@ describe('watcher', () => {
                 const r = $cmp.round;
                 return [$api.c('x-child', Child, {}, r === 0 ? [] : [$api.h('p', { key: 0, attrs: { slot: 'x' } }, [])])];
             }
-            class MyComponent4 extends Element {
+            class MyComponent4 extends LightningElement {
                 constructor() {
                     super();
                     this.round = 0;
@@ -112,7 +112,7 @@ describe('watcher', () => {
                 $cmp.state.x;
                 return [];
             }
-            class MyComponent6 extends Element {
+            class MyComponent6 extends LightningElement {
                 state = { x: 0 };
                 constructor() {
                     super();
@@ -135,7 +135,7 @@ describe('watcher', () => {
         it('should not rerender the component if a non-reactive state changes', () => {
             let counter = 0;
             let state;
-            class MyComponent7 extends Element {
+            class MyComponent7 extends LightningElement {
                 state = { x: 0 };
                 constructor() {
                     super();
@@ -158,7 +158,7 @@ describe('watcher', () => {
             function html($api, $cmp) {
                 $cmp.state.x = 1;
             }
-            class MyComponent8 extends Element {
+            class MyComponent8 extends LightningElement {
                 state = { x: 0 };
                 render() {
                     return html;
@@ -177,7 +177,7 @@ describe('watcher', () => {
                 }
                 return [];
             }
-            class MyComponent9 extends Element {
+            class MyComponent9 extends LightningElement {
                 state = { x: 0 };
                 constructor() {
                     super();
@@ -208,7 +208,7 @@ describe('watcher', () => {
                 $cmp.foo;
                 return [];
             }
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 get foo() {
                     return this.x;
                 }
@@ -235,7 +235,7 @@ describe('watcher', () => {
         it('should allow observing public prop via setter', () => {
             let counter = 0;
             let newValue, oldValue;
-            class MyComponent2 extends Element {
+            class MyComponent2 extends LightningElement {
                 set x(value) {
                     counter++;
                     oldValue = newValue;
@@ -259,7 +259,7 @@ describe('watcher', () => {
     describe('#reactivity()', () => {
         it('should react when a reactive array invokes Array.prototype.push()', () => {
             let counter = 0;
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 state = { list: [1, 2] };
 
                 pushToList(value: number) {
@@ -283,7 +283,7 @@ describe('watcher', () => {
         });
         it('should react when a reactive array invokes Array.prototype.pop()', () => {
             let counter = 0;
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 state = { list: [1, 2] };
 
                 popFromList() {
@@ -307,7 +307,7 @@ describe('watcher', () => {
         });
         it('should react when a reactive array invokes Array.prototype.unshift()', () => {
             let counter = 0;
-            class MyComponent1 extends Element {
+            class MyComponent1 extends LightningElement {
                 state = { list: [1, 2] };
                 unshiftFromList(value: number) {
                     this.state.list.unshift(value);

--- a/packages/lwc-engine/src/framework/__tests__/wc.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/wc.spec.ts
@@ -1,16 +1,16 @@
-import { Element } from "../main";
+import { LightningElement } from "../main";
 import { buildCustomElementConstructor } from "../wc";
 
 describe('wc', () => {
 
     it('should create a new constructor from LWCElement', () => {
-        class MyComponent extends Element {}
+        class MyComponent extends LightningElement {}
         const WC = buildCustomElementConstructor(MyComponent);
         expect(typeof WC).toBe('function');
     });
 
     it('should define public API in prototype chain', () => {
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             foo() {}
         }
         MyComponent.publicMethods = ['foo'];
@@ -21,7 +21,7 @@ describe('wc', () => {
     });
 
     it('should not support forceTagName', () => {
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             static forceTagName = 'button';
         }
         expect(() => {

--- a/packages/lwc-engine/src/framework/decorators/__tests__/api.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/api.spec.ts
@@ -1,10 +1,10 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 
 describe('decorators/api.ts', () => {
     describe('@api x', () => {
         it('should allow inheriting public props', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     this.breakfast = 'pancakes';
@@ -19,7 +19,7 @@ describe('decorators/api.ts', () => {
             function html($api) {
                 return [$api.c('x-component', MyComponent, {})];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 constructor() {
                     super();
                     this.parentGetter = 'parentgetter';
@@ -43,7 +43,7 @@ describe('decorators/api.ts', () => {
 
         it('should not be consider properties reactive if not used in render', function() {
             let counter = 0;
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 render() {
                     counter++;
                 }
@@ -66,7 +66,7 @@ describe('decorators/api.ts', () => {
 
         it('should consider tracked property reactive if used in render', function() {
             let counter = 0;
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 render() {
                     this.x;
                     counter++;
@@ -91,7 +91,7 @@ describe('decorators/api.ts', () => {
             function html($api, $cmp, $slotset, $ctx) {
                 return [$api.h('div', { key: 0 }, [$api.d($cmp.x)])];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 render() {
                     return html;
                 }
@@ -114,7 +114,7 @@ describe('decorators/api.ts', () => {
 
     describe('@api get/set x', () => {
         it('should allow public getters', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get breakfast() {
                     return 'pancakes';
                 }
@@ -128,7 +128,7 @@ describe('decorators/api.ts', () => {
             function html($api) {
                 return [$api.c('x-component', MyComponent, {})];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 get parentGetter() {
                     return 'parentgetter';
                 }
@@ -152,7 +152,7 @@ describe('decorators/api.ts', () => {
 
         it('should not be consider getter and setters reactive', function() {
             let counter = 0;
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get x() {
                     return 1;
                 }
@@ -181,7 +181,7 @@ describe('decorators/api.ts', () => {
 
         it('should consider tracked property reactive if used via getter and setter', function() {
             let counter = 0;
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get x() {
                     return this.y;
                 }
@@ -217,7 +217,7 @@ describe('decorators/api.ts', () => {
             function html ($api, $cmp, $slotset, $ctx) {
                 return [$api.h('div', { key: 0 }, [$api.d($cmp.validity)])];
             }
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get validity() {
                     return 'foo';
                 }
@@ -240,7 +240,7 @@ describe('decorators/api.ts', () => {
         });
 
         it('should allow calling the getter during construction', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get x() {
                     return 1;
                 }
@@ -264,7 +264,7 @@ describe('decorators/api.ts', () => {
         });
 
         it('should allow calling the setter during construction', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 get x() {
                     return 1;
                 }
@@ -290,7 +290,7 @@ describe('decorators/api.ts', () => {
 
     describe('@api foo()', () => {
         it('should allow inheriting public methods', function() {
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 x() {
                     return 1;
                 }
@@ -314,7 +314,7 @@ describe('decorators/api.ts', () => {
 
         it('should preserve the context in public methods', function() {
             let args, ctx, that;
-            class MyComponent extends Element  {
+            class MyComponent extends LightningElement  {
                 constructor() {
                     super();
                     that = this;
@@ -339,7 +339,7 @@ describe('decorators/api.ts', () => {
             const originalValue = 0;
             const newValue = 100;
 
-            class XFoo extends Element  {
+            class XFoo extends LightningElement  {
                 constructor() {
                     super();
                     this.counter = originalValue;

--- a/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import track from "../track";
 import readonly from "../readonly";
 
@@ -8,7 +8,7 @@ describe('track.ts', () => {
             expect.assertions(3);
 
             const o = { x: 1 };
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect('foo' in this).toBe(true);
@@ -28,7 +28,7 @@ describe('track.ts', () => {
             expect.assertions(2);
 
             const o = { x: 1 };
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toEqual(o);
@@ -45,7 +45,7 @@ describe('track.ts', () => {
 
         it('should make tracked properties reactive', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                 }
@@ -70,7 +70,7 @@ describe('track.ts', () => {
 
         it('should make properties of a tracked object property reactive', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFooDotX(x) {
                     this.foo.x = x;
                 }
@@ -96,7 +96,7 @@ describe('track.ts', () => {
         it('should not proxify primitive value', function() {
             expect.assertions(1);
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(1);
@@ -114,7 +114,7 @@ describe('track.ts', () => {
             expect.assertions(2);
 
             const a = [];
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toEqual(a);
@@ -133,7 +133,7 @@ describe('track.ts', () => {
             expect.assertions(1);
 
             const d = new Date();
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(d);
@@ -151,7 +151,7 @@ describe('track.ts', () => {
             expect.assertions(1);
 
             const o = Object.create({});
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(o);
@@ -166,7 +166,7 @@ describe('track.ts', () => {
         });
 
         it('should not throw an error if track is observable object', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                 }
@@ -181,7 +181,7 @@ describe('track.ts', () => {
         });
 
         it('should throw a track property is mutated during rendering', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     this.foo = 1;
                 }
@@ -197,7 +197,7 @@ describe('track.ts', () => {
 
     describe('@track regression', () => {
         test(`#609 - each instance of the same object prototype should have it's own tracked property value`, () => {
-            class XFoo extends Element  {
+            class XFoo extends LightningElement  {
                 constructor() {
                     super();
                     this.counter = 0;
@@ -224,7 +224,7 @@ describe('track.ts', () => {
     });
 
     test(`#609 - instance of the same object prototype should not share values of tracked properties`, () => {
-        class XFoo extends Element  {
+        class XFoo extends LightningElement  {
             constructor() {
                 super();
                 this.counter = 0;
@@ -262,7 +262,7 @@ describe('track.ts', () => {
 
         it('should produce a trackable object', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.foo = track({ bar: 1 });

--- a/packages/lwc-engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import wire from "../wire";
 
 describe('wire.ts', () => {
@@ -7,7 +7,7 @@ describe('wire.ts', () => {
             expect.assertions(3);
 
             const o = { x: 1 };
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     expect('foo' in this).toBe(true);
@@ -27,7 +27,7 @@ describe('wire.ts', () => {
             expect.assertions(2);
 
             const o = { x: 1 };
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toEqual(o);
@@ -44,7 +44,7 @@ describe('wire.ts', () => {
 
         it('should make wired properties reactive', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                 }
@@ -71,7 +71,7 @@ describe('wire.ts', () => {
 
         it('should make properties of a wired object property reactive', () => {
             let counter = 0;
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFooDotX(x) {
                     this.foo.x = x;
                 }
@@ -99,7 +99,7 @@ describe('wire.ts', () => {
         it('should not proxify primitive value', function() {
             expect.assertions(1);
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(1);
@@ -117,7 +117,7 @@ describe('wire.ts', () => {
             expect.assertions(2);
 
             const a = [];
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toEqual(a);
@@ -136,7 +136,7 @@ describe('wire.ts', () => {
             expect.assertions(1);
 
             const d = new Date();
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(d);
@@ -154,7 +154,7 @@ describe('wire.ts', () => {
             expect.assertions(1);
 
             const o = Object.create({});
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                     expect(this.foo).toBe(o);
@@ -169,7 +169,7 @@ describe('wire.ts', () => {
         });
 
         it('should not throw an error if wire is observable object', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 injectFoo(v) {
                     this.foo = v;
                 }
@@ -184,7 +184,7 @@ describe('wire.ts', () => {
         });
 
         it('should throw a wire property is mutated during rendering', function() {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     this.foo = 1;
                 }
@@ -200,7 +200,7 @@ describe('wire.ts', () => {
 
     describe('@wire misuse', () => {
         it('should throw when invoking wire without adapter', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     wire();

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -39,7 +39,7 @@ import decorate, { DecoratorMap } from "./decorators/decorate";
 import wireDecorator from "./decorators/wire";
 import trackDecorator from "./decorators/track";
 import apiDecorator from "./decorators/api";
-import { Element as BaseElement, createBaseElementStandardPropertyDescriptors } from "./html-element";
+import { LightningElement as BaseElement, createBaseElementStandardPropertyDescriptors } from "./html-element";
 import {
     EmptyObject,
     PatchedFlag,

--- a/packages/lwc-engine/src/framework/dom/__tests__/dom-inspection.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/dom-inspection.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 
 describe('DOM inspection', () => {
@@ -29,7 +29,7 @@ describe('DOM inspection', () => {
     }
     tmpl$1.slots = [""];
 
-    class Parent extends Element {
+    class Parent extends LightningElement {
         render() {
             return tmpl$1;
         }
@@ -57,7 +57,7 @@ describe('DOM inspection', () => {
             ])];
     }
 
-    class Container extends Element {
+    class Container extends LightningElement {
         render() {
             return tmpl$2;
         }

--- a/packages/lwc-engine/src/framework/dom/__tests__/dom.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/dom.spec.ts
@@ -1,11 +1,11 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 import { getRootNode } from "../node";
 
 describe('dom', () => {
     describe('getRootNode composed true', () => {
         it('should return correct value from child node', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 trigger() {
                     const event = new CustomEvent('foo', {
                         bubbles: true,
@@ -17,7 +17,7 @@ describe('dom', () => {
             }
             MyComponent.publicMethods = ['trigger'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 handleFoo(evt) {
                     expect(evt.target).toBe(this.template.querySelector('x-foo'));
                 }
@@ -50,7 +50,7 @@ describe('dom', () => {
         });
 
         it('should return correct value from self', () => {
-            class Parent extends Element {}
+            class Parent extends LightningElement {}
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
 
@@ -62,7 +62,7 @@ describe('dom', () => {
 
     describe('getRootNode composed false', () => {
         it('should return correct value from child node', () => {
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 trigger() {
                     const event = new CustomEvent('foo', {
                         bubbles: true,
@@ -74,7 +74,7 @@ describe('dom', () => {
             }
             MyComponent.publicMethods = ['trigger'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 handleFoo(evt) {
                     expect(evt.target).toBe(this.template.querySelector('x-foo'));
                 }
@@ -107,7 +107,7 @@ describe('dom', () => {
         });
 
         it('should return correct value from self', () => {
-            class Parent extends Element {}
+            class Parent extends LightningElement {}
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);
 
@@ -150,7 +150,7 @@ describe('dom', () => {
 
         it('should handle event.target on events dispatched on custom elements', function () {
             expect.assertions(1);
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 trigger() {
                     const event = new CustomEvent('foo', {
                         bubbles: true,
@@ -162,7 +162,7 @@ describe('dom', () => {
             }
             MyComponent.publicMethods = ['trigger'];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 handleFoo(evt) {
                     expect(evt.target).toBe(this.template.querySelector('x-foo'));
                 }

--- a/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/iframe.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 import { wrapIframeWindow } from "../iframe";
 
@@ -116,7 +116,7 @@ describe('wrapped iframe window', () => {
             function html($api) {
                 return [$api.h('iframe', { key: 0, src: 'https://salesforce.com' }, [])];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }

--- a/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/shadow-root.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from '../../html-element';
 import { h } from '../../api';
 
@@ -7,14 +7,14 @@ describe('root', () => {
         it.skip('should support this.template.host', () => {});
 
         it('should support this.template.mode', () => {
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent });
             expect(getHostShadowRoot(elm).mode).toBe('closed');
         });
 
         it('should allow searching for elements from template', () => {
             function html($api) { return [$api.h('p', { key: 0 }, [])]; }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -31,7 +31,7 @@ describe('root', () => {
             function html($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -47,7 +47,7 @@ describe('root', () => {
         it('should ignore elements from other owner', () => {
             const vnodeFromAnotherOwner = h('p', { key: 0 }, []);
             function html() { return [vnodeFromAnotherOwner]; }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -63,7 +63,7 @@ describe('root', () => {
         it('should ignore element from other owner', () => {
             const vnodeFromAnotherOwner = h('p', { key: 0 }, []);
             function html() { return [vnodeFromAnotherOwner]; }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -77,7 +77,7 @@ describe('root', () => {
         });
 
         it('should expose the shadow root via $$ShadowRoot$$ when in test mode', () => {
-            class MyComponent extends Element {}
+            class MyComponent extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             expect(elm.$$ShadowRoot$$).toBeDefined();
@@ -103,7 +103,7 @@ describe('root', () => {
                     ]),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -133,7 +133,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -155,7 +155,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -180,7 +180,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -202,7 +202,7 @@ describe('root', () => {
                     $api.t('last-text-node'),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }
@@ -223,7 +223,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 render() {
                     return tmpl1;
                 }
@@ -238,7 +238,7 @@ describe('root', () => {
                     $api.t('just text'),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -271,7 +271,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyChild extends Element {
+            class MyChild extends LightningElement {
                 render() {
                     return tmpl1;
                 }
@@ -286,7 +286,7 @@ describe('root', () => {
                     $api.t('just text'),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -325,7 +325,7 @@ describe('root', () => {
             function tmpl2($api) {
                 return [];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -340,7 +340,7 @@ describe('root', () => {
             function tmpl2($api) {
                 return [];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -355,7 +355,7 @@ describe('root', () => {
             function tmpl2($api) {
                 return [$api.t('something')];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -370,7 +370,7 @@ describe('root', () => {
             function tmpl2($api, $cmp, $slotset) {
                 return [$api.s('something', {key: 0}, [], $slotset)];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl2;
                 }
@@ -395,7 +395,7 @@ describe('root', () => {
                     }, []),
                 ];
             }
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return tmpl;
                 }

--- a/packages/lwc-engine/src/framework/dom/__tests__/slot.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/slot.spec.ts
@@ -1,4 +1,4 @@
-import { Element, getHostShadowRoot } from "../../html-element";
+import { LightningElement, getHostShadowRoot } from "../../html-element";
 import { createElement } from "../../upgrade";
 
 // https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element
@@ -17,7 +17,7 @@ describe('assignedNodes', () => {
             }
             html.slots = [''];
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -64,7 +64,7 @@ describe('assignedNodes', () => {
             }
             html.slots = ['outer', 'inner'];
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -117,7 +117,7 @@ describe('assignedNodes', () => {
             let element;
 
             beforeEach(() => {
-                class AssignedNodesChild extends Element {
+                class AssignedNodesChild extends LightningElement {
                     render() {
                         const html = function($api, $cmp, $slotset) {
                             return [
@@ -133,7 +133,7 @@ describe('assignedNodes', () => {
                     }
                 }
 
-                class AssignedNodes extends Element {
+                class AssignedNodes extends LightningElement {
                     render() {
                         return function($api, $cmp, $slotset) {
                             return [
@@ -210,7 +210,7 @@ describe('assignedNodes', () => {
             let element;
 
             beforeEach(() => {
-                class AssignedNodesChild extends Element {
+                class AssignedNodesChild extends LightningElement {
                     render() {
                         const html = function($api, $cmp, $slotset) {
                             return [
@@ -226,7 +226,7 @@ describe('assignedNodes', () => {
                     }
                 }
 
-                class AssignedNodes extends Element {
+                class AssignedNodes extends LightningElement {
                     render() {
                         return function($api, $cmp, $slotset) {
                             return [
@@ -311,7 +311,7 @@ describe('slot.name', () => {
             }
             html.slots = ['', 'foo'];
 
-            class MyComponent extends Element {
+            class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -352,7 +352,7 @@ describe('slotted elements', () => {
             ];
         }
 
-        class XChild extends Element {
+        class XChild extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', this.handleClickOnChild.bind(this));
             }
@@ -371,7 +371,7 @@ describe('slotted elements', () => {
         }
         htmlContainer.slots = [''];
 
-        class XContainer extends Element {
+        class XContainer extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', this.handleClickInContainer.bind(this));
             }
@@ -395,7 +395,7 @@ describe('slotted elements', () => {
             ];
         }
 
-        class MyMock extends Element {
+        class MyMock extends LightningElement {
             connectedCallback() {
                 this.template.addEventListener('click', this.handleClickInMock.bind(this));
             }

--- a/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
+++ b/packages/lwc-engine/src/framework/dom/__tests__/traverse.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 
 describe('#LightDom querySelectorAll()', () => {
@@ -14,7 +14,7 @@ describe('#LightDom querySelectorAll()', () => {
             }
             tmpl$1.slots = [""];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return tmpl$1;
                 }
@@ -50,7 +50,7 @@ describe('#LightDom querySelectorAll()', () => {
                     ])];
             }
 
-            class LightdomQuerySelector extends Element {
+            class LightdomQuerySelector extends LightningElement {
                 render() {
                     return tmpl$2;
                 }
@@ -69,7 +69,7 @@ describe('#LightDom querySelectorAll()', () => {
             function html1($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            class Child extends Element {
+            class Child extends LightningElement {
                 render() {
                     return html1;
                 }
@@ -77,7 +77,7 @@ describe('#LightDom querySelectorAll()', () => {
             function html2($api) {
                 return [$api.c('x-child', Child, { key: 0 }, [])];
             }
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return html2;
                 }
@@ -91,7 +91,7 @@ describe('#LightDom querySelectorAll()', () => {
             function html($api) {
                 return [$api.h('p', { key: 0 }, [])];
             }
-            const def = class MyComponent extends Element {
+            const def = class MyComponent extends LightningElement {
                 render() {
                     return html;
                 }
@@ -116,7 +116,7 @@ describe('#LightDom querySelectorAll()', () => {
             }
             tmpl$1.slots = [""];
 
-            class Parent extends Element {
+            class Parent extends LightningElement {
                 render() {
                     return tmpl$1;
                 }
@@ -152,7 +152,7 @@ describe('#LightDom querySelectorAll()', () => {
                     ])];
             }
 
-            class LightdomQuerySelector extends Element {
+            class LightdomQuerySelector extends LightningElement {
                 render() {
                     return tmpl$2;
                 }
@@ -180,7 +180,7 @@ describe('#LightDom querySelector()', () => {
         }
         tmpl$1.slots = [""];
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return tmpl$1;
             }
@@ -216,7 +216,7 @@ describe('#LightDom querySelector()', () => {
                 ])];
         }
 
-        class LightdomQuerySelector extends Element {
+        class LightdomQuerySelector extends LightningElement {
             render() {
                 return tmpl$2;
             }
@@ -232,7 +232,7 @@ describe('#LightDom querySelector()', () => {
         function html1($api) {
             return [$api.h('p', { key: 0 }, [])];
         }
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return html1;
             }
@@ -240,7 +240,7 @@ describe('#LightDom querySelector()', () => {
         function html2($api) {
             return [$api.c('x-child', Child, { key: 0 }, [])];
         }
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return html2;
             }
@@ -254,7 +254,7 @@ describe('#LightDom querySelector()', () => {
         function html($api) {
             return [$api.h('p', { key: 0 }, [])];
         }
-        const def = class MyComponent extends Element {
+        const def = class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -270,7 +270,7 @@ describe('#LightDom querySelector()', () => {
         function html($api) {
             return [$api.h('p', { key: 0 }, [])];
         }
-        const def = class MyComponent extends Element {
+        const def = class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -284,7 +284,7 @@ describe('#LightDom querySelector()', () => {
 describe('#shadowRoot querySelector', () => {
     it('should querySelector on element from template', () => {
         function html($api) { return [$api.h('ul', { key: 0 }, [$api.h('li', { key: 1 }, [])])]; }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -301,7 +301,7 @@ describe('#shadowRoot querySelector', () => {
 
     it('should not reach into child components template when querySelector invoked on child custom element', () => {
         expect.assertions(1);
-        class MyChild extends Element {
+        class MyChild extends LightningElement {
             render() {
                 return function($api) {
                     return [$api.h('div', {
@@ -315,7 +315,7 @@ describe('#shadowRoot querySelector', () => {
             return [$api.c('membrane-parent-query-selector-child-custom-element-child', MyChild, {})];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -328,7 +328,7 @@ describe('#shadowRoot querySelector', () => {
 
     it('should querySelectorAll on element from template', () => {
         function html($api) { return [$api.h('ul', { key: 0 }, [$api.h('li', { key: 1 }, [])])]; }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -345,7 +345,7 @@ describe('#shadowRoot querySelector', () => {
 
     it('should adopt elements not defined in template as part of the shadow', () => {
         function html($api) { return [$api.h('ul', { key: 0 }, [])]; }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -367,7 +367,7 @@ describe('#shadowRoot querySelector', () => {
 
     it('should not throw error if querySelector does not match any elements', () => {
         function html($api) { return [$api.h('ul', { key: 0 }, [])]; }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -384,7 +384,7 @@ describe('#shadowRoot querySelector', () => {
 
     it('should return null if querySelector does not match any elements', () => {
         function html($api) { return [$api.h('ul', { key: 0 }, [])]; }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -401,7 +401,7 @@ describe('#shadowRoot querySelector', () => {
         function html($api) {
             return [$api.h('ul', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -419,7 +419,7 @@ describe('#shadowRoot querySelector', () => {
     it('should not expose shadow root on child custom element', () => {
         expect.assertions(1);
         let childTemplate;
-        class MyChild extends Element {
+        class MyChild extends LightningElement {
             constructor() {
                 super();
                 childTemplate = this.template;
@@ -442,7 +442,7 @@ describe('#shadowRoot querySelector', () => {
             })];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             handleClick(evt) {
                 expect(evt.target.parentNode).not.toBe(childTemplate);
             }
@@ -467,7 +467,7 @@ describe('#parentNode and #parentElement', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -485,7 +485,7 @@ describe('#parentNode and #parentElement', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -505,7 +505,7 @@ describe('proxy', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -521,7 +521,7 @@ describe('proxy', () => {
         function html($api) {
             return [$api.h('span', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -539,7 +539,7 @@ describe('proxy', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [$api.h('p', { key: 1 }, [])])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -556,7 +556,7 @@ describe('proxy', () => {
         function html($api) {
             return [$api.h('div', { key: 0 }, [])];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -585,13 +585,13 @@ describe('#childNodes', () => {
         }
         tmpl.slots = [''];
 
-        class HasSlot extends Element {
+        class HasSlot extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -627,13 +627,13 @@ describe('#childNodes', () => {
         }
         tmpl.slots = [''];
 
-        class HasSlot extends Element {
+        class HasSlot extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -652,7 +652,7 @@ describe('#childNodes', () => {
     });
 
     it('should return correct elements for non-slot elements', () => {
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -684,13 +684,13 @@ describe('#childNodes', () => {
                 }, []),
             ]
         }
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -721,13 +721,13 @@ describe('#childNodes', () => {
                 }, [], $slotset),
             ]
         }
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -762,13 +762,13 @@ describe('#childNodes', () => {
                 }, [], $slotset),
             ]
         }
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -801,13 +801,13 @@ describe('#childNodes', () => {
                 $api.t('text'),
             ]
         }
-        class Child extends Element {
+        class Child extends LightningElement {
             render() {
                 return tmpl;
             }
         }
 
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -837,7 +837,7 @@ describe('#childNodes', () => {
             ];
         }
 
-        class Child extends Element {
+        class Child extends LightningElement {
             get dynamicText() {
                 return 'text';
             }
@@ -851,7 +851,7 @@ describe('#childNodes', () => {
                 $api.c('x-child', Child, {}, []),
             ];
         }
-        class Parent extends Element {
+        class Parent extends LightningElement {
 
             render() {
                 return tmplParent;
@@ -865,7 +865,7 @@ describe('#childNodes', () => {
     });
 
     it('should return correct childNodes from shadowRoot', () => {
-        class Parent extends Element {
+        class Parent extends LightningElement {
             render() {
                 return function ($api) {
                     return [
@@ -891,7 +891,7 @@ describe('#childNodes', () => {
 
 describe('assignedSlot', () => {
     it('should return null when custom element is not in slot', () => {
-        class NoSlot extends Element {}
+        class NoSlot extends LightningElement {}
 
         function html($api) {
             return [
@@ -899,7 +899,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -920,7 +920,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -943,7 +943,7 @@ describe('assignedSlot', () => {
 
         slottedHtml.slots = [""];
 
-        class WithSlot extends Element {
+        class WithSlot extends LightningElement {
             render() {
                 return slottedHtml;
             }
@@ -963,7 +963,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -979,7 +979,7 @@ describe('assignedSlot', () => {
     });
 
     it('should return correct slot when custom element is slotted', () => {
-        class InsideSlot extends Element {}
+        class InsideSlot extends LightningElement {}
 
         function slottedHtml($api, $cmp, $slotset) {
             return [
@@ -991,7 +991,7 @@ describe('assignedSlot', () => {
 
         slottedHtml.slots = [""];
 
-        class WithSlot extends Element {
+        class WithSlot extends LightningElement {
             render() {
                 return slottedHtml;
             }
@@ -1009,7 +1009,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -1037,7 +1037,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -1050,7 +1050,7 @@ describe('assignedSlot', () => {
     });
 
     it('should return null when custom element default slot content', () => {
-        class CustomElement extends Element {
+        class CustomElement extends LightningElement {
 
         }
 
@@ -1066,7 +1066,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }
@@ -1079,7 +1079,7 @@ describe('assignedSlot', () => {
     });
 
     it('should return correct slot when text is slotted', () => {
-        class InsideSlot extends Element {}
+        class InsideSlot extends LightningElement {}
 
         function slottedHtml($api, $cmp, $slotset) {
             return [
@@ -1091,7 +1091,7 @@ describe('assignedSlot', () => {
 
         slottedHtml.slots = [""];
 
-        class WithSlot extends Element {
+        class WithSlot extends LightningElement {
             render() {
                 return slottedHtml;
             }
@@ -1107,7 +1107,7 @@ describe('assignedSlot', () => {
             ];
         }
 
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             render() {
                 return html;
             }

--- a/packages/lwc-engine/src/framework/html-element.ts
+++ b/packages/lwc-engine/src/framework/html-element.ts
@@ -85,7 +85,7 @@ interface ComponentHooks {
 }
 
 // This should be as performant as possible, while any initialization should be done lazily
-function LWCElement(this: Component) {
+function LightningElement(this: Component) {
     if (isNull(vmBeingConstructed)) {
         throw new ReferenceError();
     }
@@ -129,8 +129,8 @@ function LWCElement(this: Component) {
     }
 }
 
-LWCElement.prototype = {
-    constructor: LWCElement,
+LightningElement.prototype = {
+    constructor: LightningElement,
     // HTML Element - The Good Parts
     dispatchEvent(event: ComposableEvent): boolean {
         const elm = getLinkedElement(this);
@@ -317,4 +317,4 @@ export function createBaseElementStandardPropertyDescriptors(StandardPropertyDes
     return descriptors;
 }
 
-export { LWCElement as Element };
+export { LightningElement };

--- a/packages/lwc-engine/src/framework/main.ts
+++ b/packages/lwc-engine/src/framework/main.ts
@@ -1,14 +1,18 @@
 export { createElement } from "./upgrade";
 export { getComponentDef } from "./def";
-export { Element } from "./html-element";
+export { LightningElement } from "./html-element";
 export { register } from "./services";
 export { unwrap } from "./membrane";
 
 // TODO: REMOVE THIS https://github.com/salesforce/lwc/issues/129
 export { dangerousObjectMutation } from "./membrane";
+
 export { default as api } from "./decorators/api";
 export { default as track } from "./decorators/track";
 export { default as readonly } from "./decorators/readonly";
 export { default as wire } from "./decorators/wire";
 export { default as decorate } from "./decorators/decorate";
 export { buildCustomElementConstructor } from "./wc";
+
+// Deprecated APIs
+export { LightningElement as Element } from "./html-element";

--- a/packages/lwc-engine/src/framework/modules/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/events.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 
 describe('module/events', () => {
     it('attaches click event handler to element', function() {
@@ -10,7 +10,7 @@ describe('module/events', () => {
                 ])
             ];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -45,7 +45,7 @@ describe('module/events', () => {
                 ];
             }
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 component = this;
@@ -89,7 +89,7 @@ describe('module/events', () => {
                 ];
             }
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 component = this;
@@ -121,7 +121,7 @@ describe('module/events', () => {
                 ])
             ];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -144,13 +144,13 @@ describe('module/events', () => {
 
     it('attaches click event handler to custom element', function() {
         let result: Event[] = [], cmp;
-        class MyChild extends Element {}
+        class MyChild extends LightningElement {}
         function html($api) {
             return [
                 $api.c('x-child', MyChild, {on: {click(ev: Event) { result.push(ev); }}})
             ];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -167,13 +167,13 @@ describe('module/events', () => {
 
     it('attaches custom event handler to custom element', function() {
         let result: Event[] = [], cmp;
-        class MyChild extends Element {}
+        class MyChild extends LightningElement {}
         function html($api) {
             return [
                 $api.c('x-child', MyChild, {on: {test(ev: Event) { result.push(ev); }}})
             ];
         }
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;

--- a/packages/lwc-engine/src/framework/modules/__tests__/styles.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/styles.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 
 describe('modules/styles', () => {
     it('should add style to the element', () => {
@@ -6,7 +6,7 @@ describe('modules/styles', () => {
             $api.h('div', { key: 0, style: 'display: inline' }, [ $api.t('test') ]),
         ];
         let cmp;
-        class Component extends Element {
+        class Component extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -26,7 +26,7 @@ describe('modules/styles', () => {
             $api.h('div', { key: 0, styleMap: { display: 'inline' } }, [ $api.t('test') ]),
         ];
         let cmp;
-        class Component extends Element {
+        class Component extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -46,7 +46,7 @@ describe('modules/styles', () => {
             $api.h('div', { key: 0, style: $cmp.counter % 2 ? 'display: block' : 'display: inline' }, [ $api.t('test') ]),
         ];
         let cmp;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;
@@ -72,7 +72,7 @@ describe('modules/styles', () => {
             $api.h('div', { key: 0, styleMap: $cmp.counter % 2 ? { position: 'relative' } : { display: 'inline' } }, [ $api.t('test') ]),
         ];
         let cmp;
-        class MyComponent extends Element {
+        class MyComponent extends LightningElement {
             constructor() {
                 super();
                 cmp = this;

--- a/packages/lwc-engine/src/framework/modules/__tests__/token.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/token.spec.ts
@@ -1,4 +1,4 @@
-import { createElement, Element } from '../../main';
+import { createElement, LightningElement } from '../../main';
 import { getHostShadowRoot } from "../../html-element";
 
 describe('modules/token', () => {
@@ -8,7 +8,7 @@ describe('modules/token', () => {
         ];
         tmpl.shadowToken = 'test';
 
-        class Component extends Element {
+        class Component extends LightningElement {
             render() {
                 return tmpl;
             }
@@ -30,7 +30,7 @@ describe('modules/token', () => {
             $api.h('section', { key: 0 }, [ $api.t('test') ]),
         ];
 
-        class Component extends Element {
+        class Component extends LightningElement {
             tmpl = styledTmpl;
             render() {
                 return this.tmpl;
@@ -65,7 +65,7 @@ describe('modules/token', () => {
         ];
         styledTmplB.shadowToken = 'testB';
 
-        class Component extends Element {
+        class Component extends LightningElement {
             tmpl = styledTmplA;
             render() {
                 return this.tmpl;


### PR DESCRIPTION
## Details

First step to rename `engine.Element` to `engine.LightningElement`. This PR makes `Element` an alias of `LightningElement` for BC purposes. Additionally, in changes all internal references to it (in engine). The rest of the references, everywhere else, will be changed mechanically with a tool that looks for imports from `"engine"`.

## Does this PR introduce a breaking change?

* No