### PR TITLE
fix: relax dom patching for querySelector(all) on elements

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -359,7 +359,8 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         const elm = ArrayFind.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
         return isUndefined(elm) ? null : elm;
     } else if (this instanceof HTMLBodyElement) {
-        // document.body is already patched, this should be the patch logic for elements outside lwc.
+        // This is the patching logic.
+        // We only restrict it to the document.body because it was already patched previous this logic.
         const elm = ArrayFind.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
@@ -367,6 +368,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         );
         return isUndefined(elm) ? null : elm;
     } else {
+        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow (or a root host).
         return nodeList[0];
     }
 }
@@ -391,14 +393,15 @@ function querySelectorAllPatched(this: Element /*, selector: string*/): NodeList
         const ownerKey = getNodeOwnerKey(this);
         filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
     } else if (this instanceof HTMLBodyElement) {
-        // document.body is already patched
+        // This is the patching logic.
+        // We only restrict it to the document.body because it was already patched previous this logic.
         filtered = ArrayFilter.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
     } else {
-        // temporally disable dom patching from an element outside lwc.
+        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow (or a root host).
         filtered = ArraySlice.call(nodeList);
     }
     return createStaticNodeList(filtered);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -358,14 +358,16 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         const ownerKey = getNodeOwnerKey(this);
         const elm = ArrayFind.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
         return isUndefined(elm) ? null : elm;
-    } else {
-        // element belonging to the document
+    } else if (this instanceof HTMLBodyElement) {
+        // document.body is already patched, this should be the patch logic for elements outside lwc.
         const elm = ArrayFind.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
         return isUndefined(elm) ? null : elm;
+    } else {
+        return nodeList[0];
     }
 }
 
@@ -388,13 +390,16 @@ function querySelectorAllPatched(this: Element /*, selector: string*/): NodeList
         // element inside a shadowRoot
         const ownerKey = getNodeOwnerKey(this);
         filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
-    } else {
-        // element belonging to the document
+    } else if (this instanceof HTMLBodyElement) {
+        // document.body is already patched
         filtered = ArrayFilter.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
+    } else {
+        // temporally disable dom patching from an element outside lwc.
+        filtered = ArraySlice.call(nodeList);
     }
     return createStaticNodeList(filtered);
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -360,7 +360,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         return isUndefined(elm) ? null : elm;
     } else if (this instanceof HTMLBodyElement) {
         // This is the patching logic.
-        // We only restrict it to the document.body because it was already patched previous this logic.
+        // We only restrict it to the document.body because it was already patched earlier.
         const elm = ArrayFind.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
@@ -368,7 +368,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         );
         return isUndefined(elm) ? null : elm;
     } else {
-        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow (or a root host).
+        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow.
         return nodeList[0];
     }
 }
@@ -394,14 +394,14 @@ function querySelectorAllPatched(this: Element /*, selector: string*/): NodeList
         filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
     } else if (this instanceof HTMLBodyElement) {
         // This is the patching logic.
-        // We only restrict it to the document.body because it was already patched previous this logic.
+        // We only restrict it to the document.body because it was already patched earlier.
         filtered = ArrayFilter.call(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
     } else {
-        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow (or a root host).
+        // The `this` is part of the document, patching is not applied: we are not filtering out elements inside a shadow.
         filtered = ArraySlice.call(nodeList);
     }
     return createStaticNodeList(filtered);


### PR DESCRIPTION
This PR, stop from filtering out elements inside a shadow from the results of `element.querySelector` and `element.querySelectorAll` when `element` is not inside a shadow.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`