### PR TITLE
fix(engine): support stopPropagation on the tpl (#571)

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
@@ -1,4 +1,5 @@
 import { createElement, LightningElement } from '../../framework/main';
+import { compileTemplate } from 'test-utils';
 
 describe('events', () => {
     describe('bookkeeping', () => {
@@ -31,6 +32,38 @@ describe('events', () => {
             });
             elm.click();
             expect(dispatched).toEqual(['a']);
+        });
+
+        it('invoking event.stopPropagation() in a listener on the template should prevent listeners on the host from being invoked', () => {
+            const dispatched = [];
+            const tpl = compileTemplate(`
+                <template>
+                    <button>click me</button>
+                </template>
+            `);
+
+            class MyComponent extends LightningElement {
+                renderedCallback() {
+                    this.template.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                    });
+                }
+
+                triggerInternalClick() {
+                    this.template.querySelector('button').click();
+                }
+
+                render() {
+                    return tpl;
+                }
+            }
+            MyComponent.publicMethods = ['triggerInternalClick'];
+            const elm = createElement('x-foo', { is: MyComponent });
+            document.body.appendChild(elm);
+            function a() { dispatched.push('a'); }
+            elm.addEventListener('click', a);
+            elm.triggerInternalClick();
+            expect(dispatched).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
… and not execute handler on host.

closes issue #566: Listeners on the host element where executing even if you stop propagation on the template. They don't execute on the host element if you stop propagation anywhere else in the template. This is because we manage a shared queue of listeners for both the host element and the template and we don't account for stopPropagation().

cherrypicks 7e729c81d9a041b648fd2b923d537459d2661598