### PR TITLE
fix(module-resolver): protect against invalid package.json

### DIFF
--- a/packages/@lwc/module-resolver/src/index.ts
+++ b/packages/@lwc/module-resolver/src/index.ts
@@ -43,7 +43,7 @@ function loadLwcConfig(modulePath) {
         } catch (e) {
             config = jsonPkg.lwc;
         }
-    } catch(ignore) {
+    } catch (ignore) {
         // ignore
     }
     return config;


### PR DESCRIPTION
## Details

When scanning for lwc modules, some package.json might be invalid, or corrupt, or not specify a main property, meaning it will not properly be require()'d. Add try-catch to avoid these problems.

Author: @midzelis 

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No