### PR TITLE
test(integration-test): increase timeout for wire-service test

### DIFF
--- a/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
@@ -40,7 +40,7 @@ describe('Component with a wired method', () => {
                 });
                 return todoText.value === 'Title:task 1 Completed:false';
             },
-            1000,
+            3000,
             'Should update todo id'
         );
     });


### PR DESCRIPTION
## Details

Bumping up the timeout since this test is always timing out on IE11.

```
[internet explorer 11.103 Windows 10 #0-53] [PROD_COMPAT] Component with a wired method
[internet explorer 11.103 Windows 10 #0-53] [PROD_COMPAT]   ✓ should display data correctly
[internet explorer 11.103 Windows 10 #0-53] [PROD_COMPAT]   1) should update data correctly
[internet explorer 11.103 Windows 10 #0-53] [PROD_COMPAT]
[internet explorer 11.103 Windows 10 #0-53]
[internet explorer 11.103 Windows 10 #0-53] 1 passing (20s)
[internet explorer 11.103 Windows 10 #0-53] 1 failing
[internet explorer 11.103 Windows 10 #0-53]
[internet explorer 11.103 Windows 10 #0-53] 1) Component with a wired method should update data correctly:
[internet explorer 11.103 Windows 10 #0-53] Should update todo id
[internet explorer 11.103 Windows 10 #0-53] Error: Should update todo id
[internet explorer 11.103 Windows 10 #0-53]     at execute(<Function>) - index.js:312:3
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
