### PR TITLE
fix: rollup-plugin module resolve when rootDir is a relative path

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -51,6 +51,21 @@ describe('default configuration', () => {
     });
 });
 
+describe('rollup with custom options', () => {
+    it(`should normalize rootDir when present and is a relative path`, () => {
+        const entry = path.join(simpleAppDir, 'main.js');
+
+        const rollupOptions = {
+            rootDir: path.relative(process.cwd(), path.dirname(entry)),
+        };
+
+        return doRollup(entry, { compat: false }, rollupOptions).then(({ code: actual }) => {
+            const expected = fsExpected('expected_default_config_simple_app');
+            expect(pretty(actual)).toBe(pretty(expected));
+        });
+    });
+});
+
 describe('rollup in compat mode', () => {
     it(`simple app`, () => {
         const entry = path.join(simpleAppDir, 'main.js');

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -37,8 +37,8 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
 
         options({ input }) {
             const { modules: userModules = [], rootDir } = mergedPluginOptions;
-            const defaultSrc = path.dirname(input);
-            const modules = [...userModules, ...DEFAULT_MODULES, rootDir || defaultSrc];
+            const defaultModulesDir = rootDir ? path.resolve(rootDir) : path.dirname(input);
+            const modules = [...userModules, ...DEFAULT_MODULES, defaultModulesDir];
             const resolvedModules = lwcResolver.resolveModules({ rootDir, modules });
             modulePaths = resolvedModules.reduce((map, m) => ((map[m.specifier] = m), map), {});
         },


### PR DESCRIPTION
## Details

By default `@lwc/rollup-plugin` try to find the modules in the same directory of the entry. Some times this is not enough and you need to specify the root directory of the lwc modules (rootDir option)

When the rootDir is present and is a relative path, it will not work, even if is correct relative to the `process.cwd()`

This pr normalize the rootDir option by doing a `path.resolve(rootDir)`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
