### PR TITLE
fix: update package version when releasing

### DIFF
--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -23,10 +23,18 @@ CMD_UPDATE_VERSION="lerna version ${PACKAGE_VERSION} --yes --exact --force-publi
 CMD_PREPARE="yarn prepare"
 CMD_PUBLISH_PACKAGES="lerna publish --repo-version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push --registry https://npm.lwcjs.org ${CANARY} --no-verify-access --no-verify-registry"
 
-# Run
+# Update package versions before preparing the dist files
 echo $CMD_UPDATE_VERSION;
 $CMD_UPDATE_VERSION;
+
 echo $CMD_PREPARE;
 $CMD_PREPARE;
+
+# Publish the packages to npm. Note that lerna cleans the working tree after this as of 3.0.4:
+# https://github.com/lerna/lerna/blob/3cbeeabcb443d9415bb86c4539652b85cd7b4025/commands/publish/index.js#L354-L363
 echo $CMD_PUBLISH_PACKAGES;
 $CMD_PUBLISH_PACKAGES;
+
+# Update package version again for later commit during the "commit release" stage
+echo $CMD_UPDATE_VERSION;
+$CMD_UPDATE_VERSION;


### PR DESCRIPTION
## Details

lerna changed behavior in 3.x to clean up after itself after publishing:
https://github.com/lerna/lerna/blob/3cbeeabcb443d9415bb86c4539652b85cd7b4025/commands/publish/index.js#L354-L363

Since we commit all the changes in a later stage, we need to invoke `lerna version` again after the publish to get all the version bumps back.

Will refactor later to use [--amend](https://github.com/lerna/lerna/tree/master/commands/version#--amend) so that we don't have to run `lerna version` twice.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No