### PR TITLE
test(wire-service): improve test coverage

### DIFF
--- a/packages/lwc-wire-service/src/__tests__/assert.spec.ts
+++ b/packages/lwc-wire-service/src/__tests__/assert.spec.ts
@@ -1,0 +1,30 @@
+import assert from '../assert';
+
+describe('assert', () => {
+    describe('isTrue()', () => {
+        it('should throw error that includes custom message', () => {
+            expect(
+                () => assert.isTrue(false, 'foo bar')
+            ).toThrowError(/foo bar/);
+        });
+
+        it('should not throw error for true', () => {
+            expect(
+                () => assert.isTrue(true, 'foo bar')
+            ).not.toThrow();
+        });
+    });
+    describe('isFalse()', () => {
+        it('should throw error that includes custom message', () => {
+            expect(
+                () => assert.isFalse(true, 'foo bar')
+            ).toThrowError(/foo bar/);
+        });
+
+        it('should not throw error for false', () => {
+            expect(
+                () => assert.isFalse(false, 'foo bar')
+            ).not.toThrow();
+        });
+    });
+});

--- a/packages/lwc-wire-service/src/__tests__/index.spec.ts
+++ b/packages/lwc-wire-service/src/__tests__/index.spec.ts
@@ -9,8 +9,14 @@ import {
 } from '../engine';
 
 import {
-    Context,
+    Context, ConfigContext,
 } from '../wiring';
+import {
+    CONTEXT_ID,
+    CONTEXT_CONNECTED,
+    CONTEXT_DISCONNECTED,
+    CONTEXT_UPDATED
+} from '../constants';
 
 describe('wire service', () => {
     describe('registers the service with engine', () => {
@@ -42,7 +48,7 @@ describe('wire service', () => {
             registerWireService((svc) => {
                 wireService = svc;
             });
-            const adapterId = () => {};
+            const adapterId = () => { /**/ };
             const adapterFactory = jest.fn();
             register(adapterId, adapterFactory);
             const mockDef: ElementDef = {
@@ -83,12 +89,60 @@ describe('wire service', () => {
             const mockDef = {
                 wire: {
                     target: {
-                        adapter: () => {},
+                        adapter: () => { /**/ },
                         method: 1
                     }
                 }
             };
             expect(() => wireService.wiring({} as Element, {}, mockDef, {} as Context)).toThrowError('@wire on "target": unknown adapter id: ');
+        });
+    });
+    describe('connected handling', () => {
+        const def: ElementDef = {
+            wire: {
+                target: { adapter: true }
+            }
+        };
+        it('invokes connected listeners', () => {
+            let wireService;
+            registerWireService((svc) => {
+                wireService = svc;
+            });
+            const listener = jest.fn();
+            const context: Context = {
+                [CONTEXT_ID]: {
+                    [CONTEXT_CONNECTED]: [listener],
+                    [CONTEXT_DISCONNECTED]: [],
+                    [CONTEXT_UPDATED]: {} as ConfigContext
+                }
+            };
+
+            wireService.connected({} as Element, {}, def, context);
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('disconnected handling', () => {
+        const def: ElementDef = {
+            wire: {
+                target: { adapter: true }
+            }
+        };
+        it('invokes connected listeners', () => {
+            let wireService;
+            registerWireService((svc) => {
+                wireService = svc;
+            });
+            const listener = jest.fn();
+            const context: Context = {
+                [CONTEXT_ID]: {
+                    [CONTEXT_CONNECTED]: [],
+                    [CONTEXT_DISCONNECTED]: [listener],
+                    [CONTEXT_UPDATED]: {} as ConfigContext
+                }
+            };
+
+            wireService.disconnected({} as Element, {}, def, context);
+            expect(listener).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/lwc-wire-service/src/assert.ts
+++ b/packages/lwc-wire-service/src/assert.ts
@@ -1,10 +1,5 @@
 
 export default {
-    invariant(value: any, msg: string) {
-        if (!value) {
-            throw new Error(`Invariant Violation: ${msg}`);
-        }
-    },
     isTrue(value: any, msg: string) {
         if (!value) {
             throw new Error(`Assert Violation: ${msg}`);


### PR DESCRIPTION
## Details

Add tests to improve statement and branch coverage

Before:
```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    87.17 |    65.82 |    85.19 |     87.1 |                   |
 assert.ts        |    71.43 |    66.67 |      100 |    71.43 |               4,5 |
 constants.ts     |      100 |      100 |      100 |      100 |                   |
 index.ts         |    78.95 |    21.43 |       50 |    78.38 |... 89,91,96,97,99 |
 property-trap.ts |    78.69 |       72 |    91.67 |    78.69 |... 37,38,60,65,92 |
 wiring.ts        |    98.65 |    79.41 |      100 |    98.65 |               197 |
------------------|----------|----------|----------|----------|-------------------|
```


After:
```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    97.84 |    77.92 |      100 |    97.83 |                   |
 assert.ts        |      100 |      100 |      100 |      100 |                   |
 constants.ts     |      100 |      100 |      100 |      100 |                   |
 index.ts         |    94.74 |    64.29 |      100 |    94.59 |             89,97 |
 property-trap.ts |    98.36 |       80 |      100 |    98.36 |                92 |
 wiring.ts        |    98.65 |    79.41 |      100 |    98.65 |               197 |
------------------|----------|----------|----------|----------|-------------------|
```
