### PR TITLE
fix: account for clicks on form element labels when delegating focus

### DIFF
--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
@@ -38,6 +38,7 @@ describe('focus delegation when clicking on form element label', () => {
                 .querySelector('integration-delegates-focus-non-focusable-click-target')
                 .shadowRoot.querySelector('.head');
         });
+        // Focus on input so that relatedTarget will be non-null
         headInput.click();
 
         const label = browser.execute(function() {

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+
+describe('focus delegation when clicking on form element label', () => {
+    const URL = 'http://localhost:4567/delegates-focus-non-focusable-click-target';
+
+    beforeEach(() => {
+        browser.url(URL);
+    });
+
+    it('should apply focus to element associated with label when relatedTarget is null', function() {
+        const label = browser.execute(function() {
+            return document
+                .querySelector('integration-delegates-focus-non-focusable-click-target')
+                .shadowRoot.querySelector('integration-input')
+                .shadowRoot.querySelector('label');
+        });
+        label.click();
+
+        const inputClassName = browser.execute(function() {
+            const container = document.activeElement;
+            const integrationInput = container.shadowRoot.activeElement;
+            const inputClassName = integrationInput.shadowRoot.activeElement.className;
+            return inputClassName;
+        }).value;
+
+        assert.strictEqual(inputClassName, 'internal');
+    });
+
+    it('should apply focus to element associated with label when relatedTarget is non-null', function() {
+        const headInput = browser.execute(function() {
+            return document
+                .querySelector('integration-delegates-focus-non-focusable-click-target')
+                .shadowRoot.querySelector('.head');
+        });
+        headInput.click();
+
+        const label = browser.execute(function() {
+            return document
+                .querySelector('integration-delegates-focus-non-focusable-click-target')
+                .shadowRoot.querySelector('integration-input')
+                .shadowRoot.querySelector('label');
+        });
+        label.click();
+
+        const inputClassName = browser.execute(function() {
+            const container = document.activeElement;
+            const integrationInput = container.shadowRoot.activeElement;
+            const inputClassName = integrationInput.shadowRoot.activeElement.className;
+            return inputClassName;
+        }).value;
+
+        assert.strictEqual(inputClassName, 'internal');
+    });
+});

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.html
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.html
@@ -1,0 +1,5 @@
+<template>
+    <input placeholder="head" class="head">
+    <integration-input tabindex="-1"></integration-input>
+    <input placeholder="tail" class="tail">
+</template>

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class DelegatesFocus extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/input/input.html
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/input/input.html
@@ -1,0 +1,4 @@
+<template>
+    <label for="internal">internal input</label>
+    <input id="internal" class="internal" placeholder="internal">
+</template>

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/input/input.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/integration/input/input.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class FancyInput extends LightningElement {
+    static delegatesFocus = true;
+}


### PR DESCRIPTION
## Details

This change fixes a bug that surfaces when the user clicks on a non-focusable element which results in a focus change (i.e., clicking on a form element label causes the associated form element to receive focus). The main issue was that the sequential focus navigation logic was getting executed even though we tried to skip it, due to the ordering of DOM events depending on user action:

```
Click form element   | Click form element label
==================================================
mousedown            | mousedown
FOCUSIN              | mousedown-setTimeout
mousedown-setTimeout | mouseup
mouseup              | FOCUSIN
mouseup-setTimeout   | mouseup-setTimeout
```

Specific changes:
- The delegatesFocus polyfill currently handles mouse clicks by removing the `focusin` handler (which takes care of sequential focus navigation) and then adding it back later. This proposed change modifies the timing that the handler is reinstated.
- This change removes/adds the `focusin` handler for mouse clicks regardless of whether or not the click target is focusable, eliminating what is referred to as "mousedown state". This simplifies the implementation because it avoids the question of what is and isn't focusable--something that lacks specs and varies across different browser implementations.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
