### PR TITLE
Revert "Revert "fix(engine): regular dom nodes can use object type ev…

### DIFF
--- a/packages/@lwc/engine/src/env/element.ts
+++ b/packages/@lwc/engine/src/env/element.ts
@@ -7,8 +7,6 @@
 import { hasOwnProperty, getOwnPropertyDescriptor } from "../shared/language";
 
 const {
-    addEventListener,
-    removeEventListener,
     hasAttribute,
     getAttribute,
     getAttributeNS,
@@ -23,6 +21,20 @@ const {
     getElementsByClassName,
     getElementsByTagNameNS,
 } = Element.prototype;
+
+let {
+    addEventListener,
+    removeEventListener,
+} = Element.prototype;
+
+/**
+ * This trick to try to pick up the __lwcOriginal__ out of the intrinsic is to please
+ * jsdom, who usually reuse intrinsic between different document.
+ */
+// @ts-ignore jsdom
+addEventListener = addEventListener.__lwcOriginal__ || addEventListener;
+// @ts-ignore jsdom
+removeEventListener = removeEventListener.__lwcOriginal__ || removeEventListener;
 
 const innerHTMLSetter: (this: Element, s: string) => void = hasOwnProperty.call(Element.prototype, 'innerHTML') ?
     getOwnPropertyDescriptor(Element.prototype, 'innerHTML')!.set! :

--- a/packages/@lwc/engine/src/env/window.ts
+++ b/packages/@lwc/engine/src/env/window.ts
@@ -26,7 +26,23 @@ if (typeof MO === 'undefined') {
 const MutationObserver = MO;
 const MutationObserverObserve = MutationObserver.prototype.observe;
 
+let {
+    addEventListener: windowAddEventListener,
+    removeEventListener: windowRemoveEventListener,
+} = window;
+
+/**
+ * This trick to try to pick up the __lwcOriginal__ out of the intrinsic is to please
+ * jsdom, who usually reuse intrinsic between different document.
+ */
+// @ts-ignore jsdom
+windowAddEventListener = windowAddEventListener.__lwcOriginal__ || windowAddEventListener;
+// @ts-ignore jsdom
+windowRemoveEventListener = windowRemoveEventListener.__lwcOriginal__ || windowRemoveEventListener;
+
 export {
     MutationObserver,
     MutationObserverObserve,
+    windowAddEventListener,
+    windowRemoveEventListener,
 };

--- a/packages/@lwc/engine/src/faux-shadow/events.ts
+++ b/packages/@lwc/engine/src/faux-shadow/events.ts
@@ -6,10 +6,6 @@
  */
 import assert from "../shared/assert";
 import {
-    addEventListener,
-    removeEventListener,
-} from "../env/element";
-import {
     compareDocumentPosition,
     DOCUMENT_POSITION_CONTAINED_BY,
 } from "../env/node";
@@ -19,6 +15,15 @@ import { getHost, SyntheticShadowRootInterface, getShadowRoot } from "./shadow-r
 import { eventCurrentTargetGetter, eventTargetGetter } from "../env/dom";
 import { pathComposer } from "./../3rdparty/polymer/path-composer";
 import { retarget } from "./../3rdparty/polymer/retarget";
+
+import "../polyfills/event-listener/main";
+
+// intentionally extracting the patched addEventListener and removeEventListener from Node.prototype
+// due to the issues with JSDOM patching hazard.
+const {
+    addEventListener,
+    removeEventListener,
+} = Node.prototype;
 
 interface WrappedListener extends EventListener {
     placement: EventListenerContext;
@@ -202,7 +207,6 @@ function domListener(evt: Event) {
         enumerable: true,
         configurable: true,
     });
-    patchEvent(evt);
     // in case a listener adds or removes other listeners during invocation
     const bookkeeping: WrappedListener[] = ArraySlice.call(listeners);
 
@@ -279,7 +283,7 @@ function isValidEventForCustomElement(event: Event): boolean {
 
 export function addCustomElementEventListener(elm: HTMLElement, type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(isFunction(listener), `Invalid second argument for this.template.addEventListener() in ${toString(elm)} for event "${type}". Expected an EventListener but received ${listener}.`);
+        assert.invariant(isFunction(listener), `Invalid second argument for this.addEventListener() in ${toString(elm)} for event "${type}". Expected an EventListener but received ${listener}.`);
         // TODO: issue #420
         // this is triggered when the component author attempts to add a listener programmatically into a lighting element node
         if (!isUndefined(options)) {

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -32,7 +32,7 @@ import {
     createTextHook,
     createCommentHook,
 } from "./hooks";
-import { markAsDynamicChildren, patchEvent } from "./patch";
+import { markAsDynamicChildren } from "./patch";
 import {
     isNativeShadowRootAvailable,
 } from "../env/dom";
@@ -547,9 +547,6 @@ export function b(fn: EventListener): EventListener {
     }
     const vm: VM = vmBeingRendered;
     return function(event: Event) {
-        if (vm.fallback) {
-            patchEvent(event);
-        }
         invokeEventListener(vm, fn, vm.component, event);
     };
 }

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -180,7 +180,7 @@ BaseLightningElement.prototype = {
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(vm && "cmpRoot" in vm, `${vm} is not a vm.`);
             assert.invariant(!isRendering, `${vmBeingRendered}.render() method has side effects on the state of ${vm} by adding an event listener for "${type}".`);
-            assert.invariant(isFunction(listener), `Invalid second argument for this.template.addEventListener() in ${vm} for event "${type}". Expected an EventListener but received ${listener}.`);
+            assert.invariant(isFunction(listener), `Invalid second argument for this.addEventListener() in ${vm} for event "${type}". Expected an EventListener but received ${listener}.`);
         }
         const wrappedListener = getWrappedComponentsListener(vm, listener);
         vm.elm.addEventListener(type, wrappedListener, options);

--- a/packages/@lwc/engine/src/framework/patch.ts
+++ b/packages/@lwc/engine/src/framework/patch.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { VNodes } from "../3rdparty/snabbdom/types";
-import { patchEvent } from "../faux-shadow/faux";
 import { tagNameGetter } from "../env/element";
 import { updateDynamicChildren, updateStaticChildren } from "../3rdparty/snabbdom/snabbdom";
 import { setPrototypeOf, create, isUndefined, isTrue } from "../shared/language";
@@ -99,7 +98,3 @@ export function patchCustomElementProto(elm: HTMLElement, options: { def: Compon
     setPrototypeOf(elm, patchedBridge.prototype);
     setCSSToken(elm, shadowAttribute);
 }
-
-export {
-    patchEvent,
-};

--- a/packages/@lwc/engine/src/polyfills/event-listener/README.md
+++ b/packages/@lwc/engine/src/polyfills/event-listener/README.md
@@ -1,0 +1,6 @@
+# event-listener polyfill
+
+This polyfill is needed to support re-targeting for synthetic shadow dom.
+
+It will patch addEventListener and removeEventListener to make sure that whenever you are listening for an event at any level, that event is patched accordingly but only if the event is triggered from within a shadow root. If the event is not coming from a synthetic shadow, the event
+don't need to be patched.

--- a/packages/@lwc/engine/src/polyfills/event-listener/detect.ts
+++ b/packages/@lwc/engine/src/polyfills/event-listener/detect.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export default function detect(): boolean {
+    return true;
+}

--- a/packages/@lwc/engine/src/polyfills/event-listener/main.ts
+++ b/packages/@lwc/engine/src/polyfills/event-listener/main.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import detect from './detect';
+import apply from './polyfill';
+
+if (detect()) {
+    apply();
+}

--- a/packages/@lwc/engine/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/engine/src/polyfills/event-listener/polyfill.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import {
+    windowRemoveEventListener as nativeWindowRemoveEventListener,
+    windowAddEventListener as nativeWindowAddEventListener,
+} from '../../env/window';
+import {
+    removeEventListener as nativeRemoveEventListener,
+    addEventListener as nativeAddEventListener,
+} from '../../env/element';
+import { eventTargetGetter } from '../../env/dom';
+import { DOCUMENT_POSITION_CONTAINED_BY, compareDocumentPosition } from '../../env/node';
+import { getNodeOwnerKey } from '../../faux-shadow/node';
+import { patchEvent } from '../../faux-shadow/events';
+
+function doesEventNeedsPatch(e: Event): boolean {
+    const originalTarget = eventTargetGetter.call(e);
+    if (originalTarget instanceof Node) {
+        if ((compareDocumentPosition.call(document, originalTarget) & DOCUMENT_POSITION_CONTAINED_BY) !== 0 && getNodeOwnerKey(originalTarget)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function getEventListenerWrapper(fnOrObj): EventListener | null {
+    let wrapperFn: EventListener | null = null;
+    try {
+        wrapperFn = fnOrObj.$$lwcEventWrapper$$;
+        if (!wrapperFn) {
+            const isHandlerFunction = typeof fnOrObj === 'function';
+            wrapperFn = fnOrObj.$$lwcEventWrapper$$ = function(this: EventTarget, e: Event) {
+                // we don't want to patch every event, only when the original target is coming
+                // from inside a synthetic shadow
+                if (doesEventNeedsPatch(e)) {
+                    patchEvent(e);
+                }
+                return isHandlerFunction ? fnOrObj.call(this, e) : fnOrObj.handleEvent && fnOrObj.handleEvent(e);
+            };
+        }
+    } catch (e) { /** ignore */ }
+    return wrapperFn;
+}
+
+function windowAddEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture) {
+    const handlerType = typeof fnOrObj;
+    // bail if `fnOrObj` is not a function, not an object
+    if (handlerType !== 'function' && handlerType !== 'object') {
+        return;
+    }
+    // bail if `fnOrObj` is an object without a `handleEvent` method
+    if (handlerType === 'object' && (!fnOrObj.handleEvent || typeof fnOrObj.handleEvent !== 'function')) {
+        return;
+    }
+    const wrapperFn = getEventListenerWrapper(fnOrObj);
+    nativeWindowAddEventListener.call(this, type, wrapperFn as EventListener, optionsOrCapture);
+}
+
+function windowRemoveEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture) {
+    const wrapperFn = getEventListenerWrapper(fnOrObj);
+    nativeWindowRemoveEventListener.call(this, type, wrapperFn || fnOrObj, optionsOrCapture);
+}
+
+function addEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture) {
+    const handlerType = typeof fnOrObj;
+    // bail if `fnOrObj` is not a function, not an object
+    if (handlerType !== 'function' && handlerType !== 'object') {
+        return;
+    }
+    // bail if `fnOrObj` is an object without a `handleEvent` method
+    if (handlerType === 'object' && (!fnOrObj.handleEvent || typeof fnOrObj.handleEvent !== 'function')) {
+        return;
+    }
+    const wrapperFn = getEventListenerWrapper(fnOrObj);
+    nativeAddEventListener.call(this, type, wrapperFn as EventListener, optionsOrCapture);
+}
+
+function removeEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture) {
+    const wrapperFn = getEventListenerWrapper(fnOrObj);
+    nativeRemoveEventListener.call(this, type, wrapperFn || fnOrObj, optionsOrCapture);
+}
+
+addEventListener.__lwcOriginal__ = nativeAddEventListener;
+removeEventListener.__lwcOriginal__ = nativeRemoveEventListener;
+windowAddEventListener.__lwcOriginal__ = nativeWindowAddEventListener;
+windowRemoveEventListener.__lwcOriginal__ = nativeWindowRemoveEventListener;
+
+function windowPatchListeners() {
+    window.addEventListener = windowAddEventListener;
+    window.removeEventListener = windowRemoveEventListener;
+}
+
+function nodePatchListeners() {
+    Node.prototype.addEventListener = addEventListener;
+    Node.prototype.removeEventListener = removeEventListener;
+}
+
+export default function apply() {
+    windowPatchListeners();
+    nodePatchListeners();
+}


### PR DESCRIPTION
…ent listeners " (#979)"

This reverts commit b65c7923bc68cac5893d59408c4c853789bc6282.


## Details


## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No
Has been widely communicated across consumer teams. The change has been introduced in the master branch and TFs vetted.

