### PR TITLE
fix: properly exit the state entered when clicking into shadows (#1082)

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/focus.ts
+++ b/packages/@lwc/engine/src/faux-shadow/focus.ts
@@ -148,7 +148,7 @@ export function getActiveElement(host: HTMLElement): HTMLElement | null {
     return (compareDocumentPosition.call(host, activeElement) & DOCUMENT_POSITION_CONTAINED_BY) !== 0 ? activeElement : null;
 }
 
-function relatedTargetPosition(host: HTMLElement, relatedTarget: HTMLElement): number {
+function relatedTargetPosition(host: HTMLElement, relatedTarget: EventTarget): number {
     // assert: target must be child of host
     const pos = compareDocumentPosition.call(host, relatedTarget);
     if (pos & DOCUMENT_POSITION_CONTAINED_BY) {
@@ -223,7 +223,7 @@ function keyboardFocusHandler(event: FocusEvent) {
     }
 
     const segments = getTabbableSegments(host as HTMLElement);
-    const position = relatedTargetPosition(host as HTMLElement, relatedTarget as HTMLElement);
+    const position = relatedTargetPosition(host as HTMLElement, relatedTarget);
 
     if (position === 1) {
         // probably tabbing into element
@@ -267,10 +267,9 @@ function keyboardFocusInHandler(event: FocusEvent) {
     }
 
     // Determine where the focus is coming from (Tab or Shift+Tab)
-    const post = relatedTargetPosition(host as HTMLElement, relatedTarget as HTMLElement);
+    const post = relatedTargetPosition(host as HTMLElement, relatedTarget);
     switch (post) {
         case 1:  // focus is probably coming from above
-
             if (isFirstFocusableChildReceivingFocus && relatedTarget === getPreviousTabbableElement(segments)) {
                 // the focus was on the immediate focusable elements from above,
                 // it is almost certain that the focus is due to tab keypress
@@ -294,7 +293,7 @@ function willTriggerFocusInEvent(target: HTMLElement): boolean {
     );
 }
 
-function stopFocusIn(evt) {
+function enterMouseDownState(evt) {
     const currentTarget = eventCurrentTargetGetter.call(evt);
     removeEventListener.call(currentTarget, 'focusin', keyboardFocusInHandler);
     setTimeout(() => {
@@ -305,13 +304,27 @@ function stopFocusIn(evt) {
     }, 0);
 }
 
+function exitMouseDownState(event) {
+    const currentTarget = eventCurrentTargetGetter.call(event);
+    const relatedTarget = focusEventRelatedTargetGetter.call(event);
+    // If the focused element is null or the focused element is no longer internal
+    if (isNull(relatedTarget) || relatedTargetPosition(currentTarget as HTMLElement, relatedTarget) !== 0) {
+        removeEventListener.call(currentTarget, 'focusin', enterMouseDownState, true);
+        removeEventListener.call(currentTarget, 'focusout', exitMouseDownState, true);
+    }
+}
+
 function handleFocusMouseDown(evt) {
     const target = eventTargetGetter.call(evt);
     // If we are mouse down in an element that can be focused
     // and the currentTarget's activeElement is not element we are mouse-ing down in
     // We can bail out and let the browser do its thing.
     if (willTriggerFocusInEvent(target)) {
-        addEventListener.call(eventCurrentTargetGetter.call(evt), 'focusin', stopFocusIn, true);
+        const currentTarget = eventCurrentTargetGetter.call(evt);
+        // Enter the temporary state where we disable the keyboard focusin handler when we click into the shadow.
+        addEventListener.call(currentTarget, 'focusin', enterMouseDownState, true);
+        // Exit the temporary state When focus leaves the shadow.
+        addEventListener.call(currentTarget, 'focusout', exitMouseDownState, true);
     }
 }
 

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.spec.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+const URL = 'http://localhost:4567/delegates-focus-negative-tabindex-navigate-after-clicking-inside';
+
+describe('When delegatesFocus=true and tabindex=-1, and navigating with the keyboard', () => {
+    beforeEach(() => {
+        browser.url(URL);
+    });
+
+    it.skip('should skip forwards', function () {
+        browser.click('.second-outside');
+        browser.keys(['Tab']);
+
+        var className = browser.execute(function () {
+            return document.activeElement // container
+                .shadowRoot.activeElement // input
+                .className;
+        }).value;
+
+        assert.equal(className, 'third-outside');
+    });
+
+    it.skip('should skip backwards', function () {
+        browser.click('.third-outside');
+        browser.keys(['Shift', 'Tab']);
+
+        var className = browser.execute(function () {
+            return document.activeElement // container
+                .shadowRoot.activeElement // input
+                .className;
+        }).value;
+
+        assert.equal(className, 'second-outside');
+    });
+
+    it.skip('should navigate forwards inside shadow once shadow is clicked into', function () {
+        browser.click('.first-inside');
+        browser.keys(['Tab']);
+
+        var className = browser.execute(function () {
+            return document.activeElement // container
+                .shadowRoot.activeElement // integration-child
+                .shadowRoot.activeElement // input
+                .className;
+        }).value;
+
+        assert.equal(className, 'second-inside');
+    });
+
+    it.skip('should navigate backwards inside shadow once shadow is clicked into', function () {
+        browser.click('.third-inside');
+        browser.keys(['Shift', 'Tab']);
+
+        var className = browser.execute(function () {
+            return document.activeElement // container
+                .shadowRoot.activeElement // integration-child
+                .shadowRoot.activeElement // input
+                .className;
+        }).value;
+
+        assert.equal(className, 'second-inside');
+    });
+
+    it('should continue skipping elements even after shadow is clicked into', function () {
+        browser.click('.second-inside');
+        browser.click('.second-outside');
+        browser.keys(['Tab']);
+
+        var className = browser.execute(function () {
+            return document.activeElement // container
+                .shadowRoot.activeElement // input
+                .className;
+        }).value;
+
+        assert.equal(className, 'third-outside');
+    });
+});

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/child/child.html
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/child/child.html
@@ -1,0 +1,5 @@
+<template>
+    <input class="first-inside" placeholder="first (inside)">
+    <input class="second-inside" placeholder="second (inside)">
+    <input class="third-inside" placeholder="third (inside)">
+</template>

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/child/child.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.html
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.html
@@ -1,0 +1,7 @@
+<template>
+    <input class="first-outside" placeholder="first (outside)">
+    <input class="second-outside" placeholder="second (outside)">
+    <integration-child tabindex="-1"></integration-child>
+    <input class="third-outside" placeholder="third (outside)">
+    <input class="fourth-outside" placeholder="fourth (outside)">
+</template>

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-navigate-after-clicking-inside/integration/delegates-focus-negative-tabindex-navigate-after-clicking-inside/delegates-focus-negative-tabindex-navigate-after-clicking-inside.js
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {
+}


### PR DESCRIPTION
https://github.com/salesforce/lwc/pull/1082

(cherry picked from commit d20fddabeabd71cf4c18a4e3128b6f3f2f71e3ab)

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
