### PR TITLE
fix: mutationobserver memory leak - use weakmap for bookkeeping

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -248,8 +248,8 @@ function patchedObserve(
     // maintain a list of all nodes observed by this observer
     if (observerToNodesMap.has(this)) {
         const observedNodes = observerToNodesMap.get(this)!;
-        if (observedNodes.indexOf(target) === -1) {
-            observedNodes.push(target);
+        if (ArrayIndexOf.call(observedNodes, target) === -1) {
+            ArrayPush.call(observedNodes, target);
         }
     } else {
         observerToNodesMap.set(this, [target]);

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -26,13 +26,10 @@ const {
     takeRecords: originalTakeRecords,
 } = OriginalMutationObserver.prototype;
 
-/* Internal fields to maintain relationships */
-// Field to cache wrapper
+// Internal fields to maintain relationships
 const wrapperLookupField = '$$lwcObserverCallbackWrapper$$';
-// Field to store hard references to observers that are watching a node
 const observerLookupField = '$$lwcNodeObservers$$';
 
-// Map of observer to nodes watched by the observer
 const observerToNodesMap: WeakMap<MutationObserver, Array<Node>> = new WeakMap();
 
 /**
@@ -241,7 +238,7 @@ function patchedObserve(
     // Same observer trying to observe the same node
     if (ArrayIndexOf.call(target[observerLookupField], this) === -1) {
         ArrayPush.call(target[observerLookupField], this);
-    } // else There is more bookkeeping to do here https://dom.spec.whatwg.org/#dom-mutationobserver-observe # 7
+    } // else There is more bookkeeping to do here https://dom.spec.whatwg.org/#dom-mutationobserver-observe Step #7
 
     // If the target is a SyntheticShadowRoot, observe the host since the shadowRoot is an empty documentFragment
     if (target instanceof SyntheticShadowRoot) {

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -423,60 +423,62 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
     });
-    describe('', () => {
-        let container;
-        beforeEach(() => {
-            container = document.createElement('div');
-            document.body.appendChild(container);
-        });
-        it('should not leak after disconnect', () => {
-            const node = document.createElement('div');
-            container.appendChild(node);
-            const observer = new MutationObserver(() => {});
-            observer.observe(node, observerConfig);
-            expect(node.$$lwcNodeObservers$$.length).toBe(1);
-            observer.disconnect();
-            expect(node.$$lwcNodeObservers$$.length).toBe(0);
-        });
+    if (!process.env.NATIVE_SHADOW) {
+        describe('References to mutation observers are not leaked', () => {
+            let container;
+            beforeEach(() => {
+                container = document.createElement('div');
+                document.body.appendChild(container);
+            });
+            it('should not leak after disconnect', () => {
+                const node = document.createElement('div');
+                container.appendChild(node);
+                const observer = new MutationObserver(() => {});
+                observer.observe(node, observerConfig);
+                expect(node.$$lwcNodeObservers$$.length).toBe(1);
+                observer.disconnect();
+                expect(node.$$lwcNodeObservers$$.length).toBe(0);
+            });
 
-        it('should not leak after disconnect - multiple nodes', () => {
-            const node1 = document.createElement('div');
-            const node2 = document.createElement('div');
-            container.appendChild(node1);
-            container.appendChild(node2);
-            const observer = new MutationObserver(() => {});
-            observer.observe(node1, observerConfig);
-            observer.observe(node2, observerConfig);
-            expect(node1.$$lwcNodeObservers$$.length).toBe(1);
-            expect(node2.$$lwcNodeObservers$$.length).toBe(1);
-            observer.disconnect();
-            expect(node1.$$lwcNodeObservers$$.length).toBe(0);
-            expect(node2.$$lwcNodeObservers$$.length).toBe(0);
-        });
+            it('should not leak after disconnect - multiple nodes', () => {
+                const node1 = document.createElement('div');
+                const node2 = document.createElement('div');
+                container.appendChild(node1);
+                container.appendChild(node2);
+                const observer = new MutationObserver(() => {});
+                observer.observe(node1, observerConfig);
+                observer.observe(node2, observerConfig);
+                expect(node1.$$lwcNodeObservers$$.length).toBe(1);
+                expect(node2.$$lwcNodeObservers$$.length).toBe(1);
+                observer.disconnect();
+                expect(node1.$$lwcNodeObservers$$.length).toBe(0);
+                expect(node2.$$lwcNodeObservers$$.length).toBe(0);
+            });
 
-        it('should not leak after disconnect - multiple observers', () => {
-            const node = document.createElement('div');
-            container.appendChild(node);
-            const observer1 = new MutationObserver(() => {});
-            const observer2 = new MutationObserver(() => {});
-            observer1.observe(node, observerConfig);
-            expect(node.$$lwcNodeObservers$$.length).toBe(1);
-            observer2.observe(node, observerConfig);
-            expect(node.$$lwcNodeObservers$$.length).toBe(2);
-            observer1.disconnect();
-            expect(node.$$lwcNodeObservers$$.length).toBe(1);
-            observer2.disconnect();
-            expect(node.$$lwcNodeObservers$$.length).toBe(0);
-        });
+            it('should not leak after disconnect - multiple observers', () => {
+                const node = document.createElement('div');
+                container.appendChild(node);
+                const observer1 = new MutationObserver(() => {});
+                const observer2 = new MutationObserver(() => {});
+                observer1.observe(node, observerConfig);
+                expect(node.$$lwcNodeObservers$$.length).toBe(1);
+                observer2.observe(node, observerConfig);
+                expect(node.$$lwcNodeObservers$$.length).toBe(2);
+                observer1.disconnect();
+                expect(node.$$lwcNodeObservers$$.length).toBe(1);
+                observer2.disconnect();
+                expect(node.$$lwcNodeObservers$$.length).toBe(0);
+            });
 
-        it('should not leak after disconnect - duplicate observe()s', () => {
-            const node = document.createElement('div');
-            container.appendChild(node);
-            const observer = new MutationObserver(() => {});
-            observer.observe(node, observerConfig);
-            observer.observe(node, observerConfig);
-            observer.disconnect();
-            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+            it('should not leak after disconnect - duplicate observe()s', () => {
+                const node = document.createElement('div');
+                container.appendChild(node);
+                const observer = new MutationObserver(() => {});
+                observer.observe(node, observerConfig);
+                observer.observe(node, observerConfig);
+                observer.disconnect();
+                expect(node.$$lwcNodeObservers$$.length).toBe(0);
+            });
         });
-    });
+    }
 });

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -423,4 +423,60 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
     });
+    describe('', () => {
+        let container;
+        beforeEach(() => {
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+        it('should not leak after disconnect', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - multiple nodes', () => {
+            const node1 = document.createElement('div');
+            const node2 = document.createElement('div');
+            container.appendChild(node1);
+            container.appendChild(node2);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node1, observerConfig);
+            observer.observe(node2, observerConfig);
+            expect(node1.$$lwcNodeObservers$$.length).toBe(1);
+            expect(node2.$$lwcNodeObservers$$.length).toBe(1);
+            observer.disconnect();
+            expect(node1.$$lwcNodeObservers$$.length).toBe(0);
+            expect(node2.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - multiple observers', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer1 = new MutationObserver(() => {});
+            const observer2 = new MutationObserver(() => {});
+            observer1.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer2.observe(node, observerConfig);
+            expect(node.$$lwcNodeObservers$$.length).toBe(2);
+            observer1.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(1);
+            observer2.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+
+        it('should not leak after disconnect - duplicate observe()s', () => {
+            const node = document.createElement('div');
+            container.appendChild(node);
+            const observer = new MutationObserver(() => {});
+            observer.observe(node, observerConfig);
+            observer.observe(node, observerConfig);
+            observer.disconnect();
+            expect(node.$$lwcNodeObservers$$.length).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
## Details
Use a WeakMap to store all nodes watched by an observer. On disconnect(), clean up references to the observer on all the nodes.

Limitation: If MutationObservers are not disconnected, this could lead to memory leak of nodes.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
