### PR TITLE
test(preset): add testURL config as workaround to jsdom bug

### DIFF
--- a/packages/lwc-jest-preset/jest-preset.js
+++ b/packages/lwc-jest-preset/jest-preset.js
@@ -17,4 +17,7 @@ module.exports = {
     },
     snapshotSerializers: [require.resolve('lwc-jest-serializer')],
     testMatch: [ '**/__tests__/**/?(*.)(spec|test).js' ],
+
+    // temp workaround until this is released - https://github.com/facebook/jest/pull/6792
+    testURL: "http://localhost/",
 };


### PR DESCRIPTION
## Details

A recent version bump to jsdom has broken our Jest tests run through lwc-testrunner and autobuilds. 

Context:
https://github.com/jsdom/jsdom/issues/2304
https://github.com/facebook/jest/pull/6792

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
