### PR TITLE
fix(engine): error when event listener was on document

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/events.ts
+++ b/packages/lwc-engine/src/faux-shadow/events.ts
@@ -40,8 +40,8 @@ const EventPatchDescriptors: PropertyDescriptorMap = {
             const originalTarget: EventTarget = eventTargetGetter.call(this);
 
             // Handle cases where the currentTarget is null (for async events)
-            // and when currentTarget is window.
-            if (!(currentTarget instanceof Node)) {
+            // and when currentTarget is window or document.
+            if (!(currentTarget instanceof Node) || currentTarget instanceof Document) {
                 // the event was inspected asynchronously, in which case we need to return the
                 // top custom element that belongs to the body.
                 let outerMostElement = originalTarget;

--- a/packages/lwc-integration/src/components/events/test-document-event-listener/document-event-listener.spec.js
+++ b/packages/lwc-integration/src/components/events/test-document-event-listener/document-event-listener.spec.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+describe('Event Target on window event listener', () => {
+    const URL = 'http://localhost:4567/document-event-listener/';
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should return correct target', function () {
+        browser.click('button');
+        assert.deepEqual(browser.getText('.document-event-target-tagname'), 'integration-document-event-listener');
+    });
+});

--- a/packages/lwc-integration/src/components/events/test-document-event-listener/integration/document-event-listener/document-event-listener.html
+++ b/packages/lwc-integration/src/components/events/test-document-event-listener/integration/document-event-listener/document-event-listener.html
@@ -1,0 +1,4 @@
+<template>
+    <button onclick={handleClick}>Click Me</button>
+    <div class="document-event-target-tagname">{documentEventTargetTagName}</div>
+</template>

--- a/packages/lwc-integration/src/components/events/test-document-event-listener/integration/document-event-listener/document-event-listener.js
+++ b/packages/lwc-integration/src/components/events/test-document-event-listener/integration/document-event-listener/document-event-listener.js
@@ -1,0 +1,13 @@
+import { LightningElement, track } from "lwc";
+
+export default class WindowEventListener extends LightningElement {
+    @track documentEventTargetTagName = '';
+    connectedCallback() {
+        document.addEventListener('click', (evt) => {
+            this.documentEventTargetTagName = evt.target.tagName.toLowerCase();
+        });
+    }
+    handleClick() {
+        // empty handler
+    }
+}


### PR DESCRIPTION
## Details

- Fixes issue where events added to the `document` were throwing error in `isNodeSlotted`

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
