### PR TITLE
test(engine): add getShadowRoot to test-utils

### DIFF
--- a/packages/lwc-engine/scripts/jest/test-utils.js
+++ b/packages/lwc-engine/scripts/jest/test-utils.js
@@ -1,4 +1,5 @@
 const { compileToFunction } = require('lwc-template-compiler');
+const { getShadowRoot } = require('lwc-test-utils');
 
 const TEMPLATE_CACHE = Object.create(null);
 
@@ -24,4 +25,5 @@ function compileTemplate(source, config = {}) {
 
 module.exports = {
     compileTemplate,
+    getShadowRoot,
 };


### PR DESCRIPTION
## Details

Adds `getShadowRoot` to engine's test utils.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No