### PR TITLE
fix(engine): issue 1435 disconnect bug when switching templates (#1443)

### DIFF
--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -121,13 +121,6 @@ export function clearReactiveListeners(vm: VM) {
     }
 }
 
-function clearChildLWC(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    vm.velements = [];
-}
-
 export function renderComponent(vm: VM): VNodes {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
@@ -135,7 +128,7 @@ export function renderComponent(vm: VM): VNodes {
     }
 
     clearReactiveListeners(vm);
-    clearChildLWC(vm);
+
     const vnodes = invokeComponentRenderMethod(vm);
     vm.isDirty = false;
     vm.isScheduled = false;

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -172,6 +172,10 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         // validating slots in every rendering since the allocated content might change over time
         validateSlots(vm, html);
     }
+    // right before producing the vnodes, we clear up all internal references
+    // to custom elements from the template.
+    vm.velements = [];
+    // invoke the selected template.
     const vnodes: VNodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
 
     const { styleVNode } = context;

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -406,7 +406,7 @@ function runDisconnectedCallback(vm: VM) {
         // it will be re-rendered because we are disconnecting the reactivity
         // linking, so mutations are not automatically reflected on the state
         // of disconnected components.
-        markComponentAsDirty(vm);
+        vm.isDirty = true;
     }
     clearReactiveListeners(vm);
     vm.state = VMState.disconnected;

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/dualTemplate.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/dualTemplate.js
@@ -1,0 +1,20 @@
+import { LightningElement, api, track } from 'lwc';
+import templateWithChild from './templateA.html';
+import templateWithoutChild from './templateB.html';
+
+export default class ParentWithDualTemplate extends LightningElement {
+    @track
+    _hideChild = false;
+
+    get hideChild() {
+        return this._hideChild;
+    }
+    @api
+    set hideChild(value) {
+        this._hideChild = value;
+    }
+
+    render() {
+        return this._hideChild ? templateWithoutChild : templateWithChild;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateA.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateA.html
@@ -1,0 +1,4 @@
+<template>
+    Parent with child
+    <x-test ></x-test>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateB.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate/templateB.html
@@ -1,0 +1,3 @@
+<template>
+    Parent without child
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.html
@@ -1,0 +1,3 @@
+<template>
+    <x-test></x-test>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/explicitRender/explicitRender.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+import tmpl from './explicitRender.html';
+
+export default class ExplicitRender extends LightningElement {
+    render() {
+        return tmpl;
+    }
+}


### PR DESCRIPTION
[cherrypick b0c451291a533348e534fa96847692e7aa550426]

* fix(engine): issue 1435 disconnect bug when swtiching templates

* test: tests for #1435 (#1448)

* test: tests for #1435

* test: address feedback

* fix: short circuit the call to mark children as dirty

* fix: address pr feedback

# Conflicts:
#	packages/@lwc/engine/src/framework/component.ts

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`