### PR TITLE
fix(wire-service): add lifecycle hook guards

### DIFF
--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -111,7 +111,7 @@ const wireService = {
     connected: (cmp: LightningElement, data: object, def: ElementDef, context: Context) => {
         let listeners: NoArgumentListener[];
         if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(context[CONTEXT_ID], 'wire adapter "connected" hook called without an established context');
+            assert.isTrue(!def.wire || context[CONTEXT_ID], 'wire service was not initialized prior to component creation:  "connected" service hook invoked without necessary context');
         }
         if (!def.wire || !(listeners = context[CONTEXT_ID][CONTEXT_CONNECTED])) {
             return;
@@ -122,7 +122,7 @@ const wireService = {
     disconnected: (cmp: LightningElement, data: object, def: ElementDef, context: Context) => {
         let listeners: NoArgumentListener[];
         if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(context[CONTEXT_ID], 'wire adapter "disconnected" hook called without an established context');
+            assert.isTrue(!def.wire || context[CONTEXT_ID], 'wire service was not initialized prior to component creation:  "disconnected" service hook invoked without necessary context');
         }
         if (!def.wire || !(listeners = context[CONTEXT_ID][CONTEXT_DISCONNECTED])) {
             return;


### PR DESCRIPTION
## Details

In tests we provide an API that allows users to register a test wire adapter and emit data through the wire. If a user registers the adapter after the element is created they get a cryptic error when that element is disconnected from the DOM.

Users should always register the adapter before creating the element, but we should also have a better error message than a NPE when they don't.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
