### PR TITLE
chore(synthetic-shadow): add note on APIs not supporting shadow DOM

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -298,6 +298,12 @@ export function getFilteredChildNodes(node: Node): Element[] {
 
 export function PatchedElement(elm: HTMLElement): HTMLElementConstructor {
     const Ctor = PatchedNode(elm) as HTMLElementConstructor;
+
+    // Note: Element.getElementsByTagName and Element.getElementsByClassName are purposefully
+    // omitted from the list of patched methods. In order for the querySelector* APIs to run
+    // properly in jsdom, we need to make sure those methods doesn't respect the shadow DOM
+    // semantic.
+    // https://github.com/salesforce/lwc/pull/1179#issuecomment-484041707
     return class PatchedHTMLElement extends Ctor {
         querySelector(this: Element, selector: string): Element | null {
             return lightDomQuerySelector(this, selector);

--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
@@ -1,7 +1,6 @@
 import { createElement } from 'test-utils';
 
 import ConstructorGetElementsByClassName from 'x/constructorGetElementsByClassName';
-import Parent from 'x/parent';
 
 describe('LightningElement.getElementsByClassName', () => {
     it('should throw when invoked in the constructor', () => {
@@ -13,19 +12,5 @@ describe('LightningElement.getElementsByClassName', () => {
             Error,
             /Assert Violation: this.getElementsByClassName\(\) cannot be called during the construction of the custom element for <x-constructor-get-elements-by-class-name> because no children has been added to this element yet\./
         );
-    });
-
-    // TODO - #1026 LightningElement.getElementsByClassName doesn't respect the shadow DOM
-    xit('returns the right elements', () => {
-        const elm = createElement('x-parent', { is: Parent });
-        document.body.appendChild(elm);
-
-        const parentResult = elm.getElementsByClassName('foo');
-        expect(parentResult.length).toBe(0);
-
-        const childResult = elm.shadowRoot.querySelector('x-child').getElementsByClassName('foo');
-        expect(childResult.length).toBe(2);
-        expect(childResult[0].className).toBe('foo slotted1');
-        expect(childResult[1].className).toBe('foo slotted2');
     });
 });

--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
@@ -1,7 +1,6 @@
 import { createElement } from 'test-utils';
 
 import ConstructorGetElementsByTagName from 'x/constructorGetElementsByTagName';
-import Parent from 'x/parent';
 
 describe('LightningElement.getElementsByTagName', () => {
     it('should throw when invoked in the constructor', () => {
@@ -13,19 +12,5 @@ describe('LightningElement.getElementsByTagName', () => {
             Error,
             /Assert Violation: this.getElementsByTagName\(\) cannot be called during the construction of the custom element for <x-constructor-get-elements-by-tag-name> because no children has been added to this element yet\./
         );
-    });
-
-    // TODO - #1026 LightningElement.getElementsByTagName doesn't respect the shadow DOM
-    xit('returns the right elements', () => {
-        const elm = createElement('x-parent', { is: Parent });
-        document.body.appendChild(elm);
-
-        const parentResult = elm.getElementsByTagName('div');
-        expect(parentResult.length).toBe(0);
-
-        const childResult = elm.shadowRoot.querySelector('x-child').getElementsByTagName('div');
-        expect(childResult.length).toBe(2);
-        expect(childResult[0].className).toBe('foo slotted1');
-        expect(childResult[1].className).toBe('foo slotted2');
     });
 });


### PR DESCRIPTION
## Details

This PR adds a note in the code to make sure `Element.getElementsByTagName` and `Element.getElementsByClassName` are not patched. It also remove unnecessary tests that can't be fixed for now.

Fixes #1026

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No