### PR TITLE
chore: remove gitHead property from package.json

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -18,6 +18,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -31,6 +31,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -31,6 +31,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -16,6 +16,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -22,6 +22,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/jest-resolver/package.json
+++ b/packages/@lwc/jest-resolver/package.json
@@ -19,6 +19,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/jest-serializer/package.json
+++ b/packages/@lwc/jest-serializer/package.json
@@ -10,6 +10,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -33,6 +33,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -9,6 +9,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -22,6 +22,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -19,6 +19,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -30,6 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/test-utils/package.json
+++ b/packages/@lwc/test-utils/package.json
@@ -9,6 +9,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -29,6 +29,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "0f7e222a61afa3df1557291ea373e68be8eef8a8"
+  }
 }


### PR DESCRIPTION
## Details

Remove `gitHead` property from `package.json` that was introduced by mistake with 90d9bb721c8df8ad9401e1ab54ceff15a59dde39

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No