### PR TITLE
refactor(features): default export of flags as a single object

### DIFF
--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ENABLE_REACTIVE_SETTER } from '@lwc/features';
+import features from '@lwc/features';
 import { assert, isFalse, isFunction, isObject, isTrue, isUndefined, toString } from '@lwc/shared';
 import { logError } from '../../shared/assert';
 import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
@@ -182,7 +182,7 @@ function createPublicAccessorDescriptor(
                 );
             }
             if (set) {
-                if (ENABLE_REACTIVE_SETTER) {
+                if (features.ENABLE_REACTIVE_SETTER) {
                     let ro = vm.oar[key as any] as AccessorReactiveObserver;
                     if (isUndefined(ro)) {
                         ro = vm.oar[key as any] = new AccessorReactiveObserver(vm, set);

--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -10,13 +10,13 @@ const plugin = require('../babel-plugin');
 const nonProdTests = {
     'should transform boolean-true feature flags': {
         code: `
-            import { ENABLE_FEATURE_TRUE } from '@lwc/features';
-            if (ENABLE_FEATURE_TRUE) {
+            import featureFlags from '@lwc/features';
+            if (featureFlags.ENABLE_FEATURE_TRUE) {
                 console.log('ENABLE_FEATURE_TRUE');
             }
         `,
         output: `
-            import { ENABLE_FEATURE_TRUE, runtimeFlags } from '@lwc/features';
+            import featureFlags, { runtimeFlags } from '@lwc/features';
 
             if (runtimeFlags.ENABLE_FEATURE_TRUE) {
               console.log('ENABLE_FEATURE_TRUE');
@@ -25,120 +25,120 @@ const nonProdTests = {
     },
     'should transform boolean-false feature flags': {
         code: `
-            import { ENABLE_FEATURE_FALSE } from '@lwc/features';
-            if (ENABLE_FEATURE_FALSE) {
+            import features from '@lwc/features';
+            if (features.ENABLE_FEATURE_FALSE) {
                 console.log('ENABLE_FEATURE_FALSE');
             }
         `,
         output: `
-            import { ENABLE_FEATURE_FALSE, runtimeFlags } from '@lwc/features';
+            import features, { runtimeFlags } from '@lwc/features';
 
             if (runtimeFlags.ENABLE_FEATURE_FALSE) {
               console.log('ENABLE_FEATURE_FALSE');
             }
         `,
     },
-    'should not tramsform feature flags unless the if-test is a plain indentifier': {
+    'should transform null feature flags': {
         code: `
-            import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_FALSE, ENABLE_FEATURE_NULL } from '@lwc/features';
-            if (ENABLE_FEATURE_NULL === null) {
+            import features from '@lwc/features';
+            if (features.ENABLE_FEATURE_NULL) {
+                console.log('ENABLE_FEATURE_NULL');
+            }
+        `,
+        output: `
+            import features, { runtimeFlags } from '@lwc/features';
+
+            if (runtimeFlags.ENABLE_FEATURE_NULL) {
+              console.log('ENABLE_FEATURE_NULL');
+            }
+        `,
+    },
+    'should not transform feature flags unless the if-test is a simple member expression': {
+        code: `
+            import FEATURES from '@lwc/features';
+            if (FEATURES.ENABLE_FEATURE_NULL === null) {
                 console.log('ENABLE_FEATURE_NULL === null');
             }
-            if (isTrue(ENABLE_FEATURE_TRUE)) {
+            if (isTrue(FEATURES.ENABLE_FEATURE_TRUE)) {
                 console.log('isTrue(ENABLE_FEATURE_TRUE)');
             }
-            if (!ENABLE_FEATURE_FALSE) {
+            if (!FEATURES.ENABLE_FEATURE_FALSE) {
                 console.log('!ENABLE_FEATURE_FALSE');
             }
         `,
         output: `
-            import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_FALSE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
+            import FEATURES, { runtimeFlags } from '@lwc/features';
 
-            if (ENABLE_FEATURE_NULL === null) {
+            if (FEATURES.ENABLE_FEATURE_NULL === null) {
               console.log('ENABLE_FEATURE_NULL === null');
             }
 
-            if (isTrue(ENABLE_FEATURE_TRUE)) {
+            if (isTrue(FEATURES.ENABLE_FEATURE_TRUE)) {
               console.log('isTrue(ENABLE_FEATURE_TRUE)');
             }
 
-            if (!ENABLE_FEATURE_FALSE) {
+            if (!FEATURES.ENABLE_FEATURE_FALSE) {
               console.log('!ENABLE_FEATURE_FALSE');
             }
         `,
     },
-    'should not transform identifiers that look like feature flags but are not imported': {
+    'should not transform tests that are not an actual reference to the imported binding': {
         code: `
-            import { ENABLE_FEATURE_TRUE } from '@lwc/features';
-            const ENABLE_FEATURE_FALSE = true;
-            if (ENABLE_FEATURE_FALSE) {
+            import featureFlag from '@lwc/features';
+            if (featureFlag.ENABLE_FEATURE_FALSE) {
                 console.log('ENABLE_FEATURE_FALSE');
             }
             function awesome() {
-                const ENABLE_FEATURE_TRUE = null;
-                if (ENABLE_FEATURE_TRUE) {
-                    console.log('ENABLE_FEATURE_TRUE');
+                const featureFlag = { ENABLE_FEATURE_FALSE: false };
+                if (featureFlag.ENABLE_FEATURE_FALSE) {
+                    console.log('ENABLE_FEATURE_FALSE');
                 }
             }
         `,
         output: `
-            import { ENABLE_FEATURE_TRUE, runtimeFlags } from '@lwc/features';
-            const ENABLE_FEATURE_FALSE = true;
+            import featureFlag, { runtimeFlags } from '@lwc/features';
 
-            if (ENABLE_FEATURE_FALSE) {
+            if (runtimeFlags.ENABLE_FEATURE_FALSE) {
               console.log('ENABLE_FEATURE_FALSE');
             }
 
             function awesome() {
-              const ENABLE_FEATURE_TRUE = null;
+              const featureFlag = {
+                ENABLE_FEATURE_FALSE: false
+              };
 
-              if (ENABLE_FEATURE_TRUE) {
-                console.log('ENABLE_FEATURE_TRUE');
+              if (featureFlag.ENABLE_FEATURE_FALSE) {
+                console.log('ENABLE_FEATURE_FALSE');
               }
             }
         `,
     },
     'should not transform feature flags when used with a ternary operator': {
         code: `
-            import { ENABLE_FEATURE_NULL } from '@lwc/features';
-            console.log(ENABLE_FEATURE_NULL ? 'foo' : 'bar');
+            import feats from '@lwc/features';
+            console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
         `,
         output: `
-            import { ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
-            console.log(ENABLE_FEATURE_NULL ? 'foo' : 'bar');
+            import feats, { runtimeFlags } from '@lwc/features';
+            console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
         `,
     },
     'should transform nested feature flags': {
         code: `
-            import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL } from '@lwc/features';
-            if (ENABLE_FEATURE_NULL) {
-                if (ENABLE_FEATURE_TRUE) {
+            import featureFlags from '@lwc/features';
+            if (featureFlags.ENABLE_FEATURE_NULL) {
+                if (featureFlags.ENABLE_FEATURE_TRUE) {
                     console.log('this looks like a bad idea');
                 }
             }
         `,
         output: `
-            import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
+            import featureFlags, { runtimeFlags } from '@lwc/features';
 
             if (runtimeFlags.ENABLE_FEATURE_NULL) {
               if (runtimeFlags.ENABLE_FEATURE_TRUE) {
                 console.log('this looks like a bad idea');
               }
-            }
-        `,
-    },
-    'should ignore invalid feature flags': {
-        code: `
-            import { invalidFeatureFlag } from '@lwc/features';
-            if (invalidFeatureFlag) {
-                console.log('invalidFeatureFlag');
-            }
-        `,
-        output: `
-            import { invalidFeatureFlag, runtimeFlags } from '@lwc/features';
-
-            if (invalidFeatureFlag) {
-              console.log('invalidFeatureFlag');
             }
         `,
     },
@@ -166,6 +166,93 @@ pluginTester({
     tests: nonProdTests,
 });
 
+// These tests override corresponding tests in nonProdTests since the plugin has
+// different outputs when prod:true.
+const nonProdTestOverrides = {
+    'should transform boolean-true feature flags': {
+        code: `
+            import features from '@lwc/features';
+            if (features.ENABLE_FEATURE_TRUE) {
+                console.log('ENABLE_FEATURE_TRUE');
+            }
+        `,
+        output: `
+          import features, { runtimeFlags } from '@lwc/features';
+          {
+            console.log('ENABLE_FEATURE_TRUE');
+          }
+        `,
+    },
+    'should transform boolean-false feature flags': {
+        code: `
+            import features from '@lwc/features';
+            if (features.ENABLE_FEATURE_FALSE) {
+                console.log('ENABLE_FEATURE_FALSE');
+            }
+        `,
+        output: `
+          import features, { runtimeFlags } from '@lwc/features';
+        `,
+    },
+    'should transform nested feature flags': {
+        code: `
+            import features from '@lwc/features';
+            if (features.ENABLE_FEATURE_NULL) {
+                if (features.ENABLE_FEATURE_TRUE) {
+                    console.log('nested feature flags sounds like a vary bad idea');
+                }
+            }
+            if (features.ENABLE_FEATURE_TRUE) {
+                if (features.ENABLE_FEATURE_NULL) {
+                    console.log('nested feature flags sounds like a vary bad idea');
+                }
+            }
+        `,
+        output: `
+          import features, { runtimeFlags } from '@lwc/features';
+
+          if (runtimeFlags.ENABLE_FEATURE_NULL) {
+            {
+              console.log('nested feature flags sounds like a vary bad idea');
+            }
+          }
+
+          {
+            if (runtimeFlags.ENABLE_FEATURE_NULL) {
+              console.log('nested feature flags sounds like a vary bad idea');
+            }
+          }
+        `,
+    },
+    'should not transform tests that are not an actual reference to the imported binding': {
+        code: `
+            import featureFlag from '@lwc/features';
+            if (featureFlag.ENABLE_FEATURE_FALSE) {
+                console.log('ENABLE_FEATURE_FALSE');
+            }
+            function awesome() {
+                const featureFlag = { ENABLE_FEATURE_FALSE: false };
+                if (featureFlag.ENABLE_FEATURE_FALSE) {
+                    console.log('ENABLE_FEATURE_FALSE');
+                }
+            }
+        `,
+        output: `
+            import featureFlag, { runtimeFlags } from '@lwc/features';
+
+            function awesome() {
+              const featureFlag = {
+                ENABLE_FEATURE_FALSE: false
+              };
+
+              if (featureFlag.ENABLE_FEATURE_FALSE) {
+                console.log('ENABLE_FEATURE_FALSE');
+              }
+            }
+        `,
+    },
+};
+
 pluginTester({
     title: 'prod environments',
     plugin,
@@ -174,80 +261,22 @@ pluginTester({
         prod: true,
     },
     babelOptions,
-    tests: Object.assign({}, nonProdTests, {
-        // Override of nonProdTest version
-        'should transform boolean-true feature flags': {
-            code: `
-                import { ENABLE_FEATURE_TRUE } from '@lwc/features';
-                if (ENABLE_FEATURE_TRUE) {
-                    console.log('ENABLE_FEATURE_TRUE');
-                }
-            `,
-            output: `
-                import { ENABLE_FEATURE_TRUE, runtimeFlags } from '@lwc/features';
-                {
-                  console.log('ENABLE_FEATURE_TRUE');
-                }
-            `,
-        },
-        // Override of nonProdTest version
-        'should transform boolean-false feature flags': {
-            code: `
-                import { ENABLE_FEATURE_FALSE } from '@lwc/features';
-                if (ENABLE_FEATURE_FALSE) {
-                    console.log('ENABLE_FEATURE_FALSE');
-                }
-            `,
-            output: `
-                import { ENABLE_FEATURE_FALSE, runtimeFlags } from '@lwc/features';
-            `,
-        },
-        // Override of nonProdTest version
-        'should transform nested feature flags': {
-            code: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL } from '@lwc/features';
-                if (ENABLE_FEATURE_NULL) {
-                    if (ENABLE_FEATURE_TRUE) {
-                        console.log('nested feature flags sounds like a vary bad idea');
-                    }
-                }
-                if (ENABLE_FEATURE_TRUE) {
-                    if (ENABLE_FEATURE_NULL) {
-                        console.log('nested feature flags sounds like a vary bad idea');
-                    }
-                }
-            `,
-            output: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
-
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                  {
-                    console.log('nested feature flags sounds like a vary bad idea');
-                  }
-                }
-
-                {
-                  if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('nested feature flags sounds like a vary bad idea');
-                  }
-                }
-            `,
-        },
+    tests: Object.assign({}, nonProdTests, nonProdTestOverrides, {
         'should transform both boolean and null feature flags': {
             code: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_FALSE, ENABLE_FEATURE_NULL } from '@lwc/features';
-                if (ENABLE_FEATURE_TRUE) {
+                import features from '@lwc/features';
+                if (features.ENABLE_FEATURE_TRUE) {
                     console.log('ENABLE_FEATURE_TRUE');
                 }
-                if (ENABLE_FEATURE_FALSE) {
+                if (features.ENABLE_FEATURE_FALSE) {
                     console.log('ENABLE_FEATURE_FALSE');
                 }
-                if (ENABLE_FEATURE_NULL) {
+                if (features.ENABLE_FEATURE_NULL) {
                     console.log('ENABLE_FEATURE_NULL');
                 }
             `,
             output: `
-                import { ENABLE_FEATURE_TRUE, ENABLE_FEATURE_FALSE, ENABLE_FEATURE_NULL, runtimeFlags } from '@lwc/features';
+                import features, { runtimeFlags } from '@lwc/features';
                 {
                   console.log('ENABLE_FEATURE_TRUE');
                 }

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -5,10 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export type FeatureFlag = boolean | null;
+export type FeatureFlagLookup = { [name: string]: FeatureFlag };
 
-export const ENABLE_FOO: FeatureFlag = true;
-export const ENABLE_BAR: FeatureFlag = false;
-export const ENABLE_BAZ: FeatureFlag = null;
+const featureFlagLookup: FeatureFlagLookup = {
+    ENABLE_FOO: true,
+    ENABLE_BAR: false,
+    ENABLE_REACTIVE_SETTER: null,
+};
+export default featureFlagLookup;
+
 export const ENABLE_REACTIVE_SETTER: FeatureFlag = null;
-
 export { runtimeFlags, setFeatureFlag, setFeatureFlagForTest } from './runtime';

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -4,15 +4,12 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export type FeatureFlag = boolean | null;
-export type FeatureFlagLookup = { [name: string]: FeatureFlag };
+export type FeatureFlagValue = boolean | null;
+export type FeatureFlagLookup = { [name: string]: FeatureFlagValue };
 
 const featureFlagLookup: FeatureFlagLookup = {
-    ENABLE_FOO: true,
-    ENABLE_BAR: false,
     ENABLE_REACTIVE_SETTER: null,
 };
 export default featureFlagLookup;
 
-export const ENABLE_REACTIVE_SETTER: FeatureFlag = null;
 export { runtimeFlags, setFeatureFlag, setFeatureFlagForTest } from './runtime';

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -4,14 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { FeatureFlag } from './flags';
+import { FeatureFlag, FeatureFlagLookup } from './flags';
 import { assert, create, isFalse, isTrue } from '@lwc/shared';
 
-interface FeatureFlagConfig {
-    [name: string]: FeatureFlag;
-}
-
-const runtimeFlags: FeatureFlagConfig = create(null);
+const runtimeFlags: FeatureFlagLookup = create(null);
 
 function setFeatureFlag(name: string, value: FeatureFlag) {
     assert.invariant(

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -9,6 +9,8 @@ import { assert, create, isFalse, isTrue } from '@lwc/shared';
 
 const runtimeFlags: FeatureFlagLookup = create(null);
 
+// This function is not whitelisted for use within components and is meant for
+// configuring runtime feature flags during app initialization.
 function setFeatureFlag(name: string, value: FeatureFlag) {
     assert.invariant(
         isTrue(value) || isFalse(value),
@@ -17,12 +19,12 @@ function setFeatureFlag(name: string, value: FeatureFlag) {
     runtimeFlags[name] = value;
 }
 
+// This function is added to the LWC API whitelist (for testing purposes) so we
+// add a check to make sure it is not invoked in production.
 function setFeatureFlagForTest(name: string, value: FeatureFlag) {
-    if (process.env.NODE_ENV === 'production') {
-        // this method must not leak to production
-        throw new ReferenceError();
+    if (process.env.NODE_ENV !== 'production') {
+        return setFeatureFlag(name, value);
     }
-    return setFeatureFlag(name, value);
 }
 
 export { runtimeFlags, setFeatureFlag, setFeatureFlagForTest };

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { FeatureFlagLookup, FeatureFlagValue } from './flags';
-import { assert, create, isFalse, isTrue } from '@lwc/shared';
+import features, { FeatureFlagLookup, FeatureFlagValue } from './flags';
+import { assert, create, isFalse, isTrue, isUndefined } from '@lwc/shared';
 
 const runtimeFlags: FeatureFlagLookup = create(null);
 
@@ -14,8 +14,13 @@ const runtimeFlags: FeatureFlagLookup = create(null);
 function setFeatureFlag(name: string, value: FeatureFlagValue) {
     assert.invariant(
         isTrue(value) || isFalse(value),
-        `Runtime feature flags must be set to a boolean value but received a(n) ${typeof value} value for the '${name}' flag.`
+        `Invalid ${typeof value} value specified for the "${name}" flag. Runtime feature flags can only be set to a boolean value.`
     );
+    if (isUndefined(features[name])) {
+        console.warn(
+            `LWC feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
+        );
+    }
     runtimeFlags[name] = value;
 }
 
@@ -23,6 +28,11 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
 // add a check to make sure it is not invoked in production.
 function setFeatureFlagForTest(name: string, value: FeatureFlagValue) {
     if (process.env.NODE_ENV !== 'production') {
+        if (isUndefined(features[name])) {
+            throw new Error(
+                `Feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
+            );
+        }
         return setFeatureFlag(name, value);
     }
 }

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { FeatureFlag, FeatureFlagLookup } from './flags';
+import { FeatureFlagLookup, FeatureFlagValue } from './flags';
 import { assert, create, isFalse, isTrue } from '@lwc/shared';
 
 const runtimeFlags: FeatureFlagLookup = create(null);
 
 // This function is not whitelisted for use within components and is meant for
 // configuring runtime feature flags during app initialization.
-function setFeatureFlag(name: string, value: FeatureFlag) {
+function setFeatureFlag(name: string, value: FeatureFlagValue) {
     assert.invariant(
         isTrue(value) || isFalse(value),
         `Runtime feature flags must be set to a boolean value but received a(n) ${typeof value} value for the '${name}' flag.`
@@ -21,7 +21,7 @@ function setFeatureFlag(name: string, value: FeatureFlag) {
 
 // This function is added to the LWC API whitelist (for testing purposes) so we
 // add a check to make sure it is not invoked in production.
-function setFeatureFlagForTest(name: string, value: FeatureFlag) {
+function setFeatureFlagForTest(name: string, value: FeatureFlagValue) {
     if (process.env.NODE_ENV !== 'production') {
         return setFeatureFlag(name, value);
     }

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -5,17 +5,22 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import features, { FeatureFlagLookup, FeatureFlagValue } from './flags';
-import { assert, create, isFalse, isTrue, isUndefined } from '@lwc/shared';
+import { create, isFalse, isTrue, isUndefined } from '@lwc/shared';
 
 const runtimeFlags: FeatureFlagLookup = create(null);
 
 // This function is not whitelisted for use within components and is meant for
 // configuring runtime feature flags during app initialization.
 function setFeatureFlag(name: string, value: FeatureFlagValue) {
-    assert.invariant(
-        isTrue(value) || isFalse(value),
-        `Invalid ${typeof value} value specified for the "${name}" flag. Runtime feature flags can only be set to a boolean value.`
-    );
+    const isBoolean = isTrue(value) || isFalse(value);
+    if (!isBoolean) {
+        const message = `Invalid ${typeof value} value specified for the "${name}" flag. Runtime feature flags can only be set to a boolean value.`;
+        if (process.env.NODE_ENV === 'production') {
+            console.error(message);
+        } else {
+            throw new TypeError(message);
+        }
+    }
     if (isUndefined(features[name])) {
         console.warn(
             `LWC feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -21,12 +21,13 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
             throw new TypeError(message);
         }
     }
-    if (isUndefined(features[name])) {
+    if (!isUndefined(features[name])) {
+        runtimeFlags[name] = value;
+    } else {
         console.warn(
             `LWC feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
         );
     }
-    runtimeFlags[name] = value;
 }
 
 // This function is added to the LWC API whitelist (for testing purposes) so we


### PR DESCRIPTION
## Details

This allows us to do extra validation that identifies attempts to set feature flags that aren't defined.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`