### PR TITLE
fix: issue #1304 activeElement should be patched in the prototype

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -56,7 +56,6 @@ export default function apply() {
     Document.prototype.elementFromPoint = elemFromPoint as (left: number, top: number) => Element;
 
     // Go until we reach to top of the LWC tree
-    // TODO: #1304 - this should be patched on Document.prototype instead
     defineProperty(Document.prototype, 'activeElement', {
         get(this: Document): Element | null {
             let node = DocumentPrototypeActiveElement.call(this);

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -57,7 +57,7 @@ export default function apply() {
 
     // Go until we reach to top of the LWC tree
     // TODO: #1304 - this should be patched on Document.prototype instead
-    defineProperty(document, 'activeElement', {
+    defineProperty(Document.prototype, 'activeElement', {
         get(this: Document): Element | null {
             let node = DocumentPrototypeActiveElement.call(this);
 


### PR DESCRIPTION
## Details

Addresses https://github.com/salesforce/lwc/issues/1304

In the synthetic shadow we patch the `activeElement` on the document. this PR patch changes this behavior patching the `activeElement` in the `Document.prototype`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`