### PR TITLE
fix: remove npm dependencies on private packages

### DIFF
--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -16,11 +16,11 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/features": "1.0.2",
-        "@lwc/shared": "1.0.2",
         "observable-membrane": "0.26.1"
     },
     "devDependencies": {
+        "@lwc/features": "1.0.2",
+        "@lwc/shared": "1.0.2",
         "@lwc/template-compiler": "1.0.2"
     },
     "lwc": {

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -15,7 +15,7 @@
     "files": [
         "dist/"
     ],
-    "dependencies": {
+    "devDependencies": {
         "@lwc/shared": "1.0.2"
     }
 }

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -26,7 +26,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "dependencies": {
+    "devDependencies": {
         "@lwc/shared": "1.0.2"
     }
 }

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -18,13 +18,11 @@
         "dist/",
         "types/"
     ],
-    "dependencies": {
-        "@lwc/shared": "1.0.2"
-    },
     "devDependencies": {
         "@lwc/compiler": "1.0.2",
         "@lwc/engine": "1.0.2",
-        "@lwc/rollup-plugin": "1.0.2"
+        "@lwc/rollup-plugin": "1.0.2",
+        "@lwc/shared": "1.0.2"
     },
     "lwc": {
         "modules": [


### PR DESCRIPTION
## Details

Our dist files already bundle up all our dependencies.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`