### PR TITLE
fix(synthetic-shadow): expose iframe contentWindow event methods (#1368)

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
@@ -32,10 +32,10 @@ export default function apply() {
 
 function wrapIframeWindow(win: WindowProxy): WindowProxy {
     return {
-        postMessage() {
+        addEventListener() {
             // Typescript does not like it when you treat the `arguments` object as an array
             // @ts-ignore type-mismatch
-            return win.postMessage.apply(win, arguments);
+            return win.addEventListener.apply(win, arguments);
         },
         blur() {
             // Typescript does not like it when you treat the `arguments` object as an array
@@ -51,6 +51,16 @@ function wrapIframeWindow(win: WindowProxy): WindowProxy {
             // Typescript does not like it when you treat the `arguments` object as an array
             // @ts-ignore type-mismatch
             return win.focus.apply(win, arguments);
+        },
+        postMessage() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.postMessage.apply(win, arguments);
+        },
+        removeEventListener() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.removeEventListener.apply(win, arguments);
         },
         get closed() {
             return win.closed;

--- a/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
+++ b/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
@@ -14,18 +14,25 @@ it('should not throw when unwrapping contentWindow', () => {
 });
 
 describe('HTMLIFrameElement.contentWindow patching', () => {
-    let iframe;
+    let iframe, sameOriginFrame;
 
     beforeAll(() => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
         iframe = elm.shadowRoot.querySelector('iframe');
+        sameOriginFrame = elm.shadowRoot.querySelector('[data-id="same_origin_iframe"]');
     });
 
     function testContentWindowProperty(name, fn) {
         it(`should not throw when accessing ${name}`, () => {
             expect(() => fn(iframe.contentWindow)).not.toThrowError();
+        });
+    }
+
+    function testSameOriginContentWindowProperty(name, fn) {
+        it(`should not throw when accessing ${name}`, () => {
+            expect(() => fn(sameOriginFrame.contentWindow)).not.toThrowError();
         });
     }
 
@@ -47,4 +54,11 @@ describe('HTMLIFrameElement.contentWindow patching', () => {
     testContentWindowProperty('self', contentWindow => contentWindow.self);
     testContentWindowProperty('top', contentWindow => contentWindow.top);
     testContentWindowProperty('window', contentWindow => contentWindow.window);
+
+    testSameOriginContentWindowProperty('addEventListener', contentWindow =>
+        contentWindow.addEventListener('resize', () => {})
+    );
+    testSameOriginContentWindowProperty('removeEventListener', contentWindow => {
+        contentWindow.removeEventListener('resize', () => {});
+    });
 });

--- a/packages/integration-karma/test/misc/cross-domain-iframe/x/test/test.html
+++ b/packages/integration-karma/test/misc/cross-domain-iframe/x/test/test.html
@@ -1,3 +1,4 @@
 <template>
     <iframe src="http://example.com"></iframe>
+    <iframe data-id="same_origin_iframe" src="about:blank"></iframe>
 </template>


### PR DESCRIPTION

## Details
Expose `addEventHandler()` and `removeEventHandler()` methods on the iframe `contentWindow` patch layer, plus tests.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
