### PR TITLE
chore: upgrade es5-proxy-compat to v0.21.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,106 +1,113 @@
 {
-  "name": "lwc",
-  "private": true,
-  "description": "Lightning Web Components",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/salesforce/lwc.git"
-  },
-  "scripts": {
-    "prepare": "yarn build",
-    "clean": "lerna run clean && lerna clean --yes && rm -rf node_modules",
-    "lint": "eslint packages/ scripts/ --ext=js,ts --rulesdir=./scripts/eslint/rules",
-    "format": "prettier --write '{packages,scripts}/**/*.{js,ts,json,md}'",
-    "build": "lerna run build --ignore perf-benchmarks --ignore integration-tests",
-    "test": "jest --config ./scripts/jest/root.config.js",
-    "test:ci": "lerna run --concurrency=1 --stream test -- --no-cache --runInBand --coverage",
-    "test:integration": "lerna exec --scope integration-tests -- yarn sauce",
-    "test:performance": "lerna exec --scope perf-benchmarks -- best --runner remote",
-    "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
-    "release:ci:npm": "./scripts/release_npm.sh",
-    "release:ci:changelog": "./scripts/release_changelog.sh",
-    "release:ci:dist-tags": "./scripts/release_dist-tags.sh"
-  },
-  "devDependencies": {
-    "@babel/core": "7.1.0",
-    "@commitlint/cli": "^6.2.0",
-    "@commitlint/config-conventional": "^6.1.3",
-    "@types/acorn": "~4.0.3",
-    "@types/jest": "~23.0.0",
-    "@types/node": "8.9.4",
-    "@typescript-eslint/eslint-plugin": "^1.3.0",
-    "@typescript-eslint/parser": "^1.3.0",
-    "aws-sdk": "~2.378.0",
-    "commitizen": "~2.9.6",
-    "concurrently": "^3.5.1",
-    "conventional-changelog-cli": "~1.3.5",
-    "cz-conventional-changelog": "~2.1.0",
-    "es5-proxy-compat": "0.21.4",
-    "eslint": "^5.13.0",
-    "execa": "^1.0.0",
-    "glob": "^7.1.2",
-    "husky": "^1.3.1",
-    "isbinaryfile": "^3.0.3",
-    "jest": "^24.0.0",
-    "jest-environment-jsdom-fifteen": "^1.0.0",
-    "lerna": "3.7.1",
-    "lint-staged": "^8.1.4",
-    "mime-types": "~2.1.21",
-    "prettier": "^1.16.4",
-    "rollup": "~1.7.4",
-    "rollup-plugin-cleanup": "~3.1.1",
-    "rollup-plugin-compat": "0.21.4",
-    "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-terser": "~4.0.4",
-    "rollup-plugin-typescript": "^1.0.0",
-    "semver": "^5.5.0",
-    "ts-jest": "^24.0.0",
-    "tslib": "^1.9.3",
-    "typescript": "3.3.3"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "commit-msg": "commitlint -e $GIT_PARAMS"
-    }
-  },
-  "lint-staged": {
-    "**/*.{js,ts}": [
-      "eslint --rulesdir=./scripts/eslint/rules"
+    "name": "lwc",
+    "private": true,
+    "description": "Lightning Web Components",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git"
+    },
+    "scripts": {
+        "prepare": "yarn build",
+        "clean": "lerna run clean && lerna clean --yes && rm -rf node_modules",
+        "lint": "eslint packages/ scripts/ --ext=js,ts --rulesdir=./scripts/eslint/rules",
+        "format": "prettier --write '{packages,scripts}/**/*.{js,ts,json,md}'",
+        "build": "lerna run build --ignore perf-benchmarks --ignore integration-tests",
+        "test": "jest --config ./scripts/jest/root.config.js",
+        "test:ci": "lerna run --concurrency=1 --stream test -- --no-cache --runInBand --coverage",
+        "test:integration": "lerna exec --scope integration-tests -- yarn sauce",
+        "test:performance": "lerna exec --scope perf-benchmarks -- best --runner remote",
+        "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
+        "release:ci:npm": "./scripts/release_npm.sh",
+        "release:ci:changelog": "./scripts/release_changelog.sh",
+        "release:ci:dist-tags": "./scripts/release_dist-tags.sh"
+    },
+    "devDependencies": {
+        "@babel/core": "7.1.0",
+        "@commitlint/cli": "^6.2.0",
+        "@commitlint/config-conventional": "^6.1.3",
+        "@types/acorn": "~4.0.3",
+        "@types/jest": "~23.0.0",
+        "@types/node": "8.9.4",
+        "@typescript-eslint/eslint-plugin": "^1.3.0",
+        "@typescript-eslint/parser": "^1.3.0",
+        "aws-sdk": "~2.378.0",
+        "commitizen": "~2.9.6",
+        "concurrently": "^3.5.1",
+        "conventional-changelog-cli": "~1.3.5",
+        "cz-conventional-changelog": "~2.1.0",
+        "es5-proxy-compat": "0.21.5",
+        "eslint": "^5.13.0",
+        "execa": "^1.0.0",
+        "glob": "^7.1.2",
+        "husky": "^1.3.1",
+        "isbinaryfile": "^3.0.3",
+        "jest": "^24.0.0",
+        "jest-environment-jsdom-fifteen": "^1.0.0",
+        "lerna": "3.7.1",
+        "lint-staged": "^8.1.4",
+        "mime-types": "~2.1.21",
+        "prettier": "^1.16.4",
+        "rollup": "~1.7.4",
+        "rollup-plugin-cleanup": "~3.1.1",
+        "rollup-plugin-compat": "0.21.5",
+        "rollup-plugin-node-resolve": "^4.0.0",
+        "rollup-plugin-replace": "^2.1.0",
+        "rollup-plugin-terser": "~4.0.4",
+        "rollup-plugin-typescript": "^1.0.0",
+        "semver": "^5.5.0",
+        "ts-jest": "^24.0.0",
+        "tslib": "^1.9.3",
+        "typescript": "3.3.3"
+    },
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog"
+        }
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged",
+            "commit-msg": "commitlint -e $GIT_PARAMS"
+        }
+    },
+    "lint-staged": {
+        "**/*.{js,ts}": ["eslint --rulesdir=./scripts/eslint/rules"],
+        "{packages,scripts}/**/*.{js,ts,json,md}": ["prettier --write", "git add"]
+    },
+    "workspaces": [
+        "packages/@lwc/*",
+        "packages/integration-karma",
+        "packages/integration-tests",
+        "packages/perf-benchmarks"
     ],
-    "{packages,scripts}/**/*.{js,ts,json,md}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "workspaces": [
-    "packages/@lwc/*",
-    "packages/integration-karma",
-    "packages/integration-tests",
-    "packages/perf-benchmarks"
-  ],
-  "engines": {
-    "node": ">=8.9.0",
-    "yarn": ">=1.10.1"
-  },
-  "resolutions": {
-    "@best/analyzer": "http://npm.lwcjs.org/@best/analyzer/-/@best/analyzer-0.6.4/50a8665f0a793ac3bb26b7203c6073dd80375524.tgz",
-    "@best/store-fs": "http://npm.lwcjs.org/@best/store-fs/-/@best/store-fs-0.6.4/3753eae1d2a41acb2ae312b75553818b87696286.tgz",
-    "@best/build": "http://npm.lwcjs.org/@best/build/-/@best/build-0.6.4/87209197048580de6c75981566f7ac7989daa983.tgz",
-    "@best/store": "http://npm.lwcjs.org/@best/store/-/@best/store-0.6.4/e9db2a38416cb9a3bd9bcdf8df88d86f16b163ff.tgz",
-    "@best/runner": "http://npm.lwcjs.org/@best/runner/-/@best/runner-0.6.4/90df754fc18261d1b3a3a2a06bf6f88040152c5e.tgz",
-    "@best/runtime": "http://npm.lwcjs.org/@best/runtime/-/@best/runtime-0.6.4/ca6db6026736cb3316ddea242559c46ed449dbce.tgz",
-    "@best/messager": "http://npm.lwcjs.org/@best/messager/-/@best/messager-0.6.4/cf489639e7e0583979572e496ef35725f28fbc8d.tgz",
-    "@best/utils": "http://npm.lwcjs.org/@best/utils/-/@best/utils-0.6.4/fd71038d57264c558d5994a731444c327af126e6.tgz",
-    "@best/github-integration": "http://npm.lwcjs.org/@best/github-integration/-/@best/github-integration-0.6.4/e44153436296157b28b58f933b32f01b3dde6396.tgz",
-    "@best/config": "http://npm.lwcjs.org/@best/config/-/@best/config-0.6.4/d79cfec64bacee387fcab7326385226db7a95488.tgz",
-    "@best/regex-util": "http://npm.lwcjs.org/@best/regex-util/-/@best/regex-util-0.6.4/62266c441ed3a4dac8a70d24edb2dc3699eb227c.tgz",
-    "@best/compare": "http://npm.lwcjs.org/@best/compare/-/@best/compare-0.6.4/847b5292def6f7de36970159a71cbdbc297365db.tgz"
-  }
+    "engines": {
+        "node": ">=8.9.0",
+        "yarn": ">=1.10.1"
+    },
+    "resolutions": {
+        "@best/analyzer":
+            "http://npm.lwcjs.org/@best/analyzer/-/@best/analyzer-0.6.4/50a8665f0a793ac3bb26b7203c6073dd80375524.tgz",
+        "@best/store-fs":
+            "http://npm.lwcjs.org/@best/store-fs/-/@best/store-fs-0.6.4/3753eae1d2a41acb2ae312b75553818b87696286.tgz",
+        "@best/build":
+            "http://npm.lwcjs.org/@best/build/-/@best/build-0.6.4/87209197048580de6c75981566f7ac7989daa983.tgz",
+        "@best/store":
+            "http://npm.lwcjs.org/@best/store/-/@best/store-0.6.4/e9db2a38416cb9a3bd9bcdf8df88d86f16b163ff.tgz",
+        "@best/runner":
+            "http://npm.lwcjs.org/@best/runner/-/@best/runner-0.6.4/90df754fc18261d1b3a3a2a06bf6f88040152c5e.tgz",
+        "@best/runtime":
+            "http://npm.lwcjs.org/@best/runtime/-/@best/runtime-0.6.4/ca6db6026736cb3316ddea242559c46ed449dbce.tgz",
+        "@best/messager":
+            "http://npm.lwcjs.org/@best/messager/-/@best/messager-0.6.4/cf489639e7e0583979572e496ef35725f28fbc8d.tgz",
+        "@best/utils":
+            "http://npm.lwcjs.org/@best/utils/-/@best/utils-0.6.4/fd71038d57264c558d5994a731444c327af126e6.tgz",
+        "@best/github-integration":
+            "http://npm.lwcjs.org/@best/github-integration/-/@best/github-integration-0.6.4/e44153436296157b28b58f933b32f01b3dde6396.tgz",
+        "@best/config":
+            "http://npm.lwcjs.org/@best/config/-/@best/config-0.6.4/d79cfec64bacee387fcab7326385226db7a95488.tgz",
+        "@best/regex-util":
+            "http://npm.lwcjs.org/@best/regex-util/-/@best/regex-util-0.6.4/62266c441ed3a4dac8a70d24edb2dc3699eb227c.tgz",
+        "@best/compare":
+            "http://npm.lwcjs.org/@best/compare/-/@best/compare-0.6.4/847b5292def6f7de36970159a71cbdbc297365db.tgz"
+    }
 }

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -17,7 +17,7 @@
         "@lwc/errors": "1.0.0",
         "@lwc/style-compiler": "1.0.0",
         "@lwc/template-compiler": "1.0.0",
-        "babel-preset-compat": "0.21.4",
+        "babel-preset-compat": "0.21.5",
         "rollup": "^1.7.4",
         "rollup-plugin-replace": "^2.1.0",
         "terser": "^3.17.0"

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -26,7 +26,7 @@
         "@lwc/rollup-plugin": "1.0.0",
         "@lwc/synthetic-shadow": "1.0.0",
         "@lwc/wire-service": "1.0.0",
-        "compat-polyfills": "0.21.4",
+        "compat-polyfills": "0.21.5",
         "deepmerge": "^1.5.2",
         "dotenv": "^4.0.0",
         "fs-extra": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,7 +49,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0":
+"@babel/generator@7.0.0", "@babel/generator@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0.tgz#1efd58bffa951dc846449e58ce3a1d7f02d393aa"
   integrity sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==
@@ -244,6 +244,15 @@
   integrity sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==
   dependencies:
     "@babel/helper-function-name" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helpers@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.1.0.tgz#429bf0f0020be56a4242883432084e3d70a8a141"
+  integrity sha512-V1jXUTNdTpBn37wqqN73U+eBpzlLHmxA4aDaghJBggmzly/FpIJMHXse9lgdzQQT4gs5jZ5NmYxOL8G3ROc29g==
+  dependencies:
     "@babel/template" "^7.1.0"
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -2175,10 +2184,16 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-babel-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/babel-compat/-/babel-compat-0.21.4.tgz#f815a8adc5bad2192f2288090feab37288afbf30"
-  integrity sha512-SJ6MiMKhKD/mCBQgD4u6cz8X/dRPdL6pvMu+pQoDOIX9tbFHcv6FI3dZ06KG0ywx9w8L6L5RtLoc+/qXclZbcg==
+babel-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/babel-compat/-/babel-compat-0.21.5.tgz#477afdb7a61515b50a81e90cc29171f37a7a54dc"
+  integrity sha512-bI/q1DDNV273F8RJmhuyfKf8fs2yMTo4RpXYmUofZdiuMHXIepDzbUfjl8o/L/mUGvmOXR8NMREbbcGL25Djfw==
+  dependencies:
+    "@babel/core" "7.1.0"
+    "@babel/generator" "7.0.0"
+    "@babel/helpers" "7.1.0"
+    "@babel/types" "7.0.0"
+    regenerator-runtime "^0.12.0"
 
 babel-jest@^24.0.0:
   version "24.0.0"
@@ -2202,10 +2217,10 @@ babel-plugin-jest-hoist@^24.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.0.0.tgz#3adf030b6fd67e4311479a54b24077bdfc226ec9"
   integrity sha512-ipefE7YWNyRNVaV/MonUb/I5nef53ZRFR74P9meMGmJxqt8s1BJmfhw11YeIMbcjXN4fxtWUaskZZe8yreXE1Q==
 
-babel-plugin-transform-proxy-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.21.4.tgz#082495c3436287291b88567d1eccc868ed3846eb"
-  integrity sha512-B+IBmsnXMfyPldmELqQwgpfiyrEiahwnyhUsa3HLNpkXqznUNj6b8tbtW9BSRtpGEhkgbaEZBGYLOr40GqnpoQ==
+babel-plugin-transform-proxy-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-proxy-compat/-/babel-plugin-transform-proxy-compat-0.21.5.tgz#f351c5630bafd807f3251588312ce72d451c9b3d"
+  integrity sha512-dCS2cZywzNKvTs9Fpkb67SHQviqibmQZaVVv/+VmMemZ+ZriefgV/oJx00FLOxnV31y+FXyU/f+EMRIf797Uxw==
   dependencies:
     "@babel/types" "7.0.0"
 
@@ -2218,10 +2233,10 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/babel-preset-compat/-/babel-preset-compat-0.21.4.tgz#7dbd391271534afbf9188c9ba6a33e9a84cad823"
-  integrity sha512-1B1ULWnXsvkibWcCUa79TQ2Ct0Ns5DO8IiB2FLa8xD8SwwEHfHqCCJBSoZNPXiaf6ekFBnNG2f1jKIrZXNvfCg==
+babel-preset-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/babel-preset-compat/-/babel-preset-compat-0.21.5.tgz#43eca27a571d0f7365dbc193852d5bb74afc5ab5"
+  integrity sha512-dJKautD8EmpFq4lIsL1sbe9iECu4OeM1+GpV6mgY0J2DgUsrZWjMJL4BjiRvp/StS+Yp9Ajq+YlJZNtyVZdcmg==
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.1.0"
     "@babel/plugin-proposal-object-rest-spread" "7.0.0"
@@ -2252,7 +2267,7 @@ babel-preset-compat@0.21.4:
     "@babel/plugin-transform-template-literals" "7.0.0"
     "@babel/plugin-transform-typeof-symbol" "7.0.0"
     "@babel/plugin-transform-unicode-regex" "7.0.0"
-    babel-plugin-transform-proxy-compat "0.21.4"
+    babel-plugin-transform-proxy-compat "0.21.5"
 
 babel-preset-jest@^24.0.0:
   version "24.0.0"
@@ -3075,10 +3090,10 @@ compare-versions@^3.2.1:
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.4.0.tgz#e0747df5c9cb7f054d6d3dc3e1dbc444f9e92b26"
   integrity sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==
 
-compat-polyfills@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/compat-polyfills/-/compat-polyfills-0.21.4.tgz#61198c7944018b74b543d06582095a8ae6112859"
-  integrity sha512-5bmAkcC/EtnparLnSvFKPyMnSbObvfgbZNgk9jqv5S2bXcGn+Gz0cJWhiBnA5Sb53suzHww1hAfbDAKMZeLXbg==
+compat-polyfills@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/compat-polyfills/-/compat-polyfills-0.21.5.tgz#fa48a9a8ed1cbe99ac4de5d20b1a7bbffdc41753"
+  integrity sha512-YusGuBLJV4UilOCsv8i10dLpaLPvvyV58/A5PUj8WNXmdS/xNIB5tEsUBzsvN3mo/LdD+0aNFS3LGIuJ7XWipA==
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -4166,16 +4181,16 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-proxy-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/es5-proxy-compat/-/es5-proxy-compat-0.21.4.tgz#f5edcec129925b7f9250bf03df718a1e44f00cdb"
-  integrity sha512-5GnqYjUX45OSFjoTBHiNNS88IngxJ46M/JFSJIPGVJPR8vfKyQ0q6aDAc1pEp709967+JB7eWnBKNQnWUdoEQA==
+es5-proxy-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/es5-proxy-compat/-/es5-proxy-compat-0.21.5.tgz#932a61d64202f146635a6f1f711572bfb0725291"
+  integrity sha512-fXA6BC12IRd2Y7v9eX6o00exII2pu9yvTM7ROweDKWw3e3Nspg0tZGAqWzXzBSfxw68hUTa4gZF6M7Zr/c3+Uw==
   dependencies:
-    babel-compat "0.21.4"
-    babel-plugin-transform-proxy-compat "0.21.4"
-    babel-preset-compat "0.21.4"
-    compat-polyfills "0.21.4"
-    proxy-compat "0.21.4"
+    babel-compat "0.21.5"
+    babel-plugin-transform-proxy-compat "0.21.5"
+    babel-preset-compat "0.21.5"
+    compat-polyfills "0.21.5"
+    proxy-compat "0.21.5"
 
 es6-promise@^4.0.3:
   version "4.2.5"
@@ -9374,10 +9389,10 @@ proxy-addr@~2.0.4:
     forwarded "~0.1.2"
     ipaddr.js "1.8.0"
 
-proxy-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/proxy-compat/-/proxy-compat-0.21.4.tgz#84c6d3536101c7cc71c121ed4e5a7c25ff296393"
-  integrity sha512-MYx/BYP5F6BqdhEX6mCpofB7YwfzCynrt0cZYIJPFQLODg0SSQOHwNUkgf213ed76ZgtvqfrATx1WmGDNL8daQ==
+proxy-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/proxy-compat/-/proxy-compat-0.21.5.tgz#69a8ea416e5ac2d8d8af52664e5f2558da8c72fb"
+  integrity sha512-FALEWfakYKzFh/Pj3agFF51UIyRCnHa9/guNXOyCNKYaJEJxhao915BKDAHSPSQJUznjwBWA9RkHZniiQNmn4A==
 
 proxy-from-env@^1.0.0:
   version "1.0.0"
@@ -10025,13 +10040,13 @@ rollup-plugin-cleanup@~3.1.1:
     js-cleanup "^1.0.1"
     rollup-pluginutils "^2.3.3"
 
-rollup-plugin-compat@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/rollup-plugin-compat/-/rollup-plugin-compat-0.21.4.tgz#5b6841e3d92442e61bfab737f3751f3ba5ef3f7d"
-  integrity sha512-SD0Wx1TwY0yCPpq9x2r7Bx/RdQ0mHkE4SfrC/IjZKPnIN6b1yWCsa1wUATFpyIQu9XTrwYVmvXdKL1fMRXBcUw==
+rollup-plugin-compat@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-compat/-/rollup-plugin-compat-0.21.5.tgz#75265bfe88e07495e08f150bb336292779f8e8d9"
+  integrity sha512-xQOr4Id5MyZPLdVbrgR4Y/9pB4f+dQYVv+Kd0aJN/R6kNUjj4nCddUqsNBNMHI6n+FHziDFgzVRxNvaIQY058A==
   dependencies:
     "@babel/core" "7.1.0"
-    es5-proxy-compat "0.21.4"
+    es5-proxy-compat "0.21.5"
     magic-string "~0.25.1"
     rollup-pluginutils "~2.0.1"
 


### PR DESCRIPTION
## Details

Upgrade es5-proxy-compat to v0.21.5 to include fix for https://github.com/salesforce/es5-proxy-compat/issues/116. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe issue being fixed or feature enhanced? ✅
