### PR TITLE
fix: reactivity of wire params

### DIFF
--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -18,7 +18,6 @@ import {
     defineProperties,
     fields,
     freeze,
-    isFalse,
     isFunction,
     isNull,
     seal,
@@ -36,7 +35,7 @@ import {
 import { ViewModelReflection, EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
 import { getComponentVM, VM } from './vm';
-import { valueObserved, valueMutated } from '../libs/mutation-tracker';
+import { valueMutated, valueObserved } from './mutation-tracker';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
@@ -116,10 +115,8 @@ function createBridgeToElementDescriptor(
 
             if (newValue !== vm.cmpProps[propName]) {
                 vm.cmpProps[propName] = newValue;
-                if (isFalse(vm.isDirty)) {
-                    // perf optimization to skip this step if not in the DOM
-                    valueMutated(this, propName);
-                }
+
+                valueMutated(vm, propName);
             }
             return set.call(vm.elm, newValue);
         },

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -35,7 +35,7 @@ import {
 import { ViewModelReflection, EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
 import { getComponentVM, VM } from './vm';
-import { valueMutated, valueObserved } from './mutation-tracker';
+import { componentValueMutated, valueObserved } from './mutation-tracker';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
@@ -116,7 +116,7 @@ function createBridgeToElementDescriptor(
             if (newValue !== vm.cmpProps[propName]) {
                 vm.cmpProps[propName] = newValue;
 
-                valueMutated(vm, propName);
+                componentValueMutated(vm, propName);
             }
             return set.call(vm.elm, newValue);
         },

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -35,7 +35,7 @@ import {
 import { ViewModelReflection, EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
 import { getComponentVM, VM } from './vm';
-import { componentValueMutated, valueObserved } from './mutation-tracker';
+import { componentValueMutated, componentValueObserved } from './mutation-tracker';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
 import { unlockAttribute, lockAttribute } from './attributes';
@@ -90,7 +90,7 @@ function createBridgeToElementDescriptor(
                 }
                 return;
             }
-            valueObserved(this, propName);
+            componentValueObserved(vm, propName);
             return get.call(vm.elm);
         },
         set(this: ComponentInterface, newValue: any) {

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -77,12 +77,6 @@ export function createComponent(uninitializedVm: UninitializedVM, Ctor: Componen
 
 export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
     return new ReactiveObserver(() => {
-        // if (process.env.NODE_ENV !== 'production') {
-        //     assert.invariant(
-        //         !isRendering,
-        //         `Mutating property is not allowed during the rendering life-cycle of ${vmBeingRendered}.`
-        //     );
-        // }
         const { isDirty } = vm;
         if (isFalse(isDirty)) {
             markComponentAsDirty(vm);

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -77,12 +77,12 @@ export function createComponent(uninitializedVm: UninitializedVM, Ctor: Componen
 
 export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
     return new ReactiveObserver(() => {
-        if (process.env.NODE_ENV !== 'production') {
-            assert.invariant(
-                !isRendering,
-                `Mutating property is not allowed during the rendering life-cycle of ${vmBeingRendered}.`
-            );
-        }
+        // if (process.env.NODE_ENV !== 'production') {
+        //     assert.invariant(
+        //         !isRendering,
+        //         `Mutating property is not allowed during the rendering life-cycle of ${vmBeingRendered}.`
+        //     );
+        // }
         const { isDirty } = vm;
         if (isFalse(isDirty)) {
             markComponentAsDirty(vm);

--- a/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
+++ b/packages/@lwc/engine/src/framework/decorators/__tests__/wire.spec.ts
@@ -4,58 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement, registerDecorators } from '../../main';
 import wire from '../wire';
 
-const emptyTemplate = compileTemplate(`<template></template>`);
-const WireAdapter = class EchoWireAdapter {
-    update() {}
-    connect() {}
-    disconnect() {}
-};
-
 describe('wire.ts', () => {
-    describe('integration', () => {
-        it('should make wired properties as readonly', () => {
-            let counter = 0;
-            class MyComponent extends LightningElement {
-                injectFooDotX(x) {
-                    this.foo.x = x;
-                }
-                constructor() {
-                    super();
-                    this.foo = { x: 1 };
-                }
-                render() {
-                    counter++;
-                    this.foo.x;
-                    return emptyTemplate;
-                }
-            }
-            registerDecorators(MyComponent, {
-                wire: {
-                    foo: {
-                        adapter: WireAdapter,
-                        config: function() {
-                            return {};
-                        },
-                    },
-                },
-                publicMethods: ['injectFooDotX'],
-            });
-
-            const elm = createElement('x-foo', { is: MyComponent });
-            document.body.appendChild(elm);
-            expect(() => {
-                elm.injectFooDotX(2);
-            }).toThrowError();
-            return Promise.resolve().then(() => {
-                expect(counter).toBe(1);
-            });
-        });
-    });
-
     describe('@wire misuse', () => {
         it('should throw when invoking wire without adapter', () => {
             class MyComponent extends LightningElement {

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -7,7 +7,7 @@
 import { assert, isFunction, toString } from '@lwc/shared';
 import { logError } from '../../shared/assert';
 import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
-import { valueObserved, componentValueMutated } from '../mutation-tracker';
+import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { ComponentInterface } from '../component';
 import { getComponentVM } from '../vm';
 
@@ -43,7 +43,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
                 }
                 return;
             }
-            valueObserved(this, key);
+            componentValueObserved(vm, key);
             return vm.cmpProps[key];
         },
         set(this: ComponentInterface, newValue: any) {

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -7,7 +7,7 @@
 import { assert, isFunction, toString } from '@lwc/shared';
 import { logError } from '../../shared/assert';
 import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
-import { valueObserved, valueMutated } from '../mutation-tracker';
+import { valueObserved, componentValueMutated } from '../mutation-tracker';
 import { ComponentInterface } from '../component';
 import { getComponentVM } from '../vm';
 
@@ -59,7 +59,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             }
             vm.cmpProps[key] = newValue;
 
-            valueMutated(vm, key);
+            componentValueMutated(vm, key);
         },
         enumerable: true,
         configurable: true,

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFalse, isFunction, toString } from '@lwc/shared';
+import { assert, isFunction, toString } from '@lwc/shared';
 import { logError } from '../../shared/assert';
 import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
-import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
+import { valueObserved, valueMutated } from '../mutation-tracker';
 import { ComponentInterface } from '../component';
 import { getComponentVM } from '../vm';
 
@@ -59,11 +59,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             }
             vm.cmpProps[key] = newValue;
 
-            // avoid notification of observability if the instance is already dirty
-            if (isFalse(vm.isDirty)) {
-                // perf optimization to skip this step if the component is dirty already.
-                valueMutated(this, key);
-            }
+            valueMutated(vm, key);
         },
         enumerable: true,
         configurable: true,

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -6,7 +6,7 @@
  */
 import { assert } from '@lwc/shared';
 import { isRendering, vmBeingRendered } from '../invoker';
-import { valueObserved, componentValueMutated } from '../mutation-tracker';
+import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { getComponentVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentInterface } from '../component';
@@ -36,7 +36,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             }
-            valueObserved(this, key);
+            componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
         set(this: ComponentInterface, newValue: any) {

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFalse } from '@lwc/shared';
+import { assert } from '@lwc/shared';
 import { isRendering, vmBeingRendered } from '../invoker';
-import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
+import { valueObserved, valueMutated } from '../mutation-tracker';
 import { getComponentVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentInterface } from '../component';
@@ -53,10 +53,8 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
             const reactiveOrAnyValue = reactiveMembrane.getProxy(newValue);
             if (reactiveOrAnyValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = reactiveOrAnyValue;
-                if (isFalse(vm.isDirty)) {
-                    // perf optimization to skip this step if the track property is on a component that is already dirty
-                    valueMutated(this, key);
-                }
+
+                valueMutated(vm, key);
             }
         },
         enumerable: true,

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -6,7 +6,7 @@
  */
 import { assert } from '@lwc/shared';
 import { isRendering, vmBeingRendered } from '../invoker';
-import { valueObserved, valueMutated } from '../mutation-tracker';
+import { valueObserved, componentValueMutated } from '../mutation-tracker';
 import { getComponentVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentInterface } from '../component';
@@ -54,7 +54,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
             if (reactiveOrAnyValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = reactiveOrAnyValue;
 
-                valueMutated(vm, key);
+                componentValueMutated(vm, key);
             }
         },
         enumerable: true,

--- a/packages/@lwc/engine/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine/src/framework/decorators/wire.ts
@@ -6,7 +6,7 @@
  */
 import { assert } from '@lwc/shared';
 import { ComponentInterface } from '../component';
-import { valueObserved } from '../../libs/mutation-tracker';
+import { componentValueObserved } from '../mutation-tracker';
 import { getComponentVM } from '../vm';
 import { WireAdapterConstructor } from '../wiring';
 
@@ -32,7 +32,7 @@ export function internalWireFieldDecorator(key: string): PropertyDescriptor {
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             }
-            valueObserved(this, key);
+            componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
         set(this: ComponentInterface, value: any) {

--- a/packages/@lwc/engine/src/framework/membrane.ts
+++ b/packages/@lwc/engine/src/framework/membrane.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import ObservableMembrane from 'observable-membrane';
-import { valueObserved, valueMutated } from '../libs/mutation-tracker';
+import { valueObserved, valueMutated } from './mutation-tracker';
 
 function valueDistortion(value: any) {
     return value;

--- a/packages/@lwc/engine/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine/src/framework/mutation-tracker.ts
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { valueMutated } from '../libs/mutation-tracker';
+import { valueMutated, valueObserved } from '../libs/mutation-tracker';
 import { VM } from './vm';
 
 export function componentValueMutated(vm: VM, key: PropertyKey) {
     valueMutated(vm.component, key);
+}
+
+export function componentValueObserved(vm: VM, key: PropertyKey) {
+    valueObserved(vm.component, key);
 }
 
 export * from '../libs/mutation-tracker';

--- a/packages/@lwc/engine/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine/src/framework/mutation-tracker.ts
@@ -1,0 +1,16 @@
+import {
+    valueMutated as mtValueMutated,
+    valueObserved,
+    ReactiveObserver,
+} from '../libs/mutation-tracker';
+import { VM } from './vm';
+// import { isFalse } from "@lwc/shared";
+
+export function valueMutated(vm: VM, key: PropertyKey) {
+    const { component } = vm;
+    // if (isFalse(vm.isDirty)) {
+    mtValueMutated(component, key);
+    // }
+}
+
+export { valueObserved, ReactiveObserver };

--- a/packages/@lwc/engine/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine/src/framework/mutation-tracker.ts
@@ -6,13 +6,9 @@
  */
 import { valueMutated } from '../libs/mutation-tracker';
 import { VM } from './vm';
-// import { isFalse } from "@lwc/shared";
 
 export function componentValueMutated(vm: VM, key: PropertyKey) {
-    const { component } = vm;
-    // if (isFalse(vm.isDirty)) {
-    valueMutated(component, key);
-    // }
+    valueMutated(vm.component, key);
 }
 
 export * from '../libs/mutation-tracker';

--- a/packages/@lwc/engine/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine/src/framework/mutation-tracker.ts
@@ -1,16 +1,18 @@
-import {
-    valueMutated as mtValueMutated,
-    valueObserved,
-    ReactiveObserver,
-} from '../libs/mutation-tracker';
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { valueMutated } from '../libs/mutation-tracker';
 import { VM } from './vm';
 // import { isFalse } from "@lwc/shared";
 
-export function valueMutated(vm: VM, key: PropertyKey) {
+export function componentValueMutated(vm: VM, key: PropertyKey) {
     const { component } = vm;
     // if (isFalse(vm.isDirty)) {
-    mtValueMutated(component, key);
+    valueMutated(component, key);
     // }
 }
 
-export { valueObserved, ReactiveObserver };
+export * from '../libs/mutation-tracker';

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -7,7 +7,7 @@
 import { assert } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
-import { componentValueMutated, valueObserved } from './mutation-tracker';
+import { componentValueMutated, componentValueObserved } from './mutation-tracker';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {
@@ -16,7 +16,7 @@ export function createObservedFieldPropertyDescriptor(key: string): PropertyDesc
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
             }
-            valueObserved(this, key);
+            componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
         set(this: ComponentInterface, newValue: any) {

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -7,7 +7,7 @@
 import { assert } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
-import { valueMutated, valueObserved } from './mutation-tracker';
+import { componentValueMutated, valueObserved } from './mutation-tracker';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {
@@ -28,7 +28,7 @@ export function createObservedFieldPropertyDescriptor(key: string): PropertyDesc
             if (newValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = newValue;
 
-                valueMutated(vm, key);
+                componentValueMutated(vm, key);
             }
         },
         enumerable: true,

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFalse } from '@lwc/shared';
+import { assert } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { getComponentVM } from './vm';
-import { valueMutated, valueObserved } from '../libs/mutation-tracker';
+import { valueMutated, valueObserved } from './mutation-tracker';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {
@@ -27,9 +27,8 @@ export function createObservedFieldPropertyDescriptor(key: string): PropertyDesc
 
             if (newValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = newValue;
-                if (isFalse(vm.isDirty)) {
-                    valueMutated(this, key);
-                }
+
+                valueMutated(vm, key);
             }
         },
         enumerable: true,

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -6,7 +6,7 @@
  */
 import { assert, isUndefined, ArrayPush, getOwnPropertyNames } from '@lwc/shared';
 import { ComponentInterface } from './component';
-import { valueMutated, ReactiveObserver } from './mutation-tracker';
+import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
 import { VM, runWithBoundaryProtection } from './vm';
 import { invokeComponentCallback } from './invoker';
 import { dispatchEvent } from '../env/dom';
@@ -21,7 +21,7 @@ function createFieldDataCallback(vm: VM, name: string) {
             // storing the value in the underlying storage
             cmpFields[name] = value;
 
-            valueMutated(vm, name);
+            componentValueMutated(vm, name);
         }
     };
 }

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -102,14 +102,7 @@ function createContextWatcher(
 }
 
 function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
-    const { method } = wireDef;
-    let adapter = wireDef.adapter;
-
-    // support for callable adapters
-    if ((adapter as any).adapter) {
-        adapter = (adapter as any).adapter;
-    }
-
+    const { method, adapter } = wireDef;
     const dataCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
         : createMethodDataCallback(vm, method);
@@ -207,6 +200,10 @@ export function storeWiredMethodMeta(
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback
 ) {
+    // support for callable adapters
+    if ((adapter as any).adapter) {
+        adapter = (adapter as any).adapter;
+    }
     const method = descriptor.value;
     const def: WireMethodDef = {
         adapter,

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isUndefined, ArrayPush, getOwnPropertyNames, isFalse } from '@lwc/shared';
+import { assert, isUndefined, ArrayPush, getOwnPropertyNames } from '@lwc/shared';
 import { ComponentInterface } from './component';
-import { valueMutated, ReactiveObserver } from '../libs/mutation-tracker';
+import { valueMutated, ReactiveObserver } from './mutation-tracker';
 import { VM, runWithBoundaryProtection } from './vm';
 import { invokeComponentCallback } from './invoker';
 import { dispatchEvent } from '../env/dom';
@@ -15,15 +15,13 @@ const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
 function noop(): void {}
 
 function createFieldDataCallback(vm: VM, name: string) {
-    const { component, cmpFields } = vm;
+    const { cmpFields } = vm;
     return (value: any) => {
         if (value !== vm.cmpFields[name]) {
             // storing the value in the underlying storage
             cmpFields[name] = value;
-            if (isFalse(vm.isDirty)) {
-                // perf optimization to skip this step if the track property is on a component that is already dirty
-                valueMutated(component, name);
-            }
+
+            valueMutated(vm, name);
         }
     };
 }

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -102,7 +102,14 @@ function createContextWatcher(
 }
 
 function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
-    const { method, adapter } = wireDef;
+    const { method } = wireDef;
+    let adapter = wireDef.adapter;
+
+    // support for callable adapters
+    if ((adapter as any).adapter) {
+        adapter = (adapter as any).adapter;
+    }
+
     const dataCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
         : createMethodDataCallback(vm, method);
@@ -200,10 +207,6 @@ export function storeWiredMethodMeta(
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback
 ) {
-    // support for callable adapters
-    if ((adapter as any).adapter) {
-        adapter = (adapter as any).adapter;
-    }
     const method = descriptor.value;
     const def: WireMethodDef = {
         adapter,

--- a/packages/integration-karma/test/wire/property-trap/index.spec.js
+++ b/packages/integration-karma/test/wire/property-trap/index.spec.js
@@ -79,7 +79,7 @@ describe('wire adapter update', () => {
 
             return Promise.resolve().then(() => {
                 const actualWiredValues = elm.getWiredProp();
-                expect(actualWiredValues.data.keyValue).toBe('expected');
+                expect(actualWiredValues.data.keyVal).toBe('expected');
             });
         });
 
@@ -92,7 +92,7 @@ describe('wire adapter update', () => {
 
             return Promise.resolve().then(() => {
                 const actualWiredValues = elm.getWiredProp();
-                expect(actualWiredValues.data.keyValue).toBe('a.b.c.d value');
+                expect(actualWiredValues.data.keyVal).toBe('a.b.c.d value');
             });
         });
 

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -194,28 +194,6 @@ describe('wired fields', () => {
                 expect(staticValue.textContent).toBe('modified value');
             });
     });
-
-    // failing: before it was track, now we only observe changes to the prop (not like with @track)
-    it('should rerender component when value is mutated from within the component (prop.y = 5)', () => {
-        BroadcastAdapter.clearInstances();
-        const elm = createElement('x-bc-consumer', { is: BroadcastConsumer });
-        document.body.appendChild(elm);
-        BroadcastAdapter.broadcastData({ data: 'expected value' });
-
-        return Promise.resolve()
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('expected value');
-
-                elm.setWiredPropData('modified value');
-
-                return Promise.resolve();
-            })
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('modified value');
-            });
-    });
 });
 
 describe('wired methods', () => {

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -147,29 +147,29 @@ describe('wiring', () => {
                 });
         });
 
-        it('should trigger component rerender when field is updated', () => {
+        it('should trigger component rerender when field is updated', done => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
-            return Promise.resolve()
-                .then(() => {
-                    const staticValue = elm.shadowRoot.querySelector('.static');
-                    const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
+            return Promise.resolve().then(() => {
+                const staticValue = elm.shadowRoot.querySelector('.static');
+                const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
 
-                    expect(staticValue.textContent).toBe('1,2,3');
-                    expect(dynamicValue.textContent).toBe('');
+                expect(staticValue.textContent).toBe('1,2,3');
+                expect(dynamicValue.textContent).toBe('');
 
-                    elm.setDynamicParamSource('modified value');
+                elm.setDynamicParamSource('modified value');
 
-                    return Promise.resolve();
-                })
-                .then(() => {
+                setTimeout(() => {
                     const staticValue = elm.shadowRoot.querySelector('.static');
                     const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
 
                     expect(staticValue.textContent).toBe('1,2,3');
                     expect(dynamicValue.textContent).toBe('modified value');
-                });
+
+                    done();
+                }, 5);
+            });
         });
     });
 });

--- a/packages/integration-tests/scripts/build.js
+++ b/packages/integration-tests/scripts/build.js
@@ -39,6 +39,7 @@ const wireServicePath = getModulePath(
     isProd ? 'prod' : 'dev'
 );
 const todoPath = path.join(require.resolve('../src/shared/todo.js'));
+const todoContent = fs.readFileSync(todoPath).toString();
 
 const testSufix = '.test.js';
 const testPrefix = 'test-';
@@ -86,6 +87,8 @@ function entryPointResolverPlugin() {
         resolveId(id) {
             if (id.includes(testSufix)) {
                 return id;
+            } else if (id === 'todo') {
+                return 'todo.js';
             }
         },
         load(id) {
@@ -94,6 +97,8 @@ function entryPointResolverPlugin() {
                 return testBundle.startsWith('wired-')
                     ? getTodoApp(testBundle)
                     : templates.app(testBundle);
+            } else if (id === 'todo.js') {
+                return todoContent;
             }
         },
     };
@@ -106,7 +111,6 @@ const globalModules = {
     'compat-polyfills/polyfills': 'window',
     lwc: 'LWC',
     'wire-service': 'WireService',
-    todo: 'Todo',
 };
 
 const baseInputConfig = {

--- a/packages/integration-tests/src/shared/templates.js
+++ b/packages/integration-tests/src/shared/templates.js
@@ -13,45 +13,8 @@ exports.app = function(cmpName) {
 
 exports.todoApp = function(cmpName) {
     return `
-        import { registerWireService, register as registerAdapter, ValueChangedEvent } from 'wire-service';
-        import { createElement, register } from 'lwc';
+        import { createElement } from 'lwc';
         import Cmp from 'integration/${cmpName}';
-        import { getTodo, getObservable } from 'todo';
-
-        registerWireService(register);
-
-        // Register the wire adapter for @wire(getTodo).
-        registerAdapter(getTodo, function getTodoWireAdapter(wiredEventTarget) {
-            var subscription;
-            var config;
-            wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: undefined }));
-            var observer = {
-                next: function(data) { wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: data, error: undefined })); },
-                error: function(error) { wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: error })); }
-            };
-            wiredEventTarget.addEventListener('connect', function() {
-                var observable = getObservable(config);
-                if (observable) {
-                    subscription = observable.subscribe(observer);
-                    return;
-                }
-            });
-            wiredEventTarget.addEventListener('disconnect', function() {
-                subscription.unsubscribe();
-            });
-            wiredEventTarget.addEventListener('config', function(newConfig) {
-                config = newConfig;
-                if (subscription) {
-                    subscription.unsubscribe();
-                    subscription = undefined;
-                }
-                var observable = getObservable(config);
-                if (observable) {
-                    subscription = observable.subscribe(observer);
-                    return;
-                }
-            });
-        });
 
         var element = createElement('integration-${cmpName}', { is: Cmp });
         document.body.appendChild(element);

--- a/packages/integration-tests/src/shared/templates.js
+++ b/packages/integration-tests/src/shared/templates.js
@@ -13,12 +13,10 @@ exports.app = function(cmpName) {
 
 exports.todoApp = function(cmpName) {
     return `
-        import { registerWireService, register as registerAdapter, ValueChangedEvent } from 'wire-service';
+        import { register as registerAdapter, ValueChangedEvent } from 'wire-service';
         import { createElement, register } from 'lwc';
         import Cmp from 'integration/${cmpName}';
         import { getTodo, getObservable } from 'todo';
-
-        registerWireService(register);
 
         // Register the wire adapter for @wire(getTodo).
         registerAdapter(getTodo, function getTodoWireAdapter(wiredEventTarget) {

--- a/packages/integration-tests/src/shared/templates.js
+++ b/packages/integration-tests/src/shared/templates.js
@@ -13,10 +13,12 @@ exports.app = function(cmpName) {
 
 exports.todoApp = function(cmpName) {
     return `
-        import { register as registerAdapter, ValueChangedEvent } from 'wire-service';
+        import { registerWireService, register as registerAdapter, ValueChangedEvent } from 'wire-service';
         import { createElement, register } from 'lwc';
         import Cmp from 'integration/${cmpName}';
         import { getTodo, getObservable } from 'todo';
+
+        registerWireService(register);
 
         // Register the wire adapter for @wire(getTodo).
         registerAdapter(getTodo, function getTodoWireAdapter(wiredEventTarget) {

--- a/packages/integration-tests/src/shared/todo.js
+++ b/packages/integration-tests/src/shared/todo.js
@@ -1,89 +1,116 @@
-(function(global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined'
-        ? factory(exports)
-        : typeof define === 'function' && window.define.amd
-        ? window.define(['exports'], factory)
-        : factory((global.Todo = {}));
-})(this, function(exports) {
-    'use strict';
+import { register, ValueChangedEvent } from 'wire-service';
 
-    function getSubject(initialValue, initialError) {
-        var observer;
+function getSubject(initialValue, initialError) {
+    var observer;
 
-        function next(value) {
-            observer.next(value);
-        }
-
-        function error(err) {
-            observer.error(err);
-        }
-
-        function complete() {
-            observer.complete();
-        }
-
-        var observable = {
-            subscribe: function(obs) {
-                observer = obs;
-                if (initialValue) {
-                    next(initialValue);
-                }
-                if (initialError) {
-                    error(initialError);
-                }
-                return {
-                    unsubscribe: function() {},
-                };
-            },
-        };
-
-        return {
-            next: next,
-            error: error,
-            complete: complete,
-            observable: observable,
-        };
+    function next(value) {
+        observer.next(value);
     }
 
-    function generateTodo(id, completed) {
-        return {
-            id: id,
-            title: 'task ' + id,
-            completed: completed,
-        };
+    function error(err) {
+        observer.error(err);
     }
 
-    var TODO = [
-        generateTodo(0, true),
-        generateTodo(1, false),
-        // intentionally skip 2
-        generateTodo(3, true),
-        generateTodo(4, true),
-        // intentionally skip 5
-        generateTodo(6, false),
-        generateTodo(7, false),
-    ].reduce(function(acc, value) {
-        acc[value.id] = value;
-        return acc;
-    }, {});
-
-    function getObservable(config) {
-        if (!config || !('id' in config)) {
-            return undefined;
-        }
-
-        var todo = TODO[config.id];
-        if (!todo) {
-            var subject = getSubject(undefined, { message: 'Todo not found' });
-            return subject.observable;
-        }
-
-        return getSubject(todo).observable;
+    function complete() {
+        observer.complete();
     }
 
-    const getTodo = Symbol('getTodo');
+    var observable = {
+        subscribe: function(obs) {
+            observer = obs;
+            if (initialValue) {
+                next(initialValue);
+            }
+            if (initialError) {
+                error(initialError);
+            }
+            return {
+                unsubscribe: function() {},
+            };
+        },
+    };
 
-    exports.getTodo = getTodo;
-    exports.getObservable = getObservable;
-    Object.defineProperty(exports, '__esModule', { value: true });
+    return {
+        next: next,
+        error: error,
+        complete: complete,
+        observable: observable,
+    };
+}
+
+function generateTodo(id, completed) {
+    return {
+        id: id,
+        title: 'task ' + id,
+        completed: completed,
+    };
+}
+
+var TODO = [
+    generateTodo(0, true),
+    generateTodo(1, false),
+    // intentionally skip 2
+    generateTodo(3, true),
+    generateTodo(4, true),
+    // intentionally skip 5
+    generateTodo(6, false),
+    generateTodo(7, false),
+].reduce(function(acc, value) {
+    acc[value.id] = value;
+    return acc;
+}, {});
+
+function getObservable(config) {
+    if (!config || !('id' in config)) {
+        return undefined;
+    }
+
+    var todo = TODO[config.id];
+    if (!todo) {
+        var subject = getSubject(undefined, { message: 'Todo not found' });
+        return subject.observable;
+    }
+
+    return getSubject(todo).observable;
+}
+
+const getTodo = function() {};
+
+register(getTodo, function getTodoWireAdapter(wiredEventTarget) {
+    var subscription;
+    var config;
+    wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: undefined }));
+    var observer = {
+        next: function(data) {
+            wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: data, error: undefined }));
+        },
+        error: function(error) {
+            wiredEventTarget.dispatchEvent(
+                new ValueChangedEvent({ data: undefined, error: error })
+            );
+        },
+    };
+    wiredEventTarget.addEventListener('connect', function() {
+        var observable = getObservable(config);
+        if (observable) {
+            subscription = observable.subscribe(observer);
+        }
+    });
+    wiredEventTarget.addEventListener('disconnect', function() {
+        subscription.unsubscribe();
+    });
+    wiredEventTarget.addEventListener('config', function(newConfig) {
+        config = newConfig;
+        if (subscription) {
+            subscription.unsubscribe();
+            subscription = undefined;
+        }
+        var observable = getObservable(config);
+        if (observable) {
+            subscription = observable.subscribe(observer);
+        }
+    });
 });
+
+export { getTodo };
+export { getObservable };

--- a/packages/integration-tests/src/shared/todo.js
+++ b/packages/integration-tests/src/shared/todo.js
@@ -81,7 +81,7 @@
         return getSubject(todo).observable;
     }
 
-    const getTodo = Symbol('getTodo');
+    const getTodo = function() {};
 
     exports.getTodo = getTodo;
     exports.getObservable = getObservable;

--- a/packages/integration-tests/src/shared/todo.js
+++ b/packages/integration-tests/src/shared/todo.js
@@ -81,7 +81,7 @@
         return getSubject(todo).observable;
     }
 
-    const getTodo = function() {};
+    const getTodo = Symbol('getTodo');
 
     exports.getTodo = getTodo;
     exports.getObservable = getObservable;


### PR DESCRIPTION
## Details

1. We were previously skipping calls to `valueMutated` when the component was already dirty, and was fine because what reacts to it, will rerender the component. Now it may happen that the component is dirty but we still need to call `valueMutated` because the wire mechanism also relies in the mutation tracker to detect changes on adapters config.

2. `register(adapterId, factory)` happens after `registerDecorators` and we were storing an adapter definition without the actual adapter (that is added after when doing register). This PR saves the adapter reference in registerDecorators, and when installing the wire adapters on the component it will try to get the `adapter` from the `adapterId`