### PR TITLE
fix(engine): close #849 by implementing move hook

### DIFF
--- a/packages/lwc-engine/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/lwc-engine/src/3rdparty/snabbdom/snabbdom.ts
@@ -122,7 +122,7 @@ export function updateDynamicChildren(
         } else if (sameVnode(oldStartVnode, newEndVnode)) {
             // Vnode moved right
             patchVnode(oldStartVnode, newEndVnode);
-            newEndVnode.hook.insert(
+            newEndVnode.hook.move(
                 oldStartVnode,
                 parentElm,
                 // TODO: resolve this, but using dot notation for nextSibling for now
@@ -133,7 +133,7 @@ export function updateDynamicChildren(
         } else if (sameVnode(oldEndVnode, newStartVnode)) {
             // Vnode moved left
             patchVnode(oldEndVnode, newStartVnode);
-            newStartVnode.hook.insert(
+            newStartVnode.hook.move(
                 oldEndVnode,
                 parentElm,
                 oldStartVnode.elm as Node,
@@ -175,7 +175,7 @@ export function updateDynamicChildren(
                             newStartVnode,
                         );
                         oldCh[idxInOld] = undefined as any;
-                        newStartVnode.hook.insert(
+                        newStartVnode.hook.move(
                             elmToMove,
                             parentElm,
                             oldStartVnode.elm as Node,

--- a/packages/lwc-engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/lwc-engine/src/3rdparty/snabbdom/types.ts
@@ -82,6 +82,7 @@ export interface VNodeData {
 
 export type CreateHook = (vNode: VNode) => void;
 export type InsertHook = (vNode: VNode, parentNode: Node, referenceNode: Node | null) => void;
+export type MoveHook = (vNode: VNode, parentNode: Node, referenceNode: Node | null) => void;
 export type UpdateHook = (oldVNode: VNode, vNode: VNode) => void;
 export type RemoveHook = (vNode: VNode, parentNode: Node) => void;
 export type DestroyHook = (vNode: VNode) => void;
@@ -89,6 +90,7 @@ export type DestroyHook = (vNode: VNode) => void;
 export interface Hooks {
   create: CreateHook;
   insert: InsertHook;
+  move: MoveHook;
   update: UpdateHook;
   remove: RemoveHook;
   destroy: DestroyHook;

--- a/packages/lwc-engine/src/faux-shadow/shadow-root.ts
+++ b/packages/lwc-engine/src/faux-shadow/shadow-root.ts
@@ -117,8 +117,7 @@ export class SyntheticShadowRoot extends DocumentFragment implements ShadowRoot 
         return getHost(this).baseURI;
     }
     get isConnected(this: SyntheticShadowRootInterface) {
-        // @ts-ignore remove this after upgrading ts 3.x
-        return getHost(this).isConnected;
+        return (compareDocumentPosition.call(document, getHost(this)) & DOCUMENT_POSITION_CONTAINED_BY) !== 0;
     }
     get host(this: SyntheticShadowRootInterface) {
         return getHost(this);

--- a/packages/lwc-engine/src/framework/__tests__/services.spec.ts
+++ b/packages/lwc-engine/src/framework/__tests__/services.spec.ts
@@ -69,7 +69,7 @@ describe('services', () => {
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             document.body.removeChild(elm);
-            return Promise.resolve(() => {
+            return Promise.resolve().then(() => {
                 expect(r).toBe(1);
                 expect(c).toBe(1);
                 expect(d).toBe(1);

--- a/packages/lwc-engine/src/framework/api.ts
+++ b/packages/lwc-engine/src/framework/api.ts
@@ -85,6 +85,7 @@ const TextHook: Hooks = {
     },
     update: updateNodeHook,
     insert: insertNodeHook,
+    move: insertNodeHook, // same as insert for text nodes
     remove: removeNodeHook,
     destroy: noop,
 };
@@ -100,6 +101,7 @@ const CommentHook: Hooks = {
     },
     update: updateNodeHook,
     insert: insertNodeHook,
+    move: insertNodeHook, // same as insert for comment nodes
     remove: removeNodeHook,
     destroy: noop,
 };
@@ -131,6 +133,9 @@ const ElementHook: Hooks = {
     insert: (vnode: VElement, parentNode: Node, referenceNode: Node | null) => {
         insertBefore.call(parentNode, vnode.elm as Element, referenceNode);
         createChildrenHook(vnode);
+    },
+    move: (vnode: VElement, parentNode: Node, referenceNode: Node | null) => {
+        insertBefore.call(parentNode, vnode.elm as Element, referenceNode);
     },
     remove: (vnode: VElement, parentNode: Node) => {
         removeChild.call(parentNode, vnode.elm as Node);
@@ -167,6 +172,9 @@ const CustomElementHook: Hooks = {
         insertBefore.call(parentNode, vnode.elm as Element, referenceNode);
         createChildrenHook(vnode);
         insertCustomElmHook(vnode);
+    },
+    move: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
+        insertBefore.call(parentNode, vnode.elm as Element, referenceNode);
     },
     remove: (vnode: VElement, parentNode: Node) => {
         removeChild.call(parentNode, vnode.elm as Node);

--- a/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
+++ b/packages/lwc-engine/src/framework/decorators/__tests__/track.spec.ts
@@ -295,10 +295,14 @@ describe('track.ts', () => {
 
         it('should produce a trackable object', () => {
             let counter = 0;
+            const html = compileTemplate(`<template>{foo.bar}</template>`);
             class MyComponent extends LightningElement {
                 constructor() {
                     super();
                     this.foo = track({ bar: 1 });
+                }
+                render() {
+                    return html;
                 }
                 renderedCallback() {
                     this.foo.bar = 2;
@@ -307,7 +311,7 @@ describe('track.ts', () => {
             }
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            return Promise.resolve(() => {
+            return Promise.resolve().then(() => {
                 expect(counter).toBe(2); // two rendering phases due to the mutation of this.foo
             });
         });

--- a/packages/lwc-engine/src/framework/decorators/register.ts
+++ b/packages/lwc-engine/src/framework/decorators/register.ts
@@ -34,7 +34,7 @@ export interface WireHash {
 export interface RegisterDecoratorMeta {
     readonly publicMethods?: string[];
     readonly publicProps?: PropsDef;
-    readonly track?: string[];
+    readonly track?: TrackDef;
     readonly wire?: WireHash;
 }
 
@@ -85,7 +85,7 @@ export function getDecoratorsRegisteredMeta(Ctor: ComponentConstructor): Decorat
     return signedDecoratorToMetaMap.get(Ctor);
 }
 
-function getTrackHash(target: ComponentConstructor, track: string[] | undefined): TrackDef {
+function getTrackHash(target: ComponentConstructor, track: TrackDef | undefined): TrackDef {
     if (isUndefined(track) || getOwnPropertyNames(track).length === 0) {
         return EmptyObject;
     }


### PR DESCRIPTION
## Details

We were using the `insert` hook for the cases when we just move an existing node up or down in the children collection. This was causing the node to be re-patched, which can produces unpredictable results.

## Does this PR introduce a breaking change?

* No
