### PR TITLE
fix(engine): opt-out of initial undef prop value in diff

### DIFF
--- a/packages/lwc-engine/src/framework/modules/props.ts
+++ b/packages/lwc-engine/src/framework/modules/props.ts
@@ -1,12 +1,11 @@
 import assert from "../../shared/assert";
-import { isUndefined, keys, StringToLowerCase, create, toString } from "../../shared/language";
+import { isUndefined, keys, StringToLowerCase, create, toString, isString } from "../../shared/language";
 import { getInternalField } from "../../shared/fields";
 import { ViewModelReflection } from "../utils";
 import { prepareForPropUpdate } from "../decorators/api";
 import { VNode, Module } from "../../3rdparty/snabbdom/types";
 import { getAttrNameFromPropName } from "../attributes";
 import { elementTagNameGetter } from "../dom-api";
-import { isString } from "../../../../../node_modules/lwc-compiler/src/utils";
 
 const EspecialTagAndPropMap = create(null, {
     input: { value: create(null, { value: { value: 1 }, checked: { value: 1 } }) },


### PR DESCRIPTION
Related to https://github.com/salesforce/lwc/issues/489

## Details

This is a bug-fix to make 0.24 compatible with 0.23, but we will eventually break out.

