### PR TITLE
fix(engine): fixes #973 to support cloneNode with ie11 devtool comment

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/custom-element.ts
+++ b/packages/@lwc/engine/src/faux-shadow/custom-element.ts
@@ -13,8 +13,7 @@ import { getActiveElement, handleFocusIn, handleFocus, ignoreFocusIn, ignoreFocu
 import { HTMLElementConstructor } from "../framework/base-bridge-element";
 import { createStaticNodeList } from "../shared/static-node-list";
 import { createStaticHTMLCollection } from "../shared/static-html-collection";
-
-const hasNativeSymbolsSupport = Symbol('x').toString() === 'Symbol(x)';
+import { hasNativeSymbolsSupport, isExternalChildNodeAccessorFlagOn } from "./node";
 
 export function PatchedCustomElement(Base: HTMLElement): HTMLElementConstructor {
     const Ctor = PatchedElement(Base) as HTMLElementConstructor;
@@ -98,10 +97,11 @@ export function PatchedCustomElement(Base: HTMLElement): HTMLElementConstructor 
         get childNodes(this: HTMLElement): NodeListOf<Node & Element> {
             const owner = getNodeOwner(this);
             const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));
-            if (process.env.NODE_ENV !== 'production' && isFalse(hasNativeSymbolsSupport)) {
+            if (process.env.NODE_ENV !== 'production' && isFalse(hasNativeSymbolsSupport) && isExternalChildNodeAccessorFlagOn()) {
                 // inserting a comment node as the first childNode to trick the IE11
                 // DevTool to show the content of the shadowRoot, this should only happen
                 // in dev-mode and in IE11 (which we detect by looking at the symbol).
+                // Plus it should only be in place if we know it is an external invoker.
                 ArrayUnshift.call(childNodes, getIE11FakeShadowRootPlaceholder(this));
             }
             return createStaticNodeList(childNodes);

--- a/packages/@lwc/engine/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/engine/src/faux-shadow/shadow-root.ts
@@ -18,6 +18,7 @@ import { createStaticHTMLCollection } from "../shared/static-html-collection";
 import { getOuterHTML } from "../3rdparty/polymer/outer-html";
 import { retarget } from "../3rdparty/polymer/retarget";
 import { pathComposer } from "../3rdparty/polymer/path-composer";
+import { getInternalChildNodes } from "./node";
 
 const HostKey = createFieldName('host');
 const ShadowRootKey = createFieldName('shadowRoot');
@@ -269,7 +270,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         get(this: SyntheticShadowRootInterface): ChildNode | null {
-            const { childNodes } = this;
+            const childNodes = getInternalChildNodes(this);
             return childNodes[0] || null;
         },
     },
@@ -277,7 +278,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         get(this: SyntheticShadowRootInterface): ChildNode | null {
-            const { childNodes } = this;
+            const childNodes = getInternalChildNodes(this);
             return childNodes[childNodes.length - 1] || null;
         },
     },
@@ -286,7 +287,8 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface): boolean {
-            return this.childNodes.length > 0;
+            const childNodes = getInternalChildNodes(this);
+            return childNodes.length > 0;
         },
     },
     isConnected: {
@@ -360,7 +362,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         get(this: SyntheticShadowRootInterface): string {
-            const { childNodes } = this;
+            const childNodes = getInternalChildNodes(this);
             let textContent = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
                 textContent += getTextContent(childNodes[i]);
@@ -383,7 +385,7 @@ const ElementPatchDescriptors = {
         enumerable: true,
         configurable: true,
         get(this: SyntheticShadowRootInterface): string {
-            const { childNodes } = this;
+            const childNodes = getInternalChildNodes(this);
             let innerHTML = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
                 innerHTML += getOuterHTML(childNodes[i]);

--- a/packages/@lwc/engine/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/engine/src/faux-shadow/traverse.ts
@@ -9,6 +9,7 @@ import {
     getNodeKey,
     getNodeNearestOwnerKey,
     PatchedNode,
+    getInternalChildNodes,
 } from "./node";
 import {
     childNodesGetter as nativeChildNodesGetter,
@@ -43,15 +44,16 @@ export function getNodeOwner(node: Node): HTMLElement | null {
     if (isUndefined(ownerKey)) {
         return null;
     }
+    let nodeOwner: Node | null = node;
     // At this point, node is a valid node with owner identity, now we need to find the owner node
     // search for a custom element with a VM that owns the first element with owner identity attached to it
-    while (!isNull(node) && (getNodeKey(node) !== ownerKey)) {
-        node = parentNodeGetter.call(node);
+    while (!isNull(nodeOwner) && (getNodeKey(nodeOwner) !== ownerKey)) {
+        nodeOwner = parentNodeGetter.call(nodeOwner);
     }
-    if (isNull(node)) {
+    if (isNull(nodeOwner)) {
         return null;
     }
-    return node as HTMLElement;
+    return nodeOwner as HTMLElement;
 }
 
 export function isSlotElement(elm: Element): boolean {
@@ -76,15 +78,15 @@ export function isNodeSlotted(host: Element, node: Node): boolean {
     }
     const hostKey = getNodeKey(host);
     // just in case the provided node is not an element
-    let currentElement: Element = node instanceof Element ? node : parentElementGetter.call(node);
+    let currentElement = node instanceof Element ? node : parentElementGetter.call(node);
     while (!isNull(currentElement) && currentElement !== host) {
         const elmOwnerKey = getNodeNearestOwnerKey(currentElement);
-        const parent: Element = parentElementGetter.call(currentElement);
+        const parent = parentElementGetter.call(currentElement);
         if (elmOwnerKey === hostKey) {
             // we have reached a host's node element, and only if
             // that element is an slot, then the node is considered slotted
             return isSlotElement(currentElement);
-        } else if (parent !== host && getNodeNearestOwnerKey(parent) !== elmOwnerKey) {
+        } else if (!isNull(parent) && parent !== host && getNodeNearestOwnerKey(parent) !== elmOwnerKey) {
             // we are crossing a boundary of some sort since the elm and its parent
             // have different owner key. for slotted elements, this is only possible
             // if the parent happens to be a slot that is not owned by the host
@@ -268,7 +270,7 @@ export function PatchedElement(elm: HTMLElement): HTMLElementConstructor {
             return createStaticNodeList(lightDomQuerySelectorAll(this, selectors));
         }
         get innerHTML(this: Element): string {
-            const { childNodes } = this;
+            const childNodes = getInternalChildNodes(this);
             let innerHTML = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
                 innerHTML += getOuterHTML(childNodes[i]);


### PR DESCRIPTION
## Cherry pick from https://github.com/salesforce/lwc/pull/974

* fix(engine): fixes #973 to support cloneNode with ie11 devtool comment
* fix(engine): fix for devtool logging of -bash on a root custom element
* fix(engine): more guarding around isNodeSlotted for inserted nodes

