### PR TITLE
fix(engine): use name from component constructor

### DIFF
--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -47,6 +47,9 @@ export function registerComponent(
     Ctor: ComponentConstructor,
     { name, tmpl: template }: { name: string; tmpl: Template }
 ): ComponentConstructor {
+    if (isUndefined(name)) {
+        name = Ctor.name;
+    }
     signedComponentToMetaMap.set(Ctor, { name, template });
     // chaining this method as a way to wrap existing
     // assignment of component constructor easily, without too much transformation

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -31,7 +31,7 @@ it(`throws an error if returns an invalid template`, () => {
         document.body.appendChild(elm);
     }).toThrowError(
         Error,
-        /Invalid template returned by the render\(\) method on .+\. It must return an imported template \(e\.g\.: `import html from "\.\/undefined.html"`\), instead, it has returned: .+\./
+        /Invalid template returned by the render\(\) method on .+\. It must return an imported template \(e\.g\.: `import html from "\.\/DynamicTemplate.html"`\), instead, it has returned: .+\./
     );
 });
 

--- a/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
@@ -3,14 +3,12 @@ import { createElement } from 'lwc';
 import Anonymous from 'x/anonymous';
 import Named from 'x/named';
 
-// TODO: #1033 with the transformation done by the compiler, the class name is removed, producing "[object undefined]"
-xit('should rely on the constructor name', () => {
+it('should rely on the constructor name', () => {
     const elm = createElement('x-named', { is: Named });
     expect(elm.getToString()).toBe('[object MyFancyComponent]');
 });
 
-// TODO: #1033 open issue return "[object ]" on Safari
-xit('should fallback to BaseLightningElement if constructor has no name', () => {
+it('should fallback to BaseLightningElementConstructor if constructor has no name', () => {
     const elm = createElement('x-anonymous', { is: Anonymous });
-    expect(elm.getToString()).toBe('[object BaseLightningElement]');
+    expect(elm.getToString()).toBe('[object BaseLightningElementConstructor]');
 });


### PR DESCRIPTION
use name from component constructor if its not provided when calling registerComponent

closes: #1033


## Details


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
