### PR TITLE
feat(compiler): throw on any non-whitelisted lwc imports

### DIFF
--- a/packages/babel-plugin-transform-lwc-class/src/__tests__/component.spec.js
+++ b/packages/babel-plugin-transform-lwc-class/src/__tests__/component.spec.js
@@ -2,6 +2,7 @@ const pluginTest = require('./utils/test-transform').pluginTest(
     require('../index')
 );
 
+
 describe('Element import', () => {
     pluginTest('throws if using default import on lwc', `
         import engine from 'lwc';
@@ -60,13 +61,13 @@ describe('Element import', () => {
         }
     });
 
-    pluginTest('throws if non-whitelisted lwc exports are being imported', `
+    pluginTest('throws non-whitelisted lwc api is imported', `
         import { registerTemplate } from "lwc";
         import tmpl from './localTemplate.html';
         registerTemplate(tmpl);
     `, {
         error: {
-            message: `test.js: Invalid import. "registerTemplate" is not part of the lwc api.`,
+            message: `Invalid import. "registerTemplate" is not part of the lwc api.`,
             loc: {
                 line: 1,
                 column: 7,
@@ -74,11 +75,25 @@ describe('Element import', () => {
         }
     });
 
-    pluginTest('allows importing api, track, wire, createElement, and LightningElement from "lwc"', `
-        import { api, track, wire, createElement, LightningElement } from "lwc";
+    pluginTest('allows importing whitelisted apis from "lwc"', `
+        import {
+            api,
+            track,
+            wire,
+            createElement,
+            LightningElement,
+            buildCustomElementConstructor,
+            dangerousObjectMutation,
+            getComponentDef,
+            getComponentConstructor,
+            isComponentConstructor,
+            readonly,
+            register,
+            unwrap,
+        } from "lwc";
     `, {
         output: {
-            code: `import { api, track, wire, createElement, LightningElement } from "lwc";`
+            code: `import { api, track, wire, createElement, LightningElement, buildCustomElementConstructor, dangerousObjectMutation, getComponentDef, getComponentConstructor, isComponentConstructor, readonly, register, unwrap } from "lwc";`
         }
     });
 });

--- a/packages/babel-plugin-transform-lwc-class/src/component.js
+++ b/packages/babel-plugin-transform-lwc-class/src/component.js
@@ -2,7 +2,7 @@ const { basename } = require('path');
 const moduleImports = require("@babel/helper-module-imports");
 
 const { findClassMethod, generateError, getEngineImportSpecifiers, isComponentClass, isDefaultExport } = require('./utils');
-const { GLOBAL_ATTRIBUTE_MAP, LWC_PACKAGE_EXPORTS, LWC_COMPONENT_PROPERTIES, LWC_WHITE_LISTED_INTERNAL_APIS } = require('./constants');
+const { GLOBAL_ATTRIBUTE_MAP, LWC_PACKAGE_EXPORTS, LWC_COMPONENT_PROPERTIES, LWC_API_WHITELIST } = require('./constants');
 const { LWCClassErrors } = require('lwc-errors');
 const CLASS_PROPERTY_OBSERVED_ATTRIBUTES = 'observedAttributes';
 
@@ -12,14 +12,12 @@ module.exports = function ({ types: t }) {
             const engineImportSpecifiers = getEngineImportSpecifiers(path);
 
             // validate internal api imports
-            const validLwcImports = new Set([
-                ...Object.values(LWC_PACKAGE_EXPORTS),
-                ...Object.values(LWC_WHITE_LISTED_INTERNAL_APIS),
-            ]);
-
             engineImportSpecifiers.forEach(({name}) => {
-                if (!validLwcImports.has(name)) {
-                    throw path.buildCodeFrameError(`Invalid import. "${name}" is not part of the lwc api.`);
+                if (!LWC_API_WHITELIST.has(name)) {
+                    throw generateError(path, {
+                        errorInfo: LWCClassErrors.INVALID_IMPORT_PROHIBITED_API,
+                        messageArgs: [name]
+                    });
                 }
             })
 

--- a/packages/babel-plugin-transform-lwc-class/src/constants.js
+++ b/packages/babel-plugin-transform-lwc-class/src/constants.js
@@ -49,17 +49,25 @@ const DISALLOWED_PROP_SET = new Set([
 
 const LWC_PACKAGE_ALIAS = 'lwc';
 
-
-const LWC_WHITE_LISTED_INTERNAL_APIS = {
-    CREATE_ELEMENT: 'createElement',
-}
-
 const LWC_PACKAGE_EXPORTS = {
     BASE_COMPONENT: 'LightningElement',
     API_DECORATOR: 'api',
     TRACK_DECORATOR: 'track',
     WIRE_DECORATOR: 'wire',
 }
+
+const LWC_API_WHITELIST = new Set([
+    'buildCustomElementConstructor',
+    'createElement',
+    'dangerousObjectMutation',
+    'getComponentDef',
+    'getComponentConstructor',
+    'isComponentConstructor',
+    'readonly',
+    'register',
+    'unwrap',
+    ...Object.values(LWC_PACKAGE_EXPORTS),
+]);
 
 const LWC_DECORATORS = [
     LWC_PACKAGE_EXPORTS.API_DECORATOR,
@@ -90,7 +98,7 @@ module.exports = {
     LWC_DECORATORS,
     LWC_PACKAGE_ALIAS,
     LWC_PACKAGE_EXPORTS,
-    LWC_WHITE_LISTED_INTERNAL_APIS,
+    LWC_API_WHITELIST,
 
     LWC_COMPONENT_PROPERTIES,
     DECORATOR_TYPES,

--- a/packages/lwc-errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/lwc-errors/src/compiler/error-info/lwc-class.ts
@@ -15,6 +15,13 @@ export const LWCClassErrors = {
         url: ""
     },
 
+    INVALID_IMPORT_PROHIBITED_API: {
+        code: 1001,
+        message: "Invalid import. \"{0}\" is not part of the lwc api.",
+        level: DiagnosticLevel.Error,
+        url: ""
+    },
+
     INVALID_STATIC_OBSERVEDATTRIBUTES: {
         code: 1001,
         message: "Invalid static property \"observedAttributes\". \"observedAttributes\" cannot be used to track attribute changes. Define setters for {0} instead.",


### PR DESCRIPTION
## Details
Disallow any non-whitelisted lwc import. Current whitelist contains most the lwc api, except registerTemplate. 

Whitelisted apis:
```js
'LightningElement',
'api',
'track',
'wire',
'buildCustomElementConstructor',
'createElement',
'dangerousObjectMutation',
'getComponentDef',
'getComponentConstructor',
'isComponentConstructor',
'readonly',
'register',
'unwrap',
```
Any cases that should be prevented for platform users must be handled by en eslint rule. 

Fixes: [W-5507771](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005Wv2AIAS/view)

## Does this PR introduce a breaking change?

* [X] Yes
* [ ] No

Any existing code that imports 'registerTemplate' will result in failure. 