### PR TITLE
build: script to update npm dist-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "lerna run build --ignore benchmark --ignore lwc-integration",
     "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "release:ci:npm": "./scripts/release_npm.sh",
-    "release:ci:changelog": "./scripts/release_changelog.sh"
+    "release:ci:changelog": "./scripts/release_changelog.sh",
+    "release:ci:dist-tags": "./scripts/release_dist-tags.sh"
   },
   "devDependencies": {
     "@babel/core": "7.1.0",

--- a/scripts/release_dist-tags.sh
+++ b/scripts/release_dist-tags.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if (( $# != 2 )); then
+    echo "Illegal number of parameters"
+    exit 1;
+fi
+
+LWC_VERSION="$1"
+TAG_NAME="$2"
+
+# Get the current tag
+CURRENT_TAG=$(npm dist-tags ls lwc-engine --registry='https://npm.lwcjs.org' | sed -n "s/.*${TAG_NAME}: \(.*\)/\1/p")
+
+if [[ ${CURRENT_TAG} = ${LWC_VERSION} ]]; then
+  echo "LWC version ${LWC_VERSION} already tagged to ${TAG_NAME}"
+  exit 0;
+fi
+
+CMD_UPDATE_TAGS="lerna exec --ignore benchmark --ignore lwc-integration -- npm dist-tag add \$LERNA_PACKAGE_NAME@${LWC_VERSION} ${TAG_NAME} --registry='https://npm.lwcjs.org'"
+
+echo $CMD_UPDATE_TAGS
+$CMD_UPDATE_TAGS


### PR DESCRIPTION
## Details

Script to update the npm dist-tags for packages to be used by our CI as we release versions to core. These tags will be consumed by other tools such as the playground or lwc-testrunner to run the versions of LWC that align with the Salesforce releases. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
