### PR TITLE
fix(engine): test was incorrect

### DIFF
--- a/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
@@ -9,7 +9,7 @@ import { createElement, LightningElement } from '../main';
 
 describe('watcher', () => {
     describe('integration', () => {
-        it('should rerender the component if any reactive slot changes', () => {
+        it('should not rerender the component if new elements are slotted', () => {
             let counter = 0;
 
             const childTmpl = compileTemplate(`
@@ -57,8 +57,9 @@ describe('watcher', () => {
             document.body.appendChild(elm);
             elm.updateRound();
 
-            Promise.resolve().then(_ => {
-                expect(counter).toBe(2);
+            return Promise.resolve().then(_ => {
+                // parent slotted into child, not need to rerender child
+                expect(counter).toBe(1);
             });
         });
 


### PR DESCRIPTION
## Details

* test was not returning the promise, so it was failing in the next tick
* test is not longer relevant after changing the tests to run native shadow (fixed to match that)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`