### PR TITLE
fix(compiler): resolve error code conflicts

### DIFF
--- a/packages/lwc-compiler/src/bundler/bundler.ts
+++ b/packages/lwc-compiler/src/bundler/bundler.ts
@@ -16,6 +16,7 @@ import {
 import { collectImportLocations } from "./import-location-collector";
 import { SourceMap } from "../compiler/compiler";
 import {
+    CompilerError,
     CompilerDiagnostic,
     generateCompilerDiagnostic,
     DiagnosticLevel,
@@ -123,6 +124,11 @@ export async function bundle(
         code = result.code;
         map = result.map;
     } catch (e) {
+        // Rollup may have clobbered error.code with its own data
+        if (e instanceof CompilerError && (e as any).pluginCode) {
+            e.code = (e as any).pluginCode;
+        }
+
         const diagnostic = normalizeToDiagnostic(ModuleResolutionErrors.MODULE_RESOLUTION_ERROR, e);
         diagnostic.level = DiagnosticLevel.Fatal;
         diagnostics.push(diagnostic);

--- a/packages/lwc-compiler/src/compiler/__tests__/result.spec.ts
+++ b/packages/lwc-compiler/src/compiler/__tests__/result.spec.ts
@@ -128,10 +128,11 @@ describe("compiler result", () => {
         expect(success).toBe(false);
         expect(diagnostics.length).toBe(1);
 
-        const { level, message } = diagnostics[0];
+        const { level, message, code } = diagnostics[0];
 
         expect(level).toBe(DiagnosticLevel.Fatal);
         expect(message).toContain('./nothing failed to be resolved from foo.js');
+        expect(code).toBe(1001);
     });
 
     test('compiler returns diagnostic errors when transformation encounters an error in javascript', async () => {

--- a/packages/lwc-compiler/src/diagnostics/diagnostic.ts
+++ b/packages/lwc-compiler/src/diagnostics/diagnostic.ts
@@ -15,6 +15,12 @@ export interface Diagnostic {
      * This field is optional, for example when the compiler throws an uncaught exception.
      */
     location?: Location;
+
+    /**
+     * Error code for the diagnostic. Temporarily added while all older references
+     * to Diagnostics is migrated to the new object.
+     */
+    code?: number;
 }
 
 export enum DiagnosticLevel {

--- a/packages/lwc-errors/src/compiler/errors.ts
+++ b/packages/lwc-errors/src/compiler/errors.ts
@@ -1,5 +1,5 @@
 import { templateString } from "../shared/utils";
-import { LWCErrorInfo, DiagnosticLevel } from "../shared/types";
+import { LWCErrorInfo } from "../shared/types";
 import {
     CompilerDiagnosticOrigin,
     CompilerDiagnostic,
@@ -153,7 +153,7 @@ function convertErrorToDiagnostic(error: any, fallbackErrorInfo: LWCErrorInfo, o
         ? error.message
         : generateErrorMessage(fallbackErrorInfo, [error.message]);
 
-    const level = error.level || DiagnosticLevel.Error;
+    const level = error.level || fallbackErrorInfo.level;
     const filename = getFilename(origin, error);
     const location = getLocation(origin, error);
 


### PR DESCRIPTION
## Details
Fixes a bug with converting generic errors into compiler diagnostics.
Resolves a conflict with rollup clobbering error.code.

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

If yes, please describe the impact and migration path for existing applications: