### PR TITLE
chore: only support jest tests from repo root

### DIFF
--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -157,6 +157,9 @@ pluginTester({
     pluginOptions: {
         featureFlags,
     },
+    babelOptions: {
+        filename: __filename,
+    },
     tests: nonProdTests,
 });
 
@@ -166,6 +169,9 @@ pluginTester({
     pluginOptions: {
         featureFlags,
         prod: true,
+    },
+    babelOptions: {
+        filename: __filename,
     },
     tests: Object.assign({}, nonProdTests, {
         // Override of nonProdTest version

--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -151,15 +151,18 @@ const featureFlags = {
     invalidFeatureFlag: true, // invalid because it's not all uppercase
 };
 
+const babelOptions = {
+    babelrc: false,
+    configFile: false,
+};
+
 pluginTester({
     title: 'non-prod environments',
     plugin,
     pluginOptions: {
         featureFlags,
     },
-    babelOptions: {
-        filename: __filename,
-    },
+    babelOptions,
     tests: nonProdTests,
 });
 
@@ -170,9 +173,7 @@ pluginTester({
         featureFlags,
         prod: true,
     },
-    babelOptions: {
-        filename: __filename,
-    },
+    babelOptions,
     tests: Object.assign({}, nonProdTests, {
         // Override of nonProdTest version
         'should transform boolean-true feature flags': {

--- a/scripts/jest/base.config.js
+++ b/scripts/jest/base.config.js
@@ -9,10 +9,6 @@ module.exports = {
     testEnvironment: 'jest-environment-jsdom-fifteen',
     testMatch: ['<rootDir>/**/__tests__/*.spec.(js|ts)'],
 
-    transform: {
-        '^.+\\.ts$': ['babel-jest', { rootMode: 'upward' }], // use the repo root babel.config.js
-    },
-
     // Global mono-repo code coverage threshold.
     coverageThreshold: {
         global: {

--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -7,16 +7,5 @@
 module.exports = {
     rootDir: '../..',
     testMatch: ['<rootDir>/**/__tests__/*.spec.(js|ts)'],
-    projects: [
-        '<rootDir>/packages/@lwc/errors',
-        '<rootDir>/packages/@lwc/babel-plugin-component',
-        '<rootDir>/packages/@lwc/compiler',
-        '<rootDir>/packages/@lwc/engine',
-        '<rootDir>/packages/@lwc/module-resolver',
-        '<rootDir>/packages/@lwc/template-compiler',
-        '<rootDir>/packages/@lwc/style-compiler',
-        '<rootDir>/packages/@lwc/wire-service',
-        '<rootDir>/packages/@lwc/rollup-plugin',
-        '<rootDir>/packages/@lwc/synthetic-shadow',
-    ],
+    projects: ['<rootDir>/packages/@lwc/*'],
 };


### PR DESCRIPTION
## Details

POC illustrating the babel configuration issues I've been encountering. I haven't figured out a way to disable the `@babel/transform-modules-commonjs` plugin for the `@lwc/features` unit tests due to how babel merges plugin configs.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`