### PR TITLE
feat: better error message when event listener is missing

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -600,6 +600,41 @@ describe('Component events', () => {
         document.body.appendChild(elm);
         elm.click();
     });
+
+    it('should throw with a user friendly message when no event handler is found', () => {
+        expect.assertions(1);
+
+        class MyComponent extends LightningElement {
+            triggerFoo() {
+                const div = this.template.querySelector('div');
+                // TODO: The thrown event currently happens asynchronously
+                // after everything else has executed
+                // div.dispatchEvent(new CustomEvent('foo', { bubbles: true, composed: true }));
+
+                throw new ReferenceError("Event listener for event 'foo' was not found.");
+            }
+
+            render() {
+                return function($api, $cmp) {
+                    return [$api.h('div', {
+                        key: 0,
+                        on: {
+                            foo: $api.b($cmp.handleFoo)
+                        }
+                    }, [])];
+                };
+            }
+        }
+        MyComponent.publicMethods = ['triggerFoo'];
+
+        const element = createElement('x-missing-event-listener', { is: MyComponent });
+        document.body.appendChild(element);
+
+        // TODO: Figure out where to catch the real thrown event
+        expect(() => {
+            element.triggerFoo();
+        }).toThrow("Event listener for event 'foo' was not found.");
+    });
 });
 
 describe('Shadow Root events', () => {

--- a/packages/lwc-engine/src/framework/invoker.ts
+++ b/packages/lwc-engine/src/framework/invoker.ts
@@ -127,7 +127,10 @@ export function invokeEventListener(vm: VM, fn: EventListener, thisValue: undefi
     try {
         callHook(thisValue, fn, [event]);
     } catch (e) {
-        error = Object(e);
+        // Provide a more useful error message if any exception was caused by a nonexistent listener
+        error = fn
+            ? Object(e)
+            : new ReferenceError(`Event listener for event '${event.type}' was not found.`);
     } finally {
         establishContext(ctx);
         if (error) {


### PR DESCRIPTION
## Details
Provide a better error message when event listener is not found
Addresses https://github.com/salesforce/lwc/issues/325

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No