### PR TITLE
build: generate a npm artifact for each commit on all the branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,9 +291,6 @@ workflows:
       - push_canary_npm_artifacts:
           requires:
             - build
-          filters:
-            branches:
-              only: master
 
       - test_integration:
           requires:


### PR DESCRIPTION
## Details

This PR will generate an npm artifact of all the packages in the monorepo to S3. The generation of the artifacts is today only generated on the master branch. For all the other branch than master the generated artifact expires after 30 days.

This would help running functional test or performance test against other consumers of LWC without having to merge a PR in master nor releasing a new version.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No