### PR TITLE
fix(style-compiler): invalid at-rules transformations

### DIFF
--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/actual.css
@@ -1,0 +1,52 @@
+@charset "utf-8";
+
+@namespace url(http://www.w3.org/1999/xhtml);
+
+@keyframes slidein {
+    from {
+        margin-left: 100%;
+    }
+    to {
+        margin-left: 0%;
+    }
+}
+
+@media screen and (min-width: 900px) {
+    article {
+        padding: 1rem 3rem;
+    }
+}
+
+@supports (display: grid) {
+    div {
+        display: grid;
+    }
+}
+
+@document url('https://www.example.com/') {
+    h1 {
+        color: green;
+    }
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/fonts/OpenSans-Regular-webfont.woff2') format('woff2'),
+        url('/fonts/OpenSans-Regular-webfont.woff') format('woff');
+}
+
+@viewport {
+    width: device-width;
+}
+
+@counter-style thumbs {
+    system: cyclic;
+    symbols: '\1F44D';
+    suffix: ' ';
+}
+
+@font-feature-values Font One {
+    @styleset {
+        nice-style: 12;
+    }
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
@@ -1,0 +1,4 @@
+function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+  return "@charset \"utf-8\";@namespace url(http://www.w3.org/1999/xhtml);@keyframes slidein {from {margin-left: 100%;}\nto {margin-left: 0%;}\n}@media screen and (min-width: 900px) {article" + shadowSelector + " {padding: 1rem 3rem;}\n}@supports (display: grid) {div" + shadowSelector + " {display: grid;}\n}@document url('https://www.example.com/') {h1" + shadowSelector + " {color: green;}\n}@font-face {font-family: 'Open Sans';src: url('/fonts/OpenSans-Regular-webfont.woff2') format('woff2'),\n        url('/fonts/OpenSans-Regular-webfont.woff') format('woff');}@viewport {width: device-width;}@counter-style thumbs {system: cyclic;symbols: '\\1F44D';suffix: ' ';}@font-feature-values Font One {@styleset {nice-style: 12;}}";
+}
+export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -134,6 +134,7 @@ function transformHost(selector: Selector) {
         replaceNodeWith(selector, ...contextualSelectors);
     }
 }
+
 export default function transformSelector(
     root: Root,
     transformConfig: SelectorScopingConfig,

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -155,7 +155,13 @@ function serializeCss(result: postcss.LazyResult, collectVarFunctions: boolean, 
             }
 
         } else if (node && node.type === 'atrule') {
-            // If we have an @at rule we dont want to push it to the global stack rather than the current token
+            // Certain atrules have declaration associated with for example @font-face. We need to add the rules tokens
+            // when it's the case.
+            if (currentRuleTokens.length) {
+                tokens.push(...currentRuleTokens);
+                currentRuleTokens = [];
+            }
+
             tokens.push({ type: TokenType.text, value: part });
         } else {
             // When inside anything else but a comment just push it


### PR DESCRIPTION
## Details

Fix 2 invalid CSS transformations related to at-rules:
* escape rules contained in `@keyframe` from selector scoping
* properly serialize declarations in at-rule without rules like `@font-face` or `@viewport`

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No