### PR TITLE
fix(engine): #1295 - removing hack to support old metadata in tests

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -6,9 +6,8 @@
  */
 /*
  * After all our decorator transforms have run,
- * we have created static properties attached to the class body
- * Foo.track = {...}
- *
+ * we call registerDecorators() to register the metadata
+ * of all transformed decorators.
  */
 
 const { basename, extname } = require('path');

--- a/packages/@lwc/engine/src/__tests__/dom.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/dom.spec.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../';
-import { registerDecorators } from '../framework/main';
+import { createElement, LightningElement, registerDecorators } from '../';
 
 describe('dom', () => {
     describe('composed polyfill', () => {

--- a/packages/@lwc/engine/src/__tests__/dom.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/dom.spec.ts
@@ -6,6 +6,7 @@
  */
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../';
+import { registerDecorators } from '../framework/main';
 
 describe('dom', () => {
     describe('composed polyfill', () => {
@@ -51,7 +52,9 @@ describe('dom', () => {
                     this.dispatchEvent(event);
                 }
             }
-            MyComponent.publicMethods = ['trigger'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['trigger'],
+            });
 
             const parentTmpl = compileTemplate(
                 `

--- a/packages/@lwc/engine/src/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/events.spec.ts
@@ -6,6 +6,7 @@
  */
 import { createElement, LightningElement } from '../';
 import { compileTemplate } from 'test-utils';
+import { registerDecorators } from '../framework/main';
 
 describe('events', () => {
     describe('bookkeeping', () => {
@@ -71,7 +72,9 @@ describe('events', () => {
                     return tpl;
                 }
             }
-            MyComponent.publicMethods = ['triggerInternalClick'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['triggerInternalClick'],
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             function a() {
@@ -225,10 +228,10 @@ describe('events', () => {
                     return rootHTML;
                 }
             }
-            Root.track = {
-                newTitle: 1,
-            };
-            Root.publicMethods = ['changeSomething'];
+            registerDecorators(Root, {
+                track: { newTitle: 1 },
+                publicMethods: ['changeSomething'],
+            });
             class Parent extends LightningElement {
                 render() {
                     return parentHTML;
@@ -597,7 +600,9 @@ describe('events', () => {
                     return tpl;
                 }
             }
-            MyComponent.publicMethods = ['triggerInternalClick'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['triggerInternalClick'],
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             elm.triggerInternalClick();

--- a/packages/@lwc/engine/src/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/events.spec.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { createElement, LightningElement } from '../';
+import { createElement, LightningElement, registerDecorators } from '../';
 import { compileTemplate } from 'test-utils';
-import { registerDecorators } from '../framework/main';
 
 describe('events', () => {
     describe('bookkeeping', () => {

--- a/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
@@ -8,6 +8,7 @@ import * as api from '../api';
 import { createElement, LightningElement } from '../main';
 import { registerTemplate } from '../template';
 import { compileTemplate } from 'test-utils';
+import { registerDecorators } from '../decorators/register';
 
 describe('api', () => {
     afterAll(() => jest.clearAllMocks());
@@ -22,7 +23,9 @@ describe('api', () => {
                         return 1;
                     }
                 }
-                Foo.publicMethods = ['xyz'];
+                registerDecorators(Foo, {
+                    publicMethods: ['xyz'],
+                });
                 return Foo;
             };
             factory.__circular__ = true;

--- a/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
@@ -5,10 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as api from '../api';
-import { createElement, LightningElement } from '../main';
+import { createElement, LightningElement, registerDecorators } from '../main';
 import { registerTemplate } from '../template';
 import { compileTemplate } from 'test-utils';
-import { registerDecorators } from '../decorators/register';
 
 describe('api', () => {
     afterAll(() => jest.clearAllMocks());

--- a/packages/@lwc/engine/src/framework/__tests__/diff.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/diff.spec.ts
@@ -162,18 +162,18 @@ class Table extends LightningElement {
         return tableHTML;
     }
 }
-Table.publicProps = {
-    rows: {},
-};
+registerDecorators(Table, {
+    publicProps: { rows: {} },
+});
 
 class Row extends LightningElement {
     render() {
         return rowHTML;
     }
 }
-Row.publicProps = {
-    row: {},
-};
+registerDecorators(Row, {
+    publicProps: { row: {} },
+});
 
 const rowHTML = compileTemplate(
     `

--- a/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
@@ -6,6 +6,7 @@
  */
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../main';
+import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -37,8 +38,10 @@ function createBoundaryComponent({ name, ctor }) {
             return this.error ? recoveryTmpl : baseTmpl;
         }
     }
-    Boundary.track = { error: 1 };
-    Boundary.publicMethods = ['getError'];
+    registerDecorators(Boundary, {
+        track: { error: 1 },
+        publicMethods: ['getError'],
+    });
 
     return Boundary;
 }
@@ -334,8 +337,10 @@ describe('error boundary component', () => {
                                 return boundaryWithSlot;
                             }
                         }
-                        BoundaryWithSlot.publicMethods = ['getError'];
-                        BoundaryWithSlot.track = { error: 1 };
+                        registerDecorators(BoundaryWithSlot, {
+                            track: { error: 1 },
+                            publicMethods: ['getError'],
+                        });
 
                         const boundaryElm = createElement('x-boundary-with-slot', {
                             is: BoundaryWithSlot,
@@ -375,8 +380,10 @@ describe('error boundary component', () => {
                                 throw new Error('Boundary RenderedCallback Throw');
                             }
                         }
-                        Boundary.publicMethods = ['getError'];
-                        Boundary.track = { error: 1 };
+                        registerDecorators(Boundary, {
+                            track: { error: 1 },
+                            publicMethods: ['getError'],
+                        });
 
                         const boundaryElm = createElement('x-boundary', { is: Boundary });
 
@@ -412,8 +419,10 @@ describe('error boundary component', () => {
                                 return html;
                             }
                         }
-                        ChildErrorBoundary.publicMethods = ['getError'];
-                        ChildErrorBoundary.track = { error: 1 };
+                        registerDecorators(ChildErrorBoundary, {
+                            track: { error: 1 },
+                            publicMethods: ['getError'],
+                        });
 
                         const HostErrorBoundary = createBoundaryComponent({
                             name: 'child-error-boundary',
@@ -449,8 +458,10 @@ describe('error boundary component', () => {
                             throw new Error('Child Boundary RenderedCallback Throw');
                         }
                     }
-                    ChildErrorBoundary.publicMethods = ['getError'];
-                    ChildErrorBoundary.track = { error: 1 };
+                    registerDecorators(ChildErrorBoundary, {
+                        track: { error: 1 },
+                        publicMethods: ['getError'],
+                    });
 
                     const HostErrorBoundary = createBoundaryComponent({
                         name: 'child-error-boundary',
@@ -498,8 +509,10 @@ describe('error boundary component', () => {
                                 return html;
                             }
                         }
-                        ChildErrorBoundary.publicMethods = ['getError'];
-                        ChildErrorBoundary.track = { error: 1 };
+                        registerDecorators(ChildErrorBoundary, {
+                            track: { error: 1 },
+                            publicMethods: ['getError'],
+                        });
 
                         const HostErrorBoundary = createBoundaryComponent({
                             name: 'child-error-boundary',
@@ -627,8 +640,10 @@ describe('error boundary component', () => {
                                 throw new Error('Boundary ConnectedCallback Throw');
                             }
                         }
-                        Boundary.publicMethods = ['getError'];
-                        Boundary.track = { error: 1 };
+                        registerDecorators(Boundary, {
+                            track: { error: 1 },
+                            publicMethods: ['getError'],
+                        });
 
                         const boundaryElm = createElement('x-boundary', { is: Boundary });
 
@@ -795,7 +810,9 @@ describe('error boundary component', () => {
                             return this.error ? recoveryTmpl : baseTmpl;
                         }
                     }
-                    InnerErrorBoundary.track = { error: 1 };
+                    registerDecorators(InnerErrorBoundary, {
+                        track: { error: 1 },
+                    });
 
                     const elm = createElement('inner-error-boundary', { is: InnerErrorBoundary });
                     document.body.appendChild(elm);
@@ -962,11 +979,9 @@ describe('error boundary component', () => {
                             return null;
                         }
                     }
-                    PreErrorChildContent.publicProps = {
-                        foo: {
-                            config: 1,
-                        },
-                    };
+                    registerDecorators(PreErrorChildContent, {
+                        publicProps: { foo: { config: 1 } },
+                    });
                     const baseTmpl = compileTemplate(
                         `
                     <template>

--- a/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../main';
-import { registerDecorators } from '../decorators/register';
+import { createElement, LightningElement, registerDecorators } from '../main';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 

--- a/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
@@ -6,6 +6,7 @@
  */
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../main';
+import { registerDecorators } from '../decorators/register';
 
 describe('Composed events', () => {
     it('should be able to consume events from within template', () => {
@@ -16,7 +17,9 @@ describe('Composed events', () => {
                 this.dispatchEvent(new CustomEvent('foo'));
             }
         }
-        Child.publicMethods = ['triggerFoo'];
+        registerDecorators(Child, {
+            publicMethods: ['triggerFoo'],
+        });
 
         const html = compileTemplate(
             `
@@ -42,7 +45,9 @@ describe('Composed events', () => {
                 return html;
             }
         }
-        ComposedEvents.publicMethods = ['triggerChildFoo'];
+        registerDecorators(ComposedEvents, {
+            publicMethods: ['triggerChildFoo'],
+        });
 
         const elem = createElement('x-components-events-parent', { is: ComposedEvents });
         document.body.appendChild(elem);
@@ -340,7 +345,9 @@ describe('Events on Custom Elements', () => {
                 div.dispatchEvent(new CustomEvent('c-event', { bubbles: true, composed: true }));
             }
         }
-        MyComponent.publicMethods = ['run'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['run'],
+        });
 
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
@@ -370,7 +377,9 @@ describe('Events on Custom Elements', () => {
                 div.dispatchEvent(new CustomEvent('c-event', { bubbles: true, composed: true }));
             }
         }
-        MyComponent.publicMethods = ['run'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['run'],
+        });
 
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
@@ -400,7 +409,9 @@ describe('Events on Custom Elements', () => {
                 div.dispatchEvent(new CustomEvent('c-event', { bubbles: true, composed: true }));
             }
         }
-        MyChild.publicMethods = ['run'];
+        registerDecorators(MyChild, {
+            publicMethods: ['run'],
+        });
 
         const parentTmpl = compileTemplate(
             `
@@ -421,7 +432,9 @@ describe('Events on Custom Elements', () => {
                 child.run();
             }
         }
-        MyComponent.publicMethods = ['run'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['run'],
+        });
 
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
@@ -452,7 +465,9 @@ describe('Events on Custom Elements', () => {
                 div.dispatchEvent(new CustomEvent('c-event', { bubbles: true, composed: true }));
             }
         }
-        MyChild.publicMethods = ['run'];
+        registerDecorators(MyChild, {
+            publicMethods: ['run'],
+        });
 
         const parentTmpl = compileTemplate(
             `
@@ -473,7 +488,9 @@ describe('Events on Custom Elements', () => {
                 child.run();
             }
         }
-        MyComponent.publicMethods = ['run'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['run'],
+        });
 
         const elm = createElement('x-foo', { is: MyComponent });
         document.body.appendChild(elm);
@@ -508,7 +525,9 @@ describe('Events on Custom Elements', () => {
                 this.removeEventListener('click', clickSpy);
             }
         }
-        MyComponent.publicMethods = ['removeClickListener'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['removeClickListener'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -557,7 +576,9 @@ describe('Events on Custom Elements', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -589,7 +610,9 @@ describe('Events on Custom Elements', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -645,8 +668,9 @@ describe('Events on Custom Elements', () => {
                 return html;
             }
         }
-
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -724,7 +748,9 @@ describe('Slotted element events', () => {
                 return parentTmpl;
             }
         }
-        SlottedEventTarget.publicMethods = ['clickDiv'];
+        registerDecorators(SlottedEventTarget, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('slotted-event-target', { is: SlottedEventTarget });
         document.body.appendChild(elm);
@@ -809,7 +835,9 @@ describe('Shadow Root events', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -840,7 +868,9 @@ describe('Shadow Root events', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -869,7 +899,9 @@ describe('Shadow Root events', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -894,7 +926,9 @@ describe('Shadow Root events', () => {
                 return childTmpl;
             }
         }
-        MyChild.publicMethods = ['clickDiv'];
+        registerDecorators(MyChild, {
+            publicMethods: ['clickDiv'],
+        });
 
         const parentTmpl = compileTemplate(
             `
@@ -925,7 +959,9 @@ describe('Shadow Root events', () => {
                 return parentTmpl;
             }
         }
-        MyComponent.publicMethods = ['clickChildDiv'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickChildDiv'],
+        });
 
         const elm = createElement('correct-nested-root-event-target-parent', { is: MyComponent });
         document.body.appendChild(elm);
@@ -1045,7 +1081,9 @@ describe('Removing events from shadowroot', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv', 'removeHandler'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv', 'removeHandler'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -1082,7 +1120,9 @@ describe('Removing events from shadowroot', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv', 'removeHandler'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv', 'removeHandler'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -1120,7 +1160,9 @@ describe('Removing events from cmp', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv', 'removeHandler'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv', 'removeHandler'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);
@@ -1157,7 +1199,9 @@ describe('Removing events from cmp', () => {
                 return html;
             }
         }
-        MyComponent.publicMethods = ['clickDiv', 'removeHandler'];
+        registerDecorators(MyComponent, {
+            publicMethods: ['clickDiv', 'removeHandler'],
+        });
 
         const elm = createElement('x-add-event-listener', { is: MyComponent });
         document.body.appendChild(elm);

--- a/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../main';
-import { registerDecorators } from '../decorators/register';
+import { createElement, LightningElement, registerDecorators } from '../main';
 
 describe('Composed events', () => {
     it('should be able to consume events from within template', () => {

--- a/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
@@ -6,9 +6,8 @@
  */
 import { compileTemplate } from 'test-utils';
 
-import { createElement, LightningElement } from '../main';
+import { createElement, LightningElement, registerDecorators } from '../main';
 import assertLogger from '../../shared/assert';
-import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 

--- a/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
@@ -8,6 +8,7 @@ import { compileTemplate } from 'test-utils';
 
 import { createElement, LightningElement } from '../main';
 import assertLogger from '../../shared/assert';
+import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -177,8 +178,10 @@ describe('html-element', () => {
                     });
                 }
             }
-            MyComponent.publicProps = { foo: true };
-            MyComponent.publicMethods = ['setFoo'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['setFoo'],
+                publicProps: { foo: {} },
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             elm.foo = 1;
@@ -212,7 +215,9 @@ describe('html-element', () => {
                     return this.tabIndex;
                 }
             }
-            MyComponent.publicMethods = ['getTabIndex'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['getTabIndex'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             elm.setAttribute('tabindex', 3);
@@ -231,7 +236,9 @@ describe('html-element', () => {
                     return this.tabIndex;
                 }
             }
-            MyComponent.publicMethods = ['getTabIndex'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['getTabIndex'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             elm.setAttribute('tabindex', 3);
@@ -272,7 +279,9 @@ describe('html-element', () => {
                     return this.tabIndex;
                 }
             }
-            MyComponent.publicMethods = ['getTabIndex'];
+            registerDecorators(MyComponent, {
+                publicMethods: ['getTabIndex'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             elm.setAttribute('tabindex', 3);
@@ -415,7 +424,9 @@ describe('html-element', () => {
                     return emptyTemplate;
                 }
             }
-            MyComponent.publicProps = { x: 1 };
+            registerDecorators(MyComponent, {
+                publicProps: { x: 1 },
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             elm.x = 2;
             return Promise.resolve().then(() => {
@@ -432,7 +443,9 @@ describe('html-element', () => {
                     return emptyTemplate;
                 }
             }
-            MyComponent.publicProps = { x: 1 };
+            registerDecorators(MyComponent, {
+                publicProps: { x: 1 },
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             document.body.removeChild(elm);
@@ -481,12 +494,13 @@ describe('html-element', () => {
                     return this.state.foo;
                 }
             }
+            registerDecorators(MyComponent, {
+                publicProps: { foo: {} },
+            });
 
-            MyComponent.publicProps = {
-                foo: {},
-            };
-
-            MyComponent.track = { state: 1 };
+            registerDecorators(MyComponent, {
+                track: { state: 1 },
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             elm.foo = new Map();
@@ -503,7 +517,9 @@ describe('html-element', () => {
                     this.state.foo;
                 }
             }
-            MyComponent.track = { state: 1 };
+            registerDecorators(MyComponent, {
+                track: { state: 1 },
+            });
             const elm = createElement('x-foo-tracked-null', { is: MyComponent });
 
             expect(() => document.body.appendChild(elm)).not.toLogError();
@@ -513,9 +529,9 @@ describe('html-element', () => {
             class MyComponent extends LightningElement {
                 foo = null;
             }
-            MyComponent.publicProps = {
-                foo: {},
-            };
+            registerDecorators(MyComponent, {
+                publicProps: { foo: {} },
+            });
             const elm = createElement('x-foo-init-api', { is: MyComponent });
 
             expect(() => document.body.appendChild(elm)).not.toLogError();
@@ -534,9 +550,9 @@ describe('html-element', () => {
                         called += 1;
                     }
                 }
-                MyComponent.publicProps = {
-                    role: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { role: {} },
+                });
                 const element = createElement('prop-getter-aria-role', { is: MyComponent });
                 document.body.appendChild(element);
                 element.role = 'tab';
@@ -572,9 +588,9 @@ describe('html-element', () => {
                         return 'lang';
                     }
                 }
-                MyComponent.publicProps = {
-                    lang: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { lang: {} },
+                });
 
                 const element = createElement('prop-setter-lang', { is: MyComponent });
                 element.lang = 'en';
@@ -618,9 +634,9 @@ describe('html-element', () => {
                         return 'en';
                     }
                 }
-                MyComponent.publicProps = {
-                    lang: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { lang: {} },
+                });
 
                 const element = createElement('prop-getter-lang-imperative', { is: MyComponent });
 
@@ -692,9 +708,9 @@ describe('html-element', () => {
                         return 'hidden';
                     }
                 }
-                MyComponent.publicProps = {
-                    hidden: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { hidden: {} },
+                });
 
                 const element = createElement('prop-setter-hidden', { is: MyComponent });
                 element.hidden = true;
@@ -737,9 +753,9 @@ describe('html-element', () => {
                         return 'hidden';
                     }
                 }
-                MyComponent.publicProps = {
-                    hidden: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { hidden: {} },
+                });
 
                 const element = createElement('prop-getter-hidden-imperative', { is: MyComponent });
 
@@ -815,9 +831,9 @@ describe('html-element', () => {
                     }
                 }
 
-                MyComponent.publicProps = {
-                    dir: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { dir: {} },
+                });
 
                 const element = createElement('prop-setter-dir', { is: MyComponent });
                 element.dir = 'ltr';
@@ -861,9 +877,9 @@ describe('html-element', () => {
                         return 'ltr';
                     }
                 }
-                MyComponent.publicProps = {
-                    dir: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { dir: {} },
+                });
 
                 const element = createElement('prop-getter-dir-imperative', { is: MyComponent });
 
@@ -937,9 +953,9 @@ describe('html-element', () => {
                         return 'id';
                     }
                 }
-                MyComponent.publicProps = {
-                    id: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { id: {} },
+                });
 
                 const element = createElement('prop-setter-id', { is: MyComponent });
                 element.id = 'id';
@@ -983,9 +999,9 @@ describe('html-element', () => {
                         return 'id';
                     }
                 }
-                MyComponent.publicProps = {
-                    id: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { id: {} },
+                });
 
                 const element = createElement('prop-getter-id-imperative', { is: MyComponent });
 
@@ -1061,9 +1077,9 @@ describe('html-element', () => {
                         return 'accessKey';
                     }
                 }
-                MyComponent.publicProps = {
-                    accessKey: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { accessKey: {} },
+                });
 
                 const element = createElement('prop-setter-accessKey', { is: MyComponent });
                 element.accessKey = 'accessKey';
@@ -1108,9 +1124,9 @@ describe('html-element', () => {
                         return 'accessKey';
                     }
                 }
-                MyComponent.publicProps = {
-                    accessKey: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { accessKey: {} },
+                });
                 const element = createElement('prop-getter-accessKey-imperative', {
                     is: MyComponent,
                 });
@@ -1185,9 +1201,9 @@ describe('html-element', () => {
                         return 'title';
                     }
                 }
-                MyComponent.publicProps = {
-                    title: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { title: {} },
+                });
                 const element = createElement('prop-setter-title', { is: MyComponent });
                 (element.title = {}), expect(count).toBe(1);
             });
@@ -1228,9 +1244,9 @@ describe('html-element', () => {
                         return 'title';
                     }
                 }
-                MyComponent.publicProps = {
-                    title: {},
-                };
+                registerDecorators(MyComponent, {
+                    publicProps: { title: {} },
+                });
 
                 const element = createElement('prop-getter-title-imperative', { is: MyComponent });
 

--- a/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../main';
-import { registerDecorators } from '../decorators/register';
+import { createElement, LightningElement, registerDecorators } from '../main';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 

--- a/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
@@ -6,6 +6,7 @@
  */
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../main';
+import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -164,8 +165,10 @@ describe('patch', () => {
                     calls.push('root:renderedCallback');
                 }
             }
-            Root.publicMethods = ['show', 'hide'];
-            Root.track = { state: 1 };
+            registerDecorators(Root, {
+                track: { state: 1 },
+                publicMethods: ['show', 'hide'],
+            });
 
             const elm = createElement('x-root', { is: Root });
             document.body.appendChild(elm);
@@ -238,8 +241,10 @@ describe('patch', () => {
                     calls.push('root:renderedCallback');
                 }
             }
-            Root.publicMethods = ['show'];
-            Root.track = { state: 1 };
+            registerDecorators(Root, {
+                track: { state: 1 },
+                publicMethods: ['show'],
+            });
 
             const elm = createElement('x-root', { is: Root });
             document.body.appendChild(elm);
@@ -283,8 +288,10 @@ describe('patch', () => {
                     return html;
                 }
             }
-            MyComponent.track = { state: 1 };
-            MyComponent.publicMethods = ['triggerRender'];
+            registerDecorators(MyComponent, {
+                track: { state: 1 },
+                publicMethods: ['triggerRender'],
+            });
 
             const element = createElement('x-parent', { is: MyComponent });
             document.body.appendChild(element);

--- a/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
@@ -8,6 +8,7 @@ import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../main';
 import { ViewModelReflection } from '../utils';
 import { getComponentVM } from '../vm';
+import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -184,8 +185,10 @@ describe('vm', () => {
                     this.h1 = this.h2 = false;
                 }
             }
-            Parent.track = { h1: 1, h2: 1 };
-            Parent.publicMethods = ['enable', 'disable'];
+            registerDecorators(Parent, {
+                track: { h1: 1, h2: 1 },
+                publicMethods: ['enable', 'disable'],
+            });
 
             const elm = createElement('x-parent', { is: Parent });
             document.body.appendChild(elm);

--- a/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
@@ -5,10 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../main';
+import { createElement, LightningElement, registerDecorators } from '../main';
 import { ViewModelReflection } from '../utils';
 import { getComponentVM } from '../vm';
-import { registerDecorators } from '../decorators/register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 

--- a/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
@@ -6,6 +6,7 @@
  */
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../main';
+import { registerDecorators } from '../decorators/register';
 
 describe('watcher', () => {
     describe('integration', () => {
@@ -50,8 +51,10 @@ describe('watcher', () => {
                     return parentTmpl;
                 }
             }
-            Parent.track = { round: 1 };
-            Parent.publicMethods = ['updateRound'];
+            registerDecorators(Parent, {
+                track: { round: 1 },
+                publicMethods: ['updateRound'],
+            });
 
             const elm = createElement('x-foo', { is: Parent });
             document.body.appendChild(elm);
@@ -80,8 +83,10 @@ describe('watcher', () => {
                     return counter <= 1 ? dynamicTmpl : staticTmpl;
                 }
             }
-            MyComponent9.track = { x: 1 };
-            MyComponent9.publicMethods = ['updateTracked'];
+            registerDecorators(MyComponent9, {
+                track: { x: 1 },
+                publicMethods: ['updateTracked'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent9 });
             document.body.appendChild(elm);

--- a/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../main';
-import { registerDecorators } from '../decorators/register';
+import { createElement, LightningElement, registerDecorators } from '../main';
 
 describe('watcher', () => {
     describe('integration', () => {

--- a/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -5,9 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { compileTemplate } from 'test-utils';
-import { createElement, LightningElement } from '../../main';
+import { createElement, LightningElement, registerDecorators } from '../../main';
 import wire from '../wire';
-import { registerDecorators } from '../register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 

--- a/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -7,6 +7,7 @@
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../../main';
 import wire from '../wire';
+import { registerDecorators } from '../register';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -26,7 +27,9 @@ describe('wire.ts', () => {
                     expect(this.foo).not.toBe(o);
                 }
             }
-            MyComponent.wire = { foo: {} };
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -43,8 +46,10 @@ describe('wire.ts', () => {
                     expect(this.foo).not.toBe(o);
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -67,8 +72,10 @@ describe('wire.ts', () => {
                     return emptyTemplate;
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -95,8 +102,10 @@ describe('wire.ts', () => {
                     return emptyTemplate;
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFooDotX'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFooDotX'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -116,8 +125,10 @@ describe('wire.ts', () => {
                     expect(this.foo).toBe(1);
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -135,8 +146,10 @@ describe('wire.ts', () => {
                     expect(this.foo).not.toBe(a);
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -152,8 +165,10 @@ describe('wire.ts', () => {
                     expect(this.foo).toBe(d);
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -171,8 +186,10 @@ describe('wire.ts', () => {
                     expect(this.foo).toBe(o);
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
 
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
@@ -187,8 +204,10 @@ describe('wire.ts', () => {
                     this.foo = v;
                 }
             }
-            MyComponent.wire = { foo: {} };
-            MyComponent.publicMethods = ['injectFoo'];
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+                publicMethods: ['injectFoo'],
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             document.body.appendChild(elm);
             expect(() => {
@@ -203,7 +222,9 @@ describe('wire.ts', () => {
                     return emptyTemplate;
                 }
             }
-            MyComponent.wire = { foo: {} };
+            registerDecorators(MyComponent, {
+                wire: { foo: {} },
+            });
             const elm = createElement('x-foo', { is: MyComponent });
             expect(() => {
                 document.body.appendChild(elm);

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -32,11 +32,11 @@ export interface WireDef {
 export interface PropsDef {
     [key: string]: PropDef;
 }
-interface TrackDef {
+export interface TrackDef {
     [key: string]: 1;
 }
 type PublicMethod = (...args: any[]) => any;
-interface MethodDef {
+export interface MethodDef {
     [key: string]: PublicMethod;
 }
 export interface WireHash {


### PR DESCRIPTION
## Details

* old metadata was based on static class properties to define the decorators.
* new metadata is defined via registerDecorators() call.
* unit tests were still using the old metadata format
* engine had a forking logic in def.ts to accommodate for missing decorator meta, and fake the call to registerDecorators when in tests.

This PR consolidates all that to only support registerDecorators() as the mechanism to define the metadata.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
