### PR TITLE
feat(wire): use class property default values

### DIFF
--- a/packages/lwc-wire-service/playground/x/defaultValueWire/defaultValueWire.html
+++ b/packages/lwc-wire-service/playground/x/defaultValueWire/defaultValueWire.html
@@ -1,0 +1,12 @@
+<template>
+    <template if:true={todo.error}>
+        <span>{error}</span>
+    </template>
+    <template if:true={todo.data}>
+        Title:
+        <span>{todo.data.title}</span>
+        <br> Completed:
+        <span>{todo.data.completed}</span>
+        <br>
+    </template>
+</template>

--- a/packages/lwc-wire-service/playground/x/defaultValueWire/defaultValueWire.js
+++ b/packages/lwc-wire-service/playground/x/defaultValueWire/defaultValueWire.js
@@ -1,0 +1,22 @@
+import { LightningElement, api, wire, track } from 'lwc';
+import { getTodo } from 'x/todoApi';
+
+export default class DefaultValueWire extends LightningElement {
+    @api set todoId(value) {
+        // guard against default value from parent (which is empty string)
+        if (value !== "") {
+            this._todoId = value;
+        }
+    }
+    get todoId() { return this._todoId; }
+
+    // default value of 0
+    _todoId = 0;
+
+    @wire(getTodo, { id: '$_todoId' })
+    todo;
+
+    get error() {
+        return 'Error loading data: ' + this.todo.error.message;
+    }
+}

--- a/packages/lwc-wire-service/playground/x/demo/demo.html
+++ b/packages/lwc-wire-service/playground/x/demo/demo.html
@@ -4,6 +4,7 @@
         Load a todo by id: <input type="text" value={state.todoId}  onchange={handleChange} /><br>
     </div>
     <hr>
+
     <h2>single @wire bound to field</h2>
     <x-single-wire todo-id={state.todoId}></x-single-wire>
     <hr>
@@ -18,4 +19,10 @@
 
     <h2>one @wire dependent on another @wire's output</h2>
     <x-wire-to-wire todo-id={state.todoId}></x-wire-to-wire>
-</template>
+    <hr>
+
+    <h2>single @wire with default value</h2>
+    <x-default-value-wire todo-id={state.todoId}></x-default-value-wire>
+    <hr>
+
+ </template>

--- a/packages/lwc-wire-service/src/property-trap.ts
+++ b/packages/lwc-wire-service/src/property-trap.ts
@@ -40,7 +40,13 @@ function invokeConfigListeners(configListenerMetadatas: Set<ConfigListenerMetada
     });
 }
 
-function updated(cmp: Element, reactiveParameter: ReactiveParameter, configContext: ConfigContext) {
+/**
+ * Marks a reactive parameter as having changed.
+ * @param cmp The component
+ * @param reactiveParameter Reactive parameter that has changed
+ * @param configContext The service context
+ */
+export function updated(cmp: Element, reactiveParameter: ReactiveParameter, configContext: ConfigContext) {
     if (!configContext.mutated) {
         configContext.mutated = new Set<ReactiveParameter>();
         // collect all prop changes via a microtask
@@ -95,7 +101,7 @@ export function getReactiveParameterValue(cmp: Element, reactiveParameter: React
  * Installs setter override to trap changes to a property, triggering the config listeners.
  * @param cmp The component
  * @param reactiveParameter Reactive parameter that defines the property to monitor
- * @param context The service context
+ * @param configContext The service context
  */
 export function installTrap(cmp: Object, reactiveParameter: ReactiveParameter, configContext: ConfigContext) {
     const callback = updated.bind(undefined, cmp, reactiveParameter, configContext);

--- a/packages/lwc-wire-service/src/wiring.ts
+++ b/packages/lwc-wire-service/src/wiring.ts
@@ -15,7 +15,8 @@ import {
     ComposableEvent
 } from './engine';
 import {
-    installTrap
+    installTrap,
+    updated
 } from './property-trap';
 
 export type NoArgumentListener = () => void;
@@ -153,6 +154,7 @@ export class WireEventTarget {
                     reactives
                 };
 
+                // setup listeners for all reactive parameters
                 const configContext = this._context[CONTEXT_ID][CONTEXT_UPDATED];
                 reactiveKeys.forEach(key => {
                     const reactiveParameter = buildReactiveParameter(reactives[key]);
@@ -164,7 +166,10 @@ export class WireEventTarget {
                     } else {
                         configListenerMetadatas.push(configListenerMetadata);
                     }
+                    // enqueue to pickup default values
+                    updated(this._cmp, reactiveParameter, configContext);
                 });
+
                 break;
 
             default:


### PR DESCRIPTION
Default values of class properties should be used by wires. @api values provided by parents override
the default values used in wires without multiple calls to the wire adapter.
