### PR TITLE
build: Standardize node and yarn versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
     "packages/perf-benchmarks"
   ],
   "engines": {
-    "node": ">=10.13.0 <11.0.0",
-    "yarn": ">=1.10.1"
+    "node": ">=10.16.3 <10.17.0",
+    "yarn": ">=1.17.3 <1.18.0"
   },
   "volta": {
-    "node": "10.16.2",
+    "node": "10.16.3",
     "yarn": "1.17.3"
   },
   "resolutions": {


### PR DESCRIPTION
fix:  Use a more restrictive specification for Node and Yarn versions.

BREAKING CHANGE:  Developers may encounter a build failure unless they upgrade their local Node and/or Yarn versions.

## Details

UI Platform Engineering Systems is building a CI which will be running the specified versions of Node and Yarn so to be consistent this project should use the same specification.  The "patch" versions of Node and/or Yarn can float up from this spec, but not the minor or major versions.

## Does this PR introduce breaking changes?

There are two kinds of possible breaking changes:
1.  Developers may have to upgrade their local versions of node and/or yarn. The current CI may need to have its versions upgraded.
2.  The upgraded versions may reveal flaws in the previously established build assumptions that
    a.  get caught by the build itself
    b.  don't get caught by the build, only revealed in later testing.

None of these risks are a reason not to do this, but are a reason to decide when to do it.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ / ❌
No.
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ / ❌
I think so.
