### PR TITLE
refactor: use local babel configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,4 @@
 // eslint-disable-next-line no-undef
 module.exports = {
-    presets: [
-        "@babel/preset-typescript"
-    ],
-    plugins: [
-        ["@babel/plugin-proposal-class-properties", { "loose": true }],
-        "@babel/transform-modules-commonjs",
-    ]
-}
+    babelrcRoots: ['./packages/*'],
+};

--- a/packages/@lwc/compiler/.babelrc.js
+++ b/packages/@lwc/compiler/.babelrc.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: ['@babel/transform-modules-commonjs'],
+};

--- a/packages/@lwc/engine/.babelrc.js
+++ b/packages/@lwc/engine/.babelrc.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: [
+        ['@babel/plugin-proposal-class-properties', { loose: true }],
+        '@babel/transform-modules-commonjs',
+    ],
+};

--- a/packages/@lwc/errors/.babelrc.js
+++ b/packages/@lwc/errors/.babelrc.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: [
+        ['@babel/plugin-proposal-class-properties', { loose: true }],
+        '@babel/transform-modules-commonjs',
+    ],
+};

--- a/packages/@lwc/features/.babelrc.js
+++ b/packages/@lwc/features/.babelrc.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+};

--- a/packages/@lwc/module-resolver/.babelrc.js
+++ b/packages/@lwc/module-resolver/.babelrc.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: ['@babel/transform-modules-commonjs'],
+};

--- a/packages/@lwc/style-compiler/.babelrc.js
+++ b/packages/@lwc/style-compiler/.babelrc.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: ['@babel/transform-modules-commonjs'],
+};

--- a/packages/@lwc/template-compiler/.babelrc.js
+++ b/packages/@lwc/template-compiler/.babelrc.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: [
+        ['@babel/plugin-proposal-class-properties', { loose: true }],
+        '@babel/transform-modules-commonjs',
+    ],
+};

--- a/packages/@lwc/wire-service/.babelrc.js
+++ b/packages/@lwc/wire-service/.babelrc.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: ['@babel/preset-typescript'],
+    plugins: [
+        ['@babel/plugin-proposal-class-properties', { loose: true }],
+        '@babel/transform-modules-commonjs',
+    ],
+};

--- a/scripts/jest/base.config.js
+++ b/scripts/jest/base.config.js
@@ -9,10 +9,6 @@ module.exports = {
     testEnvironment: 'jest-environment-jsdom-fifteen',
     testMatch: ['<rootDir>/**/__tests__/*.spec.(js|ts)'],
 
-    transform: {
-        '^.+\\.ts$': ['babel-jest', { rootMode: 'upward' }], // use the repo root babel.config.js
-    },
-
     // Global mono-repo code coverage threshold.
     coverageThreshold: {
         global: {


### PR DESCRIPTION
## Details

The motivation for this was because `yarn test` at the repo root gave different results from `yarn test` in `@lwc/features`, even though the babel configuration was the save via `rootMode: 'upward'`. This change simplifies the configuration of babel across our packages by using local config files. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
