### PR TITLE
fix(engine): avoid throwing when retargeting events

### DIFF
--- a/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/button/button.html
+++ b/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/button/button.html
@@ -1,0 +1,7 @@
+<template>
+    <div>
+        <template if:false={hideButton}>
+            <button>detach me</button>
+        </template>
+    </div>
+</template>

--- a/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/button/button.js
+++ b/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/button/button.js
@@ -1,0 +1,20 @@
+import { api, LightningElement } from 'lwc';
+
+export default class IntegrationButton extends LightningElement {
+    @api
+    hideButton = false;
+
+    @api
+    click() {
+        this.template.querySelector('button').click();
+    }
+
+    @api
+    lastClickHandled() {
+        if (this.template.querySelector('button') === null) {
+            this.dispatchEvent(
+                new CustomEvent('bad', { bubbles: true, composed: true })
+            );
+        }
+    }
+}

--- a/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/render-timing-event-propagation/render-timing-event-propagation.html
+++ b/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/render-timing-event-propagation/render-timing-event-propagation.html
@@ -1,0 +1,11 @@
+<template>
+    <integration-button
+        hide-button={state.hideButton}
+        onbad={handleBad}
+        onclick={handleClick}
+    ></integration-button>
+
+    <template if:true={state.bad}>
+        <p>Ruh-roh! Button was removed before the click event finished propagating!</p>
+    </template>
+</template>

--- a/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/render-timing-event-propagation/render-timing-event-propagation.js
+++ b/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/integration/render-timing-event-propagation/render-timing-event-propagation.js
@@ -1,0 +1,29 @@
+import { api, track, LightningElement } from 'lwc';
+
+export default class IntegrationRenderTiming extends LightningElement {
+    @track
+    state = {
+        bad: false,
+        hideButton: false,
+    };
+
+    @api
+    click() {
+        this.template.querySelector('integration-button').click();
+    }
+
+    renderedCallback() {
+        this.template.addEventListener('click', () => {
+            this.template.querySelector('integration-button').lastClickHandled();
+        });
+    }
+
+    handleClick() {
+        this.state.hideButton = true;
+    }
+
+    handleBad() {
+        this.state.bad = true;
+        this.template.querySelector('integration-button').setAttribute('fail', true);
+    }
+}

--- a/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/render-timing-event-propagation.spec.js
+++ b/packages/lwc-integration/src/components/lifecycle/test-render-timing-event-propagation/render-timing-event-propagation.spec.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+describe('Render timing:', () => {
+    const URL = 'http://localhost:4567/render-timing-event-propagation';
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should not render before event propagation completes', () => {
+        const button = browser.element('integration-button');
+        button.click();
+        assert.strictEqual(button.getAttribute('fail'), null);
+    });
+});


### PR DESCRIPTION
## Details

Rendering can be triggered by event listeners before the event completes its propagation path because the rehydration queue is flushed using microtask timing.

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No
