### PR TITLE
fix(compiler): prevent underscore attr name camelcasing

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -6,7 +6,7 @@
  */
 /**
  * TODO: W-5678919 - implement script to determine the next available error code
- * Next error code: 1125
+ * Next error code: 1126
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -6,7 +6,7 @@
  */
 /**
  * TODO: W-5678919 - implement script to determine the next available error code
- * Next error code: 1122
+ * Next error code: 1125
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -464,4 +464,18 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Warning,
         url: '',
     },
+    ATTRIBUTE_CANNOT_START_OR_END_WITH_UNDERSCORE: {
+        code: 1124,
+        message:
+            '{0} is not valid attribute for {1}. Attribute name cannot start or end with an underscore.',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+    ATTRIBUTE_NAME_CANNOT_CONTAIN_UNDERSCORE_WITH_HYPHEN: {
+        code: 1125,
+        message:
+            '{0} is not valid attribute for {1}. Attribute name cannot contain combination of underscore and hyphen characters.',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
 };

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -464,17 +464,26 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Warning,
         url: '',
     },
-    ATTRIBUTE_CANNOT_START_OR_END_WITH_UNDERSCORE: {
+
+    ATTRIBUTE_NAME_MUST_START_WITH_ALPHABETIC_CHARACTER: {
         code: 1124,
         message:
-            '{0} is not valid attribute for {1}. Attribute name cannot start or end with an underscore.',
+            '{0} is not valid attribute for {1}. Attribute name cannot start with non alphabetic character.',
         level: DiagnosticLevel.Error,
         url: '',
     },
-    ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_NON_ALPHA_CHARS: {
+
+    ATTRIBUTE_NAME_MUST_END_WITH_ALPHA_NUMERIC_CHARACTER: {
         code: 1125,
         message:
-            '{0} is not valid attribute for {1}. Attribute name cannot contain combination of underscore and hyphen characters.',
+            '{0} is not valid attribute for {1}. Attribute name cannot start or end with non alpha-numeric character.',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+    ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_SPECIAL_CHARS: {
+        code: 1126,
+        message:
+            '{0} is not valid attribute for {1}. Attribute name cannot contain combination of underscore and special characters.',
         level: DiagnosticLevel.Error,
         url: '',
     },

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -468,7 +468,7 @@ export const ParserDiagnostics = {
     ATTRIBUTE_NAME_MUST_START_WITH_ALPHABETIC_CHARACTER: {
         code: 1124,
         message:
-            '{0} is not valid attribute for {1}. Attribute name cannot start with non alphabetic character.',
+            '{0} is not valid attribute for {1}. Attribute name must start with alphabetic character.',
         level: DiagnosticLevel.Error,
         url: '',
     },
@@ -476,7 +476,7 @@ export const ParserDiagnostics = {
     ATTRIBUTE_NAME_MUST_END_WITH_ALPHA_NUMERIC_CHARACTER: {
         code: 1125,
         message:
-            '{0} is not valid attribute for {1}. Attribute name cannot start or end with non alpha-numeric character.',
+            '{0} is not valid attribute for {1}. Attribute name must end with alpha-numeric character.',
         level: DiagnosticLevel.Error,
         url: '',
     },

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -471,7 +471,7 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Error,
         url: '',
     },
-    ATTRIBUTE_NAME_CANNOT_CONTAIN_UNDERSCORE_WITH_HYPHEN: {
+    ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_NON_ALPHA_CHARS: {
         code: 1125,
         message:
             '{0} is not valid attribute for {1}. Attribute name cannot contain combination of underscore and hyphen characters.',

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -583,7 +583,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1125: under_-hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and hyphen characters.',
+                    'LWC1126: under_-hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and special characters.',
             });
         });
 
@@ -596,7 +596,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1125: under-_hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and hyphen characters.',
+                    'LWC1126: under-_hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and special characters.',
             });
         });
 
@@ -609,7 +609,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1124: _leading is not valid attribute for x-button. Attribute name cannot start or end with an underscore.',
+                    'LWC1124: _leading is not valid attribute for x-button. Attribute name cannot start with non alphabetic character.',
             });
         });
 
@@ -622,17 +622,40 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1124: trailing_ is not valid attribute for x-button. Attribute name cannot start or end with an underscore.',
+                    'LWC1125: trailing_ is not valid attribute for x-button. Attribute name cannot start or end with non alpha-numeric character.',
             });
         });
 
-        it('attribute name separated by underscore', () => {
+        it('should throw when detected an attribute name separated by underscore that starts with a number', () => {
+            const { warnings } = parseTemplate(`<template>
+                <x-button 2_under="bar"></x-button>
+            </template>`);
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({
+                level: DiagnosticLevel.Error,
+                message:
+                    'LWC1124: 2_under is not valid attribute for x-button. Attribute name cannot start with non alphabetic character.',
+            });
+        });
+
+        it('attribute name separated by underscore and starts with alphabetic character', () => {
             const { root } = parseTemplate(`<template>
                 <x-button under_score="bar"></x-button>
             </template>`);
 
             expect(root.children[0].props).toMatchObject({
                 under_score: { value: 'bar' },
+            });
+        });
+
+        it('attribute name separated by underscore and starts with a number', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button under_1="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                under_1: { value: 'bar' },
             });
         });
 

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -609,7 +609,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1124: _leading is not valid attribute for x-button. Attribute name cannot start with non alphabetic character.',
+                    'LWC1124: _leading is not valid attribute for x-button. Attribute name must start with alphabetic character.',
             });
         });
 
@@ -622,7 +622,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1125: trailing_ is not valid attribute for x-button. Attribute name cannot start or end with non alpha-numeric character.',
+                    'LWC1125: trailing_ is not valid attribute for x-button. Attribute name must end with alpha-numeric character.',
             });
         });
 
@@ -635,7 +635,7 @@ describe('props and attributes', () => {
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
                 message:
-                    'LWC1124: 2_under is not valid attribute for x-button. Attribute name cannot start with non alphabetic character.',
+                    'LWC1124: 2_under is not valid attribute for x-button. Attribute name must start with alphabetic character.',
             });
         });
 

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -572,6 +572,68 @@ describe('props and attributes', () => {
             'data-xx': { value: 'foo' },
         });
     });
+
+    describe('attributes with underscores', () => {
+        it('attribute name separated by underscore', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button under_score="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                under_score: { value: 'bar' },
+            });
+        });
+
+        it('attribute name separated by underscore which contains hyphen', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button under_score-hyphen="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                under_scoreHyphen: { value: 'bar' },
+            });
+        });
+
+        it('attribute name separated by underscore and immediate hyphen', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button under_-hyphen="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                under_hyphen: { value: 'bar' },
+            });
+        });
+
+        it('attribute name separated by two underscore and contains hyphen', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button under_score-second_under-score="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                under_scoreSecond_underScore: { value: 'bar' },
+            });
+        });
+
+        it('attribute name with leading underscore and hyphen', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button _leading-underscore="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                _leadingUnderscore: { value: 'bar' },
+            });
+        });
+
+        it('attribute name with trailing underscore and hyphen', () => {
+            const { root } = parseTemplate(`<template>
+                <x-button trailing-underscore_="bar"></x-button>
+            </template>`);
+
+            expect(root.children[0].props).toMatchObject({
+                trailingUnderscore_: { value: 'bar' },
+            });
+        });
+    });
 });
 
 describe('metadata', () => {

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -574,6 +574,58 @@ describe('props and attributes', () => {
     });
 
     describe('attributes with underscores', () => {
+        it('should throw when detected an attribute name with underscore + hyphen "_-" combination', () => {
+            const { warnings } = parseTemplate(`<template>
+                <x-button under_-hyphen="bar"></x-button>
+            </template>`);
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({
+                level: DiagnosticLevel.Error,
+                message:
+                    'LWC1125: under_-hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and hyphen characters.',
+            });
+        });
+
+        it('should throw when detected an attribute name with hyphen + underscore "-_" combination', () => {
+            const { warnings } = parseTemplate(`<template>
+                <x-button under-_hyphen="bar"></x-button>
+            </template>`);
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({
+                level: DiagnosticLevel.Error,
+                message:
+                    'LWC1125: under-_hyphen is not valid attribute for x-button. Attribute name cannot contain combination of underscore and hyphen characters.',
+            });
+        });
+
+        it('should throw when detected an attribute name with a leading underscore', () => {
+            const { warnings } = parseTemplate(`<template>
+                <x-button _leading="bar"></x-button>
+            </template>`);
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({
+                level: DiagnosticLevel.Error,
+                message:
+                    'LWC1124: _leading is not valid attribute for x-button. Attribute name cannot start or end with an underscore.',
+            });
+        });
+
+        it('should throw when detected an attribute name with a trailing underscore', () => {
+            const { warnings } = parseTemplate(`<template>
+                <x-button trailing_="bar"></x-button>
+            </template>`);
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({
+                level: DiagnosticLevel.Error,
+                message:
+                    'LWC1124: trailing_ is not valid attribute for x-button. Attribute name cannot start or end with an underscore.',
+            });
+        });
+
         it('attribute name separated by underscore', () => {
             const { root } = parseTemplate(`<template>
                 <x-button under_score="bar"></x-button>
@@ -594,16 +646,6 @@ describe('props and attributes', () => {
             });
         });
 
-        it('attribute name separated by underscore and immediate hyphen', () => {
-            const { root } = parseTemplate(`<template>
-                <x-button under_-hyphen="bar"></x-button>
-            </template>`);
-
-            expect(root.children[0].props).toMatchObject({
-                under_hyphen: { value: 'bar' },
-            });
-        });
-
         it('attribute name separated by two underscore and contains hyphen', () => {
             const { root } = parseTemplate(`<template>
                 <x-button under_score-second_under-score="bar"></x-button>
@@ -611,26 +653,6 @@ describe('props and attributes', () => {
 
             expect(root.children[0].props).toMatchObject({
                 under_scoreSecond_underScore: { value: 'bar' },
-            });
-        });
-
-        it('attribute name with leading underscore and hyphen', () => {
-            const { root } = parseTemplate(`<template>
-                <x-button _leading-underscore="bar"></x-button>
-            </template>`);
-
-            expect(root.children[0].props).toMatchObject({
-                _leadingUnderscore: { value: 'bar' },
-            });
-        });
-
-        it('attribute name with trailing underscore and hyphen', () => {
-            const { root } = parseTemplate(`<template>
-                <x-button trailing-underscore_="bar"></x-button>
-            </template>`);
-
-            expect(root.children[0].props).toMatchObject({
-                trailingUnderscore_: { value: 'bar' },
             });
         });
     });

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -291,8 +291,11 @@ function shouldCamelCaseAttribute(element: IRElement, attrName: string) {
 export function attributeToPropertyName(element: IRElement, attrName: string): string {
     let propName = attrName;
     if (shouldCamelCaseAttribute(element, attrName)) {
-        propName = ATTRS_PROPS_TRANFORMS[propName] || propName;
+        const attrToSplit = ATTRS_PROPS_TRANFORMS[propName] || propName;
+        propName = attrToSplit
+            .split('_')
+            .map(part => camelcase(part))
+            .join('_');
     }
-
-    return camelcase(propName);
+    return propName;
 }

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -294,7 +294,7 @@ export function attributeToPropertyName(element: IRElement, attrName: string): s
         const attrToSplit = ATTRS_PROPS_TRANFORMS[propName] || propName;
         propName = attrToSplit
             .split('_')
-            .map(part => camelcase(part))
+            .map(camelcase)
             .join('_');
     }
     return propName;

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -711,12 +711,12 @@ export default function parse(source: string, state: State): TemplateParseResult
             }
 
             // disallow attr name with an underscore combined with non alphabetic characters
-            if (name.match(/_[^a-zA-Z]|[^a-zA-Z]_/)) {
+            if (name.match(/_[^a-z]|[^a-z]_/)) {
                 const node = element.__original as parse5.AST.Default.Element;
-                warnAt(ParserDiagnostics.ATTRIBUTE_NAME_CANNOT_CONTAIN_UNDERSCORE_WITH_HYPHEN, [
-                    name,
-                    treeAdapter.getTagName(node),
-                ]);
+                warnAt(
+                    ParserDiagnostics.ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_NON_ALPHA_CHARS,
+                    [name, treeAdapter.getTagName(node)]
+                );
                 return;
             }
 

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -695,8 +695,29 @@ export default function parse(source: string, state: State): TemplateParseResult
             }
 
             const { name, location } = attr;
+
             if (!isValidHTMLAttribute(element.tag, name)) {
                 warnAt(ParserDiagnostics.INVALID_HTML_ATTRIBUTE, [name, tag], location);
+            }
+
+            // disallow attr name with leading and trailing underscores
+            if (name.startsWith('_') || name.endsWith('_')) {
+                const node = element.__original as parse5.AST.Default.Element;
+                warnAt(ParserDiagnostics.ATTRIBUTE_CANNOT_START_OR_END_WITH_UNDERSCORE, [
+                    name,
+                    treeAdapter.getTagName(node),
+                ]);
+                return;
+            }
+
+            // disallow attr name with an underscore combined with non alphabetic characters
+            if (name.match(/_[^a-zA-Z]|[^a-zA-Z]_/)) {
+                const node = element.__original as parse5.AST.Default.Element;
+                warnAt(ParserDiagnostics.ATTRIBUTE_NAME_CANNOT_CONTAIN_UNDERSCORE_WITH_HYPHEN, [
+                    name,
+                    treeAdapter.getTagName(node),
+                ]);
+                return;
             }
 
             if (attr.type === IRAttributeType.String) {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -700,21 +700,32 @@ export default function parse(source: string, state: State): TemplateParseResult
                 warnAt(ParserDiagnostics.INVALID_HTML_ATTRIBUTE, [name, tag], location);
             }
 
-            // disallow attr name with leading and trailing underscores
-            if (name.startsWith('_') || name.endsWith('_')) {
+            // disallow attr name that ends with a special character.
+            if (name.match(/[^a-z0-9]$/)) {
                 const node = element.__original as parse5.AST.Default.Element;
-                warnAt(ParserDiagnostics.ATTRIBUTE_CANNOT_START_OR_END_WITH_UNDERSCORE, [
+                warnAt(ParserDiagnostics.ATTRIBUTE_NAME_MUST_END_WITH_ALPHA_NUMERIC_CHARACTER, [
                     name,
                     treeAdapter.getTagName(node),
                 ]);
                 return;
             }
 
-            // disallow attr name with an underscore combined with non alphabetic characters
-            if (name.match(/_[^a-z]|[^a-z]_/)) {
+            // disallow attr name that doesn't start with an alphabetic character.
+            if (name.match(/^[^a-z]/)) {
+                const node = element.__original as parse5.AST.Default.Element;
+                warnAt(ParserDiagnostics.ATTRIBUTE_NAME_MUST_START_WITH_ALPHABETIC_CHARACTER, [
+                    name,
+                    treeAdapter.getTagName(node),
+                ]);
+                return;
+            }
+
+            // disallow attr name which combines underscore character with special character.
+            // We normalize camel-cased names with underscores caMel -> ca-mel; thus sanitization.
+            if (name.match(/_[^a-z0-9]|[^a-z0-9]_/)) {
                 const node = element.__original as parse5.AST.Default.Element;
                 warnAt(
-                    ParserDiagnostics.ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_NON_ALPHA_CHARS,
+                    ParserDiagnostics.ATTRIBUTE_NAME_CANNOT_COMBINE_UNDERSCORE_WITH_SPECIAL_CHARS,
                     [name, treeAdapter.getTagName(node)]
                 );
                 return;

--- a/packages/integration-karma/test/template/properties/attrs/specialCharacter/specialCharacter.html
+++ b/packages/integration-karma/test/template/properties/attrs/specialCharacter/specialCharacter.html
@@ -1,0 +1,3 @@
+<template>
+    <attrs-underscore-child under_score={public_prop}></attrs-underscore-child>
+</template>

--- a/packages/integration-karma/test/template/properties/attrs/specialCharacter/specialCharacter.js
+++ b/packages/integration-karma/test/template/properties/attrs/specialCharacter/specialCharacter.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class SpecialCharacterPublicProp extends LightningElement {
+    @api public_prop = 'underscore property';
+}

--- a/packages/integration-karma/test/template/properties/attrs/underscoreChild/underscoreChild.html
+++ b/packages/integration-karma/test/template/properties/attrs/underscoreChild/underscoreChild.html
@@ -1,0 +1,3 @@
+<template>
+    {under_score}
+</template>

--- a/packages/integration-karma/test/template/properties/attrs/underscoreChild/underscoreChild.js
+++ b/packages/integration-karma/test/template/properties/attrs/underscoreChild/underscoreChild.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class SpecialCharacterChild extends LightningElement {
+    @api under_score = 'underscore child';
+}

--- a/packages/integration-karma/test/template/properties/index.spec.js
+++ b/packages/integration-karma/test/template/properties/index.spec.js
@@ -3,6 +3,7 @@ import { createElement } from 'lwc';
 import RadioButton from 'misc/radioButton';
 import InputValue from 'live/inputValue';
 import InputChecked from 'live/inputChecked';
+import SpecialCharacterPublicProp from 'attrs/specialCharacter';
 
 describe('live properties', () => {
     describe('input [checked] property', () => {
@@ -50,6 +51,21 @@ describe('live properties', () => {
             return Promise.resolve().then(() => {
                 expect(elm.shadowRoot.querySelector('input').value).toBe('foo bar');
             });
+        });
+    });
+});
+
+describe('custom properties', () => {
+    it('should allow attribute value with underscore', () => {
+        const elm = createElement('attrs-special-character', { is: SpecialCharacterPublicProp });
+        document.body.appendChild(elm);
+
+        expect(elm.public_prop).toBe('underscore property');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('attrs-underscore-child').under_score).toEqual(
+                'underscore property'
+            );
         });
     });
 });


### PR DESCRIPTION
## Details
Fixes #1369 - prevent camel-casing of the attribute names with underscore.
Rules:
- attribute name must start with alphabetic character
- attribute name must end with alpha-numeric character
- attribute name cannot contain a combination of underscore and non-alpha-numeric characters

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
