### PR TITLE
fix(engine): non-decorated fields can be mutated during render

### DIFF
--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -8,7 +8,6 @@ import { assert, ArrayReduce, isFalse } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
 import { valueMutated, valueObserved } from '../libs/mutation-tracker';
-import { isRendering, vmBeingRendered } from './invoker';
 
 export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): PropertyDescriptorMap {
     return ArrayReduce.call(
@@ -36,12 +35,6 @@ function createObservedFieldPropertyDescriptor(key: PropertyKey): PropertyDescri
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
-                assert.invariant(
-                    !isRendering,
-                    `${vmBeingRendered}.render() method has side effects on the state of "${String(
-                        key
-                    )}" field`
-                );
             }
 
             if (newValue !== vm.cmpTrack[key]) {


### PR DESCRIPTION
## Details

This restriction was added as part of the track reform, but introduces issues with existing code. The reason why this is fine now is because memoization of field values during rendering is a valid use-case, and our magic for non-decorated fields should not effect it. Rendering is not going to be affected by lifting this since it is still in dirty mode, which means those mutations will not produce a next-tick rehydration notice.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`