### PR TITLE
fix(engine): retargeting elementFromPoint without elementsFromPoint

### DIFF
--- a/packages/@lwc/engine/src/env/document.ts
+++ b/packages/@lwc/engine/src/env/document.ts
@@ -2,9 +2,9 @@ import { getOwnPropertyDescriptor, hasOwnProperty } from "../shared/language";
 
 const DocumentPrototypeActiveElement = getOwnPropertyDescriptor(Document.prototype, 'activeElement')!.get as (this: Document) => Element | null;
 
-const elementsFromPoint = hasOwnProperty.call(Document.prototype, 'elementsFromPoint') ?
-    Document.prototype.elementsFromPoint :
-    (Document.prototype as any).msElementsFromPoint;  // IE11
+const elementFromPoint = hasOwnProperty.call(Document.prototype, 'elementFromPoint') ?
+Document.prototype.elementFromPoint :
+(Document.prototype as any).msElementFromPoint;  // IE11
 
 const {
     createDocumentFragment,
@@ -22,13 +22,13 @@ const {
 } = Document.prototype;
 
 export {
+    elementFromPoint,
     createDocumentFragment,
     createElement,
     createElementNS,
     createTextNode,
     createComment,
     DocumentPrototypeActiveElement,
-    elementsFromPoint,
     querySelector,
     querySelectorAll,
     getElementById,

--- a/packages/@lwc/engine/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/engine/src/faux-shadow/shadow-root.ts
@@ -1,15 +1,17 @@
 import assert from "../shared/assert";
 import { isNull, setPrototypeOf, defineProperty, ArrayFilter } from "../shared/language";
 import { addShadowRootEventListener, removeShadowRootEventListener } from "./events";
-import { shadowDomElementFromPoint, shadowRootQuerySelector, shadowRootQuerySelectorAll, shadowRootChildNodes, isNodeOwnedBy, isSlotElement, getRootNodeGetter, GetRootNodeOptions } from "./traverse";
+import { shadowRootQuerySelector, shadowRootQuerySelectorAll, shadowRootChildNodes, isNodeOwnedBy, isSlotElement, getRootNodeGetter, GetRootNodeOptions } from "./traverse";
 import { getInternalField, setInternalField, createFieldName } from "../shared/fields";
 import { getTextContent } from "../3rdparty/polymer/text-content";
 import { createStaticNodeList } from "../shared/static-node-list";
-import { DocumentPrototypeActiveElement } from "../env/document";
+import { DocumentPrototypeActiveElement, elementFromPoint } from "../env/document";
 import { compareDocumentPosition, DOCUMENT_POSITION_CONTAINED_BY, parentElementGetter } from "../env/node";
 import { isNativeShadowRootAvailable } from "../env/dom";
 import { createStaticHTMLCollection } from "../shared/static-html-collection";
 import { getOuterHTML } from "../3rdparty/polymer/outer-html";
+import { retarget } from "../3rdparty/polymer/retarget";
+import { pathComposer } from "../3rdparty/polymer/path-composer";
 
 const HostKey = createFieldName('host');
 const ShadowRootKey = createFieldName('shadowRoot');
@@ -256,7 +258,11 @@ export class SyntheticShadowRoot extends DocumentFragment implements ShadowRoot 
     // but we should only return elements that the shadow owns,
     // or are ancestors of the shadow
     elementFromPoint(this: SyntheticShadowRootInterface, left: number, top: number): Element | null {
-        return shadowDomElementFromPoint(getHost(this), left, top);
+        const element = elementFromPoint.call(document, left, top);
+        if (isNull(element)) {
+            return element;
+        }
+        return retarget(this, pathComposer(element, true)) as (Element | null);
     }
 
     elementsFromPoint(this: SyntheticShadowRootInterface, left: number, top: number): Element[] {

--- a/packages/@lwc/engine/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/engine/src/faux-shadow/traverse.ts
@@ -14,7 +14,6 @@ import {
 import {
     querySelectorAll, innerHTMLSetter, tagNameGetter,
 } from "../env/element";
-import { elementsFromPoint } from "../env/document";
 import { wrapIframeWindow } from "./iframe";
 import {
     ArrayReduce,
@@ -183,10 +182,6 @@ function getFirstSlottedMatch(host: HTMLElement, nodeList: NodeList): Element | 
         }
     }
     return null;
-}
-
-export function shadowDomElementFromPoint(host: HTMLElement, left: number, top: number): Element | null {
-    return getFirstMatch(host, elementsFromPoint.call(document, left, top));
 }
 
 function lightDomQuerySelectorAll(elm: Element, selectors: string): Element[] {

--- a/packages/@lwc/engine/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/engine/src/polyfills/document-shadow/polyfill.ts
@@ -1,21 +1,18 @@
-import { elementsFromPoint, DocumentPrototypeActiveElement } from "../../env/document";
+import { elementFromPoint, DocumentPrototypeActiveElement } from "../../env/document";
 import { getNodeOwnerKey } from "../../framework/vm";
 import { isNull, isUndefined, defineProperty } from "../../shared/language";
 import { parentElementGetter } from "../../env/node";
+import { retarget } from "../../3rdparty/polymer/retarget";
+import { pathComposer } from "../../3rdparty/polymer/path-composer";
 
 export default function apply() {
     function elemFromPoint(left: number, top: number): Element | null {
-        const elements = elementsFromPoint.call(document, left, top);
-        const { length } = elements;
-        let match = null;
-        for (let i = length - 1; i >= 0; i -= 1) {
-            const el = elements[i];
-            const ownerKey = getNodeOwnerKey(el);
-            if (isUndefined(ownerKey)) {
-                match = elements[i];
-            }
+        const element = elementFromPoint.call(document, left, top);
+        if (isNull(element)) {
+            return element;
         }
-        return match;
+
+        return retarget(document, pathComposer(element, true)) as (Element | null);
     }
 
     // https://github.com/Microsoft/TypeScript/issues/14139


### PR DESCRIPTION
## Details

Removing elementsFromPoint usage from elementFromPoint. Mobile Safari 10/11 doesn't have `elementsFromPoint` 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
