### PR TITLE
fix(engine): was leaking assert lib to prod

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/slot.ts
+++ b/packages/lwc-engine/src/faux-shadow/slot.ts
@@ -20,10 +20,12 @@ if (typeof MutationObserver === 'undefined') {
     function MutationObserverMock() {}
     MutationObserverMock.prototype = {
         observe() {
-            assert.isTrue(
-                process.env.NODE_ENV === 'test',
-                'MutationObserver should not be mocked outside of the jest test environment'
-            );
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(
+                    process.env.NODE_ENV === 'test',
+                    'MutationObserver should not be mocked outside of the jest test environment'
+                );
+            }
         }
     };
     (window as any).MutationObserver = MutationObserverMock;


### PR DESCRIPTION
## Details

Assert was not protected with the proper if condition, so it was leaking into prod.

## Does this PR introduce a breaking change?

* No

