### PR TITLE
fix: rename @salesforce/resource-url to @salesforce/resourceUrl

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/namespace.spec.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/namespace.spec.js
@@ -117,35 +117,35 @@ describe('"@salesforce/componentTagName" namespace mapping', () => {
     );
 });
 
-describe('"@salesforce/resource-url" namespace mapping', () => {
+describe('"@salesforce/resourceUrl" namespace mapping', () => {
     pluginTest(
         'should add namespace if not present',
-        `import resource from '@salesforce/resource-url/resource';`,
+        `import resource from '@salesforce/resourceUrl/resource';`,
         {
             output: {
-                code: `import resource from \"@salesforce/resource-url/nsC__resource\";`,
+                code: `import resource from \"@salesforce/resourceUrl/nsC__resource\";`,
             },
         },
     );
 
     pluginTest(
         'should add namespace if not present on all imports',
-        `import r1 from '@salesforce/resource-url/resource1';
-         import r2 from '@salesforce/resource-url/resource2';`,
+        `import r1 from '@salesforce/resourceUrl/resource1';
+         import r2 from '@salesforce/resourceUrl/resource2';`,
         {
             output: {
-                code: `import r1 from \"@salesforce/resource-url/nsC__resource1\";
-                             import r2 from \"@salesforce/resource-url/nsC__resource2\";`,
+                code: `import r1 from \"@salesforce/resourceUrl/nsC__resource1\";
+                             import r2 from \"@salesforce/resourceUrl/nsC__resource2\";`,
             },
         },
     );
 
     pluginTest(
         'should ignore import if namespace if already present',
-        `import resource from '@salesforce/resource-url/anotherNs__resource';`,
+        `import resource from '@salesforce/resourceUrl/anotherNs__resource';`,
         {
             output: {
-                code: `import resource from '@salesforce/resource-url/anotherNs__resource';`,
+                code: `import resource from '@salesforce/resourceUrl/anotherNs__resource';`,
             },
         },
     );

--- a/packages/babel-plugin-transform-lwc-class/src/namespace.js
+++ b/packages/babel-plugin-transform-lwc-class/src/namespace.js
@@ -28,8 +28,8 @@ function getSalesforceNamespacedModule(moduleName, namespaceMapping) {
             }
             break;
 
-        // @salesforce/resource-url/resource1 -> @salesforce/resource-url/namespace__resource1
-        case 'resource-url':
+        // @salesforce/resourceUrl/resource1 -> @salesforce/resourceUrl/namespace__resource1
+        case 'resourceUrl':
             // Only prefix with the namespace if no other namespace is provided
             if (!value.includes('__')) {
                 updatedValue = `${targetSalesforceNamespace}__${value}`;

--- a/packages/lwc-jest-transformer/src/test/modules/example/resourceUrl/__tests__/resourceUrl.test.js
+++ b/packages/lwc-jest-transformer/src/test/modules/example/resourceUrl/__tests__/resourceUrl.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import ResourceUrl from 'example/resourceUrl';
 
-jest.mock('@salesforce/resource-url/c.mocked', () => {
+jest.mock('@salesforce/resourceUrl/c.mocked', () => {
     return { default: "value set in test"};
 }, { virtual: true });
 

--- a/packages/lwc-jest-transformer/src/test/modules/example/resourceUrl/resourceUrl.js
+++ b/packages/lwc-jest-transformer/src/test/modules/example/resourceUrl/resourceUrl.js
@@ -1,8 +1,8 @@
 import { LightningElement } from 'lwc';
-import mockedImport from '@salesforce/resource-url/c.mocked';
-import unmockedImport from '@salesforce/resource-url/c.unmocked';
+import mockedImport from '@salesforce/resourceUrl/c.mocked';
+import unmockedImport from '@salesforce/resourceUrl/c.unmocked';
 
-export default class Labels extends LightningElement {
+export default class ResourceUrl extends LightningElement {
     mockedResource = mockedImport;
     unmockedResource = unmockedImport;
 }

--- a/packages/lwc-jest-transformer/src/transforms/__tests__/resource-scoped-import.test.js
+++ b/packages/lwc-jest-transformer/src/transforms/__tests__/resource-scoped-import.test.js
@@ -2,42 +2,42 @@ const test = require('./utils/test-transform').test(
     require('../resource-scoped-import')
 );
 
-describe('@salesforce/resource-url import', () => {
+describe('@salesforce/resourceUrl import', () => {
     test('does default transformation', `
-        import myResource from '@salesforce/resource-url/c.foo';
+        import myResource from '@salesforce/resourceUrl/c.foo';
     `, `
         let myResource;
 
         try {
-          myResource = require('@salesforce/resource-url/c.foo').default;
+          myResource = require('@salesforce/resourceUrl/c.foo').default;
         } catch (e) {
           myResource = 'c.foo';
         }
     `);
 
-    test('allows non-@salesforce/resource-url named imports', `
+    test('allows non-@salesforce/resourceUrl named imports', `
         import { otherNamed } from './something-valid';
-        import myResource from '@salesforce/resource-url/c.foo';
+        import myResource from '@salesforce/resourceUrl/c.foo';
     `, `
         import { otherNamed } from './something-valid';
         let myResource;
 
         try {
-          myResource = require('@salesforce/resource-url/c.foo').default;
+          myResource = require('@salesforce/resourceUrl/c.foo').default;
         } catch (e) {
           myResource = 'c.foo';
         }
     `);
 
     test('throws error if using named import', `
-        import { myResource } from '@salesforce/resource-url/c.foo';
-    `, undefined, 'Invalid import from @salesforce/resource-url/c.foo');
+        import { myResource } from '@salesforce/resourceUrl/c.foo';
+    `, undefined, 'Invalid import from @salesforce/resourceUrl/c.foo');
 
     test('throws error if renamed default imports', `
-        import { default as resource } from '@salesforce/resource-url/c.foo';
-    `, undefined, 'Invalid import from @salesforce/resource-url/c.foo');
+        import { default as resource } from '@salesforce/resourceUrl/c.foo';
+    `, undefined, 'Invalid import from @salesforce/resourceUrl/c.foo');
 
-    test('throws error if renamed multipel default imports', `
-        import { default as resource, foo } from '@salesforce/resource-url/c.foo';
-    `, undefined, 'Invalid import from @salesforce/resource-url/c.foo');
+    test('throws error if renamed multiple default imports', `
+        import { default as resource, foo } from '@salesforce/resourceUrl/c.foo';
+    `, undefined, 'Invalid import from @salesforce/resourceUrl/c.foo');
 });

--- a/packages/lwc-jest-transformer/src/transforms/resource-scoped-import.js
+++ b/packages/lwc-jest-transformer/src/transforms/resource-scoped-import.js
@@ -1,6 +1,6 @@
 const { stringScopedImportTransform} = require('./utils');
 
-const RESOURCE_IMPORT_IDENTIFIER = '@salesforce/resource-url/';
+const RESOURCE_IMPORT_IDENTIFIER = '@salesforce/resourceUrl/';
 
 module.exports = function ({ types: t }) {
     return {


### PR DESCRIPTION
## Details

To align with new naming conventions, `@salesforce/resource-url` is being renamed to `@salesforce/resourceUrl`.

## Does this PR introduce a breaking change?

* [X] Yes
* [ ] No

Impact is that existing components must be updated to the new style.
