### PR TITLE
refactor(engine): make fields non-enumerables

### DIFF
--- a/packages/lwc-engine/src/framework/vm.ts
+++ b/packages/lwc-engine/src/framework/vm.ts
@@ -525,8 +525,6 @@ export function setNodeOwnerKey(node: Node, value: number) {
         defineProperty(node, OwnerKey, {
             value,
             enumerable: true,
-            configurable: false,
-            writable: false,
         });
     } else {
         // in prod, for better perf, we just let it roll
@@ -544,8 +542,6 @@ export function setNodeKey(node: Node, value: number) {
         defineProperty(node, OwnKey, {
             value,
             enumerable: true,
-            configurable: false,
-            writable: false,
         });
     } else {
         // in prod, for better perf, we just let it roll

--- a/packages/lwc-engine/src/shared/fields.ts
+++ b/packages/lwc-engine/src/shared/fields.ts
@@ -15,18 +15,9 @@ export function createFieldName(key: string): symbol {
 
 export function setInternalField(o: object, fieldName: symbol, value: any) {
     // TODO: improve this to use  or a WeakMap
-    if (process.env.NODE_ENV !== 'production') {
-        // in dev-mode, we are more restrictive about what you can do with the internal fields
-        defineProperty(o, fieldName, {
-            value,
-            enumerable: true,
-            configurable: false,
-            writable: false,
-        });
-    } else {
-        // in prod, for better perf, we just let it roll
-        o[fieldName] = value;
-    }
+    defineProperty(o, fieldName, {
+        value,
+    });
 }
 
 export function getInternalField(o: object, fieldName: symbol): any {


### PR DESCRIPTION
## Details

We were using enumerables for fields (internal entries) in the DOM so in production we could just fallback to a regular member property, which was faster, but this is proven to be problematic with any serialization mechanism, including selenium. So, we will be using non-enumerables from now on for all modes, and even though this is slightly slower, should not be that significant.

## Does this PR introduce a breaking change?

* No
