### PR TITLE
refactor(engine): locker does not longer need to leak base constructor

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/shadow-root.ts
+++ b/packages/lwc-engine/src/faux-shadow/shadow-root.ts
@@ -113,7 +113,7 @@ function activeElementGetter(this: ShadowRoot): Element | null {
     }
     const host = getHost(this);
     // activeElement must be child of the host and owned by it
-    // TODO: what happen with delegateFocus is true for a child component?
+    // TODO: what happen with delegatesFocus is true for a child component?
     return (compareDocumentPosition.call(host, activeElement) & DOCUMENT_POSITION_CONTAINED_BY) !== 0 &&
         isNodeOwnedBy(host, activeElement) ? patchShadowDomTraversalMethods(activeElement) : null;
 }

--- a/packages/lwc-engine/src/framework/__tests__/def.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/def.spec.ts
@@ -311,6 +311,23 @@ describe('def', () => {
                 attr: 'readonly',
             });
         });
+
+        it('should not allow null prototype', function() {
+            const L = null;
+            class MyComponent extends L  {}
+            expect(() => {
+                getComponentDef(MyComponent);
+            }).toThrow();
+        });
+
+        it('should not allow null in proto chain', function() {
+            const L = null;
+            class Foo extends L {}
+            class MyComponent extends Foo  {}
+            expect(() => {
+                getComponentDef(MyComponent);
+            }).toThrow();
+        });
     });
     describe('circular references', () => {
         it('should be resolved on for __proto__', () => {
@@ -342,6 +359,19 @@ describe('def', () => {
             class B extends CircularA {}
             // make sure it picks the props from LightingElement
             expect(getComponentDef(B).props.title).toBeDefined();
+        });
+
+        it('should not allow null results', () => {
+            function CircularA() {
+                return  null;
+            }
+            CircularA.__circular__ = true;
+
+            class B extends CircularA {}
+            // make sure it picks the props from LightingElement
+            expect(() => {
+                getComponentDef(B);
+            }).toThrow();
         });
     });
 });

--- a/packages/lwc-engine/src/framework/component.ts
+++ b/packages/lwc-engine/src/framework/component.ts
@@ -38,7 +38,7 @@ export function createComponent(vm: VM, Ctor: ComponentConstructor) {
     // create the component instance
     invokeComponentConstructor(vm, Ctor);
     if (isUndefined(vm.component)) {
-        throw new ReferenceError(`Invalid construction for ${vm}, you must extend LightningElement.`);
+        throw new ReferenceError(`Invalid construction for ${Ctor}, you must extend LightningElement.`);
     }
 }
 

--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -94,18 +94,26 @@ import { patchLightningElementPrototypeWithRestrictions } from "./restrictions";
 
 const CtorToDefMap: WeakMap<any, ComponentDef> = new WeakMap();
 
-function getCtorProto(Ctor: any): any {
-    let proto = getPrototypeOf(Ctor);
+function getCtorProto(Ctor: any): ComponentConstructor {
+    let proto: ComponentConstructor | null = getPrototypeOf(Ctor);
+    if (isNull(proto)) {
+        throw new ReferenceError(`Invalid prototype chain for ${Ctor}, you must extend LightningElement.`);
+    }
     // covering the cases where the ref is circular in AMD
     if (isCircularModuleDependency(proto)) {
         const p = resolveCircularModuleDependency(proto);
+        if (process.env.NODE_ENV !== 'production') {
+            if (isNull(p)) {
+                throw new ReferenceError(`Circular module dependency must resolve to a constructor that extends LightningElement.`);
+            }
+        }
         // escape hatch for Locker and other abstractions to provide their own base class instead
         // of our Base class without having to leak it to user-land. If the circular function returns
         // itself, that's the signal that we have hit the end of the proto chain, which must always
         // be base.
         proto = p === proto ? BaseElement : p;
     }
-    return proto;
+    return proto as ComponentConstructor;
 }
 
 // According to the WC spec (https://dom.spec.whatwg.org/#dom-element-attachshadow), certain elements
@@ -137,7 +145,7 @@ function isElementComponent(Ctor: any, protoSet?: any[]): boolean {
         return false; // null, undefined, or circular prototype definition
     }
     const proto = getCtorProto(Ctor);
-    if (proto === BaseElement) {
+    if (proto as any === BaseElement) {
         return true;
     }
     getComponentDef(proto); // ensuring that the prototype chain is already expanded
@@ -199,7 +207,7 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
     let superElmProto = globalElmProto;
     let superElmDescriptors = globalElmDescriptors;
     const superProto = getCtorProto(Ctor);
-    const superDef: ComponentDef | null = superProto !== BaseElement ? getComponentDef(superProto) : null;
+    const superDef: ComponentDef | null = superProto as any !== BaseElement ? getComponentDef(superProto) : null;
     if (!isNull(superDef)) {
         props = assign(create(null), superDef.props, props);
         methods = assign(create(null), superDef.methods, methods);


### PR DESCRIPTION
Second attempt after #509 to solve #511. This was reverted on https://github.com/salesforce/lwc/pull/510 to avoid releasing new things at the moment.

## Details

Until now, Locker and other abstractions on top of LWC are using the `__circular__` flag to trick the engine to think that the component extends `LightningElement`, but that has an undesired side effect, users can invoke the SecureLightningElement constructor directly, which returns the original LightningElement.

With this change, we not longer have to return `LightningElement`, instead we return the same `SecureLightningElement` as a signal that it is the end of the proto chain.

## Does this PR introduce a breaking change?

* No
