### PR TITLE
chore: bump nodejs dependency to lts dubnium

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to Lightning Web Components
-We want to encourage the developer community to contribute to Lightning Web Components. This guide has instructions to install, build, test and contribute to the framework. 
+We want to encourage the developer community to contribute to Lightning Web Components. This guide has instructions to install, build, test and contribute to the framework.
 
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -11,8 +11,7 @@ Before you start, familiarize yourself with [Lightning Web Components](https://l
 
 ## Requirements
 
- * Node 8.x
- * NPM 6.x
+ * Node >= 10.13.0
  * Yarn >= 1.6
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "packages/perf-benchmarks"
   ],
   "engines": {
-    "node": ">=8.9.0",
+    "node": ">=10.13.0",
     "yarn": ">=1.10.1"
   },
   "resolutions": {


### PR DESCRIPTION
## Details

Bump Node.js dependency to `>=10.13.0` (LTS Dubnium).

https://github.com/nodejs/node/blob/b1bd9e3dd210d6b20d94c50758e12e93d9dbb3db/doc/changelogs/CHANGELOG_V10.md#nodejs-10-changelog

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`