### PR TITLE
fix: test expecting invalid warning

### DIFF
--- a/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
+++ b/packages/lwc-engine/src/faux-shadow/__tests__/events.spec.ts
@@ -366,9 +366,7 @@ describe('events', () => {
             return Promise.resolve().then(() => {
                 const button = elm.shadowRoot.querySelector('button');
                 const expectedTarget = elm.shadowRoot.querySelector('x-grand-child');
-                expect(() => {
-                    button.click();
-                }).toLogWarning(`Invalid event "bubblesnotcomposed" dispatched in element <x-grand-child>. Events with 'bubbles: true' must also be 'composed: true'. Without 'composed: true', the dispatched event will not be observable outside of your component.`);
+                button.click();
 
                 expect(listenerCalled).toBe(true);
                 expect(target).toBe(expectedTarget);


### PR DESCRIPTION
## Details
Test `should get called when event bubbles=true, composed=false and come from within a slot.` expected that a warning with message `Invalid event "bubblesnotcomposed" dispatched in element...` was logged. this warning was removed.

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

