### PR TITLE
fix(engine): update typescript to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semver": "^5.5.0",
     "ts-jest": "^24.0.0",
     "tslib": "^1.9.3",
-    "typescript": "3.3.3"
+    "typescript": "3.5.1"
   },
   "config": {
     "commitizen": {

--- a/packages/@lwc/engine/types/engine.d.ts
+++ b/packages/@lwc/engine/types/engine.d.ts
@@ -98,6 +98,7 @@ declare module 'lwc' {
         role: string | null;
     }
 
+    // @ts-ignore type-mismatch
     interface ShadowRootTheGoodPart extends NodeSelector {
         mode: string;
         readonly activeElement: Element | null;

--- a/packages/@lwc/template-compiler/src/shared/scope.ts
+++ b/packages/@lwc/template-compiler/src/shared/scope.ts
@@ -60,7 +60,7 @@ export function bindExpression(
     applyBinding: boolean = true
 ): BindingResult {
     const wrappedExpression = types.expressionStatement(expression);
-    const boundIdentifiers = new Set();
+    const boundIdentifiers: Set<string> = new Set();
 
     traverse(wrappedExpression, {
         noScope: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11575,10 +11575,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
## Details

This solves some inconsistencies between vscode and build, specifically `ShadowRoot` as interface and global variable at the same time for PR #1322

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`