### PR TITLE
fix(features): remove nested feature flags limitation

### DIFF
--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -108,7 +108,7 @@ const nonProdTests = {
             console.log(ENABLE_FEATURE_NULL ? 'foo' : 'bar');
         `,
     },
-    'should not transform nested feature flags': {
+    'should transform nested feature flags': {
         code: `
             import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL } from '@lwc/features';
             if (ENABLE_FEATURE_NULL) {
@@ -121,7 +121,7 @@ const nonProdTests = {
             import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
 
             if (runtimeFlags.ENABLE_FEATURE_NULL) {
-              if (ENABLE_FEATURE_TRUE) {
+              if (runtimeFlags.ENABLE_FEATURE_TRUE) {
                 console.log('this looks like a bad idea');
               }
             }
@@ -200,6 +200,37 @@ pluginTester({
             `,
             output: `
                 import { ENABLE_FEATURE_FALSE, runtimeFlags } from '@lwc/features';
+            `,
+        },
+        // Override of nonProdTest version
+        'should transform nested feature flags': {
+            code: `
+                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL } from '@lwc/features';
+                if (ENABLE_FEATURE_NULL) {
+                    if (ENABLE_FEATURE_TRUE) {
+                        console.log('nested feature flags sounds like a vary bad idea');
+                    }
+                }
+                if (ENABLE_FEATURE_TRUE) {
+                    if (ENABLE_FEATURE_NULL) {
+                        console.log('nested feature flags sounds like a vary bad idea');
+                    }
+                }
+            `,
+            output: `
+                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
+
+                if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                  {
+                    console.log('nested feature flags sounds like a vary bad idea');
+                  }
+                }
+
+                {
+                  if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('nested feature flags sounds like a vary bad idea');
+                  }
+                }
             `,
         },
         'should transform both boolean and null feature flags': {
@@ -292,36 +323,6 @@ pluginTester({
             `,
             output: `
                 console.log(runtimeFlags.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
-            `,
-        },
-        'should not transform nested feature flags': {
-            code: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL } from '@lwc/features';
-                if (ENABLE_FEATURE_NULL) {
-                    if (ENABLE_FEATURE_TRUE) {
-                        console.log('nested feature flags sounds like a vary bad idea');
-                    }
-                }
-                if (ENABLE_FEATURE_TRUE) {
-                    if (ENABLE_FEATURE_NULL) {
-                        console.log('nested feature flags sounds like a vary bad idea');
-                    }
-                }
-            `,
-            output: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
-
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                  if (ENABLE_FEATURE_TRUE) {
-                    console.log('nested feature flags sounds like a vary bad idea');
-                  }
-                }
-
-                {
-                  if (ENABLE_FEATURE_NULL) {
-                    console.log('nested feature flags sounds like a vary bad idea');
-                  }
-                }
             `,
         },
     }),

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -103,9 +103,6 @@ module.exports = function({ types: t }) {
                         path.remove();
                     }
                 }
-
-                // Nested feature flags sounds like a very bad idea
-                path.skip();
             },
         },
     };

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -8,7 +8,7 @@ const defaultFeatureFlags = require('../../');
 
 const RUNTIME_FLAGS_IDENTIFIER = 'runtimeFlags';
 
-function isRuntimeFlagLookup(path, featureFlags) {
+function isRuntimeFlag(path, featureFlags) {
     return (
         path.isMemberExpression() &&
         featureFlags[path.node.property.name] !== undefined &&
@@ -70,7 +70,6 @@ module.exports = function({ types: t }) {
                         binding.referencePaths.includes(testPath);
 
                     if (isFeatureFlag) {
-                        this.featureFlagIfStatements.push(path);
                         const value = this.featureFlags[name];
                         if (!this.opts.prod || value === null) {
                             testPath.replaceWithSourceString(`${RUNTIME_FLAGS_IDENTIFIER}.${name}`);
@@ -92,7 +91,7 @@ module.exports = function({ types: t }) {
                 // appropriate for production mode. This essentially undoes the
                 // non-production mode transform of forcing all flags to be
                 // runtime flags.
-                if (this.opts.prod && isRuntimeFlagLookup(testPath, this.featureFlags)) {
+                if (this.opts.prod && isRuntimeFlag(testPath, this.featureFlags)) {
                     const name = testPath.node.property.name;
                     const value = this.featureFlags[name];
                     if (value === true) {

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -57,7 +57,7 @@ module.exports = function({ types: t }) {
                 const testPath = path.get('test');
 
                 // If we have imported any flags and the if-test is a plain identifier
-                if (this.importDeclarationScope && testPath.isIdentifier()) {
+                if (this.importedFeatureFlags.length && testPath.isIdentifier()) {
                     const name = testPath.node.name;
                     const binding = this.importDeclarationScope.getBinding(name);
 

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -8,10 +8,10 @@ const defaultFeatureFlags = require('../../');
 
 const RUNTIME_FLAGS_IDENTIFIER = 'runtimeFlags';
 
-function isRuntimeFlagLookup(path, state) {
+function isRuntimeFlagLookup(path, featureFlags) {
     return (
         path.isMemberExpression() &&
-        state.featureFlags[path.node.property.name] !== undefined &&
+        featureFlags[path.node.property.name] !== undefined &&
         path.get('object').isIdentifier({ name: RUNTIME_FLAGS_IDENTIFIER })
     );
 }
@@ -20,12 +20,12 @@ module.exports = function({ types: t }) {
     return {
         name: 'babel-plugin-lwc-features',
         visitor: {
-            ImportDeclaration(path, state) {
+            ImportDeclaration(path) {
                 if (path.node.source.value === '@lwc/features') {
                     const specifiers = path.get('specifiers');
 
-                    state.importDeclarationScope = path.scope;
-                    state.importedFeatureFlags = specifiers
+                    this.importDeclarationScope = path.scope;
+                    this.importedFeatureFlags = specifiers
                         .map(specifier => specifier.node.imported.name)
                         .filter(name => name === name.toUpperCase());
 
@@ -45,27 +45,29 @@ module.exports = function({ types: t }) {
                     }
                 }
             },
-            IfStatement(path, state) {
+            IfStatement(path) {
                 const testPath = path.get('test');
 
-                state.featureFlags =
-                    state.featureFlags || state.opts.featureFlags || defaultFeatureFlags;
+                this.featureFlags =
+                    this.featureFlags || this.opts.featureFlags || defaultFeatureFlags;
 
                 // If we have imported any flags and the if-test is a plain identifier
-                if (state.importDeclarationScope && testPath.isIdentifier()) {
+                if (this.importDeclarationScope && testPath.isIdentifier()) {
                     const name = testPath.node.name;
-                    const binding = state.importDeclarationScope.getBinding(name);
+                    const binding = this.importDeclarationScope.getBinding(name);
 
                     // The identifier is a feature flag if it matches the name
                     // of an imported feature flag binding and it's a reference
                     // from the import declaration scope.
                     const isFeatureFlag =
-                        state.importedFeatureFlags.includes(name) &&
+                        this.importedFeatureFlags.includes(name) &&
                         binding &&
                         binding.referencePaths.includes(testPath);
+
                     if (isFeatureFlag) {
-                        const value = state.featureFlags[name];
-                        if (!state.opts.prod || value === null) {
+                        this.featureFlagIfStatements.push(path);
+                        const value = this.featureFlags[name];
+                        if (!this.opts.prod || value === null) {
                             testPath.replaceWithSourceString(`${RUNTIME_FLAGS_IDENTIFIER}.${name}`);
                             // We replaced this identifier with a member
                             // expression that uses the same identifier and we
@@ -85,9 +87,9 @@ module.exports = function({ types: t }) {
                 // appropriate for production mode. This essentially undoes the
                 // non-production mode transform of forcing all flags to be
                 // runtime flags.
-                if (state.opts.prod && isRuntimeFlagLookup(testPath, state)) {
+                if (this.opts.prod && isRuntimeFlagLookup(testPath, this.featureFlags)) {
                     const name = testPath.node.property.name;
-                    const value = state.featureFlags[name];
+                    const value = this.featureFlags[name];
                     if (value === true) {
                         // Transform the IfStatement into a BlockStatement
                         path.replaceWith(path.node.consequent);


### PR DESCRIPTION
## Details

Invoking `path.skip()` in the `IfStatement` visitor seems to somehow interfere with `@babel/preset-typescript`, resulting in typescript showing up inside some if-statements in the output file. Preventing nested feature flags was never a hard requirement so it should be fine to avoid these during code reviews.

Also includes a minor refactor to use `this` instead of `state` since they are apparently the same thing.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`