### PR TITLE
fix(compiler): remove misleading and useless stack info on CompilerError

### DIFF
--- a/packages/@lwc/errors/src/compiler/utils.ts
+++ b/packages/@lwc/errors/src/compiler/utils.ts
@@ -42,7 +42,7 @@ export class CompilerError extends Error implements CompilerDiagnostic {
         const compilerError = new CompilerError(code, message, filename, location);
 
         // The stack here is misleading and doesn't point to the cause of the original error message
-        // TODO: Retrieve stack from diagnostic once diagnostics consistently pass along origin of error
+        // TODO: W-5712064 - Enhance diagnostics with useful stack trace and source code
         compilerError.stack = undefined;
         return compilerError;
     }


### PR DESCRIPTION
## Details
The stack info is useless and misleading for end customers since it points to where the error conversation happens and not where the error itself happened.

## Does this PR introduce a breaking change?

* [ ] Yes
* [ ] No

If yes, please describe the impact and migration path for existing applications:
