### PR TITLE
fix: wrap iframe contentWindow only for iframe elements that are keyed

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/README.md
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/README.md
@@ -24,6 +24,13 @@ class foo extends LightningElement {
 
 In code compiled with compat-mode, the code will attempt to detect if `i.contentWindow` is a proxy, before trying to access `postMessage`, but at that point, the transformed code will try to check if that object contains a particular property (the proxy identification token), in which case, a cross-origin iframe will throw an error. This patch prevents that error from happening.
 
+## Bugs
+
+The wrapped iframe contentWindow has an identity discontinuity issue.
+
+1. The wrapped contentWindow is not cached. So each time the contentWindow accessor is invoked, a new wrapped object is returned.
+2. Browser APIs that provide access to iframe contentWindow have not been patched to return a wrapped contentWindow. For example, MessageEvent.source
+
 ## TODO
 
--   [ ] Only apply this patch if compat-mode is detected.
+-   [issue #1513 ] Only apply this patch if compat-mode is detected.

--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { getOwnPropertyDescriptor, defineProperty, isNull } from '@lwc/shared';
-import { isNodeShadowed } from '../../faux-shadow/node';
+import { getOwnPropertyDescriptor, defineProperty, isNull, isUndefined } from '@lwc/shared';
+import { getNodeOwnerKey } from '../../faux-shadow/node';
 
 export default function apply() {
     // the iframe property descriptor for `contentWindow` should always be available, otherwise this method should never be called
@@ -16,7 +16,8 @@ export default function apply() {
     const { get: originalGetter } = desc;
     desc.get = function(this: HTMLIFrameElement): WindowProxy | null {
         const original = (originalGetter as any).call(this);
-        if (isNull(original) || !isNodeShadowed(this)) {
+        // If the original iframe element is not a keyed node, then do not wrap it
+        if (isNull(original) || isUndefined(getNodeOwnerKey(this))) {
             return original;
         }
         // only if the element is an iframe inside a shadowRoot, we care about this problem


### PR DESCRIPTION
## Details
To preserve legacy behavior, manually inserted iframe elements by third party javascript frameworks will continue to be served unwrapped.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? 🚨
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
