### PR TITLE
refactor(wire-service): introducing LinkContextEvent

### DIFF
--- a/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as target from '../wiring';
+import { ValueChangedEvent } from '../value-changed-event';
 import {
     CONTEXT_ID,
     CONTEXT_CONNECTED,
@@ -14,7 +15,7 @@ import {
     CONTEXT_UPDATED,
     CONFIG,
 } from '../constants';
-import { Element, ElementDef, WireDef } from '../engine';
+import { LightningElement, ElementDef, WireDef } from '../engine';
 import * as dependency from '../property-trap';
 
 describe('WireEventTarget', () => {
@@ -28,7 +29,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [dupeListener];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -47,7 +48,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -69,7 +70,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [dupeListener];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -90,7 +91,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -110,7 +111,7 @@ describe('WireEventTarget', () => {
                     adapter: {},
                 };
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -129,7 +130,7 @@ describe('WireEventTarget', () => {
                     },
                 };
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -150,7 +151,7 @@ describe('WireEventTarget', () => {
                 (dependency as any).installTrap = jest.fn();
                 (dependency as any).updated = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -178,7 +179,7 @@ describe('WireEventTarget', () => {
                 const { updated } = dependency;
                 (dependency as any).updated = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -204,7 +205,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -215,7 +216,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalled();
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -242,7 +243,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -253,7 +254,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalledTimes(1);
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -286,7 +287,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext1,
                     mockWireDef,
@@ -297,7 +298,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalled();
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as Element,
+                    {} as LightningElement,
                     {} as ElementDef,
                     mockContext2,
                     mockWireDef,
@@ -313,7 +314,7 @@ describe('WireEventTarget', () => {
 
         it('throws when event type is not supported', () => {
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,
@@ -336,7 +337,7 @@ describe('WireEventTarget', () => {
             mockContext[CONTEXT_ID] = Object.create(null);
             mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [listener];
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 mockContext,
                 {} as WireDef,
@@ -353,7 +354,7 @@ describe('WireEventTarget', () => {
             mockContext[CONTEXT_ID] = Object.create(null);
             mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [listener];
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 mockContext,
                 {} as WireDef,
@@ -379,7 +380,7 @@ describe('WireEventTarget', () => {
                 },
             };
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 mockContext,
                 mockWireDef,
@@ -405,7 +406,7 @@ describe('WireEventTarget', () => {
                 },
             };
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 mockContext,
                 mockWireDef,
@@ -416,7 +417,7 @@ describe('WireEventTarget', () => {
         });
         it('throws when event type is not supported', () => {
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,
@@ -442,7 +443,7 @@ describe('WireEventTarget', () => {
                 {} as WireDef,
                 'test'
             );
-            wireEventTarget.dispatchEvent(new target.ValueChangedEvent('value'));
+            wireEventTarget.dispatchEvent(new ValueChangedEvent('value'));
             expect(mockCmp.test).toBe('value');
         });
         it('invokes wired method when ValueChangedEvent received', () => {
@@ -459,21 +460,21 @@ describe('WireEventTarget', () => {
                 { method: 1 } as WireDef,
                 'test'
             );
-            wireEventTarget.dispatchEvent(new target.ValueChangedEvent('value'));
+            wireEventTarget.dispatchEvent(new ValueChangedEvent('value'));
             expect(actual).toBe('value');
         });
         it('throws on non-ValueChangedEvent', () => {
             const test = {};
             test.toString = () => 'test';
             const wireEventTarget = new target.WireEventTarget(
-                {} as Element,
+                {} as LightningElement,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,
                 'test'
             );
             expect(() => {
-                wireEventTarget.dispatchEvent(test as target.ValueChangedEvent);
+                wireEventTarget.dispatchEvent(test as ValueChangedEvent);
             }).toThrowError('Invalid event test.');
         });
     });

--- a/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
@@ -6,6 +6,7 @@
  */
 import * as target from '../wiring';
 import { ValueChangedEvent } from '../value-changed-event';
+import { LinkContextEvent } from '../link-context-event';
 import {
     CONTEXT_ID,
     CONTEXT_CONNECTED,
@@ -15,7 +16,7 @@ import {
     CONTEXT_UPDATED,
     CONFIG,
 } from '../constants';
-import { LightningElement, ElementDef, WireDef } from '../engine';
+import { ElementDef, WireDef } from '../engine';
 import * as dependency from '../property-trap';
 
 describe('WireEventTarget', () => {
@@ -29,7 +30,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [dupeListener];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -48,7 +49,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -70,7 +71,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [dupeListener];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -91,7 +92,7 @@ describe('WireEventTarget', () => {
                 mockContext[CONTEXT_ID] = Object.create(null);
                 mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [];
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     {} as WireDef,
@@ -111,7 +112,7 @@ describe('WireEventTarget', () => {
                     adapter: {},
                 };
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -130,7 +131,7 @@ describe('WireEventTarget', () => {
                     },
                 };
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -151,7 +152,7 @@ describe('WireEventTarget', () => {
                 (dependency as any).installTrap = jest.fn();
                 (dependency as any).updated = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     {} as target.Context,
                     mockWireDef,
@@ -179,7 +180,7 @@ describe('WireEventTarget', () => {
                 const { updated } = dependency;
                 (dependency as any).updated = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -205,7 +206,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -216,7 +217,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalled();
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -243,7 +244,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -254,7 +255,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalledTimes(1);
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext,
                     mockWireDef,
@@ -287,7 +288,7 @@ describe('WireEventTarget', () => {
                 const { installTrap } = dependency;
                 (dependency as any).installTrap = jest.fn();
                 const wireEventTarget = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext1,
                     mockWireDef,
@@ -298,7 +299,7 @@ describe('WireEventTarget', () => {
                 });
                 expect(dependency.installTrap).toHaveBeenCalled();
                 const wireEventTarget1 = new target.WireEventTarget(
-                    {} as LightningElement,
+                    {} as EventTarget,
                     {} as ElementDef,
                     mockContext2,
                     mockWireDef,
@@ -314,7 +315,7 @@ describe('WireEventTarget', () => {
 
         it('throws when event type is not supported', () => {
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,
@@ -337,7 +338,7 @@ describe('WireEventTarget', () => {
             mockContext[CONTEXT_ID] = Object.create(null);
             mockContext[CONTEXT_ID][CONTEXT_CONNECTED] = [listener];
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 mockContext,
                 {} as WireDef,
@@ -354,7 +355,7 @@ describe('WireEventTarget', () => {
             mockContext[CONTEXT_ID] = Object.create(null);
             mockContext[CONTEXT_ID][CONTEXT_DISCONNECTED] = [listener];
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 mockContext,
                 {} as WireDef,
@@ -380,7 +381,7 @@ describe('WireEventTarget', () => {
                 },
             };
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 mockContext,
                 mockWireDef,
@@ -406,7 +407,7 @@ describe('WireEventTarget', () => {
                 },
             };
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 mockContext,
                 mockWireDef,
@@ -417,7 +418,7 @@ describe('WireEventTarget', () => {
         });
         it('throws when event type is not supported', () => {
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,
@@ -463,11 +464,34 @@ describe('WireEventTarget', () => {
             wireEventTarget.dispatchEvent(new ValueChangedEvent('value'));
             expect(actual).toBe('value');
         });
+        it('invokes dispatch method on element when LinkContextEvent received', () => {
+            expect.assertions(5);
+            function callback(data, disconnect) {
+                expect(data).toBe(1);
+                expect(disconnect).toBe(2);
+            }
+            const mockCmp = {
+                dispatchEvent(evt) {
+                    expect(evt.type).toBe('foo');
+                    expect(typeof evt.detail).toBe('function');
+                    expect(evt.detail).not.toBe(callback); // avoid side-channeling by not leaking the original callback
+                    evt.detail(1, 2);
+                },
+            };
+            const wireEventTarget = new target.WireEventTarget(
+                mockCmp as any,
+                {} as ElementDef,
+                {} as target.Context,
+                { method: 1 } as WireDef,
+                'test'
+            );
+            wireEventTarget.dispatchEvent(new LinkContextEvent('foo', callback));
+        });
         it('throws on non-ValueChangedEvent', () => {
             const test = {};
             test.toString = () => 'test';
             const wireEventTarget = new target.WireEventTarget(
-                {} as LightningElement,
+                {} as EventTarget,
                 {} as ElementDef,
                 {} as target.Context,
                 {} as WireDef,

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -20,8 +20,9 @@ import {
     Context,
     WireContext,
     WireEventTarget,
-    ValueChangedEvent,
 } from './wiring';
+import { ValueChangedEvent } from './value-changed-event';
+import { LinkContextEvent } from './link-context-event';
 
 export interface WireEventTarget {
     dispatchEvent(evt: ValueChangedEvent): boolean;
@@ -165,4 +166,4 @@ export function register(adapterId: any, adapterFactory: WireAdapterFactory) {
     adapterFactories.set(adapterId, adapterFactory);
 }
 
-export { ValueChangedEvent } from './wiring';
+export { ValueChangedEvent, LinkContextEvent };

--- a/packages/@lwc/wire-service/src/link-context-event.ts
+++ b/packages/@lwc/wire-service/src/link-context-event.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Event fired by wire adapters to link to a context provider
+ */
+export class LinkContextEvent {
+    type: string;
+    uid: string;
+    callback: (...args: any[]) => void;
+    constructor(uid, callback) {
+        this.type = 'LinkContextEvent';
+        this.uid = uid;
+        this.callback = callback;
+    }
+}

--- a/packages/@lwc/wire-service/src/link-context-event.ts
+++ b/packages/@lwc/wire-service/src/link-context-event.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+const LinkContextEventType = 'LinkContextEvent';
+
 /**
  * Event fired by wire adapters to link to a context provider
  */
@@ -12,8 +14,8 @@ export class LinkContextEvent {
     type: string;
     uid: string;
     callback: (...args: any[]) => void;
-    constructor(uid, callback) {
-        this.type = 'LinkContextEvent';
+    constructor(uid: string, callback: (...args: any[]) => void) {
+        this.type = LinkContextEventType;
         this.uid = uid;
         this.callback = callback;
     }

--- a/packages/@lwc/wire-service/src/value-changed-event.ts
+++ b/packages/@lwc/wire-service/src/value-changed-event.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Event fired by wire adapters to emit a new value.
+ */
+export class ValueChangedEvent {
+    value: any;
+    type: string;
+    constructor(value) {
+        this.type = 'ValueChangedEvent';
+        this.value = value;
+    }
+}

--- a/packages/@lwc/wire-service/src/value-changed-event.ts
+++ b/packages/@lwc/wire-service/src/value-changed-event.ts
@@ -5,14 +5,16 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+const ValueChangedEventType = 'ValueChangedEvent';
+
 /**
  * Event fired by wire adapters to emit a new value.
  */
 export class ValueChangedEvent {
     value: any;
     type: string;
-    constructor(value) {
-        this.type = 'ValueChangedEvent';
+    constructor(value: any) {
+        this.type = ValueChangedEventType;
         this.value = value;
     }
 }

--- a/packages/@lwc/wire-service/src/wiring.ts
+++ b/packages/@lwc/wire-service/src/wiring.ts
@@ -237,16 +237,17 @@ export class WireEventTarget {
             return false; // canceling signal since we don't want this to propagate
         } else if (evt instanceof LinkContextEvent) {
             const { uid, callback } = evt;
-            // this must dispatch an underlying dom event on the element to connect to
-            // the provider, which uses an internal unique ID defined per adapter, and
-            // provides a callback used as a side channel communication between provider
-            // and consumer adapter.
+            // This event is responsible for connecting the host element with another
+            // element in the composed path that is providing contextual data. The provider
+            // must be listening for a special dom event with the name corresponding to `uid`,
+            // which must remain secret, to guarantee that the linkage is only possible via
+            // the corresponding wire adapter.
             const internalDomEvent = new CustomEvent(uid, {
                 bubbles: true,
                 composed: true,
                 // avoid leaking the callback function directly to prevent a side channel
                 // during the linking phase to the context provider.
-                detail(...args) {
+                detail(...args: any[]) {
                     callback(...args);
                 },
             });


### PR DESCRIPTION
## Details

In preparation for Context RFC: https://github.com/salesforce/lwc-rfcs/pull/6

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

Note: we are keeping the old behavior around until we can remove it, more details on https://github.com/salesforce/lwc/issues/1357