### PR TITLE
fix(engine): template inheritance is broken

### DIFF
--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -24,7 +24,6 @@ import {
     seal,
     ArrayReduce,
     isObject,
-    isUndefined,
     isFalse,
 } from '../shared/language';
 import { HTMLElementOriginalDescriptors } from './html-properties';
@@ -44,7 +43,6 @@ import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
 import { Template } from './template';
-import { defaultEmptyTemplate } from './secure-template';
 
 const GlobalEvent = Event; // caching global reference to avoid poisoning
 
@@ -552,8 +550,7 @@ BaseLightningElementConstructor.prototype = {
     },
     render(): Template {
         const vm = getComponentVM(this);
-        const { template } = vm.def;
-        return isUndefined(template) ? defaultEmptyTemplate : template;
+        return vm.def.template;
     },
     toString(): string {
         const vm = getComponentVM(this);

--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -45,7 +45,7 @@ import { Template } from './template';
 
 export interface ComponentDef extends DecoratorMeta {
     name: string;
-    template?: Template;
+    template: Template;
     ctor: ComponentConstructor;
     bridge: HTMLElementConstructor;
     connectedCallback?: () => void;
@@ -99,7 +99,8 @@ function createComponentDef(
         );
     }
 
-    const { name, template } = meta;
+    const { name } = meta;
+    let { template } = meta;
 
     let decoratorsMeta = getDecoratorsRegisteredMeta(Ctor);
 
@@ -145,8 +146,14 @@ function createComponentDef(
         renderedCallback = renderedCallback || superDef.renderedCallback;
         errorCallback = errorCallback || superDef.errorCallback;
         render = render || superDef.render;
+        template = template || superDef.template;
     }
     props = assign(create(null), HTML_PROPS, props);
+
+    if (isUndefined(template)) {
+        // default template
+        template = defaultEmptyTemplate;
+    }
 
     const def: ComponentDef = {
         ctor: Ctor,
@@ -279,6 +286,7 @@ import {
     DecoratorMeta,
     PropsDef,
 } from './decorators/register';
+import { defaultEmptyTemplate } from './secure-template';
 
 // Typescript is inferring the wrong function type for this particular
 // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972

--- a/packages/integration-karma/test/rendering/inheritance/index.spec.js
+++ b/packages/integration-karma/test/rendering/inheritance/index.spec.js
@@ -7,18 +7,14 @@ describe('template inheritance', () => {
         const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const text = elm.shadowRoot.textContent;
-            expect(text).toBe('foo');
-        });
+        const text = elm.shadowRoot.textContent;
+        expect(text).toBe('foo');
     });
     it('should support implicit definition of no template', function() {
         const elm = createElement('x-bar', { is: Bar });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const text = elm.shadowRoot.textContent;
-            expect(text).toBe('base');
-        });
+        const text = elm.shadowRoot.textContent;
+        expect(text).toBe('base');
     });
 });

--- a/packages/integration-karma/test/rendering/inheritance/index.spec.js
+++ b/packages/integration-karma/test/rendering/inheritance/index.spec.js
@@ -1,0 +1,24 @@
+import { createElement } from 'lwc';
+import Foo from 'x/foo';
+import Bar from 'x/bar';
+
+describe('template inheritance', () => {
+    it('should support implicit definition of new template', function() {
+        const elm = createElement('x-foo', { is: Foo });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            const text = elm.shadowRoot.textContent;
+            expect(text).toBe('foo');
+        });
+    });
+    it('should support implicit definition of no template', function() {
+        const elm = createElement('x-bar', { is: Bar });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            const text = elm.shadowRoot.textContent;
+            expect(text).toBe('base');
+        });
+    });
+});

--- a/packages/integration-karma/test/rendering/inheritance/x/bar/bar.js
+++ b/packages/integration-karma/test/rendering/inheritance/x/bar/bar.js
@@ -1,0 +1,6 @@
+import Base from 'x/base';
+
+export default class Bar extends Base {
+    // not need to define render method
+    // it should use the template from Base
+}

--- a/packages/integration-karma/test/rendering/inheritance/x/base/base.html
+++ b/packages/integration-karma/test/rendering/inheritance/x/base/base.html
@@ -1,0 +1,3 @@
+<template>
+    base
+</template>

--- a/packages/integration-karma/test/rendering/inheritance/x/base/base.js
+++ b/packages/integration-karma/test/rendering/inheritance/x/base/base.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Base extends LightningElement {}

--- a/packages/integration-karma/test/rendering/inheritance/x/foo/foo.html
+++ b/packages/integration-karma/test/rendering/inheritance/x/foo/foo.html
@@ -1,0 +1,3 @@
+<template>
+    foo
+</template>

--- a/packages/integration-karma/test/rendering/inheritance/x/foo/foo.js
+++ b/packages/integration-karma/test/rendering/inheritance/x/foo/foo.js
@@ -1,0 +1,6 @@
+import Base from 'x/base';
+
+export default class Foo extends Base {
+    // not need to define render method
+    // it should use the local template
+}


### PR DESCRIPTION
## Details

* subclassing `LightningElement` while relying on the implicit nature of the template file definition is broken, if a subclass doesn't have a HTML file in the bundle, and the subclass is extending something other than the common `LightningElement`, the template used for the render is not the one from the super class, but the default empty template.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

This was broken for a long time and no-one notices because this is a very edge case, you must have an extension of a class other than `LigthningElement`, where the subclass doesn't have a HTML file, to exhibit this issue. We should consider this change a very low risk.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
