### PR TITLE
[DO-NOT-MERGE] refactor(engine): POC for distortion that blocks arbitrary fn as attr

### DIFF
--- a/packages/@lwc/engine/src/framework/membrane.ts
+++ b/packages/@lwc/engine/src/framework/membrane.ts
@@ -1,5 +1,5 @@
 import assert from "../shared/assert";
-import { toString, isFunction, isUndefined } from "../shared/language";
+import { toString, isFunction } from "../shared/language";
 import ObservableMembrane from "observable-membrane";
 import { observeMutation, notifyMutation } from "./watcher";
 


### PR DESCRIPTION
## Details

This PR is just testing the perf implications of determine if a value passing thru the reactive membrane is a function or not. This will help us to assess how much of a penalty we will have to pay for blocking arbitrary functions, which is not a very common thing, but the check to determine that is penalizing everyone during critical path.

## Does this PR introduce a breaking change?

* No
