### PR TITLE
fix(template-compiler): restrict srcdoc attribute on all iframe element

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-iframe-srcdoc-attribute/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-iframe-srcdoc-attribute/actual.html
@@ -1,3 +1,13 @@
 <template>
     <iframe srcdoc="<script src=/foo.js></script>"></iframe>
+
+    <svg>
+        <!-- TODO: #1136 template compiler should not restrict srcdoc attribute on iframe in the SVG namespace. -->
+        <iframe srcdoc="<script src=/foo.js></script>"></iframe>
+    </svg>
+
+    <math>
+        <!-- TODO: #1136 template compiler should not restrict srcdoc attribute on iframe in the MathML namespace. -->
+        <iframe srcdoc="<script src=/foo.js></script>"></iframe>
+    </math>
 </template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-iframe-srcdoc-attribute/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-iframe-srcdoc-attribute/metadata.json
@@ -10,6 +10,39 @@
                 "start": 15,
                 "length": 56
             }
+        },
+        {
+            "message": "LWC1049: Forbidden svg namespace tag found in template: '<iframe>' tag is not allowed within <svg>",
+            "code": 1049,
+            "level": 1,
+            "location": {
+                "column": 9,
+                "length": 56,
+                "line": 6,
+                "start": 207
+            }
+        }, 
+        {
+            "code": 1048,
+            "message": "LWC1048: srcdoc attribute is disallowed on <iframe> for security reasons",
+            "level": 1,
+            "location": {
+                "line": 6,
+                "column": 9,
+                "start": 207,
+                "length": 56
+            }
+        },
+        {
+            "code": 1048,
+            "message": "LWC1048: srcdoc attribute is disallowed on <iframe> for security reasons",
+            "level": 1,
+            "location": {
+                "line": 11,
+                "column": 9,
+                "start": 414,
+                "length": 56
+            }
         }
     ],
     "metadata": {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -870,11 +870,10 @@ export default function parse(
                 }
             }
 
-            if (
-                node.namespaceURI === HTML_NAMESPACE_URI &&
-                tag === 'iframe' &&
-                attrName === 'srcdoc'
-            ) {
+            // TODO #1136 - once the template compiler emits the element namespace information to the engine we should
+            // restrict the validation of the "srcdoc" attribute on the "iframe" element only if this element is
+            // part of the HTML namespace.
+            if (tag === 'iframe' && attrName === 'srcdoc') {
                 warnOnElement(ParserDiagnostics.FORBIDDEN_IFRAME_SRCDOC_ATTRIBUTE, node);
             }
         });


### PR DESCRIPTION
## Details

This PR restrict the usage of the `srcdoc` on `iframe` elements regardless of the element namespace. This change should be revisited once #1136 is fixed.

## Does this PR introduce a breaking change?

* [X] Yes
* [ ] No

Very very low chance of breakage, because this change only affects `iframe` element created in the MathML namespace.