### PR TITLE
fix: revert wire config as function

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -129,11 +129,6 @@ describe('Implicit mode', () => {
                       params: {},
                       static: {
                         id: 1
-                      },
-                      config: function($cmp) {
-                        return {
-                          id: 1
-                        };
                       }
                     }
                   }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -60,10 +60,7 @@ describe('observed fields', () => {
                   publicMethods: ["someMethod"],
                   wire: {
                     wiredProp: {
-                      adapter: createElement,
-                      config: function($cmp) {
-                        return {};
-                      }
+                      adapter: createElement
                     }
                   },
                   track: {
@@ -174,10 +171,7 @@ describe('observed fields', () => {
                     publicMethods: ["someMethod"],
                     wire: {
                       wiredProp: {
-                        adapter: createElement,
-                        config: function($cmp) {
-                          return {};
-                        }
+                        adapter: createElement
                       }
                     },
                     track: {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -40,126 +40,6 @@ describe('Transform property', () => {
                       },
                       static: {
                         key2: ["fixed", "array"]
-                      },
-                      config: function($cmp) {
-                        return {
-                          key2: ["fixed", "array"],
-                          key1: $cmp.prop1
-                        };
-                      }
-                    }
-                  }
-                });
-
-                export default _registerComponent(Test, {
-                  tmpl: _tmpl
-                });
-`,
-            },
-        }
-    );
-
-    pluginTest(
-        'transforms parameters with 2 levels deep (foo.bar)',
-        `
-        import { wire } from 'lwc';
-        import { getFoo } from 'data-service';
-        export default class Test {
-            @wire(getFoo, { key1: "$prop1.prop2", key2: ["fixed", 'array'], key3: "$p1.p2" })
-            wiredProp;
-        }
-    `,
-        {
-            output: {
-                code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
-                import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { getFoo } from "data-service";
-
-                class Test {
-                  constructor() {
-                    this.wiredProp = void 0;
-                  }
-                }
-
-                _registerDecorators(Test, {
-                  wire: {
-                    wiredProp: {
-                      adapter: getFoo,
-                      params: {
-                        key1: "prop1.prop2",
-                        key3: "p1.p2"
-                      },
-                      static: {
-                        key2: ["fixed", "array"]
-                      },
-                      config: function($cmp) {
-                        let v1 = $cmp.prop1;
-                        let v2 = $cmp.p1;
-                        return {
-                          key2: ["fixed", "array"],
-                          key1: v1 != null ? v1.prop2 : undefined,
-                          key3: v2 != null ? v2.p2 : undefined
-                        };
-                      }
-                    }
-                  }
-                });
-
-                export default _registerComponent(Test, {
-                  tmpl: _tmpl
-                });
-`,
-            },
-        }
-    );
-
-    pluginTest(
-        'transforms parameters with multiple levels deep',
-        `
-        import { wire } from 'lwc';
-        import { getFoo } from 'data-service';
-        export default class Test {
-            @wire(getFoo, { key1: "$prop1.prop2.prop3.prop4", key2: ["fixed", 'array']})
-            wiredProp;
-        }
-    `,
-        {
-            output: {
-                code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
-                import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { getFoo } from "data-service";
-
-                class Test {
-                  constructor() {
-                    this.wiredProp = void 0;
-                  }
-                }
-
-                _registerDecorators(Test, {
-                  wire: {
-                    wiredProp: {
-                      adapter: getFoo,
-                      params: {
-                        key1: "prop1.prop2.prop3.prop4"
-                      },
-                      static: {
-                        key2: ["fixed", "array"]
-                      },
-                      config: function($cmp) {
-                        let v1 = $cmp.prop1;
-                        return {
-                          key2: ["fixed", "array"],
-                          key1: 
-                            v1 != null &&
-                            (v1 = v1.prop2) != null &&
-                            (v1 = v1.prop3) != null
-                              ? v1.prop4
-                              : undefined
-                        };
                       }
                     }
                   }
@@ -208,14 +88,6 @@ describe('Transform property', () => {
                       static: {
                         key3: "fixed",
                         key4: ["fixed", "array"]
-                      },
-                      config: function($cmp) {
-                        return {
-                          key3: "fixed",
-                          key4: ["fixed", "array"],
-                          key1: $cmp.prop,
-                          key2: $cmp.prop
-                        };
                       }
                     }
                   }
@@ -299,10 +171,7 @@ describe('Transform property', () => {
                     wiredProp: {
                       adapter: getFoo,
                       params: {},
-                      static: {},
-                      config: function($cmp) {
-                        return {};
-                      }
+                      static: {}
                     }
                   }
                 });
@@ -316,7 +185,7 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'decorator accepts a member expression',
+        'decorator accepts a member epxression',
         `
       import { wire } from 'lwc';
       import { Foo } from 'data-service';
@@ -343,10 +212,7 @@ describe('Transform property', () => {
                   wiredProp: {
                     adapter: Foo.Bar,
                     params: {},
-                    static: {},
-                    config: function($cmp) {
-                      return {};
-                    }
+                    static: {}
                   }
                 }
               });
@@ -387,10 +253,7 @@ describe('Transform property', () => {
                 wiredProp: {
                   adapter: Foo.Bar,
                   params: {},
-                  static: {},
-                  config: function($cmp) {
-                    return {};
-                  }
+                  static: {}
                 }
               }
             });
@@ -451,10 +314,7 @@ describe('Transform property', () => {
                     _registerDecorators(Test, {
                       wire: {
                         wiredProp: {
-                          adapter: getFoo,
-                          config: function($cmp) {
-                            return {};
-                          }
+                          adapter: getFoo
                         }
                       }
                     });
@@ -619,12 +479,6 @@ describe('Transform property', () => {
                       },
                       static: {
                         key2: ["fixed"]
-                      },
-                      config: function($cmp) {
-                        return {
-                          key2: ["fixed"],
-                          key1: $cmp.prop1
-                        };
                       }
                     },
                     wired2: {
@@ -634,12 +488,6 @@ describe('Transform property', () => {
                       },
                       static: {
                         key2: ["array"]
-                      },
-                      config: function($cmp) {
-                        return {
-                          key2: ["array"],
-                          key1: $cmp.prop1
-                        };
                       }
                     }
                   }
@@ -687,13 +535,7 @@ describe('Transform method', () => {
                       static: {
                         key2: ["fixed"]
                       },
-                      method: 1,
-                      config: function($cmp) {
-                        return {
-                          key2: ["fixed"],
-                          key1: $cmp.prop1
-                        };
-                      }
+                      method: 1
                     }
                   }
                 });

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -60,57 +60,6 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'transforms named imports from static imports',
-        `
-        import { wire } from 'lwc';
-        import importedValue from "ns/module";
-        import { getFoo } from 'data-service';
-        export default class Test {
-            @wire(getFoo, { key1: importedValue })
-            wiredProp;
-        }
-    `,
-        {
-            output: {
-                code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
-                import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import importedValue from "ns/module";
-                import { getFoo } from "data-service";
-                
-                class Test {
-                  constructor() {
-                    this.wiredProp = void 0;
-                  }
-                }
-                
-                _registerDecorators(Test, {
-                  wire: {
-                    wiredProp: {
-                      adapter: getFoo,
-                      params: {},
-                      static: {
-                        key1: importedValue
-                      },
-                      config: function($cmp) {
-                        return {
-                          key1: importedValue
-                        };
-                      }
-                    }
-                  }
-                });
-                
-                export default _registerComponent(Test, {
-                  tmpl: _tmpl
-                });
-`,
-            },
-        }
-    );
-
-    pluginTest(
         'transforms parameters with 2 levels deep (foo.bar)',
         `
         import { wire } from 'lwc';

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -9,7 +9,6 @@ const { staticClassProperty, markAsLWCNode } = require('../../utils');
 const { LWC_COMPONENT_PROPERTIES } = require('../../constants');
 
 const WIRE_PARAM_PREFIX = '$';
-const WIRE_CONFIG_ARG_NAME = '$cmp';
 
 function isObservedProperty(configProperty) {
     const propertyValue = configProperty.get('value');
@@ -38,92 +37,6 @@ function getWiredParams(t, wireConfig) {
         });
 }
 
-function getGeneratedConfig(t, wiredValue) {
-    let counter = 0;
-    const configBlockBody = [];
-    const configProps = [];
-    const generateParameterConfigValue = memberExprPaths => {
-        if (memberExprPaths.length === 1) {
-            return {
-                configValueExpression: t.memberExpression(
-                    t.identifier(WIRE_CONFIG_ARG_NAME),
-                    t.identifier(memberExprPaths[0])
-                ),
-            };
-        }
-
-        const varName = 'v' + ++counter;
-        const varDeclaration = t.variableDeclaration('let', [
-            t.variableDeclarator(
-                t.identifier(varName),
-                t.memberExpression(
-                    t.identifier(WIRE_CONFIG_ARG_NAME),
-                    t.identifier(memberExprPaths[0])
-                )
-            ),
-        ]);
-
-        // Results in: v != null && ... (v = v.i) != null && ... (v = v.(n-1)) != null
-        let conditionTest = t.binaryExpression('!=', t.identifier(varName), t.nullLiteral());
-
-        for (let i = 1, n = memberExprPaths.length; i < n - 1; i++) {
-            const nextPropValue = t.assignmentExpression(
-                '=',
-                t.identifier(varName),
-                t.memberExpression(t.identifier(varName), t.identifier(memberExprPaths[i]))
-            );
-
-            conditionTest = t.logicalExpression(
-                '&&',
-                conditionTest,
-                t.binaryExpression('!=', nextPropValue, t.nullLiteral())
-            );
-        }
-
-        // conditionTest ? v.n : undefined
-        const configValueExpression = t.conditionalExpression(
-            conditionTest,
-            t.memberExpression(
-                t.identifier(varName),
-                t.identifier(memberExprPaths[memberExprPaths.length - 1])
-            ),
-            t.identifier('undefined')
-        );
-
-        return {
-            varDeclaration,
-            configValueExpression,
-        };
-    };
-
-    if (wiredValue.static) {
-        Array.prototype.push.apply(configProps, wiredValue.static);
-    }
-
-    if (wiredValue.params) {
-        wiredValue.params.forEach(param => {
-            const memberExprPaths = param.value.value.split('.');
-            const paramConfigValue = generateParameterConfigValue(memberExprPaths);
-
-            configProps.push(t.objectProperty(param.key, paramConfigValue.configValueExpression));
-
-            if (paramConfigValue.varDeclaration) {
-                configBlockBody.push(paramConfigValue.varDeclaration);
-            }
-        });
-    }
-
-    configBlockBody.push(t.returnStatement(t.objectExpression(configProps)));
-
-    const fnExpression = t.functionExpression(
-        null,
-        [t.identifier(WIRE_CONFIG_ARG_NAME)],
-        t.blockStatement(configBlockBody)
-    );
-
-    return t.objectProperty(t.identifier('config'), fnExpression);
-}
-
 function buildWireConfigValue(t, wiredValues) {
     return t.objectExpression(
         wiredValues.map(wiredValue => {
@@ -149,8 +62,6 @@ function buildWireConfigValue(t, wiredValues) {
             if (wiredValue.isClassMethod) {
                 wireConfig.push(t.objectProperty(t.identifier('method'), t.numericLiteral(1)));
             }
-
-            wireConfig.push(getGeneratedConfig(t, wiredValue));
 
             return t.objectProperty(
                 t.identifier(wiredValue.propertyName),

--- a/packages/integration-karma/test/api/getComponentDef/index.spec.js
+++ b/packages/integration-karma/test/api/getComponentDef/index.spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { LightningElement, api, getComponentDef } from 'lwc';
 
 import PublicProperties from 'x/publicProperties';
@@ -21,36 +20,6 @@ function testInvalidComponentConstructor(name, ctor) {
         );
     });
 }
-
-beforeAll(function() {
-    const getNormalizedFunctionAsString = fn => fn.toString().replace(/(\s|\n)/g, '');
-
-    jasmine.addMatchers({
-        toEqualWireSettings: function() {
-            return {
-                compare: function(actual, expected) {
-                    Object.keys(actual).forEach(currentKey => {
-                        const normalizedActual = Object.assign({}, actual[currentKey], {
-                            config: getNormalizedFunctionAsString(actual[currentKey].config),
-                        });
-
-                        const normalizedExpected = Object.assign({}, expected[currentKey], {
-                            config: getNormalizedFunctionAsString(
-                                expected[currentKey].config || function() {}
-                            ),
-                        });
-
-                        expect(normalizedActual).toEqual(normalizedExpected);
-                    });
-
-                    return {
-                        pass: true,
-                    };
-                },
-            };
-        },
-    });
-});
 
 testInvalidComponentConstructor('null', null);
 testInvalidComponentConstructor('undefined', undefined);
@@ -206,12 +175,9 @@ describe('@api', () => {
 describe('@wire', () => {
     it('should return the wired properties in wire object', () => {
         const { wire } = getComponentDef(WireProperties);
-        expect(wire).toEqualWireSettings({
+        expect(wire).toEqual({
             foo: {
                 adapter: wireAdapter,
-                config: function($cmp) {
-                    return {};
-                },
             },
             bar: {
                 adapter: wireAdapter,
@@ -219,9 +185,6 @@ describe('@wire', () => {
                     a: true,
                 },
                 params: {},
-                config: function($cmp) {
-                    return { a: true };
-                },
             },
             baz: {
                 adapter: wireAdapter,
@@ -230,9 +193,6 @@ describe('@wire', () => {
                 },
                 params: {
                     c: 'foo',
-                },
-                config: function($cmp) {
-                    return { b: true, c: $cmp.foo };
                 },
             },
         });
@@ -240,13 +200,10 @@ describe('@wire', () => {
 
     it('should return the wired methods in the wire object with a method flag', () => {
         const { wire } = getComponentDef(WireMethods);
-        expect(wire).toEqualWireSettings({
+        expect(wire).toEqual({
             foo: {
                 adapter: wireAdapter,
                 method: 1,
-                config: function($cmp) {
-                    return {};
-                },
             },
             bar: {
                 adapter: wireAdapter,
@@ -255,9 +212,6 @@ describe('@wire', () => {
                 },
                 params: {},
                 method: 1,
-                config: function($cmp) {
-                    return { a: true };
-                },
             },
             baz: {
                 adapter: wireAdapter,
@@ -268,25 +222,19 @@ describe('@wire', () => {
                     c: 'foo',
                 },
                 method: 1,
-                config: function($cmp) {
-                    return { b: true, c: $cmp.foo };
-                },
             },
         });
     });
 
     it('should inherit wire properties from the base class', () => {
         const { wire } = getComponentDef(WirePropertiesInheritance);
-        expect(wire).toEqualWireSettings({
+        expect(wire).toEqual({
             parentProp: {
                 adapter: wireAdapter,
                 static: {
                     parent: true,
                 },
                 params: {},
-                config: function($cmp) {
-                    return { parent: true };
-                },
             },
             overriddenInChild: {
                 adapter: wireAdapter,
@@ -294,9 +242,6 @@ describe('@wire', () => {
                     child: true,
                 },
                 params: {},
-                config: function($cmp) {
-                    return { child: true };
-                },
             },
             childProp: {
                 adapter: wireAdapter,
@@ -304,16 +249,13 @@ describe('@wire', () => {
                     child: true,
                 },
                 params: {},
-                config: function($cmp) {
-                    return { child: true };
-                },
             },
         });
     });
 
     it('should inherit the wire methods from the case class', () => {
         const { wire } = getComponentDef(WireMethodsInheritance);
-        expect(wire).toEqualWireSettings({
+        expect(wire).toEqual({
             parentMethod: {
                 adapter: wireAdapter,
                 static: {
@@ -321,11 +263,6 @@ describe('@wire', () => {
                 },
                 params: {},
                 method: 1,
-                config: function($cmp) {
-                    return {
-                        parent: true,
-                    };
-                },
             },
             overriddenInChild: {
                 adapter: wireAdapter,
@@ -334,11 +271,6 @@ describe('@wire', () => {
                 },
                 params: {},
                 method: 1,
-                config: function($cmp) {
-                    return {
-                        child: true,
-                    };
-                },
             },
             childMethod: {
                 adapter: wireAdapter,
@@ -347,11 +279,6 @@ describe('@wire', () => {
                 },
                 params: {},
                 method: 1,
-                config: function($cmp) {
-                    return {
-                        child: true,
-                    };
-                },
             },
         });
     });


### PR DESCRIPTION
## Details
Reverts #1468 and #1455 in this release of 1.1.0, due to the fact that is not in use yet.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
