### PR TITLE
fix(ci): do git tagging during release script

### DIFF
--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -18,12 +18,20 @@ if [[ $version = *"${PACKAGE_VERSION}"* ]]; then
   exit 0;
 fi
 
+# Prepend "v" to tag to mimic logic in lerna and stay consistent with previous releases
+GIT_TAG_VERSION="v${PACKAGE_VERSION}"
+
 # Command to push the packages
 CMD_PREPARE="yarn prepare"
+CMD_GIT_TAG="git tag ${GIT_TAG_VERSION} -m ${GIT_TAG_VERSION}"
 CMD_PUBLISH_PACKAGES="lerna publish --exact --force-publish=* --registry https://npm.lwcjs.org --yes --skip-git ${CANARY} --repo-version ${PACKAGE_VERSION} --npm-client npm"
 
 # Run
-echo $CMD_PREPARE;
-$CMD_PREPARE;
-echo $CMD_PUBLISH_PACKAGES;
-$CMD_PUBLISH_PACKAGES;
+echo $CMD_PREPARE
+$CMD_PREPARE
+
+echo $CMD_GIT_TAG
+$CMD_GIT_TAG
+
+echo $CMD_PUBLISH_PACKAGES
+$CMD_PUBLISH_PACKAGES


### PR DESCRIPTION
## Details

The new release script adds the `--skip-git` flag to lerna so we can do the release and changelog in a single commit. Idea is to loosely follow Lerna's algorithm by git tagging, then publishing to npm, then pushing to git with tags.

Depends on https://git.soma.salesforce.com/lwc/ci-integration/pull/3

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
