### PR TITLE
fix(engine): issue 1435 disconnect bug when switching templates

### DIFF
--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -109,13 +109,6 @@ export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
     });
 }
 
-function clearChildLWC(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    vm.velements = [];
-}
-
 export function renderComponent(vm: VM): VNodes {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
@@ -123,7 +116,6 @@ export function renderComponent(vm: VM): VNodes {
     }
 
     vm.tro.reset();
-    clearChildLWC(vm);
     const vnodes = invokeComponentRenderMethod(vm);
     vm.isDirty = false;
     vm.isScheduled = false;

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -172,6 +172,10 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         // validating slots in every rendering since the allocated content might change over time
         validateSlots(vm, html);
     }
+    // right before producing the vnodes, we clear up all internal references
+    // to custom elements from the template.
+    vm.velements = [];
+    // invoke the selected template.
     const vnodes: VNodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
 
     const { styleVNode } = context;

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -412,7 +412,7 @@ function runDisconnectedCallback(vm: VM) {
         // it will be re-rendered because we are disconnecting the reactivity
         // linking, so mutations are not automatically reflected on the state
         // of disconnected components.
-        markComponentAsDirty(vm);
+        vm.isDirty = true;
     }
     vm.state = VMState.disconnected;
     // reporting disconnection

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/dualTemplate.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/dualTemplate.js
@@ -1,0 +1,20 @@
+import { LightningElement, api, track } from 'lwc';
+import templateWithChild from './templateA.html';
+import templateWithoutChild from './templateB.html';
+
+export default class ParentWithDualTemplate extends LightningElement {
+    @track
+    _hideChild = false;
+
+    get hideChild() {
+        return this._hideChild;
+    }
+    @api
+    set hideChild(value) {
+        this._hideChild = value;
+    }
+
+    render() {
+        return this._hideChild ? templateWithoutChild : templateWithChild;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateA.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateA.html
@@ -1,0 +1,4 @@
+<template>
+    Parent with child
+    <x-test ></x-test>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateB.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateB.html
@@ -1,0 +1,3 @@
+<template>
+    Parent without child
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.html
@@ -1,0 +1,3 @@
+<template>
+    <x-test></x-test>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+import tmpl from './explicitRender.html';
+
+export default class ExplicitRender extends LightningElement {
+    render() {
+        return tmpl;
+    }
+}


### PR DESCRIPTION
## Details

Cleaning up the list of child custom elements right before invoking the template function will allow that function to populate new items into that list.

Fixed issue https://github.com/salesforce/lwc/issues/1435

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
