### PR TITLE
fix(engine): fixes issue #129 - removal of dangerousObjectMutation

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
@@ -77,7 +77,6 @@ describe('Element import', () => {
             createElement,
             LightningElement,
             buildCustomElementConstructor,
-            dangerousObjectMutation,
             getComponentDef,
             getComponentConstructor,
             isComponentConstructor,
@@ -87,7 +86,7 @@ describe('Element import', () => {
         } from "lwc";
     `, {
         output: {
-            code: `import { api, track, wire, createElement, LightningElement, buildCustomElementConstructor, dangerousObjectMutation, getComponentDef, getComponentConstructor, isComponentConstructor, readonly, register, unwrap } from "lwc";`
+            code: `import { api, track, wire, createElement, LightningElement, buildCustomElementConstructor, getComponentDef, getComponentConstructor, isComponentConstructor, readonly, register, unwrap } from "lwc";`
         }
     });
 });

--- a/packages/@lwc/babel-plugin-component/src/constants.js
+++ b/packages/@lwc/babel-plugin-component/src/constants.js
@@ -65,7 +65,6 @@ const LWC_PACKAGE_EXPORTS = {
 const LWC_API_WHITELIST = new Set([
     'buildCustomElementConstructor',
     'createElement',
-    'dangerousObjectMutation',
     'getComponentDef',
     'getComponentConstructor',
     'isComponentConstructor',

--- a/packages/@lwc/engine/src/framework/main.ts
+++ b/packages/@lwc/engine/src/framework/main.ts
@@ -15,9 +15,6 @@ export { registerComponent } from "./component";
 export { registerDecorators } from "./decorators/register";
 export { isNodeFromTemplate } from "./vm";
 
-// TODO: REMOVE THIS https://github.com/salesforce/lwc/issues/129
-export { dangerousObjectMutation } from "./membrane";
-
 export { default as api } from "./decorators/api";
 export { default as track } from "./decorators/track";
 export { default as readonly } from "./decorators/readonly";

--- a/packages/@lwc/engine/src/framework/membrane.ts
+++ b/packages/@lwc/engine/src/framework/membrane.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import assert from "../shared/assert";
-import { toString } from "../shared/language";
 import ObservableMembrane from "observable-membrane";
 import { observeMutation, notifyMutation } from "./watcher";
 
@@ -18,14 +16,6 @@ export const reactiveMembrane = new ObservableMembrane({
     valueMutated: notifyMutation,
     valueDistortion,
 });
-
-// TODO: REMOVE THIS https://github.com/salesforce/lwc/issues/129
-export function dangerousObjectMutation(obj: any): any {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.logWarning(`Dangerously Mutating Object ${toString(obj)}. This object was passed to you from a parent component, and should not be mutated here. This will be removed in the near future.`);
-    }
-    return reactiveMembrane.getProxy(unwrap(obj));
-}
 
 // Universal unwrap mechanism that works for observable membrane
 // and wrapped iframe contentWindow


### PR DESCRIPTION
## Details

Clean up experimental dangerousObjectMutation API before GA.

## Does this PR introduce a breaking change?

* Yes, anyone using that old API will be broken, but the good news is that according to others, that API is not used anymore.
