### PR TITLE
chore: add shadow semantics to sequential focus navigation

### DIFF
--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/integration/tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/integration/tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.html
@@ -2,7 +2,11 @@
     <input class="first-outside" placeholder="first (outside)">
     <input class="second-outside" placeholder="second (outside)">
     <div>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
         <integration-child class="should-never-receive-focus" tabindex="-1" data-id="click-target"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
     </div>
     <input class="third-outside" placeholder="third (outside)">
     <input class="fourth-outside" placeholder="fourth (outside)">

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/integration/tabindex-negative/tabindex-negative.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/integration/tabindex-negative/tabindex-negative.html
@@ -2,7 +2,11 @@
     <input class="first-outside" placeholder="first (outside)">
     <input class="second-outside" placeholder="second (outside)">
     <div>
-        <integration-child tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
+        <integration-child class="should-never-receive-focus" tabindex="-1"></integration-child>
     </div>
     <input class="third-outside" placeholder="third (outside)">
     <input class="fourth-outside" placeholder="fourth (outside)">

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <button>child button (should never be tabbed to)</button>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <integration-child tabindex="-1"></integration-child>
+    <input placeholder="parent input" class="parent">
+    <integration-child tabindex="-1"></integration-child>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/parent/parent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.html
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.html
@@ -1,0 +1,5 @@
+<template>
+    <input placeholder="first outer input" class="first">
+    <integration-parent tabindex="0"></integration-parent>
+    <input placeholder="last outer input" class="last">
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/integration/tabindex-zero-internal-tabindex-negative/tabindex-zero-internal-tabindex-negative.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+const URL = 'http://localhost:4567/tabindex-zero-internal-tabindex-negative';
+
+describe('Tab navigation when tabindex 0', () => {
+    beforeEach(() => {
+        browser.url(URL);
+    });
+
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (forward)', function() {
+        const firstInput = browser.execute(function() {
+            return document
+                .querySelector('integration-tabindex-zero-internal-tabindex-negative')
+                .shadowRoot.querySelector('.first');
+        });
+        firstInput.click();
+
+        browser.keys(['Tab']);
+
+        var tagName = browser.execute(function() {
+            var container = document.activeElement;
+            var parent = container.shadowRoot.activeElement;
+            var input = parent.shadowRoot.activeElement;
+            return input.tagName;
+        }).value;
+
+        assert.equal(tagName, 'INPUT');
+    });
+
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (backward)', function() {
+        const lastInput = browser.execute(function() {
+            return document
+                .querySelector('integration-tabindex-zero-internal-tabindex-negative')
+                .shadowRoot.querySelector('.last');
+        });
+        lastInput.click();
+
+        browser.keys(['Shift', 'Tab', 'Shift']);
+
+        var tagName = browser.execute(function() {
+            var container = document.activeElement;
+            var parent = container.shadowRoot.activeElement;
+            var input = parent.shadowRoot.activeElement;
+            return input.tagName;
+        }).value;
+
+        assert.equal(tagName, 'INPUT');
+    });
+});


### PR DESCRIPTION
## Details

This release aims to reduce the breadth of changes shipping to core for v1.0.0 and isolate potential issues around adding shadow semantics to sequential focus navigation.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

This PR introduces breaking changes for consumers of delegatesFocus (i.e., base components), which have been addressed.