### PR TITLE
feat(babel-plugin-component): no leading upper-case chars in prop names

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -587,6 +587,34 @@ describe('Transform property', () => {
         }
     );
 
+    pluginTest.only(
+        'throws an error if public property getter starts with an upper case letter',
+        `
+        import { api } from 'lwc';
+        export default class Test {
+            @api
+            get Upper() {
+                return this._upper;
+            }
+            set Upper(val) {
+                this._upper = val;
+            }
+        }
+    `,
+        {
+            error: {
+                message:
+                    'Invalid property name "Upper". Property name must start with a lowercase character.',
+                loc: {
+                    line: 3,
+                    column: 0,
+                    length: 40,
+                    start: 55,
+                },
+            },
+        }
+    );
+
     pluginTest(
         'throws correct error if property name is maxlength',
         `

--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -565,6 +565,29 @@ describe('Transform property', () => {
     );
 
     pluginTest(
+        'throws an error if public property name starts with an upper case letter',
+        `
+        import { api } from 'lwc';
+        export default class Test {
+            @api
+            Upper = 'foo';
+        }
+    `,
+        {
+            error: {
+                message:
+                    'Invalid property name "Upper". Property name must start with a lowercase character.',
+                loc: {
+                    line: 3,
+                    column: 0,
+                    length: 19,
+                    start: 55,
+                },
+            },
+        }
+    );
+
+    pluginTest(
         'throws correct error if property name is maxlength',
         `
         import { api } from 'lwc';

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/validate.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/validate.js
@@ -15,6 +15,8 @@ const {
 
 const { generateError } = require('../../utils');
 
+const LEADING_UPPER_CASE_REGEX = new RegExp('^[A-Z.]');
+
 function validateConflict(path, decorators) {
     const isPublicFieldTracked = decorators.some(
         decorator =>
@@ -76,6 +78,11 @@ function validatePropertyName(property) {
         throw generateError(property, {
             errorInfo: DecoratorErrors.PROPERTY_NAME_IS_AMBIGUOUS,
             messageArgs: [propertyName, camelCased],
+        });
+    } else if (LEADING_UPPER_CASE_REGEX.test(propertyName)) {
+        throw generateError(property, {
+            errorInfo: DecoratorErrors.PROPERTY_NAME_CANNOT_START_WITH_UPPERCASE_CHARACTER,
+            messageArgs: [propertyName],
         });
     }
 }

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -6,7 +6,7 @@
  */
 /**
  * TODO: W-5678919 - implement script to determine the next available error code
- * Next error code: 1126
+ * Next error code: 1134
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
@@ -190,6 +190,14 @@ export const DecoratorErrors = {
         url: '',
     },
 
+    PROPERTY_NAME_CANNOT_START_WITH_UPPERCASE_CHARACTER: {
+        code: 1133,
+        message:
+            'Invalid property name "{0}". Property name must start with a lowercase character.',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+
     SINGLE_DECORATOR_ON_SETTER_GETTER_PAIR: {
         code: 1112,
         message:


### PR DESCRIPTION
## Details
Generate a compile time error when a component declares a public property with a leading upper-case character.

Example of invalid usage:
```js
import { LightningElement, api } from 'lwc';

export default class App extends LightningElement {
    @api Upper;
}
```

## Does this PR introduce breaking changes?
* 🚨 `Yes, it does introduce breaking changes.`

This change affects an existing component that meets both conditions:
1. Component contains a parent LWC component
2. The parent component passes a lowe-cased version of the invalid property to the child component
Ex:
```js
# parent.html
<template><child-cmp upper={val}></child-cmp>
```

Playground example [here](https://developer.salesforce.com/docs/component-library/tools/playground/YKSTgG-aG/14/edit)