### PR TITLE
fix: incorrect import in dist type in @lwc/compiler

### DIFF
--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -18,11 +18,19 @@ import { MetadataCollector } from '../bundler/meta-collector';
 import { NormalizedCompilerOptions } from '../compiler/options';
 
 // TODO: once we come up with a strategy to export all types from the module,
-// below interface should be removed and resolved from template-compiler module.
+// below interfaces should be removed and resolved from template-compiler module.
 export interface TemplateMetadata {
     templateUsedIds: string[];
     definedSlots: string[];
     templateDependencies: TemplateModuleDependency[];
+}
+
+export interface TemplateTransformResult {
+    code: string;
+    map: {
+        mappings: string;
+    };
+    metadata: TemplateMetadata;
 }
 
 /**
@@ -35,7 +43,7 @@ export default function templateTransform(
     filename: string,
     options: NormalizedCompilerOptions,
     metadataCollector?: MetadataCollector
-) {
+): TemplateTransformResult {
     let result;
     let metadata;
 


### PR DESCRIPTION
## Details
This PR addresses an issue introduced with https://github.com/salesforce/lwc/pull/1174/files

The current generated `@lwc/compiler/dist/types/transformers/template.d.ts` is:

```ts
import { TemplateModuleDependency } from '@lwc/template-compiler';
import { MetadataCollector } from '../bundler/meta-collector';
import { NormalizedCompilerOptions } from '../compiler/options';
export interface TemplateMetadata {
    templateUsedIds: string[];
    definedSlots: string[];
    templateDependencies: TemplateModuleDependency[];
}
/**
 * Transforms a HTML template into module exporting a template function.
 * The transform also add a style import for the default stylesheet associated with
 * the template regardless if there is an actual style or not.
 */
export default function templateTransform(src: string, filename: string, options: NormalizedCompilerOptions, metadataCollector?: MetadataCollector): {
    code: string;
    map: {
        mappings: string;
    };
    metadata: import("../../../template-compiler/dist/types/shared/types").CompilationMetadata;
};
```

This incorrect since can't resolve correctly the import from the `template-compiler`.