### PR TITLE
fix: refactor mutation observer polyfill to fix memory leaks

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/README.md
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/README.md
@@ -8,4 +8,4 @@ This polyfill adopts the same garbage collection principle as the spec https://d
 "Nodes have a strong reference to registered observers in their registered observer list.
 Registered observers in a node’s registered observer list have a weak reference to the node."
 
-The patched observer instances do not hold a reference to their observed target. Instead, the observed target holds a strong reference to its observers. When the target node is garbage collected, the observer becomes eligible for garbege collection too.
+The patched observer instances do not hold a reference to their observed target. Instead, the observed target holds a strong reference to its observers. When the target node is garbage collected, the observer becomes eligible for garbage collection too.


### PR DESCRIPTION
## Details
The original version of the mutation observer was holding a strong reference to the observed nodes and caused memory leaks. This PR fixes the issue by eliminating the strong reference.


## Limitation
1. False positive when an observer disconnects and reconnects outside the shadow tree
  - If an observer first attaches itself to a node inside a shadow tree.
  - It later disconnects.
  - Next it attaches itself to a node outside the shadow tree.
  - If a mutation occurs inside the shadow tree, the expected result is that the observer callback is not invoked.
Currently it invokes the observer.
Proposed fix: Maintain a state between observe() and disconnect(). Recreate a new state the next time observe is called. When checking for qualifying observers, check for equality of registered observer's state

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No


