### PR TITLE
fix(engine): closes #958 after fixing parentElement ref in slotted node

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/node.ts
+++ b/packages/@lwc/engine/src/faux-shadow/node.ts
@@ -229,7 +229,7 @@ export function PatchedNode(node: Node): NodeConstructor {
             const parentNode = getShadowParent(this, value);
             // it could be that the parentNode is the shadowRoot, in which case
             // we need to return null.
-            return parentNode instanceof HTMLElement ? parentNode : null;
+            return parentNode instanceof Element ? parentNode : null;
         }
         getRootNode(this: Node, options?: GetRootNodeOptions): Node {
             return getRootNodeGetter.call(this, options);


### PR DESCRIPTION
## This is cherry picked from https://github.com/salesforce/lwc/pull/959 into 218/patch
