### PR TITLE
fix: the link of the license must be uppercased

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ If you have a general question, post it on the [Salesforce stackexchange](https:
 
 ## License
 
-The [MIT license](license) governs your use of Lightning Web Components.
+The [MIT license](LICENSE) governs your use of Lightning Web Components.


### PR DESCRIPTION
## Details

The link to the license in the README was broken because GitHub URLs to are case sensitive.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`