### PR TITLE
fix(module-resolver): wrong path separator in glob call

### DIFF
--- a/packages/@lwc/module-resolver/src/index.js
+++ b/packages/@lwc/module-resolver/src/index.js
@@ -34,6 +34,7 @@ function resolveModulesInDir(fullPathDir, { ignoreFolderName } = {}) {
     return glob.sync(MODULE_ENTRY_PATTERN, { cwd: fullPathDir }).reduce((mappings, file) => {
         const fileName = path.basename(file, MODULE_EXTENSION);
         const rootDir = path.dirname(file);
+        // the glob library normalizes paths to forward slashes only - https://github.com/isaacs/node-glob#windows
         const rootParts = rootDir.split('/');
         const registry = {
             entry: path.join(fullPathDir, file),


### PR DESCRIPTION
## Details

Glob will return the matching files with forward slashes, even on windows machines. 

Fixes https://github.com/salesforce/lwc-todomvc/issues/16 for Chrome. IE11 does not hit the "App is not defined" error but now gets a stackoverflow when loaded. Requires additional investigation.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
