### PR TITLE
fix(engine): closes #515 by removing lazy init

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/__tests__/slot.spec.ts
+++ b/packages/lwc-engine/src/faux-shadow/__tests__/slot.spec.ts
@@ -1,13 +1,13 @@
-import { LightningElement, getHostShadowRoot } from "../../framework/html-element";
 import { createElement } from "../../framework/upgrade";
 import { compileTemplate } from 'test-utils';
+import { LightningElement, getHostShadowRoot } from "../../framework/html-element";
 
 interface LightningSlotElement extends HTMLSlotElement {
     assignedElements(options?: object): Element[];
 }
 
 describe.skip('slotchange event', () => {
-    describe('declarative binding', () {
+    describe('declarative binding', () => {
         // Initialized before each test
         let element;
 
@@ -39,7 +39,7 @@ describe.skip('slotchange event', () => {
         });
     });
 
-    describe('programmatic binding', () {
+    describe('programmatic binding', () => {
         // Initialized before each test
         let element;
 


### PR DESCRIPTION
## Details

Removes the lazy initialization now that the circular dependencies are not longer an issue after the separation of framework from faux-shadow.

This fixes https://github.com/salesforce/lwc/issues/515

## Does this PR introduce a breaking change?

* No