### PR TITLE
fix: containsPatched when otherNode is null or undefined

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -190,7 +190,7 @@ function compareDocumentPositionPatched(this: Node, otherNode: Node) {
 }
 
 function containsPatched(this: Node, otherNode: Node) {
-    if (getNodeOwnerKey(this) !== getNodeOwnerKey(otherNode)) {
+    if (otherNode == null || getNodeOwnerKey(this) !== getNodeOwnerKey(otherNode)) {
         // it is from another shadow
         return false;
     }

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.contains.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.contains.spec.js
@@ -67,4 +67,12 @@ describe('Node.contains', () => {
                 .contains(shadowRoot.querySelector('.slotted'))
         ).toBe(false);
     });
+
+    it('should return false when argument is null or undefined', () => {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+
+        expect(div.contains(undefined)).toBe(false);
+        expect(div.contains(null)).toBe(false);
+    });
 });


### PR DESCRIPTION
Fixes error `TypeError: Cannot read property '$$OwnerKey$$' of null` when calling `node.contains(null)`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`