### PR TITLE
fix: disable verify when using auth token

### DIFF
--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -21,7 +21,7 @@ fi
 # Command to push the packages
 CMD_UPDATE_VERSION="lerna version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push"
 CMD_PREPARE="yarn prepare"
-CMD_PUBLISH_PACKAGES="lerna publish --repo-version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push --registry https://npm.lwcjs.org ${CANARY} --npm-client npm"
+CMD_PUBLISH_PACKAGES="lerna publish --repo-version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push --registry https://npm.lwcjs.org ${CANARY} --npm-client npm --no-verify-access --no-verify-registry"
 
 # Run
 echo $CMD_UPDATE_VERSION;


### PR DESCRIPTION
## Details

Disable npm package access and user authentication because we publish via auth token.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No