### PR TITLE
fix(engine): fixing logic for executing event handlers in root

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/events.ts
+++ b/packages/lwc-engine/src/faux-shadow/events.ts
@@ -209,11 +209,14 @@ function getWrappedShadowRootListener(sr: SyntheticShadowRoot, listener: EventLi
             const currentTarget = eventCurrentTargetGetter.call(event);
             if (
                 // it is composed and was not dispatched onto the custom element directly
-                (composed === true && target !== currentTarget) ||
-                // it is coming from a slotted element
-                isChildNode(getRootNode.call(target, event), currentTarget as Node) ||
-                // it is not composed and its is coming from from shadow
-                (composed === false && getRootNode.call(target) === currentTarget)) {
+                (target !== currentTarget) &&
+                (
+                    // it is coming from a slotted element
+                    isChildNode(getRootNode.call(target, event), currentTarget as Node) ||
+                    // it is not composed and its is coming from from shadow
+                    (composed === false && getRootNode.call(target) === currentTarget)
+                )
+            ) {
                     // TODO: we should figure why `undefined` makes sense here
                     // and how this is going to work for native shadow root?
                     listener.call(undefined, event);

--- a/packages/lwc-engine/src/framework/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/events.spec.ts
@@ -214,6 +214,80 @@ describe('Events on Custom Elements', () => {
         expect(result[1]).toBeInstanceOf(Event);
     });
 
+    it('should not execute native events handlers for events originating on the host', () => {
+        const spy = jest.fn();
+        const myComponentTmpl = compileTemplate(`
+            <template>
+
+            </template>
+        `);
+        class MyComponent extends LightningElement {
+            connectedCallback() {
+                this.template.addEventListener('click', spy);
+            }
+            render() {
+                return myComponentTmpl;
+            }
+        }
+
+        const elm = createElement('x-foo', { is: MyComponent });
+        document.body.appendChild(elm);
+        elm.click();
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not execute composed: true events handlers for events originating on the host', () => {
+        const spy = jest.fn();
+        const myComponentTmpl = compileTemplate(`
+            <template>
+
+            </template>
+        `);
+        class MyComponent extends LightningElement {
+            connectedCallback() {
+                this.template.addEventListener('custom', spy);
+            }
+            render() {
+                return myComponentTmpl;
+            }
+        }
+
+        const elm = createElement('x-foo', { is: MyComponent });
+        document.body.appendChild(elm);
+        const event = new CustomEvent('custom', {
+            bubbles: true,
+            composed: true,
+        });
+        elm.dispatchEvent(event);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not execute composed: false events handlers for events originating on the host', () => {
+        const spy = jest.fn();
+        const myComponentTmpl = compileTemplate(`
+            <template>
+
+            </template>
+        `);
+        class MyComponent extends LightningElement {
+            connectedCallback() {
+                this.template.addEventListener('custom', spy);
+            }
+            render() {
+                return myComponentTmpl;
+            }
+        }
+
+        const elm = createElement('x-foo', { is: MyComponent });
+        document.body.appendChild(elm);
+        const event = new CustomEvent('custom', {
+            bubbles: true,
+            composed: false,
+        });
+        elm.dispatchEvent(event);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     it('should add event listeners in constructor when created via createElement', function() {
         let count = 0;
 


### PR DESCRIPTION
## Details
Events dispatched on the custom element were being executed in the shadow root. This change fixes that.

Fixes #745