### PR TITLE
docs(rollup-plugin): add missing README

### DIFF
--- a/packages/@lwc/rollup-plugin/README.md
+++ b/packages/@lwc/rollup-plugin/README.md
@@ -24,7 +24,7 @@ export default {
 
 ## Options
 
--   `rootDir` (string, optional) - set the LWC module directory, when not set the `rootDir` is set to the `input` directory
+-   `rootDir` (string, optional, default: `input`) - set the LWC module directory
 -   `sourcemap` (boolean, optional, default: `false`) - make the LWC compiler produce source maps
 -   `resolveFromPackages` (boolean, optional, default: `true`) - let the rollup plugin resolve modules from the `node_modules` directory
--   `stylesheetConfig` (object, optional) - the configuration to pass to the `@lwc/style-compiler`
+-   `stylesheetConfig` (object, optional, default: `{}`) - the configuration to pass to the `@lwc/style-compiler`


### PR DESCRIPTION
## Details

This PR adds the missing `README.md` to the `@lwc/rollup-plugin` package.

## Is this PR free of breaking changes?

* ✅ `Yes`

If no, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe issue being fixed or feature enhanced? ✅