### PR TITLE
fix(engine): invert condition to apply click-event-composed polyfill

### DIFF
--- a/packages/lwc-engine/src/polyfills/click-event-composed/detect.ts
+++ b/packages/lwc-engine/src/polyfills/click-event-composed/detect.ts
@@ -16,5 +16,5 @@ export default function detect(): boolean {
     button.addEventListener('click', event => clickEvent = event);
     button.click();
 
-    return composedDescriptor.get!.call(clickEvent);
+    return !composedDescriptor.get!.call(clickEvent);
 }


### PR DESCRIPTION
## Details

Fixes a bug where the detection logic to apply the `click-event-composed` polyfill had the wrong condition. We need to apply the polyfill when the click event has `composed=false`. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

This polyfill has not been released yet.
