### PR TITLE
fix(synthetic-shadow): new added tests using the old test utils

### DIFF
--- a/packages/integration-karma/test/polyfills/html-collection/index.spec.js
+++ b/packages/integration-karma/test/polyfills/html-collection/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'test-utils';
+import { createElement } from 'lwc';
 import XTest from 'x/test';
 
 describe('HTMLCollection', () => {

--- a/packages/integration-karma/test/polyfills/node-list/index.spec.js
+++ b/packages/integration-karma/test/polyfills/node-list/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'test-utils';
+import { createElement } from 'lwc';
 import XTest from 'x/test';
 
 describe('NodeList', () => {


### PR DESCRIPTION
## Details

test utils' createElement was removed since it is not longer necessary. using lwc directly now. These new karma tests were added by another PR and the merge didn't help to identify them.

## Does this PR introduce a breaking change?

* No