### PR TITLE
fix: escape hatch for async event target accessor

### DIFF
--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/childWithOutLwcDomManual/childWithOutLwcDomManual.html
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/childWithOutLwcDomManual/childWithOutLwcDomManual.html
@@ -1,0 +1,4 @@
+<template>
+    <div>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/childWithOutLwcDomManual/childWithOutLwcDomManual.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/childWithOutLwcDomManual/childWithOutLwcDomManual.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    renderedCallback() {
+        const container = this.template.querySelector('div');
+        container.appendChild(document.createElement('span'));
+    }
+}

--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/parentWithDynamicChild/parentWithDynamicChild.html
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/parentWithDynamicChild/parentWithDynamicChild.html
@@ -1,0 +1,5 @@
+<template>
+    <div onclick={clickHandler}>
+        <x-child-with-out-lwc-dom-manual></x-child-with-out-lwc-dom-manual>
+    </div>    
+</template>

--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/parentWithDynamicChild/parentWithDynamicChild.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/parentWithDynamicChild/parentWithDynamicChild.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ParentWithDynamicChild extends LightningElement {
+    @api
+    eventListener;
+
+    clickHandler(evt) {
+        return this.eventListener && this.eventListener(evt);
+    }
+}


### PR DESCRIPTION
## Details
When event's original target is from a non-keyed node, do not retarget event when accessed asynchronously

Backport of  https://github.com/salesforce/lwc/pull/1510

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
