### PR TITLE
fix: relax condition to retarget event

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -75,7 +75,7 @@ function targetGetter(this: Event): EventTarget | null {
         }
         return retarget(doc, composedPath);
     } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
-        // If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // TODO: issue #1530 - If currentTarget is document or document.body (Third party libraries that have global event listeners)
         // and the originalTarget is not a keyed element, do not retarget
         if (isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -68,8 +68,15 @@ function targetGetter(this: Event): EventTarget | null {
     // and when an event has been added to Window
     if (!(originalCurrentTarget instanceof Node)) {
         // TODO: issue #1511 - Special escape hatch to support legacy behavior. Should be fixed.
-        // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
-        if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget as Node))) {
+        // If the originalTarget is not a keyed element and if any of the following conditions are true, do not retarget
+        // 1. event's target is being accessed async
+        // 2. currentTarget is document or document.body (Third party libraries that have global event listeners)
+        if (
+            (isNull(originalCurrentTarget) ||
+                originalCurrentTarget === document ||
+                originalCurrentTarget === document.body) &&
+            isUndefined(getNodeOwnerKey(originalTarget as Node))
+        ) {
             return originalTarget;
         }
         const doc = getOwnerDocument(originalTarget as Node);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -63,23 +63,23 @@ function targetGetter(this: Event): EventTarget | null {
     const originalCurrentTarget = eventCurrentTargetGetter.call(this);
     const originalTarget = eventTargetGetter.call(this);
     const composedPath = pathComposer(originalTarget, this.composed);
+    const doc = getOwnerDocument(originalTarget as Node);
 
     // Handle cases where the currentTarget is null (for async events),
     // and when an event has been added to Window
     if (!(originalCurrentTarget instanceof Node)) {
         // TODO: issue #1511 - Special escape hatch to support legacy behavior. Should be fixed.
-        // If the originalTarget is not a keyed element and if any of the following conditions are true, do not retarget
-        // 1. event's target is being accessed async
-        // 2. currentTarget is document or document.body (Third party libraries that have global event listeners)
-        if (
-            (isNull(originalCurrentTarget) ||
-                originalCurrentTarget === document ||
-                originalCurrentTarget === document.body) &&
-            isUndefined(getNodeOwnerKey(originalTarget as Node))
-        ) {
+        // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
+        if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;
         }
-        const doc = getOwnerDocument(originalTarget as Node);
+        return retarget(doc, composedPath);
+    } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
+        // If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // and the originalTarget is not a keyed element, do not retarget
+        if (isUndefined(getNodeOwnerKey(originalTarget as Node))) {
+            return originalTarget;
+        }
         return retarget(doc, composedPath);
     }
 

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -9,6 +9,7 @@ import { ownerDocumentGetter } from '../env/node';
 import { defaultViewGetter } from '../env/document';
 import { getAttribute } from '../env/element';
 
+// Helpful for tests running with jsdom
 export function getOwnerDocument(node: Node): Document {
     const doc = ownerDocumentGetter.call(node);
     // if doc is null, it means `this` is actually a document instance

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -57,16 +57,22 @@ if (!process.env.NATIVE_SHADOW) {
     });
 }
 
-describe('When event target is accessed async', () => {
+// legacy usecases
+describe('should not retarget event', () => {
     if (!process.env.NATIVE_SHADOW) {
-        it('#W-6586380 - should return the original target, if original target node is not keyed', done => {
+        let elm;
+        let child;
+        let originalTarget;
+        beforeAll(() => {
             spyOn(console, 'error');
-            const elm = createElement('x-parent-with-dynamic-child', {
+            elm = createElement('x-parent-with-dynamic-child', {
                 is: XParentWithDynamicChild,
             });
             document.body.appendChild(elm);
-            const child = elm.shadowRoot.querySelector('x-child-with-out-lwc-dom-manual');
-            const originalTarget = child.shadowRoot.querySelector('span');
+            child = elm.shadowRoot.querySelector('x-child-with-out-lwc-dom-manual');
+            originalTarget = child.shadowRoot.querySelector('span');
+        });
+        it('when original target node is not keyed and event is accessed async (W-6586380)', done => {
             elm.eventListener = evt => {
                 expect(evt.currentTarget).toBe(elm.shadowRoot.querySelector('div'));
                 expect(evt.target).toBe(child);
@@ -77,6 +83,15 @@ describe('When event target is accessed async', () => {
                     done();
                 });
             };
+            originalTarget.click();
+        });
+
+        it('when original target node is not keyed and currentTarget is document (W-6626752)', done => {
+            document.addEventListener('click', evt => {
+                expect(evt.currentTarget).toBe(document);
+                expect(evt.target).toBe(originalTarget);
+                done();
+            });
             originalTarget.click();
         });
     }

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -63,6 +63,7 @@ describe('should not retarget event', () => {
         let elm;
         let child;
         let originalTarget;
+
         beforeAll(() => {
             spyOn(console, 'error');
             elm = createElement('x-parent-with-dynamic-child', {
@@ -86,13 +87,23 @@ describe('should not retarget event', () => {
             originalTarget.click();
         });
 
-        it('when original target node is not keyed and currentTarget is document (W-6626752)', done => {
-            document.addEventListener('click', evt => {
-                expect(evt.currentTarget).toBe(document);
-                expect(evt.target).toBe(originalTarget);
-                done();
+        describe('received at a global listener', () => {
+            let actualCurrentTarget;
+            let actualTarget;
+            const globalListener = evt => {
+                actualCurrentTarget = evt.currentTarget;
+                actualTarget = evt.target;
+            };
+            afterAll(() => {
+                document.removeEventListener(globalListener);
             });
-            originalTarget.click();
+
+            it('when original target node is not keyed and currentTarget is document (W-6626752)', () => {
+                document.addEventListener('click', globalListener);
+                originalTarget.click();
+                expect(actualCurrentTarget).toBe(document);
+                expect(actualTarget).toBe(originalTarget);
+            });
         });
     }
 });

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -66,30 +66,33 @@ describe('event propagation in simple shadow tree', () => {
     });
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
-        const logs = dispatchEventWithLog(
-            nodes['span-manual'],
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
+        // Fire the event in next tick to allow time for the MO to key the manually inserted nodes
+        return Promise.resolve().then(() => {
+            const logs = dispatchEventWithLog(
+                nodes['span-manual'],
+                new CustomEvent('test', { composed: true, bubbles: true })
+            );
 
-        const composedPath = [
-            nodes['span-manual'],
-            nodes['div-manual'],
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes['span-manual'], nodes['span-manual'], composedPath],
-            [nodes['div-manual'], nodes['span-manual'], composedPath],
-            [nodes['x-shadow-tree'].shadowRoot, nodes['span-manual'], composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [document.body, nodes['x-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-shadow-tree'], composedPath],
-            [document, nodes['x-shadow-tree'], composedPath],
-        ]);
+            const composedPath = [
+                nodes['span-manual'],
+                nodes['div-manual'],
+                nodes['x-shadow-tree'].shadowRoot,
+                nodes['x-shadow-tree'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            expect(logs).toEqual([
+                [nodes['span-manual'], nodes['span-manual'], composedPath],
+                [nodes['div-manual'], nodes['span-manual'], composedPath],
+                [nodes['x-shadow-tree'].shadowRoot, nodes['span-manual'], composedPath],
+                [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
+                [document.body, nodes['x-shadow-tree'], composedPath],
+                [document.documentElement, nodes['x-shadow-tree'], composedPath],
+                [document, nodes['x-shadow-tree'], composedPath],
+            ]);
+        });
     });
 
     // TODO: #1141 - Event non dispatched from within a LWC shadow tree are not patched
@@ -236,34 +239,37 @@ describe('event propagation in nested shadow tree', () => {
     });
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
-        const logs = dispatchEventWithLog(
-            nodes['span-manual'],
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
+        // Fire the event in next tick to allow time for the MO to key the manually inserted nodes
+        return Promise.resolve().then(() => {
+            const logs = dispatchEventWithLog(
+                nodes['span-manual'],
+                new CustomEvent('test', { composed: true, bubbles: true })
+            );
 
-        const composedPath = [
-            nodes['span-manual'],
-            nodes['div-manual'],
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            nodes['x-nested-shadow-tree'].shadowRoot,
-            nodes['x-nested-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes['span-manual'], nodes['span-manual'], composedPath],
-            [nodes['div-manual'], nodes['span-manual'], composedPath],
-            [nodes['x-shadow-tree'].shadowRoot, nodes['span-manual'], composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'], nodes['x-nested-shadow-tree'], composedPath],
-            [document.body, nodes['x-nested-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-nested-shadow-tree'], composedPath],
-            [document, nodes['x-nested-shadow-tree'], composedPath],
-        ]);
+            const composedPath = [
+                nodes['span-manual'],
+                nodes['div-manual'],
+                nodes['x-shadow-tree'].shadowRoot,
+                nodes['x-shadow-tree'],
+                nodes['x-nested-shadow-tree'].shadowRoot,
+                nodes['x-nested-shadow-tree'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            expect(logs).toEqual([
+                [nodes['span-manual'], nodes['span-manual'], composedPath],
+                [nodes['div-manual'], nodes['span-manual'], composedPath],
+                [nodes['x-shadow-tree'].shadowRoot, nodes['span-manual'], composedPath],
+                [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
+                [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
+                [nodes['x-nested-shadow-tree'], nodes['x-nested-shadow-tree'], composedPath],
+                [document.body, nodes['x-nested-shadow-tree'], composedPath],
+                [document.documentElement, nodes['x-nested-shadow-tree'], composedPath],
+                [document, nodes['x-nested-shadow-tree'], composedPath],
+            ]);
+        });
     });
 
     it('propagate event from a inner host', () => {

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -66,8 +66,10 @@ describe('event propagation in simple shadow tree', () => {
     });
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
-        // Fire the event in next tick to allow time for the MO to key the manually inserted nodes
-        return Promise.resolve().then(() => {
+        // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
+        return new Promise(resolve => {
+            setTimeout(resolve);
+        }).then(() => {
             const logs = dispatchEventWithLog(
                 nodes['span-manual'],
                 new CustomEvent('test', { composed: true, bubbles: true })
@@ -239,8 +241,10 @@ describe('event propagation in nested shadow tree', () => {
     });
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
-        // Fire the event in next tick to allow time for the MO to key the manually inserted nodes
-        return Promise.resolve().then(() => {
+        // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
+        return new Promise(resolve => {
+            setTimeout(resolve);
+        }).then(() => {
             const logs = dispatchEventWithLog(
                 nodes['span-manual'],
                 new CustomEvent('test', { composed: true, bubbles: true })


### PR DESCRIPTION
## Details
No retargeting if event's original target is from a manually injected node into a non-portal parentNode and if the currentTarget is one of the following
1. target is accessed async, so currentTarget is null
2. currentTarget is document
3. currentTarget is document.body

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌Will add one, but feels wrong to add tests for the expected behavior of a hack :(
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
