### PR TITLE
fix(compiler): warning when using forceTagName and is

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/component.spec.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/component.spec.js
@@ -76,7 +76,7 @@ describe('observedAttributes array', () => {
             }
         }
     });
-})
+});
 
 describe('render method', () => {
     pluginTest('inject render method', `

--- a/packages/babel-plugin-transform-lwc-class/src/component.js
+++ b/packages/babel-plugin-transform-lwc-class/src/component.js
@@ -3,6 +3,7 @@ const moduleImports = require("@babel/helper-module-imports");
 const { findClassMethod, getEngineImportSpecifiers, isComponentClass, isDefaultExport } = require('./utils');
 const { GLOBAL_ATTRIBUTE_MAP, LWC_PACKAGE_EXPORTS, LWC_COMPONENT_PROPERTIES } = require('./constants');
 const CLASS_PROPERTY_OBSERVED_ATTRIBUTES = 'observedAttributes';
+const CLASS_PROPERTY_FORCE_TAG_NAME = 'forceTagName';
 
 module.exports = function ({ types: t }) {
     return {
@@ -26,6 +27,8 @@ module.exports = function ({ types: t }) {
                 throw path.buildCodeFrameError(
                     `Invalid static property "observedAttributes". "observedAttributes" cannot be used to track attribute changes. Define setters for ${observedAttributeNames.join(', ')} instead.`
                 );
+            } else if (isForceTagNameStaticProperty(path)) {
+                console.warn(`It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on "forceTagName" as it will be deprecated in the near future.`);
             }
         },
         Class(path, state) {
@@ -53,6 +56,11 @@ module.exports = function ({ types: t }) {
     function isObservedAttributesStaticProperty(classPropertyPath) {
         const { static: isStaticProperty, key: { name: propertyName } } = classPropertyPath.node;
         return (isStaticProperty && propertyName === CLASS_PROPERTY_OBSERVED_ATTRIBUTES);
+    }
+
+    function isForceTagNameStaticProperty(classPropertyPath) {
+        const { static: isStaticProperty, key: { name: propertyName } } = classPropertyPath.node;
+        return (isStaticProperty && propertyName === CLASS_PROPERTY_FORCE_TAG_NAME);
     }
 
     function getBaseName({ file }) {

--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -252,6 +252,9 @@ export function c(sel: string, Ctor: ComponentConstructor, data: VNodeData, chil
     const { forceTagName } = Ctor;
     let tag = sel, text, elm; // tslint:disable-line
     if (!isUndefined(attrs) && !isUndefined(attrs.is)) {
+        if (process.env.NODE_ENV !== 'production') {
+            assert.logWarning(`"is" attribute has been deprecated and will be removed in the near future.`);
+        }
         tag = sel;
         sel = attrs.is as string;
     } else if (!isUndefined(forceTagName)) {

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -148,7 +148,9 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
         const ctorName = Ctor.name;
         assert.isTrue(ctorName && isString(ctorName), `${toString(Ctor)} should have a "name" property with string value, but found ${ctorName}.`);
         assert.isTrue(Ctor.constructor, `Missing ${ctorName}.constructor, ${ctorName} should have a "constructor" property.`);
-
+        if (Ctor.forceTagName) {
+            assert.logWarning(`"forceTagName" has been deprecated and will be removed in the near future.`);
+        }
         assertValidForceTagName(Ctor);
     }
 

--- a/packages/lwc-template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/metadata.json
+++ b/packages/lwc-template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/metadata.json
@@ -2,5 +2,22 @@
   "metadata": {
     "templateUsedIds": ["p", "foo"],
     "templateDependencies": ["ns-foo", "ns-bar", "ns-buzz", "ns-table", "ns-input"]
-  }
+  },
+  "warnings": [{
+    "length": 12,
+    "level": "warning",
+    "message": "It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on \"is\" as it will be deprecated in the near future.",
+    "start": 561
+    }, {
+      "length": 13,
+      "level": "warning",
+      "message": "It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on \"is\" as it will be deprecated in the near future.",
+      "start": 670
+    }, {
+        "length": 13,
+        "level": "warning",
+        "message": "It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on \"is\" as it will be deprecated in the near future.",
+        "start": 765
+    }
+  ]
 }

--- a/packages/lwc-template-compiler/src/__tests__/fixtures/directive-is/is-with-other-directives/metadata.json
+++ b/packages/lwc-template-compiler/src/__tests__/fixtures/directive-is/is-with-other-directives/metadata.json
@@ -2,5 +2,11 @@
   "metadata": {
     "templateUsedIds": ["rows"],
     "templateDependencies": ["ns-row"]
-  }
+  },
+  "warnings": [{
+    "length": 11,
+    "level": "warning",
+    "message": "It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on \"is\" as it will be deprecated in the near future.",
+    "start": 68
+  }]
 }

--- a/packages/lwc-template-compiler/src/__tests__/fixtures/directive-is/is/metadata.json
+++ b/packages/lwc-template-compiler/src/__tests__/fixtures/directive-is/is/metadata.json
@@ -1,5 +1,11 @@
 {
   "metadata": {
     "templateDependencies": ["ns-row"]
-  }
+  },
+  "warnings": [{
+    "length": 11,
+    "level": "warning",
+    "message": "It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on \"is\" as it will be deprecated in the near future.",
+    "start": 55
+  }]
 }

--- a/packages/lwc-template-compiler/src/parser/index.ts
+++ b/packages/lwc-template-compiler/src/parser/index.ts
@@ -431,7 +431,7 @@ export default function parse(source: string, state: State): {
             if (isAttr.type !== IRAttributeType.String) {
                 return warnAt(`Is attribute value can't be an expression`, isAttr.location);
             }
-
+            warnAt(`It has been determined that there are valid workarounds for the accessibility issues that this escape hatch was created for. Please refactor your component to not rely on "is" as it will be deprecated in the near future.`, isAttr.location, 'warning');
             // Don't remove the is, because passed as attribute
             component = isAttr.value;
         }


### PR DESCRIPTION
## Details
Deprecation warnings for `is` and `forceTagName`

First piece of https://github.com/salesforce/lwc/issues/469

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No