### PR TITLE
fix(features): flag name must match name of imported binding

### DIFF
--- a/packages/@lwc/features/README.md
+++ b/packages/@lwc/features/README.md
@@ -14,6 +14,20 @@ application layer.
 
 ### Limitations
 
+#### Must be all uppercase
+
+```
+// Does not work
+if (enableFoo) {
+    ...
+}
+
+// Does work
+if (ENABLE_FOO) {
+    ...
+}
+```
+
 #### Only works with if-statements
 
 ```

--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -127,17 +127,35 @@ const nonProdTests = {
             }
         `,
     },
+    'should ignore invalid feature flags': {
+        code: `
+            import { invalidFeatureFlag } from '@lwc/features';
+            if (invalidFeatureFlag) {
+                console.log('invalidFeatureFlag');
+            }
+        `,
+        output: `
+            import { invalidFeatureFlag, runtimeFlags } from '@lwc/features';
+
+            if (invalidFeatureFlag) {
+              console.log('invalidFeatureFlag');
+            }
+        `,
+    },
+};
+
+const featureFlags = {
+    ENABLE_FEATURE_TRUE: true,
+    ENABLE_FEATURE_FALSE: false,
+    ENABLE_FEATURE_NULL: null,
+    invalidFeatureFlag: true, // invalid because it's not all uppercase
 };
 
 pluginTester({
     title: 'non-prod environments',
     plugin,
     pluginOptions: {
-        featureFlags: {
-            ENABLE_FEATURE_TRUE: true,
-            ENABLE_FEATURE_FALSE: false,
-            ENABLE_FEATURE_NULL: null,
-        },
+        featureFlags,
     },
     tests: nonProdTests,
 });
@@ -146,11 +164,7 @@ pluginTester({
     title: 'prod environments',
     plugin,
     pluginOptions: {
-        featureFlags: {
-            ENABLE_FEATURE_TRUE: true,
-            ENABLE_FEATURE_FALSE: false,
-            ENABLE_FEATURE_NULL: null,
-        },
+        featureFlags,
         prod: true,
     },
     tests: Object.assign({}, nonProdTests, {


### PR DESCRIPTION
## Details

The existing test for this was failing because the `@lwc/features` test suite was not running in CI.

Added an extra restriction for flag names to be all uppercase to reduce ambiguity of which bindings are flag names vs `enableFeature`/`disableFeature`/`runtimeFlags`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
