### PR TITLE
test(engine): patching initially undefined props

### DIFF
--- a/packages/lwc-engine/src/framework/modules/__tests__/props.spec.ts
+++ b/packages/lwc-engine/src/framework/modules/__tests__/props.spec.ts
@@ -183,4 +183,27 @@ describe('module/props', () => {
         expect(newVnode.elm.foo).toBeUndefined();
     });
 
+    // Should NOT PASS until we eliminate backwards-compatibility support for
+    // https://github.com/salesforce/lwc/pull/490
+    it.skip('should consider initially undefined values', () => {
+        const elm = document.createElement('div');
+        elm.foo = 1;
+        const oldVnode = { data: {} };
+        const newVnode = { data: { props: { foo: undefined } }, elm };
+
+        target.update(oldVnode, newVnode);
+        expect(newVnode.elm.foo).toBeUndefined();
+    });
+
+    // Should PASS until we eliminate backwards-compatibility support for
+    // https://github.com/salesforce/lwc/pull/490
+    it('should not consider initially undefined values', () => {
+        const elm = document.createElement('div');
+        elm.foo = 1;
+        const oldVnode = { data: {} };
+        const newVnode = { data: { props: { foo: undefined } }, elm };
+
+        target.update(oldVnode, newVnode);
+        expect(newVnode.elm.foo).toBe(1);
+    });
 });


### PR DESCRIPTION
## Details

Tests for https://github.com/salesforce/lwc/pull/490

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No