### PR TITLE
fix(compiler): don't use project-wide config

### DIFF
--- a/packages/@lwc/compiler/src/babel-plugins.ts
+++ b/packages/@lwc/compiler/src/babel-plugins.ts
@@ -44,6 +44,7 @@ import transformObjectRestSpread from '@babel/plugin-proposal-object-rest-spread
 // Base babel configuration
 export const BABEL_CONFIG_BASE = {
     babelrc: false,
+    configFile: false,
     sourceMaps: true,
     parserOpts: {
         plugins: [

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -22,7 +22,6 @@ export default function(
         plugins: [[lwcClassTransformPlugin, { isExplicitImport }], ...BABEL_PLUGINS_BASE],
         filename,
         sourceMaps: options.outputConfig.sourcemap,
-        configFile: false,
     });
 
     let result;


### PR DESCRIPTION
## Details
Modify the lwc compiler to avoid using the project wide babel.config.js file. This was discovered when adding support to LWC LSP when opening standalone projects. If that standalone project was using a babel.config.js file, it was interfering with the lwc compiler babel transforms, which should be isolated. lwc compiler already pases babelrc: false as a default option. babelConfig: false is the way to disable the project wide config. Project wide configs are new in babel 7.x. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:

