### PR TITLE
fix: remove side effects assertion in non-decorated fields

### DIFF
--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -8,7 +8,6 @@ import { assert, ArrayReduce, isFalse } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
 import { valueMutated, valueObserved } from '../libs/mutation-tracker';
-import { isRendering, vmBeingRendered } from './invoker';
 
 export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): PropertyDescriptorMap {
     return ArrayReduce.call(
@@ -34,15 +33,6 @@ function createObservedFieldPropertyDescriptor(key: PropertyKey): PropertyDescri
         },
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
-                assert.invariant(
-                    !isRendering,
-                    `${vmBeingRendered}.render() method has side effects on the state of "${String(
-                        key
-                    )}" field`
-                );
-            }
 
             if (newValue !== vm.cmpTrack[key]) {
                 vm.cmpTrack[key] = newValue;

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -33,6 +33,9 @@ function createObservedFieldPropertyDescriptor(key: PropertyKey): PropertyDescri
         },
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
+            }
 
             if (newValue !== vm.cmpTrack[key]) {
                 vm.cmpTrack[key] = newValue;

--- a/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.html
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.html
@@ -1,0 +1,4 @@
+<template>
+    <p class="computedLabel">{computedLabel}</p>
+    <p class="label">{label}</p>
+</template>

--- a/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.js
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.js
@@ -1,0 +1,14 @@
+import { LightningElement, api } from 'lwc';
+
+export default class FieldForCache extends LightningElement {
+    @api label;
+    cachedLabel = null;
+
+    get computedLabel() {
+        if (this.cachedLabel === null) {
+            this.cachedLabel = this.label + ' computed';
+        }
+
+        return this.cachedLabel;
+    }
+}

--- a/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.html
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.html
@@ -1,1 +1,5 @@
-<template></template>
+<template>
+    <p class="rendered-times">{counter}</p>
+    <p class="expando">{expandoCounter}</p>
+    <p class="label">{label}</p>
+</template>

--- a/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.js
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.js
@@ -1,11 +1,22 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 import tpl from './fieldWithSideEffect.html';
 
 export default class FieldWithSideEffect extends LightningElement {
+    @api label;
+    @api useExpando = false;
     counter = 0;
 
+    constructor() {
+        super();
+        this.expandoCounter = 0;
+    }
+
     render() {
-        this.counter++;
+        if (this.useExpando) {
+            this.expandoCounter++;
+        } else {
+            this.counter++;
+        }
 
         return tpl;
     }


### PR DESCRIPTION
## Details
This restriction was added as part of the track reform, but introduces issues with existing code. The reason why this is fine now is because memoization of field values during rendering is a valid use-case, and our magic for non-decorated fields should not effect it. Rendering is not going to be affected by lifting this since it is still in dirty mode, which means those mutations will not produce a next-tick rehydration notice.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`