### PR TITLE
fix: relax condition to retarget event

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -86,7 +86,7 @@ function targetGetter(this: ComposableEvent): EventTarget | null {
         }
         return retarget(doc, composedPath);
     } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
-        // If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // TODO: issue #1530 - If currentTarget is document or document.body (Third party libraries that have global event listeners)
         // and the originalTarget is not a keyed element, do not retarget
         if (isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -79,8 +79,15 @@ function targetGetter(this: ComposableEvent): EventTarget | null {
     // and when an event has been added to Window
     if (!(originalCurrentTarget instanceof Node)) {
         // TODO: issue #1511 - Special escape hatch to support legacy behavior. Should be fixed.
-        // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
-        if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget as Node))) {
+        // If the originalTarget is not a keyed element and if any of the following conditions are true, do not retarget
+        // 1. event's target is being accessed async
+        // 2. currentTarget is document or document.body (Third party libraries that have global event listeners)
+        if (
+            (isNull(originalCurrentTarget) ||
+                originalCurrentTarget === document ||
+                originalCurrentTarget === document.body) &&
+            isUndefined(getNodeOwnerKey(originalTarget as Node))
+        ) {
             return originalTarget;
         }
         const doc = getOwnerDocument(originalTarget as Node);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -74,23 +74,23 @@ function targetGetter(this: ComposableEvent): EventTarget | null {
     const originalCurrentTarget = eventCurrentTargetGetter.call(this);
     const originalTarget = eventTargetGetter.call(this);
     const composedPath = pathComposer(originalTarget, this.composed);
+    const doc = getOwnerDocument(originalTarget as Node);
 
     // Handle cases where the currentTarget is null (for async events),
     // and when an event has been added to Window
     if (!(originalCurrentTarget instanceof Node)) {
         // TODO: issue #1511 - Special escape hatch to support legacy behavior. Should be fixed.
-        // If the originalTarget is not a keyed element and if any of the following conditions are true, do not retarget
-        // 1. event's target is being accessed async
-        // 2. currentTarget is document or document.body (Third party libraries that have global event listeners)
-        if (
-            (isNull(originalCurrentTarget) ||
-                originalCurrentTarget === document ||
-                originalCurrentTarget === document.body) &&
-            isUndefined(getNodeOwnerKey(originalTarget as Node))
-        ) {
+        // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
+        if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;
         }
-        const doc = getOwnerDocument(originalTarget as Node);
+        return retarget(doc, composedPath);
+    } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
+        // If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // and the originalTarget is not a keyed element, do not retarget
+        if (isUndefined(getNodeOwnerKey(originalTarget as Node))) {
+            return originalTarget;
+        }
         return retarget(doc, composedPath);
     }
 

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -8,6 +8,7 @@
 import { ownerDocumentGetter } from '../env/node';
 import { defaultViewGetter } from '../env/document';
 
+// Helpful for tests running with jsdom
 export function getOwnerDocument(node: Node): Document {
     const doc = ownerDocumentGetter.call(node);
     // if doc is null, it means `this` is actually a document instance

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -57,16 +57,22 @@ if (!process.env.NATIVE_SHADOW) {
     });
 }
 
-describe('When event target is accessed async', () => {
+// legacy usecases
+describe('should not retarget event', () => {
     if (!process.env.NATIVE_SHADOW) {
-        it('#W-6586380 - should return the original target, if original target node is not keyed', done => {
+        let elm;
+        let child;
+        let originalTarget;
+        beforeAll(() => {
             spyOn(console, 'error');
-            const elm = createElement('x-parent-with-dynamic-child', {
+            elm = createElement('x-parent-with-dynamic-child', {
                 is: XParentWithDynamicChild,
             });
             document.body.appendChild(elm);
-            const child = elm.shadowRoot.querySelector('x-child-with-out-lwc-dom-manual');
-            const originalTarget = child.shadowRoot.querySelector('span');
+            child = elm.shadowRoot.querySelector('x-child-with-out-lwc-dom-manual');
+            originalTarget = child.shadowRoot.querySelector('span');
+        });
+        it('when original target node is not keyed and event is accessed async (W-6586380)', done => {
             elm.eventListener = evt => {
                 expect(evt.currentTarget).toBe(elm.shadowRoot.querySelector('div'));
                 expect(evt.target).toBe(child);
@@ -77,6 +83,15 @@ describe('When event target is accessed async', () => {
                     done();
                 });
             };
+            originalTarget.click();
+        });
+
+        it('when original target node is not keyed and currentTarget is document (W-6626752)', done => {
+            document.addEventListener('click', evt => {
+                expect(evt.currentTarget).toBe(document);
+                expect(evt.target).toBe(originalTarget);
+                done();
+            });
             originalTarget.click();
         });
     }

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -63,6 +63,7 @@ describe('should not retarget event', () => {
         let elm;
         let child;
         let originalTarget;
+
         beforeAll(() => {
             spyOn(console, 'error');
             elm = createElement('x-parent-with-dynamic-child', {
@@ -86,13 +87,23 @@ describe('should not retarget event', () => {
             originalTarget.click();
         });
 
-        it('when original target node is not keyed and currentTarget is document (W-6626752)', done => {
-            document.addEventListener('click', evt => {
-                expect(evt.currentTarget).toBe(document);
-                expect(evt.target).toBe(originalTarget);
-                done();
+        describe('received at a global listener', () => {
+            let actualCurrentTarget;
+            let actualTarget;
+            const globalListener = evt => {
+                actualCurrentTarget = evt.currentTarget;
+                actualTarget = evt.target;
+            };
+            afterAll(() => {
+                document.removeEventListener(globalListener);
             });
-            originalTarget.click();
+
+            it('when original target node is not keyed and currentTarget is document (W-6626752)', () => {
+                document.addEventListener('click', globalListener);
+                originalTarget.click();
+                expect(actualCurrentTarget).toBe(document);
+                expect(actualTarget).toBe(originalTarget);
+            });
         });
     }
 });


### PR DESCRIPTION
## Details
No retargeting if event's original target is from a manually injected node into a non-portal parentNode and if the currentTarget is one of the following
1. target is accessed async
2. currentTarget is document
3. currentTarget is document.body

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
