### PR TITLE
fix(engine): identify LWC console logs

### DIFF
--- a/packages/lwc-engine/src/framework/def.ts
+++ b/packages/lwc-engine/src/framework/def.ts
@@ -358,7 +358,7 @@ function getPublicPropertiesHash(target: ComponentConstructor): PropsDef {
                     msg.push(`  * Use \`this.getAttribute("${attribute}")\` to access the attribute value. This option is best suited for accessing the value in a getter during the rendering process.`);
                     msg.push(`  * Declare \`static observedAttributes = ["${attribute}"]\` and use \`attributeChangedCallback(attrName, oldValue, newValue)\` to get a notification each time the attribute changes. This option is best suited for reactive programming, eg. fetching new data each time the attribute is updated.`);
                 }
-                console.error(msg.join('\n')); // tslint:disable-line
+                assert.logError(msg.join('\n'));
             }
         }
 

--- a/packages/lwc-engine/src/framework/membrane.ts
+++ b/packages/lwc-engine/src/framework/membrane.ts
@@ -24,7 +24,7 @@ export const reactiveMembrane = new ObservableMembrane({
 // TODO: REMOVE THIS https://github.com/salesforce/lwc/issues/129
 export function dangerousObjectMutation(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {
-        assert.logWarning(`Dangerously Mutating Object ${toString(obj)}. This object was passed to you from a parent component, and should not be mutated here. This will be removed in the near future.`, null);
+        assert.logWarning(`Dangerously Mutating Object ${toString(obj)}. This object was passed to you from a parent component, and should not be mutated here. This will be removed in the near future.`);
     }
     return reactiveMembrane.getProxy(unwrap(obj));
 }

--- a/packages/lwc-engine/src/framework/restrictions.ts
+++ b/packages/lwc-engine/src/framework/restrictions.ts
@@ -29,7 +29,7 @@ function getNodeRestrictionsDescriptors(node: Node): PropertyDescriptorMap {
             get(this: Node) {
                 assert.logWarning(
                     `Discouraged access to property 'childNodes' on 'Node': It returns a live NodeList and should not be relied upon. Instead, use 'querySelectorAll' which returns a static NodeList.`,
-                    (this instanceof Element) ? this as Element : getShadowRootHost(this as ShadowRoot)
+                    (this instanceof Element) ? this as Element : (getShadowRootHost(this as ShadowRoot) || undefined)
                 );
                 return originalChildNodesDescriptor!.get!.call(this);
             },

--- a/packages/lwc-engine/src/shared/__tests__/assert.spec.js
+++ b/packages/lwc-engine/src/shared/__tests__/assert.spec.js
@@ -1,0 +1,32 @@
+import assert  from '../assert';
+
+const _originalConsole = global.console;
+const restoreConsole = () => {
+    global.console = _originalConsole;
+};
+
+describe('assert', () => {
+    afterEach(restoreConsole);
+
+    describe('logError', () => {
+        it('should prefix error messages with [LWC error]', () => {
+            global.console = {error: jest.fn()};
+
+            assert.logError('error-msg', null);
+
+            expect(global.console.error).toBeCalled();
+            expect(global.console.error.mock.calls[0][0]).toBe('[LWC error]: error-msg');
+        });
+    });
+
+    describe('logWarning', () => {
+        it('should prefix warning messages with [LWC warning]', () => {
+            global.console = {warn: jest.fn()};
+
+            assert.logWarning('warning-msg', null);
+
+            expect(global.console.warn).toBeCalled();
+            expect(global.console.warn.mock.calls[0][0]).toBe('[LWC warning]: warning-msg');
+        });
+    });
+});

--- a/packages/lwc-engine/src/shared/assert.ts
+++ b/packages/lwc-engine/src/shared/assert.ts
@@ -66,8 +66,8 @@ const assert = {
     fail(msg: string) {
         throw new Error(msg);
     },
-    logError(message: string, elm: Element | null) {
-        let msg = message;
+    logError(message: string, elm?: Element) {
+        let msg = `[LWC error]: ${message}`;
 
         if (elm) {
             msg = `${msg}\n${getFormattedComponentStack(elm)}`;
@@ -83,8 +83,8 @@ const assert = {
             console.error(e); // tslint:disable-line
         }
     },
-    logWarning(message: string, elm: Element | null) {
-        let msg = message;
+    logWarning(message: string, elm?: Element) {
+        let msg = `[LWC warning]: ${message}`;
 
         if (elm) {
             msg = `${msg}\n${getFormattedComponentStack(elm)}`;
@@ -99,7 +99,7 @@ const assert = {
         } catch (e) {
             // first line is the dummy message and second this function (which does not need to be there)
             const stackTraceLines: string[] = StringSplit.call(e.stack, '\n').splice(2);
-            console.group(`Warning: ${msg}`); // tslint:disable-line
+            console.group(msg); // tslint:disable-line
             forEach.call(stackTraceLines, (trace) => {
                 // We need to format this as a string,
                 // because Safari will detect that the string


### PR DESCRIPTION
## Details
Adds [LWC err/warn] prefix in `assert.logError` and `assert.logWarning` to clearly identify LWC's console logs

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
