### PR TITLE
fix: move mutation observer to its own modules

### DIFF
--- a/packages/@lwc/engine/src/env/mutation-observer.ts
+++ b/packages/@lwc/engine/src/env/mutation-observer.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+let MO = (window as any).MutationObserver;
+
+// MutationObserver is not yet implemented in jsdom:
+// https://github.com/jsdom/jsdom/issues/639
+if (typeof MO === 'undefined') {
+    /* eslint-disable-next-line no-inner-declarations */
+    function MutationObserverMock() {}
+
+    MutationObserverMock.prototype = {
+        observe() {
+            if (process.env.NODE_ENV !== 'production') {
+                if (process.env.NODE_ENV !== 'test') {
+                    throw new Error(`MutationObserver should not be mocked outside of the jest test environment`);
+                }
+            }
+        }
+    };
+    MO = (window as any).MutationObserver = MutationObserverMock;
+}
+
+const MutationObserver = MO;
+
+// Eventually, import the patched MutationObserver polyfill here
+// to ensure rest of the framework uses the patched version
+
+let MutationObserverObserve = MutationObserver.prototype.observe;
+export {
+    MutationObserver,
+    MutationObserverObserve
+};

--- a/packages/@lwc/engine/src/env/window.ts
+++ b/packages/@lwc/engine/src/env/window.ts
@@ -4,29 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-let MO = (window as any).MutationObserver;
-
-// MutationObserver is not yet implemented in jsdom:
-// https://github.com/jsdom/jsdom/issues/639
-if (typeof MO === 'undefined') {
-    /* eslint-disable-next-line no-inner-declarations */
-    function MutationObserverMock() {}
-
-    MutationObserverMock.prototype = {
-        observe() {
-            if (process.env.NODE_ENV !== 'production') {
-                if (process.env.NODE_ENV !== 'test') {
-                    throw new Error(`MutationObserver should not be mocked outside of the jest test environment`);
-                }
-            }
-        }
-    };
-    MO = (window as any).MutationObserver = MutationObserverMock;
-}
-
-const MutationObserver = MO;
-const MutationObserverObserve = MutationObserver.prototype.observe;
-
 let {
     addEventListener: windowAddEventListener,
     removeEventListener: windowRemoveEventListener,
@@ -42,8 +19,6 @@ windowAddEventListener = windowAddEventListener.__lwcOriginal__ || windowAddEven
 windowRemoveEventListener = windowRemoveEventListener.__lwcOriginal__ || windowRemoveEventListener;
 
 export {
-    MutationObserver,
-    MutationObserverObserve,
     windowAddEventListener,
     windowRemoveEventListener,
 };

--- a/packages/@lwc/engine/src/faux-shadow/node.ts
+++ b/packages/@lwc/engine/src/faux-shadow/node.ts
@@ -20,7 +20,7 @@ import {
     parentNodeGetter as nativeParentNodeGetter,
     cloneNode as nativeCloneNode,
 } from '../env/node';
-import { MutationObserver, MutationObserverObserve } from '../env/window';
+import { MutationObserver, MutationObserverObserve } from '../env/mutation-observer';
 import { setAttribute } from '../env/element';
 import { getNodeOwner, isSlotElement, getRootNodeGetter, isNodeOwnedBy } from './traverse';
 import { NodeConstructor } from '../framework/base-bridge-element';

--- a/packages/@lwc/engine/src/faux-shadow/slot.ts
+++ b/packages/@lwc/engine/src/faux-shadow/slot.ts
@@ -26,7 +26,7 @@ import {
 import {
     MutationObserverObserve,
     MutationObserver,
-} from "../env/window";
+} from "../env/mutation-observer";
 import { PatchedElement, isSlotElement, isNodeOwnedBy, getNodeOwner, getAllMatches, getFilteredChildNodes } from "./traverse";
 import { HTMLSlotElementConstructor } from "../framework/base-bridge-element";
 import {


### PR DESCRIPTION
## Details
Moving cached references of MutationObserver to a separate modules in preparation for patching mutation observer

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No


