### PR TITLE
chore: restrict node to TLS (v10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "packages/perf-benchmarks"
   ],
   "engines": {
-    "node": ">=10.13.0",
+    "node": ">=10.13.0 <11.0.0",
     "yarn": ">=1.10.1"
   },
   "resolutions": {


### PR DESCRIPTION
## Details

Some developers have reported that they cannot install this repo in NodeJS v12.
After debugging a bit, many of our dependencies (karma, webdriver-io) still rely on old versions of primitive libraries such as fibers or node-gyp. 
We need to wait until those libraries upgrade for us to do the same.

In the mean time Im restricting the version in package.json
We should do the same in all repos.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`