### PR TITLE
fix: prevent tabbing into subtrees with tabindex -1 (#1206)

### DIFF
--- a/packages/@lwc/engine/src/faux-shadow/focus.ts
+++ b/packages/@lwc/engine/src/faux-shadow/focus.ts
@@ -18,19 +18,20 @@ import {
     getAttribute,
 } from '../env/element';
 import {
-    DOCUMENT_POSITION_CONTAINED_BY,
     compareDocumentPosition,
+    DOCUMENT_POSITION_CONTAINED_BY,
     DOCUMENT_POSITION_PRECEDING,
     DOCUMENT_POSITION_FOLLOWING,
 } from '../env/node';
 import {
-    ArraySlice,
     ArrayIndexOf,
+    ArrayReverse,
+    ArraySlice,
+    getOwnPropertyDescriptor,
+    hasOwnProperty,
     isFalse,
     isNull,
     toString,
-    ArrayReverse,
-    hasOwnProperty,
 } from '../shared/language';
 import {
     DocumentPrototypeActiveElement,
@@ -42,6 +43,7 @@ import {
     focusEventRelatedTargetGetter,
 } from '../env/dom';
 import { isDelegatingFocus } from './shadow-root';
+import { patchedGetRootNode } from './traverse';
 
 const TabbableElementsQuery = `
     button:not([tabindex="-1"]):not([disabled]),
@@ -113,26 +115,6 @@ export function isFocusable(element: HTMLElement): boolean {
     );
 }
 
-function getFirstTabbableMatch(elements: HTMLElement[]): HTMLElement | null {
-    for (let i = 0, len = elements.length; i < len; i += 1) {
-        const elm = elements[i];
-        if (isTabbable(elm)) {
-            return elm;
-        }
-    }
-    return null;
-}
-
-function getLastTabbableMatch(elements: HTMLElement[]): HTMLElement | null {
-    for (let i = elements.length - 1; i >= 0; i -= 1) {
-        const elm = elements[i];
-        if (isTabbable(elm)) {
-            return elm;
-        }
-    }
-    return null;
-}
-
 interface QuerySegments {
     prev: HTMLElement[];
     inner: HTMLElement[];
@@ -144,7 +126,7 @@ function getTabbableSegments(host: HTMLElement): QuerySegments {
     const inner = ArraySlice.call(querySelectorAll.call(host, TabbableElementsQuery));
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
-            tabIndexGetter.call(host) === -1 || isDelegatingFocus(host),
+            getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host),
             `The focusin event is only relevant when the tabIndex property is -1 on the host.`
         );
     }
@@ -197,16 +179,6 @@ function relatedTargetPosition(host: HTMLElement, relatedTarget: EventTarget): n
     return -1;
 }
 
-function getPreviousTabbableElement(segments: QuerySegments): HTMLElement | null {
-    const { prev } = segments;
-    return getFirstTabbableMatch(ArrayReverse.call(prev));
-}
-
-function getNextTabbableElement(segments: QuerySegments): HTMLElement | null {
-    const { next } = segments;
-    return getFirstTabbableMatch(next);
-}
-
 function muteEvent(event) {
     event.preventDefault();
     event.stopPropagation();
@@ -219,73 +191,73 @@ function muteFocusEventsDuringExecution(func: Function) {
     windowRemoveEventListener.call(window, 'focusout', muteEvent, true);
 }
 
-function focusOnNextOrBlur(focusEventTarget: EventTarget, segments: QuerySegments) {
-    muteFocusEventsDuringExecution(() => {
-        const nextNode = getNextTabbableElement(segments);
-        if (isNull(nextNode)) {
-            // nothing to focus on, blur to invalidate the operation
-            (focusEventTarget as HTMLElement).blur();
-        } else {
-            nextNode.focus();
-        }
-    });
-}
-
-function focusOnPrevOrBlur(focusEventTarget: EventTarget, segments: QuerySegments) {
-    muteFocusEventsDuringExecution(() => {
-        const prevNode = getPreviousTabbableElement(segments);
-        if (isNull(prevNode)) {
-            // nothing to focus on, blur to invalidate the operation
-            (focusEventTarget as HTMLElement).blur();
-        } else {
-            prevNode.focus();
-        }
-    });
-}
-
-function isFirstTabbableChild(target: EventTarget, segments: QuerySegments): boolean {
-    return getFirstTabbableMatch(segments.inner) === target;
-}
-
-function isLastTabbableChild(target: EventTarget, segments: QuerySegments): boolean {
-    return getLastTabbableMatch(segments.inner) === target;
+function focusOnNextOrBlur(
+    segment: HTMLElement[],
+    target: EventTarget,
+    relatedTarget: EventTarget
+) {
+    const next = getNextTabbable(segment, relatedTarget);
+    if (isNull(next)) {
+        // nothing to focus on, blur to invalidate the operation
+        muteFocusEventsDuringExecution(() => {
+            (target as HTMLElement).blur();
+        });
+    } else {
+        muteFocusEventsDuringExecution(() => {
+            next.focus();
+        });
+    }
 }
 
 function keyboardFocusHandler(event: FocusEvent) {
     const host = eventCurrentTargetGetter.call(event);
     const target = eventTargetGetter.call(event);
 
-    // Ideally, we would be able to use a "focus" event that doesn't bubble
-    // but, IE11 doesn't support relatedTarget on focus events so we have to use
-    // focusin instead. The logic below is predicated on non-bubbling events
-    // So, if currentTarget(host) ir not target, we know that the event is bubbling
-    // and we escape because focus occured on something below the host.
+    // If the host delegating focus with tabindex=0 is not the target, we know
+    // that the event was dispatched on a descendant node of the host. This
+    // means the focus is coming from below and we don't need to do anything.
     if (host !== target) {
+        // Focus is coming from above
         return;
     }
 
     const relatedTarget = focusEventRelatedTargetGetter.call(event);
-
     if (isNull(relatedTarget)) {
+        // If relatedTarget is null, the user is most likely tabbing into the document from the
+        // browser chrome. We can't do much in this case because the tab direction is unknown. This is an
+        // edge case and only comes up if the custom element is the first or last tabbable element
+        // in the document.
+        // TODO: Is the above statement true? Couldn't we figure it out by looking at the position
+        // of the target relative to all tabbable elements in the document?
         return;
     }
 
     const segments = getTabbableSegments(host as HTMLElement);
-    const position = relatedTargetPosition(host as HTMLElement, relatedTarget);
 
+    const position = relatedTargetPosition(host as HTMLElement, relatedTarget);
     if (position === 1) {
-        // probably tabbing into element
-        const first = getFirstTabbableMatch(segments.inner);
-        if (!isNull(first)) {
+        // Focus is coming from above
+        const root = patchedGetRootNode.call(host);
+        const inner = segments.inner;
+
+        let firstTabbable: HTMLElement | null = null;
+        for (let i = 0, len = inner.length; i < len; i += 1) {
+            if (isTabbableFrom(root, inner[i])) {
+                firstTabbable = inner[i];
+                break;
+            }
+        }
+
+        if (!isNull(firstTabbable)) {
             muteFocusEventsDuringExecution(() => {
-                first.focus();
+                firstTabbable!.focus();
             });
         } else {
-            focusOnNextOrBlur(target, segments);
+            focusOnNextOrBlur(segments.next, target, relatedTarget);
         }
     } else if (host === target) {
-        // Shift tabbed back to the host
-        focusOnPrevOrBlur(host, segments);
+        // Host is receiving focus from below, either from its shadow or from a sibling
+        focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
     }
 }
 
@@ -295,45 +267,75 @@ function keyboardFocusHandler(event: FocusEvent) {
 // via keyboard navigation (tab or shift+tab)
 // Focusing via mouse should be disqualified before this gets called
 function keyboardFocusInHandler(event: FocusEvent) {
-    const host = eventCurrentTargetGetter.call(event);
-    const target = eventTargetGetter.call(event);
     const relatedTarget = focusEventRelatedTargetGetter.call(event);
-    const segments = getTabbableSegments(host as HTMLElement);
-    const isFirstFocusableChildReceivingFocus = isFirstTabbableChild(target, segments);
-    const isLastFocusableChildReceivingFocus = isLastTabbableChild(target, segments);
-    if (
-        // If we receive a focusin event that is not focusing on the first or last
-        // element inside of a shadow, we can assume that the user is tabbing between
-        // elements inside of the custom element shadow, so we do nothing
-        (isFalse(isFirstFocusableChildReceivingFocus) &&
-            isFalse(isLastFocusableChildReceivingFocus)) ||
-        // If related target is null, user is probably tabbing into the document from the browser chrome (location bar?)
-        // If relatedTarget is null, we can't do much here because we don't know what direction the user is tabbing
-        // This is a bit of an edge case, and only comes up if the custom element is the very first or very last
-        // tabbable element in a document
-        isNull(relatedTarget)
-    ) {
+    if (isNull(relatedTarget)) {
+        // If relatedTarget is null, the user is most likely tabbing into the document from the
+        // browser chrome. We can't do much in this case because the tab direction is unknown. This is an
+        // edge case and only comes up if the custom element is the first or last tabbable element
+        // in the document.
+        // TODO: Is the above statement true? Couldn't we figure it out by looking at the position
+        // of the target relative to all tabbable elements in the document?
         return;
     }
 
-    // Determine where the focus is coming from (Tab or Shift+Tab)
-    const post = relatedTargetPosition(host as HTMLElement, relatedTarget);
-    switch (post) {
-        case 1: // focus is probably coming from above
-            if (isFirstFocusableChildReceivingFocus) {
-                // the focus was on the immediate focusable elements from above,
-                // it is almost certain that the focus is due to tab keypress
-                focusOnNextOrBlur(target, segments);
-            }
-            break;
-        case 2: // focus is probably coming from below
-            if (isLastFocusableChildReceivingFocus) {
-                // the focus was on the immediate focusable elements from above,
-                // it is almost certain that the focus is due to tab keypress
-                focusOnPrevOrBlur(target, segments);
-            }
-            break;
+    const host = eventCurrentTargetGetter.call(event) as HTMLElement;
+    const segments = getTabbableSegments(host);
+
+    if (ArrayIndexOf.call(segments.inner, relatedTarget) !== -1) {
+        // If relatedTarget is contained by the host's subtree we can assume that the user is
+        // tabbing between elements inside of the shadow. Do nothing.
+        return;
     }
+
+    const target = eventTargetGetter.call(event) as HTMLElement;
+
+    // Determine where the focus is coming from (Tab or Shift+Tab)
+    const position = relatedTargetPosition(host, relatedTarget);
+    if (position === 1) {
+        // Focus is coming from above
+        focusOnNextOrBlur(segments.next, target, relatedTarget);
+    }
+    if (position === 2) {
+        // Focus is coming from below
+        focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
+    }
+}
+
+const ownerDocumentGetter: (this: Node) => Document | null = getOwnPropertyDescriptor(
+    Node.prototype,
+    'ownerDocument'
+)!.get!;
+
+// Use this function to determine whether you can start from one root and end up
+// at another element via tabbing.
+function isTabbableFrom(fromRoot: Node, toElm: HTMLElement): boolean {
+    if (!isTabbable(toElm)) {
+        return false;
+    }
+    const ownerDocument = ownerDocumentGetter.call(toElm);
+    let root = patchedGetRootNode.call(toElm);
+    while (root !== ownerDocument && root !== fromRoot) {
+        const sr = root as ShadowRoot;
+        const host = sr.host!;
+        if (getAttribute.call(host, 'tabindex') === '-1') {
+            return false;
+        }
+        root = host && patchedGetRootNode.call(host);
+    }
+    return true;
+}
+
+function getNextTabbable(tabbables: HTMLElement[], relatedTarget: EventTarget): HTMLElement | null {
+    const len = tabbables.length;
+    if (len > 0) {
+        for (let i = 0; i < len; i += 1) {
+            const next = tabbables[i];
+            if (isTabbableFrom(patchedGetRootNode.call(relatedTarget), next)) {
+                return next;
+            }
+        }
+    }
+    return null;
 }
 
 function willTriggerFocusInEvent(target: HTMLElement): boolean {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/integration/tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/integration/tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.html
@@ -2,7 +2,11 @@
     <input class="first-outside" placeholder="first (outside)">
     <input class="second-outside" placeholder="second (outside)">
     <div>
-        <integration-child tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
     </div>
     <input class="third-outside" placeholder="third (outside)">
     <input class="fourth-outside" placeholder="fourth (outside)">

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/integration/tabindex-negative/tabindex-negative.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/integration/tabindex-negative/tabindex-negative.html
@@ -2,7 +2,11 @@
     <input class="first-outside" placeholder="first (outside)">
     <input class="second-outside" placeholder="second (outside)">
     <div>
-        <integration-child tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
     </div>
     <input class="third-outside" placeholder="third (outside)">
     <input class="fourth-outside" placeholder="fourth (outside)">

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
@@ -7,12 +7,41 @@
 const assert = require('assert');
 const URL = 'http://localhost:4567/tabindex-toggle';
 
-describe('Tab navigation without tabindex', () => {
-    before(() => {
+describe('Tab navigation and tabindex toggling', () => {
+    beforeEach(() => {
         browser.url(URL);
     });
 
-    it('should support tabindex toggling', function() {
+    it('should work when going from -1 to no tabindex', function() {
+        // Set the tabindex to -1
+        browser.click('.toggle');
+
+        browser.click('.second-outside');
+        browser.keys(['Tab']);
+
+        let className = browser.execute(function() {
+            var container = document.activeElement;
+            var input = container.shadowRoot.activeElement;
+            return input.className;
+        }).value;
+        assert.equal(className, 'third-outside');
+
+        // Remove the tabindex
+        browser.click('.toggle');
+
+        browser.click('.second-outside');
+        browser.keys(['Tab']);
+
+        className = browser.execute(function() {
+            var container = document.activeElement;
+            var child = container.shadowRoot.activeElement;
+            var input = child.shadowRoot.activeElement;
+            return input.className;
+        }).value;
+        assert.equal(className, 'first-inside');
+    });
+
+    it('should work when going from no tabindex to -1', function() {
         browser.click('.second-outside');
         browser.keys(['Tab']);
 
@@ -36,19 +65,5 @@ describe('Tab navigation without tabindex', () => {
             return input.className;
         }).value;
         assert.equal(className, 'third-outside');
-
-        // Toggle the tabindex <x-child>
-        browser.click('.toggle');
-
-        browser.click('.second-outside');
-        browser.keys(['Tab']);
-
-        className = browser.execute(function() {
-            var container = document.activeElement;
-            var child = container.shadowRoot.activeElement;
-            var input = child.shadowRoot.activeElement;
-            return input.className;
-        }).value;
-        assert.equal(className, 'first-inside');
     });
 });

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <button>child button (should never be tabbed to)</button>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <integration-child tabindex="-1"></integration-child>
+    <input placeholder="parent input" class="parent">
+    <integration-child tabindex="-1"></integration-child>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.html
@@ -1,0 +1,5 @@
+<template>
+    <input placeholder="first outer input" class="first">
+    <integration-parent tabindex="0"></integration-parent>
+    <input placeholder="last outer input" class="last">
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+const URL = 'http://localhost:4567/tabindex-zero-internal-tabindex-negative';
+
+describe('Tab navigation when tabindex 0', () => {
+    beforeEach(() => {
+        browser.url(URL);
+    });
+
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (forward)', function() {
+        const firstInput = browser.execute(function() {
+            return document
+                .querySelector('integration-tabindex-zero-internal-tabindex-negative')
+                .shadowRoot.querySelector('.first');
+        });
+        firstInput.click();
+
+        browser.keys(['Tab']);
+
+        var tagName = browser.execute(function() {
+            var container = document.activeElement;
+            var parent = container.shadowRoot.activeElement;
+            var input = parent.shadowRoot.activeElement;
+            return input.tagName;
+        }).value;
+
+        assert.equal(tagName, 'INPUT');
+    });
+
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (backward)', function() {
+        const lastInput = browser.execute(function() {
+            return document
+                .querySelector('integration-tabindex-zero-internal-tabindex-negative')
+                .shadowRoot.querySelector('.last');
+        });
+        lastInput.click();
+
+        browser.keys(['Shift', 'Tab', 'Shift']);
+
+        var tagName = browser.execute(function() {
+            var container = document.activeElement;
+            var parent = container.shadowRoot.activeElement;
+            var input = parent.shadowRoot.activeElement;
+            return input.tagName;
+        }).value;
+
+        assert.equal(tagName, 'INPUT');
+    });
+});

--- a/packages/integration-tests/src/components/events/test-slotted-native-element-event-target/slotted-native-element-event-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-slotted-native-element-event-target/slotted-native-element-event-target.spec.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const assert = require('assert');
-
 describe('Event target in slot elements', () => {
     const URL = 'http://localhost:4567/slotted-native-element-event-target/';
 
@@ -14,8 +12,25 @@ describe('Event target in slot elements', () => {
     });
 
     it('should receive event with correct target', function() {
-        browser.click('p');
-        browser.waitForVisible('.correct-event-target');
-        assert.strictEqual(browser.getText('.correct-event-target'), 'Event target is correct');
+        const p = browser.execute(function() {
+            return document
+                .querySelector('integration-slotted-native-element-event-target')
+                .shadowRoot.querySelector('p');
+        });
+        p.click();
+
+        browser.waitUntil(
+            () => {
+                var child = browser.execute(function() {
+                    return document
+                        .querySelector('integration-slotted-native-element-event-target')
+                        .shadowRoot.querySelector('integration-child')
+                        .shadowRoot.querySelector('.correct-event-target');
+                });
+                return child.value !== null && child.getText() === 'Event target is correct';
+            },
+            500,
+            "did not receive expected event target in slot element's parent handler"
+        );
     });
 });


### PR DESCRIPTION
## Details

(cherry picked from commit 9f273f559ffb3e5065cb161eabc3341a2f82a38f)

## Does this PR introduce a breaking change?

No