### PR TITLE
fix: provide a way to disable document patching

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
@@ -22,19 +22,16 @@ import { getNodeOwnerKey } from '../../faux-shadow/node';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 
-export default function apply() {
-    // Inside the apply() so that we fetch the value only when the polyfill is run
-    // Also helps to cache the flag value
-    let skipGlobalPatching: boolean;
-    function isGlobalPatchingSkipped() {
-        if (isUndefined(skipGlobalPatching)) {
-            skipGlobalPatching =
-                document.body.getAttribute('data-global-patching-skipped-temporarily') ===
-                'clock-is-ticking';
-        }
-        return isTrue(skipGlobalPatching);
+let skipGlobalPatching: boolean;
+function isGlobalPatchingSkipped() {
+    if (isUndefined(skipGlobalPatching)) {
+        skipGlobalPatching =
+            document.body.getAttribute('data-global-patching-bypass') === 'temporary-bypass';
     }
+    return isTrue(skipGlobalPatching);
+}
 
+export default function apply() {
     const HTMLBodyElementPrototype = HTMLBodyElement.prototype;
     // The following patched methods hide shadowed elements from global
     // traversing mechanisms. They are simplified for performance reasons to

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -31,19 +31,16 @@ import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 
-export default function apply() {
-    // Inside the apply() so that we fetch the value only when the polyfill is run
-    // Also helps to cache the flag value
-    let skipGlobalPatching: boolean;
-    function isGlobalPatchingSkipped() {
-        if (isUndefined(skipGlobalPatching)) {
-            skipGlobalPatching =
-                document.body.getAttribute('data-global-patching-skipped-temporarily') ===
-                'clock-is-ticking';
-        }
-        return isTrue(skipGlobalPatching);
+let skipGlobalPatching: boolean;
+function isGlobalPatchingSkipped() {
+    if (isUndefined(skipGlobalPatching)) {
+        skipGlobalPatching =
+            document.body.getAttribute('data-global-patching-bypass') === 'temporary-bypass';
     }
+    return isTrue(skipGlobalPatching);
+}
 
+export default function apply() {
     function elemFromPoint(this: Document, left: number, top: number) {
         const element = elementFromPoint.call(this, left, top);
         if (isNull(element)) {


### PR DESCRIPTION
## Details
Provide a way for core folks to bypass shadow semantics on document and document.body(shoot themselves in the foot)

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No


