### PR TITLE
fix(synthetic-shadow): fix MutationObserver disconnect() memory leak

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -9,6 +9,7 @@ import {
     ArrayReduce,
     ArrayPush,
     ArraySplice,
+    ArrayForEach,
     create,
     defineProperty,
     defineProperties,
@@ -206,7 +207,7 @@ function patchedDisconnect(this: PatchedMutationObserver): void {
     originalDisconnect.call(this);
     // Remove all instances of this MutationObserver from the target Nodes
     if (!isUndefined(this.observerLookups)) {
-        this.observerLookups.forEach(observerLookup => {
+        ArrayForEach.call(this.observerLookups, observerLookup => {
             const index = ArrayIndexOf.call(observerLookup, this);
             if (index !== -1) {
                 ArraySplice.call(observerLookup, index, 1);
@@ -235,7 +236,7 @@ function patchedObserve(
     if (isUndefined(this.observerLookups)) {
         this.observerLookups = [];
     }
-    this.observerLookups.push(target[observerLookupField]);
+    ArrayPush.call(this.observerLookups, target[observerLookupField]);
     // If the target is a SyntheticShadowRoot, observe the host since the shadowRoot is an empty documentFragment
     if (target instanceof SyntheticShadowRoot) {
         target = (target as ShadowRoot).host;

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -9,7 +9,7 @@ import {
     ArrayReduce,
     ArrayPush,
     ArraySplice,
-    ArrayForEach,
+    forEach,
     create,
     defineProperty,
     defineProperties,
@@ -207,7 +207,7 @@ function patchedDisconnect(this: PatchedMutationObserver): void {
     originalDisconnect.call(this);
     // Remove all instances of this MutationObserver from the target Nodes
     if (!isUndefined(this.observerLookups)) {
-        ArrayForEach.call(this.observerLookups, observerLookup => {
+        forEach.call(this.observerLookups, observerLookup => {
             const index = ArrayIndexOf.call(observerLookup, this);
             if (index !== -1) {
                 ArraySplice.call(observerLookup, index, 1);

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -422,5 +422,56 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 expect(hostSpy).not.toHaveBeenCalled();
             });
         });
+
+        it('should not leak after disconnect', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - multiple nodes', () => {
+            const node1 = document.createElement('div');
+            const node2 = document.createElement('div');
+            container.appendChild(node1);
+            container.appendChild(node2);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node1, observerConfig);
+            observer.observe(node2, observerConfig);
+            expect(node1.$$lwcNodeObservers$$.length).toBe(1);
+            expect(node2.$$lwcNodeObservers$$.length).toBe(1);
+            observer.disconnect();
+            expect(node1.$$lwcNodeObservers$$.length).toBe(0);
+            expect(node2.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - multiple observers', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer1 = new MutationObserver(() => {});
+            const observer2 = new MutationObserver(() => {});
+            observer1.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer2.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(2);
+            observer1.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer2.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - duplicate observe()s', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node, observerConfig);
+            observer.observe(node, observerConfig);
+            observer.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
     });
 });

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -472,6 +472,5 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             observer.disconnect();
             expect(node.$$lwcNodeObservers$$.length).toBe(0);
         });
-
     });
 });


### PR DESCRIPTION
## Details

When a MutationObserver observes a DOM node, it creates a link from that DOM node to itself. When `disconnect()` is called, it should remove the association to avoid leaking the MutationObserver itself.

This is especially important when observing DOM nodes like `document.body` which are never removed from the DOM.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅