### PR TITLE
fix: [cp] remove side effects assertion in non-decorated fields (#1491)

### DIFF
--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -8,7 +8,6 @@ import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
 import assert from '../shared/assert';
 import { valueMutated, valueObserved } from '../libs/mutation-tracker';
-import { isRendering, vmBeingRendered } from './invoker';
 import { isFalse, ArrayReduce } from '../shared/language';
 
 export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): PropertyDescriptorMap {
@@ -37,12 +36,6 @@ function createObservedFieldPropertyDescriptor(key: PropertyKey): PropertyDescri
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
-                assert.invariant(
-                    !isRendering,
-                    `${vmBeingRendered}.render() method has side effects on the state of "${String(
-                        key
-                    )}" field`
-                );
             }
 
             if (newValue !== vm.cmpTrack[key]) {

--- a/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.html
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.html
@@ -1,0 +1,4 @@
+<template>
+    <p class="computedLabel">{computedLabel}</p>
+    <p class="label">{label}</p>
+</template>

--- a/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.js
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldForCache/fieldForCache.js
@@ -1,0 +1,14 @@
+import { LightningElement, api } from 'lwc';
+
+export default class FieldForCache extends LightningElement {
+    @api label;
+    cachedLabel = null;
+
+    get computedLabel() {
+        if (this.cachedLabel === null) {
+            this.cachedLabel = this.label + ' computed';
+        }
+
+        return this.cachedLabel;
+    }
+}

--- a/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.html
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.html
@@ -1,1 +1,5 @@
-<template></template>
+<template>
+    <p class="rendered-times">{counter}</p>
+    <p class="expando">{expandoCounter}</p>
+    <p class="label">{label}</p>
+</template>

--- a/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.js
+++ b/packages/integration-karma/test/component/observed-fields/x/fieldWithSideEffect/fieldWithSideEffect.js
@@ -1,11 +1,22 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 import tpl from './fieldWithSideEffect.html';
 
 export default class FieldWithSideEffect extends LightningElement {
+    @api label;
+    @api useExpando = false;
     counter = 0;
 
+    constructor() {
+        super();
+        this.expandoCounter = 0;
+    }
+
     render() {
-        this.counter++;
+        if (this.useExpando) {
+            this.expandoCounter++;
+        } else {
+            this.counter++;
+        }
 
         return tpl;
     }


### PR DESCRIPTION
## Details
Cherrypicks #1491 

* fix: remove side effects assertion in observed fields

* fix: assert is valid vm during setter

# Conflicts:
#	packages/@lwc/engine/src/framework/observed-fields.ts

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`