### PR TITLE
fix(jest-transformer): add babel-preset-jest dependency

### DIFF
--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -21,7 +21,8 @@
     },
     "peerDependencies": {
         "@lwc/compiler": "0.37.x",
-        "@lwc/engine": "0.37.x"
+        "@lwc/engine": "0.37.x",
+        "jest": "24.x"
     },
     "devDependencies": {
         "@lwc/compiler": "0.37.0",


### PR DESCRIPTION
## Details

The Jest transformer imports and uses `babel-preset-jest` directly but does not declare it as a dependency. 

Although always not fully correct, this did not result in any errors before because the dependency would get hoisted to the project level `node_modules` via other Jest dependencies anyway. In newer versions of Jest, however, `babel-preset-jest` is nested in `jest-config/node_modules` and not accessible by the transformer.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
