### PR TITLE
fix(engine): invert condition to apply click-event-composed polyfill

### DIFF
--- a/packages/lwc-engine/src/polyfills/click-event-composed/detect.ts
+++ b/packages/lwc-engine/src/polyfills/click-event-composed/detect.ts
@@ -16,5 +16,5 @@ export default function detect(): boolean {
     button.addEventListener('click', event => clickEvent = event);
     button.click();
 
-    return composedDescriptor.get!.call(clickEvent);
+    return !composedDescriptor.get!.call(clickEvent);
 }


### PR DESCRIPTION
(cherry picked from commit dc506e4ec602d4825a537c4e6ca6748eb0dda36c)

## Details

https://github.com/salesforce/lwc/pull/590

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No