### PR TITLE
fix(compiler): add early decorator import detection @W-5382040

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/decorators.spec.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/decorators.spec.js
@@ -75,7 +75,7 @@ describe('decorators', () => {
         }
     });
 
-    pluginTest('compiler should correctly point out missing "track" decorator import error', `
+    pluginTest('compiler should correctly point out missing "api" decorator import error', `
         import { LightningElement } from 'lwc';
         export default class Test extends LightningElement {
             @api title = 'hello'

--- a/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
+++ b/packages/babel-plugin-transform-lwc-class/src/decorators/index.js
@@ -136,11 +136,11 @@ function removeImportSpecifiers(specifiers) {
     }
 }
 
-function assertDecoratorImports(path, importedDecoratorNames = []) {
-    if (!path) {
+function assertDecoratorImports(classPath, importedDecoratorNames = []) {
+    if (!classPath) {
         return;
     }
-    const pathBody = path.get('body');
+    const pathBody = classPath.get('body');
 
     assertClassDecoratorsImported(pathBody, importedDecoratorNames);
     assertExportDefaultDeclarationDecoratorsImported(pathBody,importedDecoratorNames);

--- a/packages/babel-plugin-transform-lwc-class/src/utils.js
+++ b/packages/babel-plugin-transform-lwc-class/src/utils.js
@@ -53,13 +53,11 @@ function getEngineImportsStatements(path) {
 function getEngineImportSpecifiers(path) {
     const imports = getEngineImportsStatements(path);
 
-
-    const importSpecifiers = imports.reduce((acc, importStatement) => {
+    return imports.reduce((acc, importStatement) => {
         // Flat-map the specifier list for each import statement
         return [...acc, ...importStatement.get('specifiers')];
     }, []).reduce((acc, specifier) => {
         // Validate engine import specifier
-
 
         if (specifier.isImportNamespaceSpecifier()) {
             throw specifier.buildCodeFrameError(
@@ -74,11 +72,8 @@ function getEngineImportSpecifiers(path) {
         // Get the list of specifiers with their name
         const imported = specifier.get('imported').node.name;
 
-
         return [...acc, { name: imported, path: specifier }];
     }, []);
-
-    return importSpecifiers;
 }
 
 function isComponentClass(classPath, componentBaseClassImports) {

--- a/packages/lwc-compiler/src/compiler/__tests__/result.spec.ts
+++ b/packages/lwc-compiler/src/compiler/__tests__/result.spec.ts
@@ -270,31 +270,6 @@ describe("compiler result", () => {
         const { success, diagnostics }  = await compile(config);
         expect(diagnostics[0].message).toContain("Invalid decorator usage. It seems that you are not importing '@api' decorator from the 'lwc'");
     });
-
-    test('compiler does not produce an error if all decorators have been imported', async () => {
-        const config = {
-            name: "foo",
-            namespace: "x",
-            files: {
-                "foo.js": `import { api, track, wire, LightningElement } from 'lwc';
-                import { getTodo } from "todo";
-                export default class Test extends LightningElement {
-                    @wire(getTodo, {})
-                    wiredProp;
-
-                    @track
-                    mytrack = "track";
-
-                    @api
-                    title = "api";
-                }
-                `,
-                "foo.html": `<template></template>`,
-            },
-        };
-        const { success, diagnostics }  = await compile(config);
-        expect(success).toBe(true);
-    });
 });
 
 describe("compiler metadata", () => {


### PR DESCRIPTION
## Details

If babel-plugin-transform-lwc-class transform doesn't do early detection of a decorator usage that has not been imported from lwc, the issue is then caught by the babel with a bogus message. This PR adds validation earlier at the program visitor. 
Fixes https://github.com/salesforce/lwc/issues/601

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
