### PR TITLE
fix(engine): bug introduced that breaks circular on proto chain

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/def.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/def.spec.ts
@@ -312,4 +312,24 @@ describe('def', () => {
             });
         });
     });
+    describe('circular references', () => {
+        it('should be resolved on for __proto__', () => {
+            class A extends LightningElement  {}
+            A.publicProps = {
+                a: {}
+            };
+
+            // circular artifact for A
+            function CircularA() {
+                return A;
+            }
+            CircularA.__circular__ = true;
+
+            class B extends CircularA {}
+            // make sure it picks the props from A
+            expect(getComponentDef(B).props.a).toEqual(getComponentDef(A).props.a);
+            // make sure it picks the props from LightingElement
+            expect(getComponentDef(B).props.title).toBeDefined();
+        });
+    });
 });

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -96,7 +96,7 @@ const CtorToDefMap: WeakMap<any, ComponentDef> = new WeakMap();
 
 function getCtorProto(Ctor: any): any {
     const proto = getPrototypeOf(Ctor);
-    return isCircularModuleDependency(Ctor) ? resolveCircularModuleDependency(proto) : proto;
+    return isCircularModuleDependency(proto) ? resolveCircularModuleDependency(proto) : proto;
 }
 
 // According to the WC spec (https://dom.spec.whatwg.org/#dom-element-attachshadow), certain elements


### PR DESCRIPTION
## Details

I broke this one a week ago when changing the detection of circular references. 

## Does this PR introduce a breaking change?

* No

