### PR TITLE
chore: remove babel-core from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/acorn": "~4.0.3",
     "@types/jest": "~23.0.0",
     "@types/node": "8.9.4",
-    "babel-core": "~7.0.0-0",
     "babel-preset-minify": "0.5.0-alpha.5a128fd5",
     "commitizen": "~2.9.6",
     "conventional-changelog-cli": "~1.3.5",

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
@@ -2,8 +2,6 @@ const test = require('./utils/test-transform').test(
     require('../apex-scoped-import')
 );
 
-const DEFAULT_FUNCTION = function() { return Promise.resolve(); };
-
 describe('@salesforce/apex import', () => {
     test('does default transformation', `
         import myMethod from '@salesforce/apex/FooController.fooMethod';
@@ -11,7 +9,7 @@ describe('@salesforce/apex import', () => {
         let myMethod;
 
         try {
-          myMethod = require("@salesforce/apex/FooController.fooMethod").default;
+          myMethod = require('@salesforce/apex/FooController.fooMethod').default;
         } catch (e) {
           myMethod = function () {
             return Promise.resolve();
@@ -27,7 +25,7 @@ describe('@salesforce/apex import', () => {
         let myMethod;
 
         try {
-          myMethod = require("@salesforce/apex/FooController.fooMethod").default;
+          myMethod = require('@salesforce/apex/FooController.fooMethod').default;
         } catch (e) {
           myMethod = function () {
             return Promise.resolve();

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/label-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/label-scoped-import.test.js
@@ -9,9 +9,9 @@ describe('@salesforce/label import', () => {
         let myLabel;
 
         try {
-          myLabel = require("@salesforce/label/c.foo").default;
+          myLabel = require('@salesforce/label/c.foo').default;
         } catch (e) {
-          myLabel = "c.foo";
+          myLabel = 'c.foo';
         }
     `);
 
@@ -23,9 +23,9 @@ describe('@salesforce/label import', () => {
         let myLabel;
 
         try {
-          myLabel = require("@salesforce/label/c.foo").default;
+          myLabel = require('@salesforce/label/c.foo').default;
         } catch (e) {
-          myLabel = "c.foo";
+          myLabel = 'c.foo';
         }
     `);
 
@@ -40,33 +40,4 @@ describe('@salesforce/label import', () => {
     test('throws error if renamed multipel default imports', `
         import { default as label, foo } from '@salesforce/label/c.foo';
     `, undefined, 'Invalid import from @salesforce/label/c.foo');
-});
-
-// W-5140078 - remove these when all usages of @label are converted to @salesforce/label
-describe('legacy @label import', () => {
-    test('does default transformation', `
-        import myLabel from '@label/c.foo';
-    `, `
-        let myLabel;
-
-        try {
-          myLabel = require("@label/c.foo").default;
-        } catch (e) {
-          myLabel = "c.foo";
-        }
-    `);
-
-    test('allows non-@label named imports', `
-        import { otherNamed } from './something-valid';
-        import myLabel from '@label/c.foo';
-    `, `
-        import { otherNamed } from './something-valid';
-        let myLabel;
-
-        try {
-          myLabel = require("@label/c.foo").default;
-        } catch (e) {
-          myLabel = "c.foo";
-        }
-    `);
 });

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/resource-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/resource-scoped-import.test.js
@@ -9,9 +9,9 @@ describe('@salesforce/resource-url import', () => {
         let myResource;
 
         try {
-          myResource = require("@salesforce/resource-url/c.foo").default;
+          myResource = require('@salesforce/resource-url/c.foo').default;
         } catch (e) {
-          myResource = "c.foo";
+          myResource = 'c.foo';
         }
     `);
 
@@ -23,9 +23,9 @@ describe('@salesforce/resource-url import', () => {
         let myResource;
 
         try {
-          myResource = require("@salesforce/resource-url/c.foo").default;
+          myResource = require('@salesforce/resource-url/c.foo').default;
         } catch (e) {
-          myResource = "c.foo";
+          myResource = 'c.foo';
         }
     `);
 

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/schema-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/schema-scoped-import.test.js
@@ -9,10 +9,10 @@ describe('@salesforce/schema import', () => {
         let objectApiName;
 
         try {
-          objectApiName = require("@salesforce/schema/Opportunity").default;
+          objectApiName = require('@salesforce/schema/Opportunity').default;
         } catch (e) {
           objectApiName = {
-            objectApiName: "Opportunity"
+            objectApiName: 'Opportunity'
           };
         }
     `);
@@ -23,11 +23,11 @@ describe('@salesforce/schema import', () => {
         let objectApiName;
 
         try {
-          objectApiName = require("@salesforce/schema/Opportunity.Account").default;
+          objectApiName = require('@salesforce/schema/Opportunity.Account').default;
         } catch (e) {
           objectApiName = {
-            objectApiName: "Opportunity",
-            fieldApiName: "Account"
+            objectApiName: 'Opportunity',
+            fieldApiName: 'Account'
           };
         }
     `);
@@ -38,11 +38,11 @@ describe('@salesforce/schema import', () => {
         let objectApiName;
 
         try {
-          objectApiName = require("@salesforce/schema/Opportunity.Account.Name").default;
+          objectApiName = require('@salesforce/schema/Opportunity.Account.Name').default;
         } catch (e) {
           objectApiName = {
-            objectApiName: "Opportunity",
-            fieldApiName: "Account.Name"
+            objectApiName: 'Opportunity',
+            fieldApiName: 'Account.Name'
           };
         }
     `);
@@ -55,10 +55,10 @@ describe('@salesforce/schema import', () => {
         let objectApiName;
 
         try {
-          objectApiName = require("@salesforce/schema/Opportunity").default;
+          objectApiName = require('@salesforce/schema/Opportunity').default;
         } catch (e) {
           objectApiName = {
-            objectApiName: "Opportunity"
+            objectApiName: 'Opportunity'
           };
         }
     `);

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/user-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/user-scoped-import.test.js
@@ -11,9 +11,9 @@ describe('@salesforce/user import', () => {
         let id;
 
         try {
-          id = require("@salesforce/user/Id").default;
+          id = require('@salesforce/user/Id').default;
         } catch (e) {
-          id = "${DEFAULT_ID}";
+          id = '${DEFAULT_ID}';
         }
     `);
 
@@ -25,9 +25,9 @@ describe('@salesforce/user import', () => {
         let id;
 
         try {
-          id = require("@salesforce/user/Id").default;
+          id = require('@salesforce/user/Id').default;
         } catch (e) {
-          id = "${DEFAULT_ID}";
+          id = '${DEFAULT_ID}';
         }
     `);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,10 +1947,6 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-core@~7.0.0-0:
-  version "7.0.0-bridge.0"
-  resolved "http://npm.lwcjs.org/babel-core/-/babel-core-7.0.0-bridge.0/95a492ddd90f9b4e9a4a1da14eb335b87b634ece.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-
 babel-eslint@^8.0.3:
   version "8.2.2"
   resolved "http://npm.lwcjs.org/babel-eslint/-/babel-eslint-8.2.2/1102273354c6f0b29b4ea28a65f97d122296b68b.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"


### PR DESCRIPTION
## Details

Remove `babel-core` from repo workspace. Fix #550 

**Changes:**
* Remove `babel-core` from `package.json`
* Update test snapshot to match with new version of babel (converting double quotes to single quotes)

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No