### PR TITLE
fix: errors package as hard dep in jest-transformer

### DIFF
--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -15,12 +15,12 @@
     "@babel/core": "7.1.0",
     "@babel/plugin-transform-modules-commonjs": "7.1.0",
     "@babel/template": "~7.1.2",
+    "@lwc/errors": "0.33.17",
     "deasync": "0.1.12"
   },
   "peerDependencies": {
     "@lwc/compiler": "0.33.x",
-    "@lwc/engine": "0.33.x",
-    "@lwc/errors": "0.33.x"
+    "@lwc/engine": "0.33.x"
   },
   "devDependencies": {
     "@lwc/compiler": "0.33.17",


### PR DESCRIPTION
## Details

`@lwc/errors` is required for `@lwc/jest-transformer` to properly function so move it from a peer to a hard dependency. Will clear up warnings consumers see when building.

Fixes https://github.com/salesforce/lwc/issues/868

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
