### PR TITLE
refactor: remove @lwc/shared dependency from compile time

### DIFF
--- a/packages/@lwc/compiler/src/rollup-plugins/module-resolver.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/module-resolver.ts
@@ -7,7 +7,6 @@
 import path from 'path';
 import { Plugin } from 'rollup';
 import { ModuleResolutionErrors, generateCompilerError } from '@lwc/errors';
-import { hasOwnProperty } from '@lwc/shared';
 
 import { NormalizedCompilerOptions, BundleFiles } from '../compiler/options';
 
@@ -16,6 +15,8 @@ const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
 const VALID_EXTENSIONS = ['.js', '.ts', '.html', '.css']; // order of resolution is important
+
+const { hasOwnProperty } = Object.prototype;
 
 function isRelativeImport(id: string) {
     return id.startsWith('.');

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { hasOwnProperty } from '@lwc/shared';
 import * as CompilerErrors from '../compiler/error-info';
 import { LWCErrorInfo } from '../shared/types';
 
@@ -14,6 +13,8 @@ const ERROR_CODE_RANGES = {
         max: 1999,
     },
 };
+
+const { hasOwnProperty } = Object.prototype;
 
 interface ExtendedMatcher extends jest.Matchers<void> {
     toBeUniqueCode: (key: string, seenErrorCodes: Set<number>) => object;

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { TemplateErrors, invariant, generateCompilerError } from '@lwc/errors';
-import { hasOwnProperty } from '@lwc/shared';
 
 export type Format = 'module' | 'function';
 
@@ -52,6 +51,8 @@ const AVAILABLE_OPTION_NAMES = new Set([
     'experimentalDynamicDirective',
     'stylesheetConfig',
 ]);
+
+const { hasOwnProperty } = Object.prototype;
 
 export function mergeConfig(config: Config): ResolvedConfig {
     invariant(

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as parse5 from 'parse5-with-errors';
-import { hasOwnProperty } from '@lwc/shared';
 
 import {
     treeAdapter,
@@ -89,6 +88,8 @@ import {
     normalizeToDiagnostic,
     ParserDiagnostics,
 } from '@lwc/errors';
+
+const { hasOwnProperty } = Object.prototype;
 
 function isStyleElement(irElement: IRElement) {
     const element = irElement.__original as parse5.AST.Default.Element;

--- a/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
+++ b/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
@@ -29,7 +29,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { hasOwnProperty } from '@lwc/shared';
+const { hasOwnProperty } = Object.prototype;
 
 const HTML_ELEMENT_ATTRIBUTE_MAP = {
     '*': [

--- a/scripts/tasks/version-check.js
+++ b/scripts/tasks/version-check.js
@@ -6,7 +6,6 @@
  */
 'use strict';
 
-const { hasOwnProperty } = require('@lwc/shared');
 const path = require('path');
 const glob = require('glob');
 const semver = require('semver');
@@ -16,6 +15,8 @@ const PACKAGES = glob.sync('packages/**/package.json', {
     absolute: true,
     cwd: PACKAGES_DIR,
 });
+
+const { hasOwnProperty } = Object.prototype;
 
 let areVersionsInSync = true;
 for (const location of PACKAGES) {


### PR DESCRIPTION
## Details

`@lwc/shared` is a private package and should only be used by other packages that generate a distribution files

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
