### PR TITLE
test(engine): add global events test

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/faux-shadow/__tests__/events.spec.ts
@@ -28,7 +28,7 @@ const createComponentWithOnClickHandler = function(eventName, eventConfig) {
 }
 
 describe('global events', () => {
-    describe.only('custom event dispatched with { bubbles:true, composed:true }', () => {
+    describe('custom event dispatched with { bubbles:true, composed:true }', () => {
         it('should receive a callback for the event assigned to the "window"', () => {
             const dispatched = [];
 


### PR DESCRIPTION
## Details
This PR is ONLY a test coverage for global component event bubbling issue #960 and to be merged into @caridy 's fix.

NOTE: the CI will fail until Caridy's fix is introduced. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
