### PR TITLE
fix(engine): handling dom node ancestor event handlers

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/events.ts
+++ b/packages/lwc-engine/src/faux-shadow/events.ts
@@ -40,8 +40,9 @@ const EventPatchDescriptors: PropertyDescriptorMap = {
             const originalTarget: EventTarget = eventTargetGetter.call(this);
 
             // Handle cases where the currentTarget is null (for async events)
-            // and when currentTarget is window or document.
-            if (!(currentTarget instanceof Node) || currentTarget instanceof Document) {
+            // when currentTarget is window or document
+            // when currentTarget is not an LWC node
+            if (!(currentTarget instanceof Node) || currentTarget instanceof Document || getRootNode.call(currentTarget, GET_ROOT_NODE_CONFIG_FALSE) === document) {
                 // the event was inspected asynchronously, in which case we need to return the
                 // top custom element that belongs to the body.
                 let outerMostElement = originalTarget;

--- a/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.spec.js
+++ b/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.spec.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+describe('Event listeners outside of LWC tree', () => {
+    const URL = 'http://localhost:4567/event-listener-on-ancestor-current-target';
+    let element;
+
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should report correct target', function () {
+        browser.click('.click-div');
+        console.log(browser.getText('.target-tag-name'));
+        assert.strictEqual(browser.getText('.target-tag-name').toLowerCase(), 'integration-event-listener-on-ancestor-current-target');
+    });
+});

--- a/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/integration/event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.html
+++ b/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/integration/event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.html
@@ -1,0 +1,4 @@
+<template>
+    <div class="target-tag-name">{eventTargetTagName}</div>
+    <div class="click-div" onclick={handleClick}>Click me</div>
+</template>

--- a/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/integration/event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.js
+++ b/packages/lwc-integration/src/components/events/test-event-listener-on-ancestor-current-target/integration/event-listener-on-ancestor-current-target/event-listener-on-ancestor-current-target.js
@@ -1,0 +1,17 @@
+import { LightningElement, track } from 'lwc';
+
+export default class EventListenerOnAncestorCurrentTarget extends LightningElement {
+    @track eventTargetTagName;
+    connectedCallback() {
+        document.body.addEventListener('click', (e) => {
+            try {
+                this.eventTargetTagName = e.target.tagName;
+            } catch (e) {
+                this.eventTargetTagName = e.message;
+            }
+        })
+    }
+    handleClick(e) {
+
+    }
+}


### PR DESCRIPTION
## Details

Fixes an issue where upstream DOM event handlers were throwing an error because of our retargeting logic. This addresses that issue.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
