### PR TITLE
fix: guard usage of Array methods on nodelist and htmlcollection

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -6,7 +6,6 @@
  */
 import {
     ArrayFilter,
-    ArrayFind,
     ArrayPush,
     ArraySlice,
     assert,
@@ -64,6 +63,7 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { isGlobalPatchingSkipped } from '../shared/utils';
 import { getNodeOwnerKey, isNodeShadowed } from '../faux-shadow/node';
 import { assignedSlotGetterPatched } from './slot';
+import { collectionFilter, collectionFind } from '../shared/node-collection-util';
 
 // when finding a slot in the DOM, we can fold it if it is contained
 // inside another slot.
@@ -348,11 +348,11 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
     } else if (isNodeShadowed(this)) {
         // element inside a shadowRoot
         const ownerKey = getNodeOwnerKey(this);
-        const elm = ArrayFind.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
+        const elm = collectionFind(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
         return isUndefined(elm) ? null : elm;
     } else {
         // element belonging to the document
-        const elm = ArrayFind.call(
+        const elm = collectionFind(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
@@ -379,10 +379,10 @@ function querySelectorAllPatched(this: Element /*, selector: string*/): NodeList
     } else if (isNodeShadowed(this)) {
         // element inside a shadowRoot
         const ownerKey = getNodeOwnerKey(this);
-        filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
+        filtered = collectionFilter(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
     } else {
         // element belonging to the document
-        filtered = ArrayFilter.call(
+        filtered = collectionFilter(
             nodeList,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
@@ -419,12 +419,12 @@ defineProperties(Element.prototype, {
                 arguments
             ) as [string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 // TODO: issue #1222 - remove global bypass
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(this)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -436,12 +436,12 @@ defineProperties(Element.prototype, {
                 string
             ]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 // TODO: issue #1222 - remove global bypass
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(this)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,
@@ -453,12 +453,12 @@ defineProperties(Element.prototype, {
                 arguments
             ) as [string, string]);
             const ownerKey = getNodeOwnerKey(this);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 // TODO: issue #1222 - remove global bypass
                 elm => getNodeOwnerKey(elm) === ownerKey || isGlobalPatchingSkipped(this)
             );
-            return createStaticHTMLCollection(filtered);
+            return createStaticHTMLCollection(filtered as Array<Element>);
         },
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -8,7 +8,6 @@ import {
     ArrayFind,
     ArrayIndexOf,
     ArrayReverse,
-    ArraySlice,
     assert,
     fields,
     isNull,
@@ -42,6 +41,7 @@ import {
 } from '../env/dom';
 import { isDelegatingFocus } from './shadow-root';
 import { getOwnerDocument, getOwnerWindow } from '../shared/utils';
+import { collectionSlice, collectionIndexOf } from '../shared/node-collection-util';
 
 const { createFieldName, getHiddenField, setHiddenField } = fields;
 
@@ -83,7 +83,7 @@ interface QuerySegments {
 function getTabbableSegments(host: HTMLElement): QuerySegments {
     const doc = getOwnerDocument(host);
     const all = documentQuerySelectorAll.call(doc, TabbableElementsQuery);
-    const inner = ArraySlice.call(querySelectorAll.call(host, TabbableElementsQuery));
+    const inner = collectionSlice(querySelectorAll.call(host, TabbableElementsQuery));
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
             getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host),
@@ -92,22 +92,22 @@ function getTabbableSegments(host: HTMLElement): QuerySegments {
     }
     const firstChild = inner[0];
     const lastChild = inner[inner.length - 1];
-    const hostIndex = ArrayIndexOf.call(all, host);
+    const hostIndex = collectionIndexOf(all, host);
 
     // Host element can show up in our "previous" section if its tabindex is 0
     // We want to filter that out here
-    const firstChildIndex = hostIndex > -1 ? hostIndex : ArrayIndexOf.call(all, firstChild);
+    const firstChildIndex = hostIndex > -1 ? hostIndex : collectionIndexOf(all, firstChild);
 
     // Account for an empty inner list
     const lastChildIndex =
-        inner.length === 0 ? firstChildIndex + 1 : ArrayIndexOf.call(all, lastChild) + 1;
-    const prev = ArraySlice.call(all, 0, firstChildIndex);
-    const next = ArraySlice.call(all, lastChildIndex);
+        inner.length === 0 ? firstChildIndex + 1 : collectionIndexOf(all, lastChild) + 1;
+    const prev = collectionSlice(all, 0, firstChildIndex);
+    const next = collectionSlice(all, lastChildIndex);
     return {
         prev,
         inner,
         next,
-    };
+    } as QuerySegments;
 }
 
 export function getActiveElement(host: HTMLElement): Element | null {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -13,7 +13,6 @@ import {
     isUndefined,
     isTrue,
     ArrayFilter,
-    ArraySlice,
     isNull,
     ArrayReduce,
     defineProperties,
@@ -31,6 +30,7 @@ import {
 import { childNodesGetter, parentNodeGetter } from '../env/node';
 import { createStaticNodeList } from '../shared/static-node-list';
 import { isNodeShadowed, getNodeNearestOwnerKey } from '../faux-shadow/node';
+import { collectionSlice } from '../shared/node-collection-util';
 
 // We can use a single observer without having to worry about leaking because
 // "Registered observers in a node’s registered observer list have a weak
@@ -64,7 +64,7 @@ function initSlotObserver() {
 }
 
 function getFilteredSlotFlattenNodes(slot: HTMLElement): Node[] {
-    const childNodes = ArraySlice.call(childNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice(childNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayReduce, ArrayPush, ArraySlice, assert, isNull, isUndefined } from '@lwc/shared';
+import { ArrayReduce, ArrayPush, assert, isNull, isUndefined } from '@lwc/shared';
 import { getNodeKey, getNodeNearestOwnerKey } from './node';
 import {
     childNodesGetter,
@@ -20,6 +20,7 @@ import {
     getShadowRootResolver,
     getShadowRoot,
 } from './shadow-root';
+import { collectionSlice } from '../shared/node-collection-util';
 
 export function getNodeOwner(node: Node): HTMLElement | null {
     if (!(node instanceof Node)) {
@@ -115,7 +116,7 @@ export function getFilteredChildNodes(node: Node): Element[] {
     if (!isHostElement(node) && !isSlotElement(node)) {
         // regular element - fast path
         children = childNodesGetter.call(node);
-        return ArraySlice.call(children);
+        return collectionSlice(children);
     }
     if (isHostElement(node)) {
         // we need to get only the nodes that were slotted
@@ -159,7 +160,7 @@ export function getFilteredSlotAssignedNodes(slot: HTMLElement): Node[] {
     if (isNull(owner)) {
         return [];
     }
-    const childNodes = ArraySlice.call(childNodesGetter.call(slot)) as Node[];
+    const childNodes = collectionSlice(childNodesGetter.call(slot)) as Node[];
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -5,8 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
-    ArrayFilter,
-    ArrayFind,
     ArraySlice,
     defineProperty,
     getOwnPropertyDescriptor,
@@ -30,6 +28,7 @@ import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 import { isGlobalPatchingSkipped } from '../../shared/utils';
+import { collectionFilter, collectionFind } from '../../shared/node-collection-util';
 
 function elemFromPoint(this: Document, left: number, top: number) {
     const element = elementFromPoint.call(this, left, top);
@@ -98,7 +97,7 @@ defineProperty(Document.prototype, 'querySelector', {
         const elements = documentQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [
             string
         ]);
-        const filtered = ArrayFind.call(
+        const filtered = collectionFind(
             elements,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
@@ -115,7 +114,7 @@ defineProperty(Document.prototype, 'querySelectorAll', {
         const elements = documentQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [
             string
         ]);
-        const filtered = ArrayFilter.call(
+        const filtered = collectionFilter(
             elements,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
@@ -132,12 +131,12 @@ defineProperty(Document.prototype, 'getElementsByClassName', {
         const elements = documentGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [
             string
         ]);
-        const filtered = ArrayFilter.call(
+        const filtered = collectionFilter(
             elements,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
-        return createStaticHTMLCollection(filtered);
+        return createStaticHTMLCollection(filtered as Array<Element>);
     },
     writable: true,
     enumerable: true,
@@ -149,12 +148,12 @@ defineProperty(Document.prototype, 'getElementsByTagName', {
         const elements = documentGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [
             string
         ]);
-        const filtered = ArrayFilter.call(
+        const filtered = collectionFilter(
             elements,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
-        return createStaticHTMLCollection(filtered);
+        return createStaticHTMLCollection(filtered as Array<Element>);
     },
     writable: true,
     enumerable: true,
@@ -167,12 +166,12 @@ defineProperty(Document.prototype, 'getElementsByTagNameNS', {
             string,
             string
         ]);
-        const filtered = ArrayFilter.call(
+        const filtered = collectionFilter(
             elements,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
-        return createStaticHTMLCollection(filtered);
+        return createStaticHTMLCollection(filtered as Array<Element>);
     },
     writable: true,
     enumerable: true,
@@ -188,7 +187,7 @@ defineProperty(
     {
         value(this: Document): NodeListOf<Element> {
             const elements = getElementsByName.apply(this, ArraySlice.call(arguments) as [string]);
-            const filtered = ArrayFilter.call(
+            const filtered = collectionFilter(
                 elements,
                 // TODO: issue #1222 - remove global bypass
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)

--- a/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-collection-util.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isUndefined, isTrue, ArrayPush } from '@lwc/shared';
+/**
+ * Issue #1545 - Writing our own utils to handle NodeList and HTMLCollection. This is to not conflict with
+ * some legacy third party libraries like prototype.js that patch Array.prototype.
+ */
+
+/**
+ * Custom implementation of filter since using Array.prototype.filter conflicts with other
+ * legacy libraries like prototype.js
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Polyfill
+ */
+export function collectionFilter<T extends Node, K extends Element>(
+    collection: NodeListOf<T> | HTMLCollectionOf<K>,
+    fn: (value: T | K, index?: number, collection?: NodeListOf<T> | HTMLCollectionOf<K>) => boolean
+): Array<T | K> {
+    const res: Array<T | K> = [];
+    const length = collection.length;
+    for (let i = 0; i < length; i++) {
+        const curr = collection[i];
+        if (isTrue(fn(curr, i, collection))) {
+            ArrayPush.call(res, curr);
+        }
+    }
+    return res;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
+ */
+export function collectionFind<T extends Node>(
+    collection: NodeListOf<T>,
+    fn: (value: T, index?: number, nodelist?: NodeListOf<T>) => boolean
+): T | undefined {
+    const length = collection.length;
+    for (let i = 0; i < length; i++) {
+        const curr = collection[i];
+        if (isTrue(fn(curr, i, collection))) {
+            return curr;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Streamlining_cross-browser_behavior
+ */
+export function collectionSlice<T extends Node>(
+    collection: NodeListOf<T>,
+    begin?: number,
+    end?: number
+): Array<T> {
+    end = !isUndefined(end) ? end : collection.length;
+    const cloned: T[] = [];
+    const len = collection.length;
+
+    // Handle negative value for "begin"
+    let start = !isUndefined(begin) ? begin : 0;
+    start = start >= 0 ? start : Math.max(0, len + start);
+
+    // Handle negative value for "end"
+    let upTo = !isUndefined(end) ? Math.min(end, len) : len;
+    if (end < 0) {
+        upTo = len + end;
+    }
+
+    // Actual expected size of the slice
+    const size = upTo - start;
+
+    if (size > 0) {
+        for (let i = 0; i < size; i++) {
+            ArrayPush.call(cloned, collection[start + i]);
+        }
+    }
+    return cloned;
+}
+
+/**
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#Polyfill
+ */
+export function collectionIndexOf<T extends Node>(
+    collection: NodeListOf<T>,
+    searchItem: T,
+    fromIndex: number = 0
+): number {
+    const len = collection.length;
+    let i = Math.min(fromIndex, len);
+    if (i < 0) {
+        i = Math.max(0, len + i);
+    } else if (i >= len) {
+        return -1;
+    }
+
+    for (; i !== len; ++i) {
+        if (collection[i] === searchItem) {
+            return i;
+        }
+    }
+    return -1;
+}


### PR DESCRIPTION
## Details
Legacy third party libraries that patch prototype of Array intrinsic are incapable of handling NodeList and HTMLCollection instances. For example, one such library is older version(1.7) of prototype.js
So this PR is to guard lwc engine against such legacy libraries by writing its own custom utils.

Fixes https://github.com/salesforce/lwc/issues/1545
## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
