### PR TITLE
fix: error from disconnecting an already disconnected vm

### DIFF
--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -182,7 +182,10 @@ function resetComponentStateWhenRemoved(vm: VM) {
 export function removeVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-        assert.isTrue(vm.state === VMState.connected, `${vm} must be inserted.`);
+        assert.isTrue(
+            vm.state === VMState.connected || vm.state === VMState.disconnected,
+            `${vm} must have been connected.`
+        );
     }
     resetComponentStateWhenRemoved(vm);
 }

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
@@ -2,33 +2,19 @@ import { createElement } from 'lwc';
 import ParentCmp from 'x/parent';
 
 describe('disconnecting root vm', () => {
-    // unhandledrejection is not supported in ie11 or firefox. In those browsers we will get false positives
-    // but we will get the failure in chrome and safari.
-    // We dont use the error handler because karma does not triggers it.
-    if (!process.env.COMPAT) {
-        it('should not throw an error when disconnecting an already disconnected child vm', function(done) {
-            let unhandledErrorEvent = null;
-            const unhandledErrorListener = event => {
-                event.preventDefault();
-                unhandledErrorEvent = event;
-            };
+    it('should not throw an error when disconnecting an already disconnected child vm', function(done) {
+        const elm = createElement('x-parent', { is: ParentCmp });
+        elm.labels = ['label 1', 'label 2'];
+        document.body.appendChild(elm);
 
-            window.addEventListener('unhandledrejection', unhandledErrorListener);
+        return Promise.resolve().then(() => {
+            elm.labels = [];
+            document.body.removeChild(elm);
 
-            const elm = createElement('x-parent', { is: ParentCmp });
-            elm.labels = ['label 1', 'label 2'];
-            document.body.appendChild(elm);
-
-            return Promise.resolve().then(() => {
-                elm.labels = [];
-                document.body.removeChild(elm);
-
-                setTimeout(() => {
-                    expect(unhandledErrorEvent).toBe(null);
-                    window.removeEventListener('unhandledrejection', unhandledErrorListener);
-                    done();
-                });
+            setTimeout(() => {
+                expect(elm.getError()).toBe(null);
+                done();
             });
         });
-    }
+    });
 });

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
@@ -1,0 +1,34 @@
+import { createElement } from 'lwc';
+import ParentCmp from 'x/parent';
+
+describe('disconnecting root vm', () => {
+    // unhandledrejection is not supported in ie11 or firefox. In those browsers we will get false positives
+    // but we will get the failure in chrome and safari.
+    // We dont use the error handler because karma does not triggers it.
+    if (!process.env.COMPAT) {
+        it('should not throw an error when disconnecting an already disconnected child vm', function(done) {
+            let unhandledErrorEvent = null;
+            const unhandledErrorListener = event => {
+                event.preventDefault();
+                unhandledErrorEvent = event;
+            };
+
+            window.addEventListener('unhandledrejection', unhandledErrorListener);
+
+            const elm = createElement('x-parent', { is: ParentCmp });
+            elm.labels = ['label 1', 'label 2'];
+            document.body.appendChild(elm);
+
+            return Promise.resolve().then(() => {
+                elm.labels = [];
+                document.body.removeChild(elm);
+
+                setTimeout(() => {
+                    expect(unhandledErrorEvent).toBe(null);
+                    window.removeEventListener('unhandledrejection', unhandledErrorListener);
+                    done();
+                });
+            });
+        });
+    }
+});

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/x/child/child.html
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    {label}
+</template>

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/x/child/child.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ChildCmp extends LightningElement {
+    @api label;
+}

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.html
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <template for:each={labels} for:item="label">
+        <x-child key={label} label={label}></x-child>
+    </template>
+</template>

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ParentCmp extends LightningElement {
+    @api labels = [];
+}

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/x/parent/parent.js
@@ -2,4 +2,13 @@ import { LightningElement, api } from 'lwc';
 
 export default class ParentCmp extends LightningElement {
     @api labels = [];
+    _error = null;
+
+    @api getError() {
+        return this._error;
+    }
+
+    errorCallback(error) {
+        this._error = error;
+    }
 }


### PR DESCRIPTION
https://playground.lwcjs.org/projects/S_7PCquA7/3/edit


## Details
When you remove a rootVM with pending rehydration(s) which results in removing custom elements by the snabbdom, an error is shown in the console: `VM2206 engine.js:356 Uncaught (in promise) Error: Assert Violation: [object:vm undefined (3)] must be inserted.`

The issue is that when the rootVM is removed, all custom elements in that hierarchy are disconnected, and when a rehydration is scheduled for a vm in that subtree that will end up removing a vm, another call by the snabbdom to disconnect the vm is done, failing with an assertion by the engine.

You can see the issue in this playground repro: https://playground.lwcjs.org/projects/S_7PCquA7/3/edit


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`