### PR TITLE
refactor(engine): tunning all types and removing unnecessary exports

### DIFF
--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -1,7 +1,7 @@
 import assert from "./assert";
 import { vmBeingRendered, invokeEventListener } from "./invoker";
 import { freeze, isArray, isUndefined, isNull, isFunction, isObject, isString, ArrayPush, assign, create, forEach, StringSlice, StringCharCodeAt, isNumber, isTrue, hasOwnProperty } from "./language";
-import { EmptyArray, SPACE_CHAR, ViewModelReflection, resolveCircularModuleDependency } from "./utils";
+import { EmptyArray, SPACE_CHAR, ViewModelReflection, resolveCircularModuleDependency, isCircularModuleDependency } from "./utils";
 import { renderVM, createVM, appendVM, removeVM, VM, getCustomElementVM, SlotSet, allocateInSlot } from "./vm";
 import { ComponentConstructor } from "./component";
 import { VNode, VNodeData, VNodes, VElement, VComment, VText, Hooks } from "../3rdparty/snabbdom/types";
@@ -221,7 +221,9 @@ export function s(slotName: string, data: VNodeData, children: VNodes, slotset: 
 
 // [c]ustom element node
 export function c(sel: string, Ctor: ComponentConstructor, data: VNodeData, children?: VNodes): VElement {
-    Ctor = resolveCircularModuleDependency(Ctor);
+    if (isCircularModuleDependency(Ctor)) {
+        Ctor = resolveCircularModuleDependency(Ctor);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `c() 1st argument sel must be a string.`);

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -8,37 +8,27 @@ import {
 } from "./invoker";
 import { isArray, ArrayIndexOf, ArraySplice, isObject, isFunction, isUndefined } from "./language";
 import { invokeServiceHook, Services } from "./services";
-import { PropsDef, WireHash, TrackDef } from './def';
+import { PropsDef, WireHash } from './def';
 import { VM } from "./vm";
 import { VNodes } from "../3rdparty/snabbdom/types";
-import { Template } from "./template";
 
 export type ErrorCallback = (error: any, stack: string) => void;
-export interface Component {
-    readonly classList: DOMTokenList;
-    readonly root: ShadowRoot;
-    render?: () => (void | Template);
-    connectedCallback?: () => void;
-    disconnectedCallback?: () => void;
-    renderedCallback?: () => void;
-    errorCallback?: ErrorCallback;
-    [key: string]: any;
+export interface ComponentInterface {
+    // TODO: complete the entire interface used by the engine
+    setAttribute(attrName: string, value: any): void;
 }
 
 // TODO: review this with the compiler output
 export interface ComponentConstructor {
-    new (): Component;
+    new (): ComponentInterface;
     readonly name: string;
     readonly forceTagName?: keyof HTMLElementTagNameMap;
     readonly publicMethods?: string[];
     readonly publicProps?: PropsDef;
-    readonly track?: TrackDef;
+    readonly track?: string[];
     readonly wire?: WireHash;
     readonly labels?: string[];
     readonly templateUsedProps?: string[];
-    // support for circular
-    <T>(): T;
-    readonly __circular__?: any;
 }
 
 export function createComponent(vm: VM, Ctor: ComponentConstructor) {

--- a/packages/lwc-engine/src/framework/decorators/api.ts
+++ b/packages/lwc-engine/src/framework/decorators/api.ts
@@ -2,7 +2,7 @@ import assert from "../assert";
 import { isRendering, vmBeingRendered, isBeingConstructed } from "../invoker";
 import { isObject, isNull, isTrue, hasOwnProperty, toString } from "../language";
 import { observeMutation, notifyMutation } from "../watcher";
-import { Component, ComponentConstructor } from "../component";
+import { ComponentInterface, ComponentConstructor } from "../component";
 import { VM, getComponentVM } from "../vm";
 import { isUndefined, isFunction } from "../language";
 import { reactiveMembrane } from "../membrane";
@@ -22,15 +22,15 @@ export default function api(target: ComponentConstructor, propName: PropertyKey,
     // initializing getters and setters for each public prop on the target prototype
     if (COMPUTED_SETTER_MASK & config || COMPUTED_GETTER_MASK & config) {
         if (process.env.NODE_ENV !== 'production') {
-            assert.invariant(!descriptor || (isFunction(descriptor.get) || isFunction(descriptor.set)), `Invalid property ${propName} definition in ${target}, it cannot be a prototype definition if it is a public property. Instead use the constructor to define it.`);
+            assert.invariant(!descriptor || (isFunction(descriptor.get) || isFunction(descriptor.set)), `Invalid property ${toString(propName)} definition in ${target}, it cannot be a prototype definition if it is a public property. Instead use the constructor to define it.`);
             const mustHaveGetter = COMPUTED_GETTER_MASK & config;
             const mustHaveSetter = COMPUTED_SETTER_MASK & config;
             if (mustHaveGetter) {
-                assert.isTrue(isObject(descriptor) && isFunction(descriptor.get), `Missing getter for property ${propName} decorated with @api in ${target}`);
+                assert.isTrue(isObject(descriptor) && isFunction(descriptor.get), `Missing getter for property ${toString(propName)} decorated with @api in ${target}`);
             }
             if (mustHaveSetter) {
-                assert.isTrue(isObject(descriptor) && isFunction(descriptor.set), `Missing setter for property ${propName} decorated with @api in ${target}`);
-                assert.isTrue(mustHaveGetter, `Missing getter for property ${propName} decorated with @api in ${target}. You cannot have a setter without the corresponding getter.`);
+                assert.isTrue(isObject(descriptor) && isFunction(descriptor.set), `Missing setter for property ${toString(propName)} decorated with @api in ${target}`);
+                assert.isTrue(mustHaveGetter, `Missing getter for property ${toString(propName)} decorated with @api in ${target}. You cannot have a setter without the corresponding getter.`);
             }
         }
         // if it is configured as an accessor it must have a descriptor
@@ -48,27 +48,27 @@ export function prepareForPropUpdate(vm: VM) {
     vmBeingUpdated = vm;
 }
 
-export function createPublicPropertyDescriptor(proto: ComponentConstructor, key: PropertyKey, descriptor: PropertyDescriptor | undefined): PropertyDescriptor {
+function createPublicPropertyDescriptor(proto: ComponentConstructor, key: PropertyKey, descriptor: PropertyDescriptor | undefined): PropertyDescriptor {
     return {
-        get(this: Component): any {
+        get(this: ComponentInterface): any {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.vm(vm);
             }
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
-                    assert.logError(`${vm} constructor should not read the value of property "${key}". The owner component has not yet set the value. Instead use the constructor to set default values for properties.`);
+                    assert.logError(`${vm} constructor should not read the value of property "${toString(key)}". The owner component has not yet set the value. Instead use the constructor to set default values for properties.`);
                 }
                 return;
             }
             observeMutation(this, key);
             return vm.cmpProps[key];
         },
-        set(this: Component, newValue: any) {
+        set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.vm(vm);
-                assert.invariant(!isRendering, `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${key}`);
+                assert.invariant(!isRendering, `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(key)}`);
             }
             if (isTrue(vm.isRoot) || isBeingConstructed(vm)) {
                 vmBeingUpdated = vm;
@@ -77,7 +77,7 @@ export function createPublicPropertyDescriptor(proto: ComponentConstructor, key:
                     // Then newValue if newValue is observable (plain object or array)
                     const isObservable = reactiveMembrane.getProxy(newValue) !== newValue;
                     if (!isObservable && !isNull(newValue) && isObject(newValue)) {
-                        assert.logWarning(`Assigning a non-reactive value ${newValue} to member property ${key} of ${vm} is not common because mutations on that value cannot be observed.`);
+                        assert.logWarning(`Assigning a non-reactive value ${newValue} to member property ${toString(key)} of ${vm} is not common because mutations on that value cannot be observed.`);
                     }
                 }
             }
@@ -85,7 +85,7 @@ export function createPublicPropertyDescriptor(proto: ComponentConstructor, key:
                 if (vmBeingUpdated !== vm) {
                     // logic for setting new properties of the element directly from the DOM
                     // is only recommended for root elements created via createElement()
-                    assert.logWarning(`If property ${key} decorated with @api in ${vm} is used in the template, the value ${toString(newValue)} set manually may be overridden by the template, consider binding the property only in the template.`);
+                    assert.logWarning(`If property ${toString(key)} decorated with @api in ${vm} is used in the template, the value ${toString(newValue)} set manually may be overridden by the template, consider binding the property only in the template.`);
                 }
             }
             vmBeingUpdated = null; // releasing the lock
@@ -102,27 +102,27 @@ export function createPublicPropertyDescriptor(proto: ComponentConstructor, key:
     };
 }
 
-export function createPublicAccessorDescriptor(Ctor: ComponentConstructor, key: PropertyKey, descriptor: PropertyDescriptor): PropertyDescriptor {
+function createPublicAccessorDescriptor(Ctor: ComponentConstructor, key: PropertyKey, descriptor: PropertyDescriptor): PropertyDescriptor {
     const { get, set, enumerable } = descriptor;
     if (!isFunction(get)) {
         if (process.env.NODE_ENV !== 'production') {
-            assert.fail(`Invalid attempt to create public property descriptor ${key} in ${Ctor}. It is missing the getter declaration with @api get ${key}() {} syntax.`);
+            assert.fail(`Invalid attempt to create public property descriptor ${toString(key)} in ${Ctor}. It is missing the getter declaration with @api get ${toString(key)}() {} syntax.`);
         }
         throw new TypeError();
     }
     return {
-        get(this: Component): any {
+        get(this: ComponentInterface): any {
             if (process.env.NODE_ENV !== 'production') {
                 const vm = getComponentVM(this);
                 assert.vm(vm);
             }
             return get.call(this);
         },
-        set(this: Component, newValue: any) {
+        set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.vm(vm);
-                assert.invariant(!isRendering, `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${key}`);
+                assert.invariant(!isRendering, `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(key)}`);
             }
             if (vm.isRoot || isBeingConstructed(vm)) {
                 vmBeingUpdated = vm;
@@ -131,7 +131,7 @@ export function createPublicAccessorDescriptor(Ctor: ComponentConstructor, key: 
                     // Then newValue if newValue is observable (plain object or array)
                     const isObservable = reactiveMembrane.getProxy(newValue) !== newValue;
                     if (!isObservable && !isNull(newValue) && isObject(newValue)) {
-                        assert.logWarning(`Assigning a non-reactive value ${newValue} to member property ${key} of ${vm} is not common because mutations on that value cannot be observed.`);
+                        assert.logWarning(`Assigning a non-reactive value ${newValue} to member property ${toString(key)} of ${vm} is not common because mutations on that value cannot be observed.`);
                     }
                 }
             }
@@ -139,7 +139,7 @@ export function createPublicAccessorDescriptor(Ctor: ComponentConstructor, key: 
                 if (vmBeingUpdated !== vm) {
                     // logic for setting new properties of the element directly from the DOM
                     // is only recommended for root elements created via createElement()
-                    assert.logWarning(`If property ${key} decorated with @api in ${vm} is used in the template, the value ${toString(newValue)} set manually may be overridden by the template, consider binding the property only in the template.`);
+                    assert.logWarning(`If property ${toString(key)} decorated with @api in ${vm} is used in the template, the value ${toString(newValue)} set manually may be overridden by the template, consider binding the property only in the template.`);
                 }
             }
             vmBeingUpdated = null; // releasing the lock
@@ -147,7 +147,7 @@ export function createPublicAccessorDescriptor(Ctor: ComponentConstructor, key: 
             if (set) {
                 set.call(this, reactiveMembrane.getReadOnlyProxy(newValue));
             } else if (process.env.NODE_ENV !== 'production') {
-                assert.fail(`Invalid attempt to set a new value for property ${key} of ${vm} that does not has a setter decorated with @api.`);
+                assert.fail(`Invalid attempt to set a new value for property ${toString(key)} of ${vm} that does not has a setter decorated with @api.`);
             }
         },
         enumerable,

--- a/packages/lwc-engine/src/framework/decorators/track.ts
+++ b/packages/lwc-engine/src/framework/decorators/track.ts
@@ -1,10 +1,10 @@
 import assert from "../assert";
-import { isArray, isObject, isUndefined } from "../language";
+import { isArray, isObject, isUndefined, toString } from "../language";
 import { isRendering, vmBeingRendered } from "../invoker";
 import { observeMutation, notifyMutation } from "../watcher";
 import { getComponentVM } from "../vm";
 import { reactiveMembrane } from '../membrane';
-import { ComponentConstructor, Component } from "../component";
+import { ComponentConstructor, ComponentInterface } from "../component";
 
 export default function track(target: ComponentConstructor, prop: PropertyKey, descriptor: PropertyDescriptor | undefined): PropertyDescriptor;
 export default function track(target: any, prop?, descriptor?): any {
@@ -27,7 +27,7 @@ export default function track(target: any, prop?, descriptor?): any {
 
 export function createTrackedPropertyDescriptor(Ctor: any, key: PropertyKey, enumerable: boolean): PropertyDescriptor {
     return {
-        get(this: Component): any {
+        get(this: ComponentInterface): any {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.vm(vm);
@@ -35,7 +35,7 @@ export function createTrackedPropertyDescriptor(Ctor: any, key: PropertyKey, enu
             observeMutation(this, key);
             return vm.cmpTrack[key];
         },
-        set(this: Component, newValue: any) {
+        set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.vm(vm);
@@ -48,7 +48,7 @@ export function createTrackedPropertyDescriptor(Ctor: any, key: PropertyKey, enu
                     // Then newValue if newValue is observable (plain object or array)
                     const isObservable = reactiveOrAnyValue !== newValue;
                     if (!isObservable && newValue !== null && (isObject(newValue) || isArray(newValue))) {
-                        assert.logWarning(`Property "${key}" of ${vm} is set to a non-trackable object, which means changes into that object cannot be observed.`);
+                        assert.logWarning(`Property "${toString(key)}" of ${vm} is set to a non-trackable object, which means changes into that object cannot be observed.`);
                     }
                 }
                 vm.cmpTrack[key] = reactiveOrAnyValue;

--- a/packages/lwc-engine/src/framework/invoker.ts
+++ b/packages/lwc-engine/src/framework/invoker.ts
@@ -6,7 +6,7 @@ import {
 import { evaluateTemplate } from "./template";
 import { isUndefined, isFunction } from "./language";
 import { getComponentStack, VM } from "./vm";
-import { ComponentConstructor, Component } from "./component";
+import { ComponentConstructor, ComponentInterface } from "./component";
 import { VNodes } from "../3rdparty/snabbdom/types";
 import { startMeasure, endMeasure } from "./performance-timing";
 
@@ -119,7 +119,7 @@ export function invokeComponentRenderMethod(vm: VM): VNodes {
     return result || [];
 }
 
-export function invokeEventListener(vm: VM, fn: EventListener, thisValue: undefined | Component, event: Event) {
+export function invokeEventListener(vm: VM, fn: EventListener, thisValue: undefined | ComponentInterface, event: Event) {
     const { context, callHook } = vm;
     const ctx = currentContext;
     establishContext(context);

--- a/packages/lwc-engine/src/framework/performance-timing.ts
+++ b/packages/lwc-engine/src/framework/performance-timing.ts
@@ -1,6 +1,6 @@
 import { VM } from './vm';
 
-export type MeasurementPhase =
+type MeasurementPhase =
     | 'constructor'
     | 'render'
     | 'patch'

--- a/packages/lwc-engine/src/framework/restrictions.ts
+++ b/packages/lwc-engine/src/framework/restrictions.ts
@@ -1,6 +1,6 @@
 import assert from "./assert";
 import { getPropertyDescriptor, defineProperties, getOwnPropertyNames, forEach, assign, isString, isUndefined, ArraySlice, toString } from "./language";
-import { Component } from "./component";
+import { ComponentInterface } from "./component";
 import { getGlobalHTMLPropertiesInfo, getPropNameFromAttrName } from "./attributes";
 import { isBeingConstructed, isRendering, vmBeingRendered } from "./invoker";
 import { getShadowRootVM, getNodeKey, getCustomElementVM, VM, getNodeOwnerKey } from "./vm";
@@ -249,7 +249,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
     });
 }
 
-function getComponentRestrictionsDescriptors(cmp: Component): PropertyDescriptorMap {
+function getComponentRestrictionsDescriptors(cmp: ComponentInterface): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
         throw new ReferenceError();
@@ -257,7 +257,7 @@ function getComponentRestrictionsDescriptors(cmp: Component): PropertyDescriptor
     const originalSetAttribute = cmp.setAttribute;
     return {
         setAttribute: {
-            value(this: Component, attrName: string, value: any) {
+            value(this: ComponentInterface, attrName: string, value: any) {
                 // logging errors for experimental and special attributes
                 if (isString(attrName)) {
                     const propName = getPropNameFromAttrName(attrName);
@@ -288,7 +288,7 @@ function getLightingElementProtypeRestrictionsDescriptors(proto: object): Proper
             return; // no need to redefine something that we are already exposing
         }
         descriptors[propName] = {
-            get(this: Component) {
+            get(this: ComponentInterface) {
                 const { error, attribute, readOnly, experimental } = info[propName];
                 const msg: any[] = [];
                 msg.push(`Accessing the global HTML property "${propName}" in ${this} is disabled.`);
@@ -340,7 +340,7 @@ export function patchCustomElementWithRestrictions(elm: HTMLElement) {
     defineProperties(elm, getCustomElementRestrictionsDescriptors(elm));
 }
 
-export function patchComponentWithRestrictions(cmp: Component) {
+export function patchComponentWithRestrictions(cmp: ComponentInterface) {
     defineProperties(cmp, getComponentRestrictionsDescriptors(cmp));
 }
 

--- a/packages/lwc-engine/src/framework/services.ts
+++ b/packages/lwc-engine/src/framework/services.ts
@@ -6,8 +6,8 @@ import { VNodeData } from "../3rdparty/snabbdom/types";
 import { ComponentDef } from "./def";
 import { VM } from "./vm";
 
-export type ServiceCallback = (component: object, data: VNodeData, def: ComponentDef, context: Context) => void;
-export interface ServiceDef {
+type ServiceCallback = (component: object, data: VNodeData, def: ComponentDef, context: Context) => void;
+interface ServiceDef {
     wiring?: ServiceCallback;
     connected?: ServiceCallback;
     disconnected?: ServiceCallback;

--- a/packages/lwc-engine/src/framework/template.ts
+++ b/packages/lwc-engine/src/framework/template.ts
@@ -6,7 +6,7 @@ import { RenderAPI } from "./api";
 import { Context } from "./context";
 import { SlotSet, VM, resetShadowRoot } from "./vm";
 import { EmptyArray } from "./utils";
-import { Component } from "./component";
+import { ComponentInterface } from "./component";
 import { removeAttribute, setAttribute } from "./dom-api";
 
 export interface Template {
@@ -48,7 +48,7 @@ function validateFields(vm: VM, html: any) {
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    const component = vm.component as Component;
+    const component = vm.component as ComponentInterface;
     // validating identifiers used by template that should be provided by the component
     const { ids = [] } = html;
     forEach.call(ids, (propName: string) => {

--- a/packages/lwc-engine/src/framework/upgrade.ts
+++ b/packages/lwc-engine/src/framework/upgrade.ts
@@ -2,7 +2,7 @@ import assert from "./assert";
 import { isUndefined, assign, isNull, isObject } from "./language";
 import { createVM, removeVM, appendVM, renderVM, getCustomElementVM, getNodeKey } from "./vm";
 import { ComponentConstructor } from "./component";
-import { resolveCircularModuleDependency, setInternalField, getInternalField, createSymbol } from "./utils";
+import { resolveCircularModuleDependency, setInternalField, getInternalField, createSymbol, isCircularModuleDependency } from "./utils";
 import { setAttribute } from "./dom-api";
 
 const { removeChild, appendChild, insertBefore, replaceChild } = Node.prototype;
@@ -59,7 +59,10 @@ export function createElement(sel: string, options: any = {}): HTMLElement {
         throw new TypeError();
     }
 
-    const Ctor = resolveCircularModuleDependency((options as any).is);
+    let Ctor = (options as any).is as ComponentConstructor;
+    if (isCircularModuleDependency(Ctor)) {
+        Ctor = resolveCircularModuleDependency(Ctor);
+    }
 
     let { mode, fallback } = (options as any);
     // TODO: for now, we default to open, but eventually it should default to 'closed'

--- a/packages/lwc-engine/src/framework/utils.ts
+++ b/packages/lwc-engine/src/framework/utils.ts
@@ -57,6 +57,15 @@ export function assertValidForceTagName(Ctor: ComponentConstructor) {
     }
 }
 
+interface CircularModuleDependency {
+    <T>(): T;
+    readonly __circular__?: any;
+}
+
+export function isCircularModuleDependency(value: any): value is CircularModuleDependency {
+    return hasOwnProperty.call(value, '__circular__');
+}
+
 /**
  * When LWC is used in the context of an Aura application, the compiler produces AMD
  * modules, that doesn't resolve properly circular dependencies between modules. In order
@@ -66,10 +75,11 @@ export function assertValidForceTagName(Ctor: ComponentConstructor) {
  * This method returns the resolved value if it received a factory as argument. Otherwise
  * it returns the original value.
  */
-export function resolveCircularModuleDependency(valueOrFactory: any): any {
-    return hasOwnProperty.call(valueOrFactory, '__circular__') ?
-        valueOrFactory() :
-        valueOrFactory;
+export function resolveCircularModuleDependency(fn: CircularModuleDependency): ComponentConstructor {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.invariant(isFunction(fn), `If callbackQueue is scheduled, it is because there must be at least one callback on this pending queue instead of ${nextTickCallbackQueue}.`);
+    }
+    return fn();
 }
 
 /**

--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -11,7 +11,7 @@ import { parentElementGetter } from "./dom-api";
 import { VNodeData, VNodes } from "../3rdparty/snabbdom/types";
 import { Template } from "./template";
 import { ComponentDef } from "./def";
-import { Component } from "./component";
+import { ComponentInterface } from "./component";
 import { Context } from "./context";
 import { startMeasure, endMeasure } from "./performance-timing";
 import { patchCustomElement } from "./dom/faux";
@@ -36,15 +36,15 @@ export interface VM {
     cmpTrack: Record<string, any>;
     cmpTemplate?: Template;
     cmpRoot: ShadowRoot;
-    callHook: (cmp: Component | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
-    setHook: (cmp: Component, prop: PropertyKey, newValue: any) => void;
-    getHook: (cmp: Component, prop: PropertyKey) => any;
+    callHook: (cmp: ComponentInterface | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
+    setHook: (cmp: ComponentInterface, prop: PropertyKey, newValue: any) => void;
+    getHook: (cmp: ComponentInterface, prop: PropertyKey) => any;
     isScheduled: boolean;
     isDirty: boolean;
     isRoot: boolean;
     fallback: boolean;
     mode: string;
-    component?: Component;
+    component?: ComponentInterface;
     deps: VM[][];
     toString(): string;
 }
@@ -52,15 +52,15 @@ export interface VM {
 let idx: number = 0;
 let uid: number = 0;
 
-function callHook(cmp: Component | undefined, fn: (...args: any[]) => any, args?: any[]): any {
+function callHook(cmp: ComponentInterface | undefined, fn: (...args: any[]) => any, args?: any[]): any {
     return fn.apply(cmp, args);
 }
 
-function setHook(cmp: Component, prop: PropertyKey, newValue: any) {
+function setHook(cmp: ComponentInterface, prop: PropertyKey, newValue: any) {
     cmp[prop] = newValue;
 }
 
-function getHook(cmp: Component, prop: PropertyKey): any {
+function getHook(cmp: ComponentInterface, prop: PropertyKey): any {
     return cmp[prop];
 }
 
@@ -438,7 +438,7 @@ export function getComponentStack(vm: VM): string {
     do {
         const currentVm: VM | undefined = getInternalField(elm, ViewModelReflection);
         if (!isUndefined(currentVm)) {
-            ArrayPush.call(wcStack, (currentVm.component as Component).toString());
+            ArrayPush.call(wcStack, (currentVm.component as ComponentInterface).toString());
         }
         // TODO: bug #435 - shadowDOM will preventing this walking process, we
         // need to find a different way to find the right boundary
@@ -474,7 +474,7 @@ export function getCustomElementVM(elm: HTMLElement): VM {
     return getInternalField(elm, ViewModelReflection) as VM;
 }
 
-export function getComponentVM(component: Component): VM {
+export function getComponentVM(component: ComponentInterface): VM {
     // TODO: this eventually should not rely on the symbol, and should use a Weak Ref
     if (process.env.NODE_ENV !== 'production') {
         assert.vm(getInternalField(component, ViewModelReflection));

--- a/packages/lwc-engine/src/framework/wc.ts
+++ b/packages/lwc-engine/src/framework/wc.ts
@@ -2,11 +2,13 @@ import { ComponentConstructor } from "./component";
 import { isUndefined, isObject, isNull, defineProperties } from "./language";
 import { createVM, appendVM, renderVM, removeVM, getCustomElementVM, CreateVMInit } from "./vm";
 import assert from "./assert";
-import { resolveCircularModuleDependency } from "./utils";
+import { resolveCircularModuleDependency, isCircularModuleDependency } from "./utils";
 import { getComponentDef } from "./def";
 
 export function buildCustomElementConstructor(Ctor: ComponentConstructor, options?: ShadowRootInit): Function {
-    Ctor = resolveCircularModuleDependency(Ctor);
+    if (isCircularModuleDependency(Ctor)) {
+        Ctor = resolveCircularModuleDependency(Ctor);
+    }
     const def = getComponentDef(Ctor);
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isUndefined(Ctor.forceTagName), `The experimental support for web components does not include the support for \`static forceTagName\` to "${Ctor.forceTagName}" declaration in the class definition for ${Ctor}.`);


### PR DESCRIPTION
## Details

* adjusting all types
* removing unnecessary exports after running `ts-unused-exports tsconfig.json packages/lwc-engine/src/framework/main.ts`

## Does this PR introduce a breaking change?

* No