### PR TITLE
fix(wire-service): workaround babel minify issue in compat mode

### DIFF
--- a/packages/lwc-wire-service/src/property-trap.ts
+++ b/packages/lwc-wire-service/src/property-trap.ts
@@ -55,13 +55,16 @@ function updatedFuture(cmp: Element, configContext: ConfigContext) {
     // configContext.mutated must be set prior to invoking this function
     const mutated = configContext.mutated as Set<ReactiveParameter>;
     delete configContext.mutated;
+
+    // pull this variable out of scope to workaround babel minify issue - https://github.com/babel/minify/issues/877
+    let listeners;
     mutated.forEach(reactiveParameter => {
         const value = getReactiveParameterValue(cmp, reactiveParameter);
         if (configContext.values[reactiveParameter.reference] === value) {
             return;
         }
         configContext.values[reactiveParameter.reference] = value;
-        const listeners = configContext.listeners[reactiveParameter.head];
+        listeners = configContext.listeners[reactiveParameter.head];
         for (let i = 0, len = listeners.length; i < len; i++) {
             uniqueListeners.add(listeners[i]);
         }


### PR DESCRIPTION
## Details

babel-minify has an outstanding issue that mistakenly inserts a `void 0` to a loop, causing the loop to essentially be a no-op. This causes wire-service to not load data correctly in compat mode.

https://github.com/babel/minify/issues/877

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
