### PR TITLE
chore: update internal peer dependencies

### DIFF
--- a/packages/lwc-jest-resolver/package.json
+++ b/packages/lwc-jest-resolver/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "lwc-module-resolver": "0.24.x"
+    "lwc-module-resolver": "0.25.x"
   },
   "devDependencies": {
     "lwc-engine": "0.25.2",

--- a/packages/lwc-jest-transformer/package.json
+++ b/packages/lwc-jest-transformer/package.json
@@ -18,8 +18,8 @@
     "deasync": "0.1.12"
   },
   "peerDependencies": {
-    "lwc-compiler": "0.24.x",
-    "lwc-engine": "0.24.x"
+    "lwc-compiler": "0.25.x",
+    "lwc-engine": "0.25.x"
   },
   "devDependencies": {
     "lwc-compiler": "0.25.2",

--- a/packages/rollup-plugin-lwc-compiler/package.json
+++ b/packages/rollup-plugin-lwc-compiler/package.json
@@ -19,7 +19,7 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "lwc-compiler": "0.24.x",
-    "lwc-engine": "0.24.x"
+    "lwc-compiler": "0.25.x",
+    "lwc-engine": "0.25.x"
   }
 }


### PR DESCRIPTION
## Details

Update internal package dependencies to unbreak the CI after the release of `0.25.2`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No