### PR TITLE
feat: allow MemberExpression on wire adapters

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -226,7 +226,7 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'decorator does not accept a nested member expression',
+        'decorator allows wire provider member expression',
         `
     import { wire } from 'lwc';
     import { Foo } from 'data-service';
@@ -270,7 +270,7 @@ describe('Transform property', () => {
         'decorator rejects nested member expression',
         `
         import { wire } from 'lwc';
-        import getFoo from 'foo';
+        import Foo from 'foo';
         export default class Test {
             @wire(Foo.Bar.Buzz, {}) wiredProp;
         }
@@ -282,7 +282,7 @@ describe('Transform property', () => {
                     line: 4,
                     column: 6,
                     length: 12,
-                    start: 88,
+                    start: 85,
                 },
             },
         }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -267,7 +267,7 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'decorator accepts a default import function identifier as first parameter',
+        'decorator rejects nested member expression',
         `
         import { wire } from 'lwc';
         import getFoo from 'foo';

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -185,42 +185,105 @@ describe('Transform property', () => {
     );
 
     pluginTest(
+        'decorator accepts a member epxression',
+        `
+      import { wire } from 'lwc';
+      import { Foo } from 'data-service';
+      export default class Test {
+          @wire(Foo.Bar, {}) wiredProp;
+      }
+  `,
+        {
+            output: {
+                code: `
+              import { registerDecorators as _registerDecorators } from "lwc";
+              import _tmpl from "./test.html";
+              import { registerComponent as _registerComponent } from "lwc";
+              import { Foo } from "data-service";
+
+              class Test {
+                constructor() {
+                  this.wiredProp = void 0;
+                }
+              }
+
+              _registerDecorators(Test, {
+                wire: {
+                  wiredProp: {
+                    adapter: Foo.Bar,
+                    params: {},
+                    static: {}
+                  }
+                }
+              });
+
+              export default _registerComponent(Test, {
+                tmpl: _tmpl
+              });
+              `,
+            },
+        }
+    );
+
+    pluginTest(
+        'decorator does not accept a nested member expression',
+        `
+    import { wire } from 'lwc';
+    import { Foo } from 'data-service';
+    export default class Test {
+        @wire(Foo.Bar, {}) wiredProp;
+    }
+`,
+        {
+            output: {
+                code: `
+            import { registerDecorators as _registerDecorators } from "lwc";
+            import _tmpl from "./test.html";
+            import { registerComponent as _registerComponent } from "lwc";
+            import { Foo } from "data-service";
+
+            class Test {
+              constructor() {
+                this.wiredProp = void 0;
+              }
+            }
+
+            _registerDecorators(Test, {
+              wire: {
+                wiredProp: {
+                  adapter: Foo.Bar,
+                  params: {},
+                  static: {}
+                }
+              }
+            });
+
+            export default _registerComponent(Test, {
+              tmpl: _tmpl
+            });
+            `,
+            },
+        }
+    );
+
+    pluginTest(
         'decorator accepts a default import function identifier as first parameter',
         `
         import { wire } from 'lwc';
         import getFoo from 'foo';
         export default class Test {
-            @wire(getFoo, {}) wiredProp;
+            @wire(Foo.Bar.Buzz, {}) wiredProp;
         }
     `,
         {
-            output: {
-                code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
-                import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import getFoo from "foo";
-
-                class Test {
-                  constructor() {
-                    this.wiredProp = void 0;
-                  }
-                }
-
-                _registerDecorators(Test, {
-                  wire: {
-                    wiredProp: {
-                      adapter: getFoo,
-                      params: {},
-                      static: {}
-                    }
-                  }
-                });
-
-                export default _registerComponent(Test, {
-                  tmpl: _tmpl
-                });
-`,
+            error: {
+                message: '@wire identifier cant contain nested member expressions',
+                loc: {
+                    line: 4,
+                    column: 6,
+                    length: 12,
+                    start: 88,
+                },
             },
         }
     );

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -277,7 +277,7 @@ describe('Transform property', () => {
     `,
         {
             error: {
-                message: '@wire identifier cant contain nested member expressions',
+                message: '@wire identifier cannot contain nested member expressions',
                 loc: {
                     line: 4,
                     column: 6,

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -43,7 +43,7 @@ function buildWireConfigValue(t, wiredValues) {
             const wireConfig = [];
             if (wiredValue.adapter) {
                 wireConfig.push(
-                    t.objectProperty(t.identifier('adapter'), t.identifier(wiredValue.adapter.name))
+                    t.objectProperty(t.identifier('adapter'), wiredValue.adapter.expression)
                 );
             }
 
@@ -127,12 +127,15 @@ module.exports = function transform(t, klass, decorators) {
         }
 
         const referenceLookup = scopedReferenceLookup(path.scope);
+        const isMemberExpression = id.isMemberExpression();
+        const isIdentifier = id.isIdentifier();
 
-        if (id.isIdentifier()) {
-            const adapterName = id.node.name;
-            const reference = referenceLookup(adapterName);
+        if (isIdentifier || isMemberExpression) {
+            const referenceName = isMemberExpression ? id.node.object.name : id.node.name;
+            const reference = referenceLookup(referenceName);
             wiredValue.adapter = {
-                name: adapterName,
+                name: referenceName,
+                expression: t.cloneDeep(id.node),
                 reference: reference.type === 'module' ? reference.value : undefined,
             };
         }

--- a/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
@@ -211,4 +211,16 @@ export const DecoratorErrors = {
         level: DiagnosticLevel.Error,
         url: '',
     },
+    FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS: {
+        code: 1131,
+        message: '@wire identifier cant contain computed properties',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+    FUNCTION_IDENTIFIER_CANNOT_HAVE_NESTED_MEMBER_EXRESSIONS: {
+        code: 1132,
+        message: '@wire identifier cant contain nested member expressions',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
 };

--- a/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
@@ -213,13 +213,13 @@ export const DecoratorErrors = {
     },
     FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS: {
         code: 1131,
-        message: '@wire identifier cant contain computed properties',
+        message: '@wire identifier cannot contain computed properties',
         level: DiagnosticLevel.Error,
         url: '',
     },
     FUNCTION_IDENTIFIER_CANNOT_HAVE_NESTED_MEMBER_EXRESSIONS: {
         code: 1132,
-        message: '@wire identifier cant contain nested member expressions',
+        message: '@wire identifier cannot contain nested member expressions',
         level: DiagnosticLevel.Error,
         url: '',
     },


### PR DESCRIPTION
## Details
Allow MemberExpression on wire adapters

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

Allows the following syntax on wires
```js
export default class Test {
    @wire(Foo.Bar, {}) wiredProp;
}
```