### PR TITLE
fix: remove harmful warning that encourages composed events

### DIFF
--- a/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/html-element.spec.ts
@@ -407,22 +407,6 @@ describe('html-element', () => {
             );
         });
 
-        it('should log warning when dispatching event in the custom element with bubble=true and composed=false', function() {
-            class Foo extends LightningElement {
-                connectedCallback() {
-                    this.dispatchEvent(new CustomEvent('foobar', { bubbles: true, composed: false }));
-                }
-            }
-
-            const elm = createElement('x-foo', { is: Foo });
-
-            expect(() => (
-                document.body.appendChild(elm)
-            )).toLogWarning(
-                `Invalid event "foobar" dispatched in element <x-foo>. Events with 'bubbles: true' must also be 'composed: true'. Without 'composed: true', the dispatched event will not be observable outside of your component.`
-            );
-        });
-
         it('should log warning when event name does not start with alphabetic lowercase characters', function() {
             class Foo extends LightningElement {
                 connectedCallback() {

--- a/packages/lwc-engine/src/framework/base-lightning-element.ts
+++ b/packages/lwc-engine/src/framework/base-lightning-element.ts
@@ -152,11 +152,10 @@ BaseLightningElement.prototype = {
             if (!(event instanceof GlobalEvent)) {
                 throw new Error(`Failed to execute 'dispatchEvent' on ${getComponentAsString(this)}: parameter 1 is not of type 'Event'.`);
             }
-            const { type: evtName, composed, bubbles } = event;
+
+            const { type: evtName } = event;
             assert.isFalse(isBeingConstructed(vm), `this.dispatchEvent() should not be called during the construction of the custom element for ${getComponentAsString(this)} because no one is listening for the event "${evtName}" just yet.`);
-            if (bubbles && ('composed' in event && !composed)) {
-                assert.logWarning(`Invalid event "${evtName}" dispatched in element ${getComponentAsString(this)}. Events with 'bubbles: true' must also be 'composed: true'. Without 'composed: true', the dispatched event will not be observable outside of your component.`, elm);
-            }
+
             if (vm.idx === 0) {
                 assert.logWarning(`Unreachable event "${evtName}" dispatched from disconnected element ${getComponentAsString(this)}. Events can only reach the parent element after the element is connected (via connectedCallback) and before the element is disconnected(via disconnectedCallback).`, elm);
             }


### PR DESCRIPTION
## Details

Removes a warning that was encouraging users to compose their events if they decided it should bubble (which is also arguably unnecessary).

`bubbles: true, composed: false` is a valid configuration for when you might want your event to bubble in the parent template but not all the way to the document.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No