### PR TITLE
fix(synthetic-shadow): add missing getElementsBy[ClassName|TagName]

### DIFF
--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
@@ -15,8 +15,7 @@ describe('LightningElement.getElementsByClassName', () => {
         );
     });
 
-    // TODO - #1026 LightningElement.getElementsByClassName doesn't respect the shadow DOM
-    xit('returns the right elements', () => {
+    it('returns the right elements', () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
@@ -15,8 +15,7 @@ describe('LightningElement.getElementsByTagName', () => {
         );
     });
 
-    // TODO - #1026 LightningElement.getElementsByTagName doesn't respect the shadow DOM
-    xit('returns the right elements', () => {
+    it('returns the right elements', () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
 


### PR DESCRIPTION
## Details

This PR fixes the implementation of `LightningElement.getElementsByClassName` and `LightningElement.getElementsByTagName` to enforce the shadow DOM restriction.

Fixes #1026

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No
