### PR TITLE
fix(module-resolver): protect against invalid package.json

### DIFF
--- a/packages/@lwc/module-resolver/src/index.js
+++ b/packages/@lwc/module-resolver/src/index.js
@@ -19,14 +19,17 @@ const LWC_CONFIG_FILE = '.lwcrc';
 function loadLwcConfig(modulePath) {
     const packageJsonPath = path.join(modulePath, 'package.json');
     const lwcConfigPath = path.join(modulePath, LWC_CONFIG_FILE);
-    const jsonPkg = require(packageJsonPath);
     let config;
     try {
-        config = fs.readFileSync(lwcConfigPath, 'utf8');
-    } catch (e) {
-        config = jsonPkg.lwc;
+        const jsonPkg = require(packageJsonPath);
+        try {
+            config = fs.readFileSync(lwcConfigPath, 'utf8');
+        } catch (e) {
+            config = jsonPkg.lwc;
+        }
+    } catch(ignore) {
+        // ignore
     }
-
     return config;
 }
 


### PR DESCRIPTION
## Details
When scanning for lwc modules, some package.json might be invalid, or corrupt, or not specify a main property, meaning it will not properly be require()'d. Add try-catch to avoid these problems. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:


