### PR TITLE
fix: issue with Node.textContent returning text in comment nodes

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
@@ -25,8 +25,10 @@ export function getTextContent(node: Node): string {
             const childNodes = getFilteredChildNodes(node);
             let content = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
-                if (childNodes[i].nodeType !== COMMENT_NODE) {
-                    content += getTextContent(childNodes[i]);
+                const currentNode = childNodes[i];
+
+                if (currentNode.nodeType !== COMMENT_NODE) {
+                    content += getTextContent(currentNode);
                 }
             }
             return content;

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 // This code is inspired by Polymer ShadyDOM Polyfill
 
 import { getFilteredChildNodes } from '../../faux-shadow/traverse';
-import { ELEMENT_NODE } from '../../env/node';
+import { ELEMENT_NODE, COMMENT_NODE } from '../../env/node';
 
 export function getTextContent(node: Node): string {
     switch (node.nodeType) {
@@ -25,7 +25,9 @@ export function getTextContent(node: Node): string {
             const childNodes = getFilteredChildNodes(node);
             let content = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
-                content += getTextContent(childNodes[i]);
+                if (childNodes[i].nodeType !== COMMENT_NODE) {
+                    content += getTextContent(childNodes[i]);
+                }
             }
             return content;
         }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -477,8 +477,10 @@ const NodePatchDescriptors = {
             const childNodes = getInternalChildNodes(this);
             let textContent = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
-                if (childNodes[i].nodeType !== COMMENT_NODE) {
-                    textContent += getTextContent(childNodes[i]);
+                const currentNode = childNodes[i];
+
+                if (currentNode.nodeType !== COMMENT_NODE) {
+                    textContent += getTextContent(currentNode);
                 }
             }
             return textContent;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -37,6 +37,7 @@ import {
     insertBefore,
     replaceChild,
     appendChild,
+    COMMENT_NODE,
 } from '../env/node';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
@@ -476,7 +477,9 @@ const NodePatchDescriptors = {
             const childNodes = getInternalChildNodes(this);
             let textContent = '';
             for (let i = 0, len = childNodes.length; i < len; i += 1) {
-                textContent += getTextContent(childNodes[i]);
+                if (childNodes[i].nodeType !== COMMENT_NODE) {
+                    textContent += getTextContent(childNodes[i]);
+                }
             }
             return textContent;
         },

--- a/packages/integration-karma/test/polyfills/text-content/index.spec.js
+++ b/packages/integration-karma/test/polyfills/text-content/index.spec.js
@@ -1,0 +1,16 @@
+describe('Node.textContent', () => {
+    it('should not return comment text when Node.nodeType is ELEMENT_NODE', () => {
+        const elm = document.createElement('div');
+        elm.appendChild(document.createComment('Some comment'));
+        elm.appendChild(document.createTextNode('text content'));
+        elm.appendChild(document.createComment('Some other comment'));
+
+        expect(elm.textContent).toBe('text content');
+    });
+
+    it('should return comment text when Node.nodeType is COMMENT_NODE', () => {
+        const elm = document.createComment('Some comment');
+
+        expect(elm.textContent).toBe('Some comment');
+    });
+});

--- a/packages/integration-karma/test/polyfills/text-content/index.spec.js
+++ b/packages/integration-karma/test/polyfills/text-content/index.spec.js
@@ -4,26 +4,29 @@ import XTest from 'x/test';
 describe('Node.textContent', () => {
     it('should not return comment text when Node.nodeType is ELEMENT_NODE', () => {
         const elm = document.createElement('div');
-        elm.appendChild(document.createComment('Some comment'));
-        elm.appendChild(document.createTextNode('text content'));
-        elm.appendChild(document.createComment('Some other comment'));
+        elm.innerHTML =
+            '<div>' +
+            '<!-- Some comment -->' +
+            'text content' +
+            '<!-- Some other comment -->' +
+            '</div>';
 
         expect(elm.textContent).toBe('text content');
     });
 
     it('should not return comment text from 2nd level ELEMENT_NODE', () => {
         const elm = document.createElement('div');
-        const secondLevelElement = document.createElement('div');
 
-        secondLevelElement.appendChild(document.createComment('2nd level comment'));
-        secondLevelElement.appendChild(document.createTextNode('2nd level text'));
-
-        elm.appendChild(document.createComment('Some comment'));
-        elm.appendChild(document.createTextNode('text content'));
-
-        elm.appendChild(secondLevelElement);
-
-        elm.appendChild(document.createComment('Some other comment'));
+        elm.innerHTML =
+            '<div>' +
+            '<!-- Some comment -->' +
+            'text content' +
+            '<div>' +
+            '<!-- 2nd level comment -->' +
+            '2nd level text' +
+            '</div>' +
+            '<!-- Some other comment -->' +
+            '</div>';
 
         expect(elm.textContent).toBe('text content2nd level text');
     });

--- a/packages/integration-karma/test/polyfills/text-content/index.spec.js
+++ b/packages/integration-karma/test/polyfills/text-content/index.spec.js
@@ -1,3 +1,6 @@
+import { createElement } from 'lwc';
+import XTest from 'x/test';
+
 describe('Node.textContent', () => {
     it('should not return comment text when Node.nodeType is ELEMENT_NODE', () => {
         const elm = document.createElement('div');
@@ -8,9 +11,36 @@ describe('Node.textContent', () => {
         expect(elm.textContent).toBe('text content');
     });
 
+    it('should not return comment text from 2nd level ELEMENT_NODE', () => {
+        const elm = document.createElement('div');
+        const secondLevelElement = document.createElement('div');
+
+        secondLevelElement.appendChild(document.createComment('2nd level comment'));
+        secondLevelElement.appendChild(document.createTextNode('2nd level text'));
+
+        elm.appendChild(document.createComment('Some comment'));
+        elm.appendChild(document.createTextNode('text content'));
+
+        elm.appendChild(secondLevelElement);
+
+        elm.appendChild(document.createComment('Some other comment'));
+
+        expect(elm.textContent).toBe('text content2nd level text');
+    });
+
     it('should return comment text when Node.nodeType is COMMENT_NODE', () => {
         const elm = document.createComment('Some comment');
 
         expect(elm.textContent).toBe('Some comment');
+    });
+
+    it('should not return comment text from the shadowRoot', () => {
+        const elm = createElement('x-parent', { is: XTest });
+        document.body.appendChild(elm);
+
+        // since we remove the comments from the template, we need to add it manually
+        elm.shadowRoot.appendChild(document.createComment('Some comment'));
+
+        expect(elm.shadowRoot.textContent).toBe('text content');
     });
 });

--- a/packages/integration-karma/test/polyfills/text-content/x/test/test.html
+++ b/packages/integration-karma/test/polyfills/text-content/x/test/test.html
@@ -1,0 +1,4 @@
+<template>
+    <!-- This is a comment, it should not be part of the textContent -->
+    text content
+</template>

--- a/packages/integration-karma/test/polyfills/text-content/x/test/test.js
+++ b/packages/integration-karma/test/polyfills/text-content/x/test/test.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {}


### PR DESCRIPTION
## Details
From https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent:

> textContent returns the concatenation of the textContent of every child node, excluding comments and processing instructions. This is an empty string if the node has no children

This pr fixes the current implementation to match the standard.
## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`