### PR TITLE
refactor(engine): locker does not longer need to leak base constructor

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/def.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/def.spec.ts
@@ -331,5 +331,17 @@ describe('def', () => {
             // make sure it picks the props from LightingElement
             expect(getComponentDef(B).props.title).toBeDefined();
         });
+
+        it('should allow escape hatch for Locker and other systems to provide their own base class to mimic LightningElement', () => {
+            // circular artifact for LightingElement
+            function CircularA() {
+                return CircularA; // because it returns itself, the engine knows what to do.
+            }
+            CircularA.__circular__ = true;
+
+            class B extends CircularA {}
+            // make sure it picks the props from LightingElement
+            expect(getComponentDef(B).props.title).toBeDefined();
+        });
     });
 });

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -6,7 +6,7 @@ import {
     vmBeingRendered,
     invokeEventListener,
 } from "./invoker";
-import { isArray, ArrayIndexOf, ArraySplice, isObject, isFunction, isUndefined } from "../shared/language";
+import { isArray, ArrayIndexOf, ArraySplice, isFunction, isUndefined } from "../shared/language";
 import { invokeServiceHook, Services } from "./services";
 import { PropsDef, WireHash } from './def';
 import { VM } from "./vm";
@@ -37,9 +37,8 @@ export function createComponent(vm: VM, Ctor: ComponentConstructor) {
     }
     // create the component instance
     invokeComponentConstructor(vm, Ctor);
-
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(isObject(vm.component), `Invalid construction for ${vm}, maybe you are missing the call to super() on classes extending Element.`);
+    if (isUndefined(vm.component)) {
+        throw new ReferenceError(`Invalid construction for ${vm}, you must extend LightningElement.`);
     }
 }
 

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -95,8 +95,17 @@ import { patchLightningElementPrototypeWithRestrictions } from "./restrictions";
 const CtorToDefMap: WeakMap<any, ComponentDef> = new WeakMap();
 
 function getCtorProto(Ctor: any): any {
-    const proto = getPrototypeOf(Ctor);
-    return isCircularModuleDependency(proto) ? resolveCircularModuleDependency(proto) : proto;
+    let proto = getPrototypeOf(Ctor);
+    // covering the cases where the ref is circular in AMD
+    if (isCircularModuleDependency(proto)) {
+        const p = resolveCircularModuleDependency(proto);
+        // escape hatch for Locker and other abstractions to provide their own base class instead
+        // of our Base class without having to leak it to user-land. If the circular function returns
+        // itself, that's the signal that we have hit the end of the proto chain, which must always
+        // be base.
+        proto = p === proto ? BaseElement : p;
+    }
+    return proto;
 }
 
 // According to the WC spec (https://dom.spec.whatwg.org/#dom-element-attachshadow), certain elements


### PR DESCRIPTION
## Details

Until now, Locker and other abstractions on top of LWC are using the `__circular__` flag to trick the engine to think that the component extends `LightningElement`, but that has an undesired side effect, users can invoke the SecureLightningElement constructor directly, which returns the original LightningElement.

With this change, we not longer have to return `LightningElement`, instead we return the same `SecureLightningElement` as a signal that it is the end of the proto chain.

## Does this PR introduce a breaking change?

* No
