### PR TITLE
fix(engine): refactor boundary protection for render phase

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -615,8 +615,8 @@ export function ll(
     id: string,
     context?: (...args: any[]) => any
 ): EventListener {
-    const vmBeingRendered: VM | null = getVMBeingRendered();
-    if (isNull(vmBeingRendered)) {
+    const vm: VM | null = getVMBeingRendered();
+    if (isNull(vm)) {
         throw new Error();
     }
     // bind the original handler with b() so we can call it
@@ -628,7 +628,7 @@ export function ll(
         // located service for the locator metadata
         const {
             context: { locator },
-        } = vmBeingRendered;
+        } = vm;
         if (!isUndefined(locator)) {
             const { locator: locatorService } = Services;
             if (locatorService) {
@@ -641,7 +641,7 @@ export function ll(
                 // a registered `locator` service will be invoked with
                 // access to the context.locator.resolved, which will contain:
                 // outer id, outer context, inner id, and inner context
-                invokeServiceHook(vmBeingRendered, locatorService);
+                invokeServiceHook(vm, locatorService);
             }
         }
         // invoke original event listener via b()

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -41,7 +41,7 @@ import { observeMutation, notifyMutation } from './watcher';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
-import { Template } from './template';
+import { Template, isEvaluatingTemplate } from './template';
 
 const GlobalEvent = Event; // caching global reference to avoid poisoning
 
@@ -98,7 +98,7 @@ function createBridgeToElementDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${propName}`
                 );
                 assert.isFalse(
@@ -244,7 +244,7 @@ BaseLightningElement.prototype = {
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             assert.invariant(
-                !isRendering,
+                !isRendering && !isEvaluatingTemplate,
                 `${vmBeingRendered}.render() method has side effects on the state of ${vm} by adding an event listener for "${type}".`
             );
             assert.invariant(

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -35,13 +35,13 @@ import {
 } from './component';
 import { setInternalField, setHiddenField } from '../shared/fields';
 import { ViewModelReflection, EmptyObject } from './utils';
-import { vmBeingConstructed, isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
+import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
 import { getComponentVM, VM } from './vm';
 import { observeMutation, notifyMutation } from './watcher';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
-import { Template, isEvaluatingTemplate } from './template';
+import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 
 const GlobalEvent = Event; // caching global reference to avoid poisoning
 
@@ -97,9 +97,14 @@ function createBridgeToElementDescriptor(
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering && !isEvaluatingTemplate,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${propName}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `When updating the template of ${vmBeingRendered}, one of the accessors used by the template has side effects on the state of ${vm}.${propName}`
                 );
                 assert.isFalse(
                     isBeingConstructed(vm),
@@ -242,10 +247,15 @@ BaseLightningElement.prototype = {
     ) {
         const vm = getComponentVM(this);
         if (process.env.NODE_ENV !== 'production') {
+            const vmBeingRendered = getVMBeingRendered();
             assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             assert.invariant(
-                !isRendering && !isEvaluatingTemplate,
+                !isInvokingRender,
                 `${vmBeingRendered}.render() method has side effects on the state of ${vm} by adding an event listener for "${type}".`
+            );
+            assert.invariant(
+                !isUpdatingTemplate,
+                `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm} by adding an event listener for "${type}".`
             );
             assert.invariant(
                 isFunction(listener),

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -24,7 +24,7 @@ import { invokeServiceHook, Services } from './services';
 import { VM, getComponentVM, UninitializedVM } from './vm';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { tagNameGetter } from '../env/element';
-import { Template } from './template';
+import { Template, isEvaluatingTemplate } from './template';
 
 export type ErrorCallback = (error: any, stack: string) => void;
 export interface ComponentInterface {
@@ -149,8 +149,8 @@ export function markComponentAsDirty(vm: VM) {
             vm.isDirty,
             `markComponentAsDirty() for ${vm} should not be called when the component is already dirty.`
         );
-        assert.isFalse(
-            isRendering,
+        assert.isTrue(
+            !isRendering && !isEvaluatingTemplate,
             `markComponentAsDirty() for ${vm} cannot be called during rendering of ${vmBeingRendered}.`
         );
     }

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -12,6 +12,7 @@ import { ComponentInterface, ComponentConstructor } from '../component';
 import { getComponentVM } from '../vm';
 import { isUndefined, isFunction } from '../../shared/language';
 import { getDecoratorsRegisteredMeta } from './register';
+import { isEvaluatingTemplate } from '../template';
 
 /**
  * @api decorator to mark public fields and public methods in
@@ -89,7 +90,7 @@ function createPublicPropertyDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
                         key
                     )}`
@@ -138,7 +139,7 @@ function createPublicAccessorDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
                         key
                     )}`

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -5,14 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import assert from '../../shared/assert';
-import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
+import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { isObject, toString, isFalse } from '../../shared/language';
 import { observeMutation, notifyMutation } from '../watcher';
 import { ComponentInterface, ComponentConstructor } from '../component';
 import { getComponentVM } from '../vm';
 import { isUndefined, isFunction } from '../../shared/language';
 import { getDecoratorsRegisteredMeta } from './register';
-import { isEvaluatingTemplate } from '../template';
+import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
 /**
  * @api decorator to mark public fields and public methods in
@@ -88,10 +88,17 @@ function createPublicPropertyDescriptor(
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering && !isEvaluatingTemplate,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
+                        key
+                    )}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                         key
                     )}`
                 );
@@ -138,9 +145,16 @@ function createPublicAccessorDescriptor(
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering && !isEvaluatingTemplate,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
+                        key
+                    )}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                         key
                     )}`
                 );

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -11,6 +11,7 @@ import { observeMutation, notifyMutation } from '../watcher';
 import { getComponentVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentConstructor, ComponentInterface } from '../component';
+import { isEvaluatingTemplate } from '../template';
 
 /**
  * @track decorator to mark fields as reactive in
@@ -74,7 +75,7 @@ export function createTrackedPropertyDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${String(
                         key
                     )}`

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -87,7 +87,6 @@ export function createTrackedPropertyDescriptor(
                         key
                     )}`
                 );
-                // when updating the template of this ${currentOwnerVM}, one of the accessors used by the template has side effects on the state of the vm
             }
             const reactiveOrAnyValue = reactiveMembrane.getProxy(newValue);
             if (reactiveOrAnyValue !== vm.cmpTrack[key]) {

--- a/packages/@lwc/engine/src/framework/invoker.ts
+++ b/packages/@lwc/engine/src/framework/invoker.ts
@@ -124,6 +124,7 @@ export function invokeComponentRenderMethod(vm: VM): VNodes {
         () => {
             // job
             const html = callHook(component, render);
+            isRendering = false;
             result = evaluateTemplate(vm, html);
         },
         () => {

--- a/packages/@lwc/engine/src/framework/invoker.ts
+++ b/packages/@lwc/engine/src/framework/invoker.ts
@@ -132,6 +132,10 @@ export function invokeComponentRenderMethod(vm: VM): VNodes {
             setVMBeingRendered(vmBeingRenderedInception);
         }
     );
+    // html can be undefined when
+    // 1. There is an error during invocation of the component's render(), this case is handled by the boundary protection
+    // 2. When the component's render() returns undefined. In this case we throw an dev mode assertion and let boundary protection handle it
+    // In both cases, we degrade gracefully in production mode by returning an empty template
     return isUndefined(html) ? [] : evaluateTemplate(vm, html);
 }
 

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -24,6 +24,7 @@ import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
 import { isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
 import { getShadowRootVM, getComponentVM } from './vm';
+import { isEvaluatingTemplate } from './template';
 
 function generateDataDescriptor(options: PropertyDescriptor): PropertyDescriptor {
     return assign(
@@ -212,7 +213,7 @@ function getShadowRootRestrictionsDescriptors(
         addEventListener: generateDataDescriptor({
             value(this: ShadowRoot, type: string) {
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
                         sr
                     )} by adding an event listener for "${type}".`
@@ -309,7 +310,7 @@ function getCustomElementRestrictionsDescriptors(
         addEventListener: generateDataDescriptor({
             value(this: HTMLElement, type: string) {
                 assert.invariant(
-                    !isRendering,
+                    !isRendering && !isEvaluatingTemplate,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
                         elm
                     )} by adding an event listener for "${type}".`

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -22,9 +22,9 @@ import {
 } from '../shared/language';
 import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
-import { isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
+import { isBeingConstructed, isInvokingRender } from './invoker';
 import { getShadowRootVM, getComponentVM } from './vm';
-import { isEvaluatingTemplate } from './template';
+import { isUpdatingTemplate, getVMBeingRendered } from './template';
 
 function generateDataDescriptor(options: PropertyDescriptor): PropertyDescriptor {
     return assign(
@@ -212,9 +212,16 @@ function getShadowRootRestrictionsDescriptors(
         }),
         addEventListener: generateDataDescriptor({
             value(this: ShadowRoot, type: string) {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering && !isEvaluatingTemplate,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
+                        sr
+                    )} by adding an event listener for "${type}".`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${toString(
                         sr
                     )} by adding an event listener for "${type}".`
                 );
@@ -309,9 +316,16 @@ function getCustomElementRestrictionsDescriptors(
         }),
         addEventListener: generateDataDescriptor({
             value(this: HTMLElement, type: string) {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering && !isEvaluatingTemplate,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
+                        elm
+                    )} by adding an event listener for "${type}".`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${toString(
                         elm
                     )} by adding an event listener for "${type}".`
                 );

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -188,21 +188,21 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         () => {
             // invoke the selected template.
             vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
-            const { styleVNode } = context;
-            if (!isNull(styleVNode)) {
-                ArrayUnshift.call(vnodes, styleVNode);
-            }
-
-            if (process.env.NODE_ENV !== 'production') {
-                assert.invariant(
-                    isArray(vnodes),
-                    `Compiler should produce html functions that always return an array.`
-                );
-            }
         },
         () => {
             isEvaluatingTemplate = isEvaluatingTemplateInception;
         }
     );
+    const { styleVNode } = context;
+    if (!isNull(styleVNode)) {
+        ArrayUnshift.call(vnodes, styleVNode);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+        assert.invariant(
+            isArray(vnodes),
+            `Compiler should produce html functions that always return an array.`
+        );
+    }
     return vnodes;
 }

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -157,7 +157,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
                 }
 
                 // Check that the template was built by the compiler
-                if (!isTemplateRegistered(html)) {
+                if (isUndefined(html) || !isTemplateRegistered(html)) {
                     throw new TypeError(
                         `Invalid template returned by the render() method on ${vm}. It must return an imported template (e.g.: \`import html from "./${
                             vm.def.name

--- a/packages/@lwc/engine/src/framework/watcher.ts
+++ b/packages/@lwc/engine/src/framework/watcher.ts
@@ -25,7 +25,7 @@ const TargetToReactiveRecordMap: WeakMap<object, ReactiveRecord> = new WeakMap()
 export function notifyMutation(target: object, key: PropertyKey) {
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
-            !isRendering,
+            !isRendering && !isEvaluatingTemplate,
             `Mutating property ${toString(key)} of ${toString(
                 target
             )} is not allowed during the rendering life-cycle of ${vmBeingRendered}.`
@@ -78,3 +78,4 @@ export function observeMutation(target: object, key: PropertyKey) {
 import { scheduleRehydration } from './vm';
 import { markComponentAsDirty } from './component';
 import { vmBeingRendered, isRendering } from './invoker';
+import { isEvaluatingTemplate } from './template';

--- a/packages/@lwc/engine/src/framework/watcher.ts
+++ b/packages/@lwc/engine/src/framework/watcher.ts
@@ -24,11 +24,18 @@ const TargetToReactiveRecordMap: WeakMap<object, ReactiveRecord> = new WeakMap()
 
 export function notifyMutation(target: object, key: PropertyKey) {
     if (process.env.NODE_ENV !== 'production') {
+        const vmBeingRendered = getVMBeingRendered();
         assert.invariant(
-            !isRendering && !isEvaluatingTemplate,
+            !isInvokingRender,
             `Mutating property ${toString(key)} of ${toString(
                 target
-            )} is not allowed during the rendering life-cycle of ${vmBeingRendered}.`
+            )} is not allowed when invoking the render() of ${vmBeingRendered}.`
+        );
+        assert.invariant(
+            !isUpdatingTemplate,
+            `Mutating property ${toString(key)} of ${toString(
+                target
+            )} is not allowed when updating the template of ${vmBeingRendered}.`
         );
     }
     const reactiveRecord = TargetToReactiveRecordMap.get(target);
@@ -51,10 +58,10 @@ export function notifyMutation(target: object, key: PropertyKey) {
 }
 
 export function observeMutation(target: object, key: PropertyKey) {
-    if (isNull(vmBeingRendered)) {
+    const vm = getVMBeingRendered();
+    if (isNull(vm)) {
         return; // nothing to subscribe to
     }
-    const vm = vmBeingRendered;
     let reactiveRecord = TargetToReactiveRecordMap.get(target);
     if (isUndefined(reactiveRecord)) {
         const newRecord = create(null);
@@ -77,5 +84,5 @@ export function observeMutation(target: object, key: PropertyKey) {
 
 import { scheduleRehydration } from './vm';
 import { markComponentAsDirty } from './component';
-import { vmBeingRendered, isRendering } from './invoker';
-import { isEvaluatingTemplate } from './template';
+import { isInvokingRender } from './invoker';
+import { isUpdatingTemplate, getVMBeingRendered } from './template';

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import Parent from 'x/dualTemplate1506';
+
+it('setting tracked value in disconnectedCallback should not throw', () => {
+    const elm = createElement('x-parent', { is: Parent });
+    document.body.appendChild(elm);
+    expect(
+        elm.shadowRoot.querySelector('x-disconnected-callback-sets-tracked-value')
+    ).not.toBeNull();
+    elm.toggleTemplate();
+
+    return Promise.resolve().then(() => {
+        expect(elm.shadowRoot.querySelector('div').textContent).toBe('simple template');
+    });
+});

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.html
@@ -1,0 +1,3 @@
+<template>
+    <div>Child Component</div>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.js
@@ -1,0 +1,10 @@
+import { LightningElement, track } from 'lwc';
+
+export default class Child extends LightningElement {
+    @track
+    state = true;
+
+    disconnectedCallback() {
+        this.state = false;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/dualTemplate1506.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/dualTemplate1506.js
@@ -1,0 +1,16 @@
+import { LightningElement, api, track } from 'lwc';
+import SimpleTemplate from './simpleTemplate.html';
+import TemplateWithChild from './templateWithChild.html';
+
+export default class Parent extends LightningElement {
+    @track _toggle = false;
+
+    @api
+    toggleTemplate() {
+        this._toggle = !this._toggle;
+    }
+
+    render() {
+        return this._toggle ? SimpleTemplate : TemplateWithChild;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/simpleTemplate.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/simpleTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <div>simple template</div>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/templateWithChild.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/templateWithChild.html
@@ -1,0 +1,3 @@
+<template>
+    <x-disconnected-callback-sets-tracked-value></x-disconnected-callback-sets-tracked-value>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -16,23 +16,10 @@ function testInvalidTemplate(type, template) {
     });
 }
 
+testInvalidTemplate('undefined', undefined);
 testInvalidTemplate('null', null);
 testInvalidTemplate('string', '<h1>template</h1>');
 testInvalidTemplate('object', {});
-
-if (process.env.NODE_ENV !== 'production') {
-    // If render() returns undefined, we throw in dev mode and let boundary protection handle it
-    testInvalidTemplate('undefined', undefined);
-} else {
-    // In prod mode, we degrade gracefully and return an empty template
-    it(`renders a blank template when render() returns undefined`, () => {
-        const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
-        elm.template = undefined;
-
-        document.body.appendChild(elm);
-        expect(elm.shadowRoot.childNodes.length).toBe(0);
-    });
-}
 
 it(`throws an error if returns an invalid template`, () => {
     const invalidTemplate = () => {};

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -16,10 +16,23 @@ function testInvalidTemplate(type, template) {
     });
 }
 
-testInvalidTemplate('undefined', undefined);
 testInvalidTemplate('null', null);
 testInvalidTemplate('string', '<h1>template</h1>');
 testInvalidTemplate('object', {});
+
+if (process.env.NODE_ENV !== 'production') {
+    // If render() returns undefined, we throw in dev mode and let boundary protection handle it
+    testInvalidTemplate('undefined', undefined);
+} else {
+    // In prod mode, we degrade gracefully and return an empty template
+    it(`renders a blank template when render() returns undefined`, () => {
+        const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
+        elm.template = undefined;
+
+        document.body.appendChild(elm);
+        expect(elm.shadowRoot.childNodes.length).toBe(0);
+    });
+}
 
 it(`throws an error if returns an invalid template`, () => {
     const invalidTemplate = () => {};


### PR DESCRIPTION
## Details
1. User land code is protected from making dangerous mutation during rendering phase.
2. Rendering a component is two steps, first the render() is invoked and then the returned template is evaluated.
3. The userland code was being protected using one global flag called `isRendering`. 
4.  In between these two steps, the engine is executing its own routine and does not need to be protected from dangerous mutations.

This PR separated the flag into two. One for render invocation and another for template evaluation.

Addresses issue https://github.com/salesforce/lwc/issues/1506

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`


If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
