### PR TITLE
fix: fix condition for extracting children getter

### DIFF
--- a/packages/@lwc/engine/src/env/element.ts
+++ b/packages/@lwc/engine/src/env/element.ts
@@ -47,7 +47,7 @@ const matches: (this: Element, selector: string) => boolean = hasOwnProperty.cal
     Element.prototype.matches :
     (Element.prototype as any).msMatchesSelector; // IE11
 
-const childrenGetter: (this: HTMLElement) => HTMLCollectionOf<Element> = hasOwnProperty.call(Element.prototype, 'innerHTML') ?
+const childrenGetter: (this: HTMLElement) => HTMLCollectionOf<Element> = hasOwnProperty.call(Element.prototype, 'children') ?
     getOwnPropertyDescriptor(Element.prototype, 'children')!.get! :
     getOwnPropertyDescriptor(HTMLElement.prototype, 'children')!.get!;  // IE11
 


### PR DESCRIPTION
## Details
The condition to extract children descriptor from Element.prototype or HTMLElement.prototype has a bug. It is checking the wrong property
Backport of https://github.com/salesforce/lwc/pull/1039
## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No