### PR TITLE
refactor(engine): implementation of wired reform

### DIFF
--- a/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -79,7 +79,7 @@ describe('wire.ts', () => {
             });
         });
 
-        it('should make properties of a wired object property reactive', () => {
+        it('should make wired properties as readonly', () => {
             let counter = 0;
             class MyComponent extends LightningElement {
                 injectFooDotX(x) {
@@ -100,10 +100,11 @@ describe('wire.ts', () => {
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
-            elm.injectFooDotX(2);
-
+            expect(() => {
+                elm.injectFooDotX(2);
+            }).toThrowError();
             return Promise.resolve().then(() => {
-                expect(counter).toBe(2);
+                expect(counter).toBe(1);
             });
         });
 

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -20,7 +20,7 @@ import { getDecoratorsRegisteredMeta } from './register';
  */
 export default function api(
     target: ComponentConstructor,
-    propName: PropertyKey,
+    propName: string,
     descriptor: PropertyDescriptor | undefined
 ): PropertyDescriptor {
     if (process.env.NODE_ENV !== 'production') {
@@ -60,7 +60,7 @@ export default function api(
 
 function createPublicPropertyDescriptor(
     proto: ComponentConstructor,
-    key: PropertyKey,
+    key: string,
     descriptor: PropertyDescriptor | undefined
 ): PropertyDescriptor {
     return {

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -19,7 +19,7 @@ import { ComponentConstructor, ComponentInterface } from '../component';
  */
 export default function track(
     target: ComponentConstructor,
-    prop: PropertyKey,
+    prop: string,
     descriptor: PropertyDescriptor | undefined
 ): PropertyDescriptor;
 export default function track(target: any, prop?, descriptor?): any {
@@ -55,9 +55,9 @@ export default function track(target: any, prop?, descriptor?): any {
     );
 }
 
-export function createTrackedPropertyDescriptor(
-    Ctor: any,
-    key: PropertyKey,
+function createTrackedPropertyDescriptor(
+    Ctor: ComponentConstructor,
+    key: string,
     enumerable: boolean
 ): PropertyDescriptor {
     return {
@@ -67,7 +67,7 @@ export function createTrackedPropertyDescriptor(
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             }
             valueObserved(this, key);
-            return vm.cmpTrack[key];
+            return vm.cmpFields[key];
         },
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
@@ -81,8 +81,8 @@ export function createTrackedPropertyDescriptor(
                 );
             }
             const reactiveOrAnyValue = reactiveMembrane.getProxy(newValue);
-            if (reactiveOrAnyValue !== vm.cmpTrack[key]) {
-                vm.cmpTrack[key] = reactiveOrAnyValue;
+            if (reactiveOrAnyValue !== vm.cmpFields[key]) {
+                vm.cmpFields[key] = reactiveOrAnyValue;
                 if (isFalse(vm.isDirty)) {
                     // perf optimization to skip this step if the track property is on a component that is already dirty
                     valueMutated(this, key);

--- a/packages/@lwc/engine/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine/src/framework/decorators/wire.ts
@@ -4,15 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { createTrackedPropertyDescriptor } from './track';
 import assert from '../../shared/assert';
-import { isObject, isUndefined } from '../../shared/language';
+import { isObject, isUndefined, isFalse } from '../../shared/language';
 import { DecoratorFunction } from './decorate';
-import { ComponentConstructor } from '../component';
+import { ComponentConstructor, ComponentInterface } from '../component';
+import { isRendering, vmBeingRendered } from '../invoker';
+import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
+import { getComponentVM } from '../vm';
+import { reactiveMembrane } from '../membrane';
 
 function wireDecorator(
     target: ComponentConstructor,
-    prop: PropertyKey,
+    prop: string,
     descriptor: PropertyDescriptor | undefined
 ): PropertyDescriptor | any {
     if (process.env.NODE_ENV !== 'production') {
@@ -32,7 +35,7 @@ function wireDecorator(
             );
         }
     }
-    return createTrackedPropertyDescriptor(
+    return createWiredPropertyDescriptor(
         target,
         prop,
         isObject(descriptor) ? descriptor.enumerable === true : true
@@ -54,4 +57,44 @@ export default function wire(_adapter: any, _config: any): DecoratorFunction {
         }
         throw new TypeError();
     }
+}
+
+function createWiredPropertyDescriptor(
+    Ctor: ComponentConstructor,
+    key: string,
+    enumerable: boolean
+): PropertyDescriptor {
+    return {
+        get(this: ComponentInterface): any {
+            const vm = getComponentVM(this);
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+            }
+            valueObserved(this, key);
+            return vm.cmpFields[key];
+        },
+        set(this: ComponentInterface, newValue: any) {
+            const vm = getComponentVM(this);
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+                assert.invariant(
+                    !isRendering,
+                    `${vmBeingRendered}.render() method has side effects on the wired field ${vm}.${String(
+                        key
+                    )}`
+                );
+            }
+            // making the wired value as readonly
+            newValue = reactiveMembrane.getReadOnlyProxy(newValue);
+            if (newValue !== vm.cmpFields[key]) {
+                vm.cmpFields[key] = newValue;
+                if (isFalse(vm.isDirty)) {
+                    // perf optimization to skip this step if the track property is on a component that is already dirty
+                    valueMutated(this, key);
+                }
+            }
+        },
+        enumerable,
+        configurable: true,
+    };
 }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -86,9 +86,9 @@ export interface UninitializedVM {
     /** Adopted Children List */
     aChildren: VNodes;
     velements: VCustomElement[];
-    cmpProps: any;
+    cmpProps: Record<string, any>;
     cmpSlots: SlotSet;
-    cmpTrack: any;
+    cmpFields: Record<string, any>;
     callHook: (
         cmp: ComponentInterface | undefined,
         fn: (...args: any[]) => any,
@@ -227,7 +227,7 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
         data: EmptyObject,
         context: create(null),
         cmpProps: create(null),
-        cmpTrack: create(null),
+        cmpFields: create(null),
         cmpSlots: useSyntheticShadow ? create(null) : undefined,
         callHook,
         setHook,


### PR DESCRIPTION
__EXPERIMENTAL_REFACTOR__

## Details

First refactor to slowly iron out the way a wire adapter sets values into a wired fields. In this first step, we transform the behavior of the value set into a field from a reactive proxy to a readonly proxy.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

The potential impact here is for someone wiring to a field, and making manual mutations to the value that was wired. The workaround is to split out that logic into a tracked value, while keeping the wired field as set by the adapter.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
