### PR TITLE
test: remove flacky focus Karma test

### DIFF
--- a/packages/integration-karma/test/polyfills/focus-event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/focus-event-composed/index.spec.js
@@ -24,20 +24,3 @@ if (isFocusEventConstructorSupported()) {
     });
 }
 
-it('should make trusted FocusEvent composed', (done) => {
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-
-    // IE11 is the only browser dispatching the event asynchronously, so we need to make the assertion in the event
-    // handler instead of after the input.focus() invocation.
-    input.addEventListener('focus', event => {
-        expect(event instanceof FocusEvent).toBe(true);
-        expect(event.composed).toBe(true);
-
-        done();
-    });
-
-    input.focus();
-});
-
-


### PR DESCRIPTION
## Details

Disable flacky focus test. All the focus related test suffer from the same issue, where the `focus` event handler is only invoked when the browser window is focussed. Because of this, you can't use the karma watch mode and let the tests run in background otherwise it times out.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No