### PR TITLE
refactor: rename to experimentalComputedMemberExpression

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/config.json
@@ -1,3 +1,3 @@
 {
-   "computedMemberExpression": true
+   "experimentalComputedMemberExpression": true
 }

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -16,13 +16,13 @@ export interface Config {
      *        {list[0].name}
      *    </template>
      */
-    computedMemberExpression?: boolean;
+    experimentalComputedMemberExpression?: boolean;
     secure?: boolean;
     stylesheetConfig?: StylesheetConfig;
 }
 
 export interface ResolvedConfig {
-    computedMemberExpression: boolean;
+    experimentalComputedMemberExpression: boolean;
     secure: boolean;
     stylesheetConfig: StylesheetConfig;
 
@@ -38,14 +38,14 @@ export interface ResolvedConfig {
 
 const DEFAULT_CONFIG: ResolvedConfig = {
     secure: false,
-    computedMemberExpression: false,
+    experimentalComputedMemberExpression: false,
     format: 'module',
     stylesheetConfig: {}
 };
 
 const AVAILABLE_OPTION_NAMES = new Set([
     'secure',
-    'computedMemberExpression',
+    'experimentalComputedMemberExpression',
     'stylesheetConfig'
 ]);
 

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -65,7 +65,7 @@ export function parseExpression(source: string, element: IRNode, state: State): 
 
             MemberExpression: {
                 exit(path) {
-                    const shouldReportComputed = !state.config.computedMemberExpression
+                    const shouldReportComputed = !state.config.experimentalComputedMemberExpression
                         && (path.node as types.MemberExpression).computed;
                     invariant(!shouldReportComputed, ParserDiagnostics.COMPUTED_PROPERTY_ACCESS_NOT_ALLOWED);
 

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -145,7 +145,7 @@ export interface CompilationWarning {
 
 export interface CompilationOptions {
     token: string;
-    computedMemberExpression?: boolean;
+    experimentalComputedMemberExpression?: boolean;
 }
 
 export interface DependencyParameter {


### PR DESCRIPTION
## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No