### PR TITLE
fix: ownerkey lookup of root ele manually injected into another lwc e…

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/__tests__/node-properties.spec.ts
+++ b/packages/@lwc/engine/src/faux-shadow/__tests__/node-properties.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { compileTemplate } from 'test-utils';
+import { createElement, LightningElement } from '../../framework/main';
+import assertLogger from '../../shared/assert';
+
+describe('patched node properties', () => {
+    describe('parentNode', () => {
+        afterEach(() => {
+            while (document.body.firstChild) {
+                document.body.removeChild(document.body.firstChild);
+            }
+        });
+        it('should fetch parentNode of nested root element', () => {
+            jest.spyOn(assertLogger, 'logError').mockImplementation(() => {});
+            const nestedRootElementTmpl = compileTemplate(`
+            <template>
+                <div></div>
+            </template>
+            `);
+            class NestedRootElement extends LightningElement {
+                render() {
+                    return nestedRootElementTmpl;
+                }
+            }
+
+            const nestedRootElement = createElement('x-nested', { is: NestedRootElement });
+            const rootElementTmpl = compileTemplate(`
+            <template>
+                <div class='expectedParent'></div>
+            </template>
+            `);
+            class RootElement extends LightningElement {
+                render() {
+                    return rootElementTmpl;
+                }
+                renderedCallback() {
+                    this.template.querySelector('div').appendChild(nestedRootElement);
+                }
+            }
+            const rootElem = createElement('x-root', { is: RootElement });
+            document.body.appendChild(rootElem);
+            expect(nestedRootElement.parentNode).not.toBeNull();
+            expect(nestedRootElement.parentNode).toBe(document.querySelector('.expectedParent'));
+            assertLogger.logError.mockRestore();
+        });
+        it('should fetch parentNode of nested root element when parent node marked as lwc:dom="manual"', () => {
+            const nestedRootElementTmpl = compileTemplate(`
+            <template>
+                <div></div>
+            </template>
+            `);
+            class NestedRootElement extends LightningElement {
+                render() {
+                    return nestedRootElementTmpl;
+                }
+            }
+
+            const nestedRootElement = createElement('x-nested', { is: NestedRootElement });
+            const rootElementTmpl = compileTemplate(`
+            <template>
+                <div class='expectedParent' lwc:dom="manual"></div>
+            </template>
+            `);
+            class RootElement extends LightningElement {
+                render() {
+                    return rootElementTmpl;
+                }
+                renderedCallback() {
+                    this.template.querySelector('div').appendChild(nestedRootElement);
+                }
+            }
+            const rootElem = createElement('x-root', { is: RootElement });
+            document.body.appendChild(rootElem);
+            expect(nestedRootElement.parentNode).not.toBeNull();
+            expect(nestedRootElement.parentNode).toBe(document.querySelector('.expectedParent'));
+        });
+    });
+});

--- a/packages/@lwc/engine/src/faux-shadow/node.ts
+++ b/packages/@lwc/engine/src/faux-shadow/node.ts
@@ -44,14 +44,12 @@ export function setNodeOwnerKey(node: Node, key: number) {
 
 export function getNodeNearestOwnerKey(node: Node): number | undefined {
     let ownerNode: Node | null = node;
+    let ownerKey: number | undefined;
     // search for the first element with owner identity (just in case of manually inserted elements)
     while (!isNull(ownerNode)) {
-        if (!isUndefined(ownerNode[OwnerKey])) {
-            return ownerNode[OwnerKey];
-        } else if (!isUndefined(ownerNode[OwnKey])) {
-            // perf optimization:
-            // root elements have ownKey but not ownerKey, we don't need to walk up anymore
-            return;
+        ownerKey = ownerNode[OwnerKey];
+        if (!isUndefined(ownerKey)) {
+            return ownerKey;
         }
         ownerNode = parentNodeGetter.call(ownerNode);
     }


### PR DESCRIPTION
backport https://github.com/salesforce/lwc/pull/1018

## Details
Looking up the ownerKey of a node was returning null for root element which are nested inside an aura component. The aura component is nested inside another root element. This was because of a perf optimization in getNodeNearestOwnerKey() which was stopping at the inner root element.

```
  <lwc-root-component-1>
           <aura-component-a>
                   <lwc-root-component-2>
                   </lwc-root-component-2>
           </aura-component-a> 
   </lwc-root-component-1>
```


## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
