### PR TITLE
fix(rollup-plugin): plugin now correctly resolves relative ts imports

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -1,0 +1,62 @@
+(function (lwc) {
+    'use strict';
+
+    function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+      return "\n" + (nativeShadow ? (":host {color: var(--lwc-my-color);}") : (hostSelector + " {color: var(--lwc-my-color);}")) + "\n";
+    }
+    var _implicitStylesheets = [stylesheet];
+
+    function tmpl($api, $cmp, $slotset, $ctx) {
+      const {
+        d: api_dynamic,
+        h: api_element
+      } = $api;
+      return [api_element("div", {
+        key: 0
+      }, [api_dynamic($cmp.x)])];
+    }
+
+    var _xFoo = lwc.registerTemplate(tmpl);
+    tmpl.stylesheets = [];
+
+    if (_implicitStylesheets) {
+      tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+    }
+    tmpl.stylesheetTokens = {
+      hostAttribute: "undefined-undefined_foo-host",
+      shadowAttribute: "undefined-undefined_foo"
+    };
+
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
+      const {
+        c: api_custom_element,
+        h: api_element
+      } = $api;
+      return [api_element("div", {
+        classMap: {
+          "container": true
+        },
+        key: 1
+      }, [api_custom_element("x-foo", _xFoo, {
+        props: {
+          "x": "1"
+        },
+        key: 0
+      }, [])])];
+    }
+
+    var App = lwc.registerTemplate(tmpl$1);
+    tmpl$1.stylesheets = [];
+    tmpl$1.stylesheetTokens = {
+      hostAttribute: "undefined-undefined_app-host",
+      shadowAttribute: "undefined-undefined_app"
+    };
+
+    // @ts-ignore
+    const container = document.getElementById('main');
+    const element = lwc.createElement('x-app', {
+      is: App
+    });
+    container.appendChild(element); // testing relative import works
+
+}(LWC));

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/js_imports_ts/src/main.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/js_imports_ts/src/main.js
@@ -1,0 +1,3 @@
+import { doNothing } from "./utils.ts";
+
+doNothing();

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/js_imports_ts/src/utils.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/js_imports_ts/src/utils.ts
@@ -1,0 +1,3 @@
+export function doNothing() {
+    return;
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_imports_js/src/main.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_imports_js/src/main.ts
@@ -1,0 +1,3 @@
+import { doNothing } from "./utils.js";
+
+doNothing();

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_imports_js/src/utils.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_imports_js/src/utils.js
@@ -1,0 +1,3 @@
+export function doNothing() {
+    return;
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/main.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/main.ts
@@ -1,0 +1,13 @@
+// @ts-ignore
+import { createElement } from "lwc";
+// @ts-ignore
+import App from "x/app";
+import { doNothing } from "./utils";
+
+
+const container = document.getElementById('main');
+const element = createElement('x-app', { is: App });
+container.appendChild(element);
+
+// testing relative import works
+doNothing();

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/utils.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/utils.ts
@@ -1,0 +1,3 @@
+export function doNothing() {
+    return;
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/app/app.html
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/app/app.html
@@ -1,0 +1,5 @@
+<template>
+    <div class="container">
+        <x-foo x="1"></x-foo>
+    </div>
+</template>

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/app/app.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/app/app.ts
@@ -1,0 +1,10 @@
+import { LightningElement } from "lwc";
+
+export default class App extends LightningElement {
+    private list;
+
+    constructor() {
+        super();
+        this.list = [];
+    }
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.css
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.css
@@ -1,0 +1,3 @@
+:host {
+    color: var(--lwc-my-color);
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.html
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.html
@@ -1,0 +1,3 @@
+<template>
+    <div>{x}</div>
+</template>

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/ts_simple_app/src/x/foo/foo.ts
@@ -1,0 +1,6 @@
+import { api, LightningElement } from "lwc";
+
+export default class Foo extends LightningElement {
+    // @ts-ignore
+    @api x;
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -24,6 +24,8 @@ function fsExpected(fileName) {
 const fixturesDir = path.join(__dirname, 'fixtures');
 const simpleAppDir = path.join(fixturesDir, 'simple_app/src');
 const tsAppDir = path.join(fixturesDir, 'ts_simple_app/src');
+const tsImportsJsDir = path.join(fixturesDir, 'ts_imports_js/src');
+const jsImportsTsDir = path.join(fixturesDir, 'js_imports_ts/src');
 
 describe('default configuration', () => {
     it(`simple app`, () => {
@@ -83,6 +85,24 @@ describe('typescript relative import', () => {
         return doRollup(entry, { compat: false }).then(({ code: actual }) => {
             const expected = fsExpected('expected_default_config_ts_simple_app');
             expect(pretty(actual)).toBe(pretty(expected));
+        });
+    });
+});
+
+describe('typescript relative import', () => {
+    it(`should throw when .ts imports .js file`, () => {
+        const entry = path.join(tsImportsJsDir, 'main.ts');
+        return doRollup(entry, { compat: false }).catch(error => {
+            expect(error).toEqual(new Error('Importing a .js file into a .ts is not supported'));
+        });
+    });
+});
+
+describe('javascript relative import', () => {
+    it(`should throw when .js imports .ts file`, () => {
+        const entry = path.join(jsImportsTsDir, 'main.js');
+        return doRollup(entry, { compat: false }).catch(error => {
+            expect(error).toEqual(new Error('Importing a .ts file into a .js is not supported'));
         });
     });
 });

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -23,6 +23,7 @@ function fsExpected(fileName) {
 
 const fixturesDir = path.join(__dirname, 'fixtures');
 const simpleAppDir = path.join(fixturesDir, 'simple_app/src');
+const tsAppDir = path.join(fixturesDir, 'ts_simple_app/src');
 
 describe('default configuration', () => {
     it(`simple app`, () => {
@@ -71,6 +72,16 @@ describe('rollup in compat mode', () => {
         const entry = path.join(simpleAppDir, 'main.js');
         return doRollup(entry, { compat: true }).then(({ code: actual }) => {
             const expected = fsExpected('expected_compat_config_simple_app');
+            expect(pretty(actual)).toBe(pretty(expected));
+        });
+    });
+});
+
+describe('typescript relative import', () => {
+    it(`should resolve to .ts file`, () => {
+        const entry = path.join(tsAppDir, 'main.ts');
+        return doRollup(entry, { compat: false }).then(({ code: actual }) => {
+            const expected = fsExpected('expected_default_config_ts_simple_app');
             expect(pretty(actual)).toBe(pretty(expected));
         });
     });

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -92,6 +92,7 @@ describe('typescript relative import', () => {
 describe('typescript relative import', () => {
     it(`should throw when .ts imports .js file`, () => {
         const entry = path.join(tsImportsJsDir, 'main.ts');
+        expect.assertions(1);
         return doRollup(entry, { compat: false }).catch(error => {
             expect(error).toEqual(new Error('Importing a .js file into a .ts is not supported'));
         });
@@ -101,6 +102,7 @@ describe('typescript relative import', () => {
 describe('javascript relative import', () => {
     it(`should throw when .js imports .ts file`, () => {
         const entry = path.join(jsImportsTsDir, 'main.js');
+        expect.assertions(1);
         return doRollup(entry, { compat: false }).catch(error => {
             expect(error).toEqual(new Error('Importing a .ts file into a .js is not supported'));
         });

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -51,14 +51,15 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
 
             // Normalize relative import to absolute import
             if (importee.startsWith('.') && importer) {
+                const ext = path.extname(importee) || path.extname(importer);
                 const normalizedPath = path.resolve(path.dirname(importer), importee);
-                const absPath = pluginUtils.addExtension(normalizedPath);
+                const absPath = pluginUtils.addExtension(normalizedPath, ext);
 
                 if (isImplicitHTMLImport(normalizedPath, importer) && !fs.existsSync(absPath)) {
                     return IMPLICIT_DEFAULT_HTML_PATH;
                 }
 
-                return pluginUtils.addExtension(normalizedPath);
+                return pluginUtils.addExtension(normalizedPath, ext);
             }
         },
 


### PR DESCRIPTION
## Details

The rollup-plugin was failing to resolve relative imports if using Typescript.  It was always assuming a `.js` file extension.  This PR fixes that bug and adds a test to ensure TS relative imports work.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
