### PR TITLE
fix: custom collection util to handle nodelist and htmlcollection

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -83,7 +83,7 @@ interface QuerySegments {
 function getTabbableSegments(host: HTMLElement): QuerySegments {
     const doc = getOwnerDocument(host);
     const all = documentQuerySelectorAll.call(doc, TabbableElementsQuery);
-    const inner = collectionSlice.call(querySelectorAll.call(host, TabbableElementsQuery));
+    const inner = collectionSlice(querySelectorAll.call(host, TabbableElementsQuery));
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
             getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host),
@@ -92,17 +92,17 @@ function getTabbableSegments(host: HTMLElement): QuerySegments {
     }
     const firstChild = inner[0];
     const lastChild = inner[inner.length - 1];
-    const hostIndex = collectionIndexOf.call(all, host);
+    const hostIndex = collectionIndexOf(all, host);
 
     // Host element can show up in our "previous" section if its tabindex is 0
     // We want to filter that out here
-    const firstChildIndex = hostIndex > -1 ? hostIndex : collectionIndexOf.call(all, firstChild);
+    const firstChildIndex = hostIndex > -1 ? hostIndex : collectionIndexOf(all, firstChild);
 
     // Account for an empty inner list
     const lastChildIndex =
-        inner.length === 0 ? firstChildIndex + 1 : collectionIndexOf.call(all, lastChild) + 1;
-    const prev = collectionSlice.call(all, 0, firstChildIndex);
-    const next = collectionSlice.call(all, lastChildIndex);
+        inner.length === 0 ? firstChildIndex + 1 : collectionIndexOf(all, lastChild) + 1;
+    const prev = collectionSlice(all, 0, firstChildIndex);
+    const next = collectionSlice(all, lastChildIndex);
     return {
         prev,
         inner,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -26,7 +26,6 @@ import {
     ArrayFind,
     ArrayIndexOf,
     ArrayReverse,
-    ArraySlice,
     isNull,
     isUndefined,
     toString,
@@ -43,6 +42,7 @@ import {
 import { isDelegatingFocus } from './shadow-root';
 import { getOwnerDocument, getOwnerWindow } from '../shared/utils';
 import { patchedGetRootNode } from './traverse';
+import { collectionSlice, collectionIndexOf } from '../shared/node-collection-util';
 
 const TabbableElementsQuery = `
     button:not([tabindex="-1"]):not([disabled]),
@@ -83,7 +83,7 @@ interface QuerySegments {
 function getTabbableSegments(host: HTMLElement): QuerySegments {
     const doc = getOwnerDocument(host);
     const all = documentQuerySelectorAll.call(doc, TabbableElementsQuery);
-    const inner = ArraySlice.call(querySelectorAll.call(host, TabbableElementsQuery));
+    const inner = collectionSlice.call(querySelectorAll.call(host, TabbableElementsQuery));
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
             getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host),
@@ -92,22 +92,22 @@ function getTabbableSegments(host: HTMLElement): QuerySegments {
     }
     const firstChild = inner[0];
     const lastChild = inner[inner.length - 1];
-    const hostIndex = ArrayIndexOf.call(all, host);
+    const hostIndex = collectionIndexOf.call(all, host);
 
     // Host element can show up in our "previous" section if its tabindex is 0
     // We want to filter that out here
-    const firstChildIndex = hostIndex > -1 ? hostIndex : ArrayIndexOf.call(all, firstChild);
+    const firstChildIndex = hostIndex > -1 ? hostIndex : collectionIndexOf.call(all, firstChild);
 
     // Account for an empty inner list
     const lastChildIndex =
-        inner.length === 0 ? firstChildIndex + 1 : ArrayIndexOf.call(all, lastChild) + 1;
-    const prev = ArraySlice.call(all, 0, firstChildIndex);
-    const next = ArraySlice.call(all, lastChildIndex);
+        inner.length === 0 ? firstChildIndex + 1 : collectionIndexOf.call(all, lastChild) + 1;
+    const prev = collectionSlice.call(all, 0, firstChildIndex);
+    const next = collectionSlice.call(all, lastChildIndex);
     return {
         prev,
         inner,
         next,
-    };
+    } as QuerySegments;
 }
 
 export function getActiveElement(host: HTMLElement): Element | null {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -72,7 +72,7 @@ export function getFilteredSlotAssignedNodes(slot: HTMLElement): Node[] {
     if (isNull(owner)) {
         return [];
     }
-    const childNodes = collectionSlice.call(nativeChildNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice(nativeChildNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch
@@ -89,7 +89,7 @@ export function getFilteredSlotAssignedNodes(slot: HTMLElement): Node[] {
 }
 
 function getFilteredSlotFlattenNodes(slot: HTMLElement): Node[] {
-    const childNodes = collectionSlice.call(nativeChildNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice(nativeChildNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -15,7 +15,6 @@ import {
     isUndefined,
     isTrue,
     ArrayFilter,
-    ArraySlice,
     isNull,
     ArrayReduce,
 } from '../shared/language';
@@ -31,6 +30,7 @@ import { childNodesGetter as nativeChildNodesGetter } from '../env/node';
 import { createStaticNodeList } from '../shared/static-node-list';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { PatchedElement } from './element';
+import { collectionSlice } from '../shared/node-collection-util';
 
 interface HTMLSlotElementConstructor {
     prototype: HTMLSlotElement;
@@ -72,7 +72,7 @@ export function getFilteredSlotAssignedNodes(slot: HTMLElement): Node[] {
     if (isNull(owner)) {
         return [];
     }
-    const childNodes = ArraySlice.call(nativeChildNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice.call(nativeChildNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch
@@ -89,7 +89,7 @@ export function getFilteredSlotAssignedNodes(slot: HTMLElement): Node[] {
 }
 
 function getFilteredSlotFlattenNodes(slot: HTMLElement): Node[] {
-    const childNodes = ArraySlice.call(nativeChildNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice.call(nativeChildNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
@@ -10,14 +10,8 @@ import {
     getElementsByTagNameNS as elementGetElementsByTagNameNS,
     querySelectorAll as elementQuerySelectorAll,
 } from '../../env/element';
-import {
-    ArrayFilter,
-    ArrayFind,
-    ArraySlice,
-    defineProperty,
-    isTrue,
-    isUndefined,
-} from '../../shared/language';
+import { ArraySlice, defineProperty, isTrue, isUndefined } from '../../shared/language';
+import { collectionFilter, collectionFind } from '../../shared/node-collection-util';
 import { getNodeOwnerKey } from '../../faux-shadow/node';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
@@ -52,11 +46,11 @@ export default function apply() {
             ]);
             const ownerKey = getNodeOwnerKey(this);
             // Return the first non shadow element
-            const filtered = ArrayFind.call(
+            const filtered = collectionFind.call(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
-            return !isUndefined(filtered) ? filtered : null;
+            return !isUndefined(filtered) ? (filtered as Element) : null;
         },
         writable: true,
         enumerable: true,
@@ -69,11 +63,11 @@ export default function apply() {
                 string
             ]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
-            return createStaticNodeList(filtered);
+            return createStaticNodeList(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -86,11 +80,11 @@ export default function apply() {
                 arguments
             ) as [string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -103,11 +97,11 @@ export default function apply() {
                 string
             ]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -120,11 +114,11 @@ export default function apply() {
                 arguments
             ) as [string, string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-body-shadow/polyfill.ts
@@ -46,7 +46,7 @@ export default function apply() {
             ]);
             const ownerKey = getNodeOwnerKey(this);
             // Return the first non shadow element
-            const filtered = collectionFind.call(
+            const filtered = collectionFind(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
@@ -63,7 +63,7 @@ export default function apply() {
                 string
             ]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
@@ -80,7 +80,7 @@ export default function apply() {
                 arguments
             ) as [string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
@@ -97,7 +97,7 @@ export default function apply() {
                 string
             ]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );
@@ -114,7 +114,7 @@ export default function apply() {
                 arguments
             ) as [string, string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(elm)
             );

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -15,7 +15,6 @@ import {
     querySelectorAll as documentQuerySelectorAll,
 } from '../../env/document';
 import {
-    ArrayFind,
     ArraySlice,
     defineProperty,
     isNull,
@@ -30,7 +29,7 @@ import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 import { getOwnerDocument } from '../../shared/utils';
-import { collectionFilter } from '../../shared/node-collection-util';
+import { collectionFilter, collectionFind } from '../../shared/node-collection-util';
 
 let skipGlobalPatching: boolean;
 function isGlobalPatchingSkipped(node: Node) {
@@ -109,7 +108,7 @@ export default function apply() {
             const elements = documentQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [
                 string
             ]);
-            const filtered = ArrayFind.call(
+            const filtered = collectionFind(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -125,7 +125,7 @@ export default function apply() {
             const elements = documentQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [
                 string
             ]);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
@@ -141,7 +141,7 @@ export default function apply() {
             const elements = documentGetElementsByClassName.apply(this, ArraySlice.call(
                 arguments
             ) as [string]);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
@@ -157,7 +157,7 @@ export default function apply() {
             const elements = documentGetElementsByTagName.apply(this, ArraySlice.call(
                 arguments
             ) as [string]);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
@@ -173,7 +173,7 @@ export default function apply() {
             const elements = documentGetElementsByTagNameNS.apply(this, ArraySlice.call(
                 arguments
             ) as [string, string]);
-            const filtered = collectionFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
@@ -195,7 +195,7 @@ export default function apply() {
                 const elements = getElementsByName.apply(this, ArraySlice.call(arguments) as [
                     string
                 ]);
-                const filtered = collectionFilter.call(
+                const filtered = collectionFilter(
                     elements,
                     elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
                 );

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -15,7 +15,6 @@ import {
     querySelectorAll as documentQuerySelectorAll,
 } from '../../env/document';
 import {
-    ArrayFilter,
     ArrayFind,
     ArraySlice,
     defineProperty,
@@ -31,6 +30,7 @@ import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 import { getOwnerDocument } from '../../shared/utils';
+import { collectionFilter } from '../../shared/node-collection-util';
 
 let skipGlobalPatching: boolean;
 function isGlobalPatchingSkipped(node: Node) {
@@ -125,11 +125,11 @@ export default function apply() {
             const elements = documentQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [
                 string
             ]);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
-            return createStaticNodeList(filtered);
+            return createStaticNodeList(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -141,11 +141,11 @@ export default function apply() {
             const elements = documentGetElementsByClassName.apply(this, ArraySlice.call(
                 arguments
             ) as [string]);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -157,11 +157,11 @@ export default function apply() {
             const elements = documentGetElementsByTagName.apply(this, ArraySlice.call(
                 arguments
             ) as [string]);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -173,11 +173,11 @@ export default function apply() {
             const elements = documentGetElementsByTagNameNS.apply(this, ArraySlice.call(
                 arguments
             ) as [string, string]);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter.call(
                 elements,
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -195,11 +195,11 @@ export default function apply() {
                 const elements = getElementsByName.apply(this, ArraySlice.call(arguments) as [
                     string
                 ]);
-                const filtered = ArrayFilter.call(
+                const filtered = collectionFilter.call(
                     elements,
                     elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
                 );
-                return createStaticNodeList(filtered);
+                return createStaticNodeList(filtered as Array<Element>);
             },
             writable: true,
             enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isUndefined, isTrue } from './language';
+/**
+ * Writing our own utils to handle NodeList and HTMLCollection. This is to not conflict with
+ * some legacy third party libraries like prototype.js that patch Array.prototype.
+ */
+
+/**
+ * Custom implementation of filter since using Array.prototype.filter conflicts with other
+ * legacy libraries like prototype.js
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Polyfill
+ */
+export function collectionFilter<T extends Node, K extends Element>(
+    this: NodeListOf<T> | HTMLCollectionOf<K>,
+    fn: (value: T | K, index?: number, collection?: NodeListOf<T> | HTMLCollectionOf<K>) => boolean,
+    thisArg?: any
+): Array<T | K> {
+    const res: Array<T | K> = [];
+    const length = this.length;
+    for (let i = 0; i < length; i++) {
+        const curr = this[i];
+        if (isTrue(fn.call(thisArg, curr, i, this))) {
+            res.push(curr);
+        }
+    }
+    return res;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
+ */
+export function collectionFind<T extends Node>(
+    this: NodeListOf<T>,
+    fn: (value: T, index?: number, nodelist?: NodeListOf<T>) => boolean,
+    thisArg?: any
+): T | undefined {
+    const length = this.length;
+    for (let i = 0; i < length; i++) {
+        const curr = this[i];
+        if (isTrue(fn.call(thisArg, curr, i, this))) {
+            return curr;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Streamlining_cross-browser_behavior
+ */
+export function collectionSlice<T extends Node>(
+    this: NodeListOf<T>,
+    begin?: number,
+    end?: number
+): Array<T> {
+    end = !isUndefined(end) ? end : this.length;
+    const cloned: T[] = [];
+    const len = this.length;
+
+    // Handle negative value for "begin"
+    let start = !isUndefined(begin) ? begin : 0;
+    start = start >= 0 ? start : Math.max(0, len + start);
+
+    // Handle negative value for "end"
+    let upTo = !isUndefined(end) ? Math.min(end, len) : len;
+    if (end < 0) {
+        upTo = len + end;
+    }
+
+    // Actual expected size of the slice
+    const size = upTo - start;
+
+    if (size > 0) {
+        for (let i = 0; i < size; i++) {
+            cloned.push(this[start + i]);
+        }
+    }
+    return cloned;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#Polyfill
+ */
+export function collectionIndexOf<T extends Node>(
+    this: NodeListOf<T>,
+    searchItem: T,
+    fromIndex: number = 0
+): number {
+    const len = this.length;
+    let i = Math.min(fromIndex, len);
+    if (i < 0) {
+        i = Math.max(0, len + i);
+    } else if (i >= len) {
+        return -1;
+    }
+
+    for (; i !== len; ++i) {
+        if (this[i] === searchItem) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined, isTrue } from './language';
+import { isUndefined, isTrue, ArrayPush } from './language';
 /**
  * Writing our own utils to handle NodeList and HTMLCollection. This is to not conflict with
  * some legacy third party libraries like prototype.js that patch Array.prototype.
@@ -16,16 +16,15 @@ import { isUndefined, isTrue } from './language';
  * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Polyfill
  */
 export function collectionFilter<T extends Node, K extends Element>(
-    this: NodeListOf<T> | HTMLCollectionOf<K>,
-    fn: (value: T | K, index?: number, collection?: NodeListOf<T> | HTMLCollectionOf<K>) => boolean,
-    thisArg?: any
+    collection: NodeListOf<T> | HTMLCollectionOf<K>,
+    fn: (value: T | K, index?: number, collection?: NodeListOf<T> | HTMLCollectionOf<K>) => boolean
 ): Array<T | K> {
     const res: Array<T | K> = [];
-    const length = this.length;
+    const length = collection.length;
     for (let i = 0; i < length; i++) {
-        const curr = this[i];
-        if (isTrue(fn.call(thisArg, curr, i, this))) {
-            res.push(curr);
+        const curr = collection[i];
+        if (isTrue(fn.call(undefined, curr, i, collection))) {
+            ArrayPush.call(res, curr);
         }
     }
     return res;
@@ -35,14 +34,13 @@ export function collectionFilter<T extends Node, K extends Element>(
  * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
  */
 export function collectionFind<T extends Node>(
-    this: NodeListOf<T>,
-    fn: (value: T, index?: number, nodelist?: NodeListOf<T>) => boolean,
-    thisArg?: any
+    collection: NodeListOf<T>,
+    fn: (value: T, index?: number, nodelist?: NodeListOf<T>) => boolean
 ): T | undefined {
-    const length = this.length;
+    const length = collection.length;
     for (let i = 0; i < length; i++) {
-        const curr = this[i];
-        if (isTrue(fn.call(thisArg, curr, i, this))) {
+        const curr = collection[i];
+        if (isTrue(fn.call(undefined, curr, i, collection))) {
             return curr;
         }
     }
@@ -53,13 +51,13 @@ export function collectionFind<T extends Node>(
  * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Streamlining_cross-browser_behavior
  */
 export function collectionSlice<T extends Node>(
-    this: NodeListOf<T>,
+    collection: NodeListOf<T>,
     begin?: number,
     end?: number
 ): Array<T> {
-    end = !isUndefined(end) ? end : this.length;
+    end = !isUndefined(end) ? end : collection.length;
     const cloned: T[] = [];
-    const len = this.length;
+    const len = collection.length;
 
     // Handle negative value for "begin"
     let start = !isUndefined(begin) ? begin : 0;
@@ -76,7 +74,7 @@ export function collectionSlice<T extends Node>(
 
     if (size > 0) {
         for (let i = 0; i < size; i++) {
-            cloned.push(this[start + i]);
+            ArrayPush.call(cloned, collection[start + i]);
         }
     }
     return cloned;
@@ -86,11 +84,11 @@ export function collectionSlice<T extends Node>(
  * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#Polyfill
  */
 export function collectionIndexOf<T extends Node>(
-    this: NodeListOf<T>,
+    collection: NodeListOf<T>,
     searchItem: T,
     fromIndex: number = 0
 ): number {
-    const len = this.length;
+    const len = collection.length;
     let i = Math.min(fromIndex, len);
     if (i < 0) {
         i = Math.max(0, len + i);
@@ -99,7 +97,7 @@ export function collectionIndexOf<T extends Node>(
     }
 
     for (; i !== len; ++i) {
-        if (this[i] === searchItem) {
+        if (collection[i] === searchItem) {
             return i;
         }
     }

--- a/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
@@ -23,7 +23,7 @@ export function collectionFilter<T extends Node, K extends Element>(
     const length = collection.length;
     for (let i = 0; i < length; i++) {
         const curr = collection[i];
-        if (isTrue(fn.call(undefined, curr, i, collection))) {
+        if (isTrue(fn(curr, i, collection))) {
             ArrayPush.call(res, curr);
         }
     }
@@ -40,7 +40,7 @@ export function collectionFind<T extends Node>(
     const length = collection.length;
     for (let i = 0; i < length; i++) {
         const curr = collection[i];
-        if (isTrue(fn.call(undefined, curr, i, collection))) {
+        if (isTrue(fn(curr, i, collection))) {
             return curr;
         }
     }


### PR DESCRIPTION
## Details
Writing our own utils to handle NodeList and HTMLCollection. This is to not conflict with some legacy third party libraries like prototype.js that patch Array.prototype and is incapable of handling NodeList and HTMLCollection.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
