### PR TITLE
fix(engine): issue 427 to support native components in html

### DIFF
--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -85,6 +85,7 @@ export interface VNodeData {
     context?: CustomElementContext;
     on?: On;
     ns?: string; // for SVGs
+    validateFn?: () => void;
 }
 
 export type CreateHook = (vNode: VNode) => void;

--- a/packages/integration-karma/test/component/native-components/index.spec.js
+++ b/packages/integration-karma/test/component/native-components/index.spec.js
@@ -1,0 +1,14 @@
+import { createElement } from 'lwc';
+
+import Parent from 'x/parent';
+import Child from 'x/child';
+
+if (process.env.NATIVE_SHADOW) {
+    it('native components should be useable from within LWC templates', () => {
+        const elem = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elem);
+        const childElm = elem.shadowRoot.querySelector('x-child');
+        expect(childElm.shadowRoot instanceof ShadowRoot).toBe(true);
+        expect(childElm instanceof Child).toBe(true);
+    });
+}

--- a/packages/integration-karma/test/component/native-components/x/child/child.js
+++ b/packages/integration-karma/test/component/native-components/x/child/child.js
@@ -1,0 +1,10 @@
+export default class Child extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+    }
+    connectedCallback() {
+        this.shadowRoot.innerHTML = 'miami';
+    }
+}
+customElements.define('x-child', Child);

--- a/packages/integration-karma/test/component/native-components/x/parent/parent.html
+++ b/packages/integration-karma/test/component/native-components/x/parent/parent.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/integration-karma/test/component/native-components/x/parent/parent.js
+++ b/packages/integration-karma/test/component/native-components/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}


### PR DESCRIPTION
## Details

This PR adds support for using vanilla web components inside LWC templates, there are a couple of rules in place:

* the remapping between the tagName and the corresponding vanilla component must be preserved. there are various ways to do that, including the package.json->lwc->module configuration.
* the LWC component will require the vanilla component to be registered before the template is instantiated, it CANNOT be upgraded after the fact, that's why we require the import to be resolved ahead of time.
* the result of the creation of the element MUST result on an instance of the resolved constructor, otherwise it throws.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
