### PR TITLE
test: include prerelease versions in the version check

### DIFF
--- a/scripts/tasks/version-check.js
+++ b/scripts/tasks/version-check.js
@@ -23,7 +23,9 @@ for (const location of PACKAGES) {
     for (const dep of Object.keys(peerDependencies)) {
         if (
             devDependencies.hasOwnProperty(dep) &&
-            !semver.satisfies(devDependencies[dep], peerDependencies[dep])
+            !semver.satisfies(devDependencies[dep], peerDependencies[dep], {
+                includePrerelease: true,
+            })
         ) {
             const error = [
                 `Peer and dev versions of ${dep} in ${name} are out of sync.`,


### PR DESCRIPTION
## Details
Relax the version check to account for non-semantic core versions. This should be fine because this check is just to make sure our peer deps are aligned across our packages.

## Does this PR introduce a breaking change?
No