### PR TITLE
ci: add changelog script back for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:integration": "yarn run build && lerna exec --scope lwc-integration -- yarn sauce",
     "test:performance": "lerna exec --scope benchmark -- best --runner remote",
     "build": "lerna run build --ignore benchmark --ignore lwc-integration",
+    "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "release:ci:npm": "./scripts/release_npm.sh",
     "release:ci:changelog": "./scripts/release_changelog.sh"
   },


### PR DESCRIPTION
## Details

The `scripts/release_changelog.sh` script still depends on the `changelog:generate` script. Adding it back.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
