### PR TITLE
fix(engine): closes issue #566 to support stopPropagation on the temp…

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
@@ -1,4 +1,5 @@
 import { createElement, LightningElement } from '../../framework/main';
+import { compileTemplate } from 'test-utils';
 
 describe('events', () => {
     describe('bookkeeping', () => {
@@ -31,6 +32,38 @@ describe('events', () => {
             });
             elm.click();
             expect(dispatched).toEqual(['a']);
+        });
+
+        it('invoking event.stopPropagation() in a listener on the template should prevent listeners on the host from being invoked', () => {
+            const dispatched = [];
+            const tpl = compileTemplate(`
+                <template>
+                    <button>click me</button>
+                </template>
+            `);
+
+            class MyComponent extends LightningElement {
+                renderedCallback() {
+                    this.template.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                    });
+                }
+
+                triggerInternalClick() {
+                    this.template.querySelector('button').click();
+                }
+
+                render() {
+                    return tpl;
+                }
+            }
+            MyComponent.publicMethods = ['triggerInternalClick'];
+            const elm = createElement('x-foo', { is: MyComponent });
+            document.body.appendChild(elm);
+            function a() { dispatched.push('a'); }
+            elm.addEventListener('click', a);
+            elm.triggerInternalClick();
+            expect(dispatched).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
…late and not execute handler on host

Listeners on the host element where executing even if you stop propagation on the template. They don't execute on the host element if you stop propagation anywhere else in the template. This is because we manage a shared queue of listeners for both the host element and the template and we don't account for stopPropagation().


## Details


## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:


## Reminders ( please delete this section before submitting )
-------------------------------------------------------------

### The PR fulfills these requirements:
* Tests for the changes have been added (for bug fixes / features)
* Docs have been added / updated (for bug fixes / features)

### PR Title
LWC PR title follows [conventional commit](../CONTRIBUTING.md#create-a-pull-request) format and is automatically validated by our CI.
```shell
ex:
commit-type(optional scope): commit description. ( NOTE: space between column and the message )

Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, proposal.
Scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
```
