### PR TITLE
fix: use absolute license/contributing links and place at bottom.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # Lightning Web Components Repository
 
-This repository contains the source code for the Lightning Web Components Engine and Compiler. Additionally, it contains examples, documentation, meeting notes and discussion notes for developers [contributing](contributing) or using Lightning Web Components. 
+This repository contains the source code for the Lightning Web Components Engine and Compiler. Additionally, it contains examples, documentation, meeting notes and discussion notes for developers [contributing][contributing] or using Lightning Web Components. 
 
 ## Getting Started
 
-Read the [Lightning Web Components Dev Guide](https://lwc.dev/guide/introduction).
+Read the [Lightning Web Components Dev Guide][introduction].
 
 ## Contributing
 
-To set up your environment and start contributing, read our [contributing documentation](contributing).
+To set up your environment and start contributing, read our [contributing documentation][contributing].
 
 ## Questions
 
-If you have a general question, post it on the [Salesforce stackexchange](https://salesforce.stackexchange.com/questions/tagged/lightning-web-components) and tag it with **`lightning-web-components`**.
+If you have a general question, post it on the [Salesforce stackexchange][salesforce-stackexchange] and tag it with **`lightning-web-components`**.
 
 ## License
 
-The [MIT license](license) governs your use of Lightning Web Components.
+The [MIT license][license] governs your use of Lightning Web Components.
+
+[introduction]: https://lwc.dev/guide/introduction
+[salesforce-stackexchange]: https://salesforce.stackexchange.com/questions/tagged/lightning-web-components
+[contributing]: https://github.com/salesforce/lwc/blob/master/CONTRIBUTING.md
+[license]: https://github.com/salesforce/lwc/blob/master/LICENSE


### PR DESCRIPTION
## Details

- Update link for license to full path
- Update link for contributing to full path
- Update links inline to the bottom of the readme.md

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe issue being fixed or feature enhanced? ✅
