### PR TITLE
fix(engine): refactor boundary protection for render phase

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -23,7 +23,8 @@ import {
     toString,
 } from '@lwc/shared';
 import { logError } from '../shared/assert';
-import { vmBeingRendered, invokeEventListener, invokeComponentCallback } from './invoker';
+import { invokeEventListener, invokeComponentCallback } from './invoker';
+import { getVMBeingRendered } from './template';
 import {
     EmptyArray,
     resolveCircularModuleDependency,
@@ -229,11 +230,12 @@ function addNS(vnode: VElement) {
 }
 
 function addVNodeToChildLWC(vnode: VCustomElement) {
-    ArrayPush.call((vmBeingRendered as VM).velements, vnode);
+    ArrayPush.call((getVMBeingRendered() as VM).velements, vnode);
 }
 
 // [h]tml node
 export function h(sel: string, data: ElementCompilerData, children: VNodes): VElement {
+    const vmBeingRendered = getVMBeingRendered();
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `h() 1st argument sel must be a string.`);
         assert.isTrue(isObject(data), `h() 2nd argument data must be an object.`);
@@ -302,6 +304,7 @@ export function ti(value: any): number {
     // If value is less than -1, we don't care
     const shouldNormalize = value > 0 && !(isTrue(value) || isFalse(value));
     if (process.env.NODE_ENV !== 'production') {
+        const vmBeingRendered = getVMBeingRendered();
         if (shouldNormalize) {
             logError(
                 `Invalid tabindex value \`${toString(
@@ -351,7 +354,7 @@ export function c(
     if (isCircularModuleDependency(Ctor)) {
         Ctor = resolveCircularModuleDependency(Ctor);
     }
-
+    const vmBeingRendered = getVMBeingRendered();
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `c() 1st argument sel must be a string.`);
         assert.isTrue(isFunction(Ctor), `c() 2nd argument Ctor must be a function.`);
@@ -420,6 +423,7 @@ export function i(
     const list: VNodes = [];
     // TODO: #1276 - compiler should give us some sort of indicator when a vnodes collection is dynamic
     sc(list);
+    const vmBeingRendered = getVMBeingRendered();
     if (isUndefined(iterable) || iterable === null) {
         if (process.env.NODE_ENV !== 'production') {
             logError(
@@ -541,7 +545,7 @@ export function t(text: string): VText {
         key,
 
         hook: TextHook,
-        owner: vmBeingRendered as VM,
+        owner: getVMBeingRendered() as VM,
     };
 }
 
@@ -559,7 +563,7 @@ export function p(text: string): VComment {
         key,
 
         hook: CommentHook,
-        owner: vmBeingRendered as VM,
+        owner: getVMBeingRendered() as VM,
     };
 }
 
@@ -573,6 +577,7 @@ export function d(value: any): VNode | null {
 
 // [b]ind function
 export function b(fn: EventListener): EventListener {
+    const vmBeingRendered = getVMBeingRendered();
     if (isNull(vmBeingRendered)) {
         throw new Error();
     }
@@ -584,6 +589,7 @@ export function b(fn: EventListener): EventListener {
 
 // [f]unction_[b]ind
 export function fb(fn: (...args: any[]) => any): () => any {
+    const vmBeingRendered = getVMBeingRendered();
     if (isNull(vmBeingRendered)) {
         throw new Error();
     }
@@ -599,10 +605,10 @@ export function ll(
     id: string,
     context?: (...args: any[]) => any
 ): EventListener {
-    if (isNull(vmBeingRendered)) {
+    const vm: VM | null = getVMBeingRendered();
+    if (isNull(vm)) {
         throw new Error();
     }
-    const vm: VM = vmBeingRendered;
     // bind the original handler with b() so we can call it
     // after resolving the locator
     const eventListener = b(originalHandler);
@@ -642,7 +648,7 @@ export function k(compilerKey: number, obj: any): string | void {
         case 'object':
             if (process.env.NODE_ENV !== 'production') {
                 assert.fail(
-                    `Invalid key value "${obj}" in ${vmBeingRendered}. Key must be a string or number.`
+                    `Invalid key value "${obj}" in ${getVMBeingRendered()}. Key must be a string or number.`
                 );
             }
     }
@@ -650,6 +656,7 @@ export function k(compilerKey: number, obj: any): string | void {
 
 // [g]lobal [id] function
 export function gid(id: string | undefined | null): string | null | undefined {
+    const vmBeingRendered = getVMBeingRendered();
     if (isUndefined(id) || id === '') {
         if (process.env.NODE_ENV !== 'production') {
             logError(
@@ -668,6 +675,7 @@ export function gid(id: string | undefined | null): string | null | undefined {
 
 // [f]ragment [id] function
 export function fid(url: string | undefined | null): string | null | undefined {
+    const vmBeingRendered = getVMBeingRendered();
     if (isUndefined(url) || url === '') {
         if (process.env.NODE_ENV !== 'production') {
             if (isUndefined(url)) {

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -7,12 +7,13 @@
 import { ENABLE_REACTIVE_SETTER } from '@lwc/features';
 import { assert, isFalse, isFunction, isObject, isTrue, isUndefined, toString } from '@lwc/shared';
 import { logError } from '../../shared/assert';
-import { isRendering, vmBeingRendered, isBeingConstructed } from '../invoker';
+import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { valueObserved, valueMutated, ReactiveObserver } from '../../libs/mutation-tracker';
 import { ComponentInterface, ComponentConstructor } from '../component';
 import { getComponentVM, rerenderVM } from '../vm';
 import { getDecoratorsRegisteredMeta } from './register';
 import { addCallbackToNextTick } from '../utils';
+import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
 /**
  * @api decorator to mark public fields and public methods in
@@ -88,10 +89,17 @@ function createPublicPropertyDescriptor(
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
+                        key
+                    )}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                         key
                     )}`
                 );
@@ -174,9 +182,16 @@ function createPublicAccessorDescriptor(
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
+                        key
+                    )}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                         key
                     )}`
                 );

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFalse, isUndefined } from '@lwc/shared';
-import { isRendering, vmBeingRendered } from '../invoker';
+import { assert, isFalse, isUndefined, toString } from '@lwc/shared';
 import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
+import { isInvokingRender } from '../invoker';
 import { getComponentVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentConstructor, ComponentInterface } from '../component';
+import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
 /**
  * @track decorator to mark fields as reactive in
@@ -71,10 +72,17 @@ export function createTrackedPropertyDescriptor(
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
-                    !isRendering,
-                    `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${String(
+                    !isInvokingRender,
+                    `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
+                        key
+                    )}`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                         key
                     )}`
                 );

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -23,8 +23,9 @@ import {
 import { logError } from '../shared/assert';
 import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
-import { isBeingConstructed, isRendering, vmBeingRendered } from './invoker';
+import { isBeingConstructed, isInvokingRender } from './invoker';
 import { getShadowRootVM, getComponentVM } from './vm';
+import { isUpdatingTemplate, getVMBeingRendered } from './template';
 
 function generateDataDescriptor(options: PropertyDescriptor): PropertyDescriptor {
     return assign(
@@ -217,9 +218,16 @@ function getShadowRootRestrictionsDescriptors(
                 listener: EventListener,
                 options?: boolean | AddEventListenerOptions
             ) {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
+                        sr
+                    )} by adding an event listener for "${type}".`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${toString(
                         sr
                     )} by adding an event listener for "${type}".`
                 );
@@ -327,10 +335,17 @@ function getCustomElementRestrictionsDescriptors(
                 listener: EventListener,
                 options?: boolean | AddEventListenerOptions
             ) {
+                const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
-                    !isRendering,
+                    !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${toString(
                         this
+                    )} by adding an event listener for "${type}".`
+                );
+                assert.invariant(
+                    !isUpdatingTemplate,
+                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${toString(
+                        elm
                     )} by adding an event listener for "${type}".`
                 );
                 // TODO: #420 - this is triggered when the component author attempts to add a listener

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -22,7 +22,7 @@ import { VNode, VNodes } from '../3rdparty/snabbdom/types';
 import * as api from './api';
 import { RenderAPI } from './api';
 import { Context } from './context';
-import { SlotSet, VM, resetShadowRoot } from './vm';
+import { SlotSet, VM, resetShadowRoot, runWithBoundaryProtection } from './vm';
 import { EmptyArray } from './utils';
 import { isTemplateRegistered, registerTemplate } from './secure-template';
 import {
@@ -31,6 +31,17 @@ import {
     applyStyleAttributes,
     resetStyleAttributes,
 } from './stylesheet';
+import { startMeasure, endMeasure } from './performance-timing';
+
+export let isUpdatingTemplate: boolean = false;
+
+let vmBeingRendered: VM | null = null;
+export function getVMBeingRendered(): VM | null {
+    return vmBeingRendered;
+}
+export function setVMBeingRendered(vm: VM | null) {
+    vmBeingRendered = vm;
+}
 
 export { registerTemplate };
 export interface Template {
@@ -120,69 +131,102 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
             )}`
         );
     }
+    const isUpdatingTemplateInception = isUpdatingTemplate;
+    const vmOfTemplateBeingUpdatedInception = vmBeingRendered;
+    let vnodes: VNodes = [];
 
-    const { component, context, cmpSlots, cmpTemplate } = vm;
-    // reset the cache memoizer for template when needed
-    if (html !== cmpTemplate) {
-        // perf opt: do not reset the shadow root during the first rendering (there is nothing to reset)
-        if (!isUndefined(cmpTemplate)) {
-            // It is important to reset the content to avoid reusing similar elements generated from a different
-            // template, because they could have similar IDs, and snabbdom just rely on the IDs.
-            resetShadowRoot(vm);
+    runWithBoundaryProtection(
+        vm,
+        vm.owner,
+        () => {
+            // pre
+            vmBeingRendered = vm;
+            if (process.env.NODE_ENV !== 'production') {
+                startMeasure('render', vm);
+            }
+        },
+        () => {
+            // job
+            const { component, context, cmpSlots, cmpTemplate, tro } = vm;
+            tro.observe(() => {
+                // reset the cache memoizer for template when needed
+                if (html !== cmpTemplate) {
+                    // perf opt: do not reset the shadow root during the first rendering (there is nothing to reset)
+                    if (!isUndefined(cmpTemplate)) {
+                        // It is important to reset the content to avoid reusing similar elements generated from a different
+                        // template, because they could have similar IDs, and snabbdom just rely on the IDs.
+                        resetShadowRoot(vm);
+                    }
+
+                    // Check that the template was built by the compiler
+                    if (isUndefined(html) || !isTemplateRegistered(html)) {
+                        throw new TypeError(
+                            `Invalid template returned by the render() method on ${vm}. It must return an imported template (e.g.: \`import html from "./${
+                                vm.def.name
+                            }.html"\`), instead, it has returned: ${toString(html)}.`
+                        );
+                    }
+
+                    vm.cmpTemplate = html;
+
+                    // Populate context with template information
+                    context.tplCache = create(null);
+
+                    resetStyleAttributes(vm);
+
+                    const { stylesheets, stylesheetTokens } = html;
+                    if (isUndefined(stylesheets) || stylesheets.length === 0) {
+                        context.styleVNode = null;
+                    } else if (!isUndefined(stylesheetTokens)) {
+                        const { hostAttribute, shadowAttribute } = stylesheetTokens;
+                        applyStyleAttributes(vm, hostAttribute, shadowAttribute);
+                        // Caching style vnode so it can be reused on every render
+                        context.styleVNode = evaluateCSS(
+                            vm,
+                            stylesheets,
+                            hostAttribute,
+                            shadowAttribute
+                        );
+                    }
+
+                    if (process.env.NODE_ENV !== 'production') {
+                        // one time operation for any new template returned by render()
+                        // so we can warn if the template is attempting to use a binding
+                        // that is not provided by the component instance.
+                        validateFields(vm, html);
+                    }
+                }
+
+                if (process.env.NODE_ENV !== 'production') {
+                    assert.isTrue(
+                        isObject(context.tplCache),
+                        `vm.context.tplCache must be an object associated to ${cmpTemplate}.`
+                    );
+                    // validating slots in every rendering since the allocated content might change over time
+                    validateSlots(vm, html);
+                }
+                // right before producing the vnodes, we clear up all internal references
+                // to custom elements from the template.
+                vm.velements = [];
+                // Set the global flag that template is being updated
+                isUpdatingTemplate = true;
+
+                vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
+                const { styleVNode } = context;
+                if (!isNull(styleVNode)) {
+                    ArrayUnshift.call(vnodes, styleVNode);
+                }
+            });
+        },
+        () => {
+            // post
+            isUpdatingTemplate = isUpdatingTemplateInception;
+            vmBeingRendered = vmOfTemplateBeingUpdatedInception;
+            if (process.env.NODE_ENV !== 'production') {
+                endMeasure('render', vm);
+            }
         }
-
-        // Check that the template was built by the compiler
-        if (!isTemplateRegistered(html)) {
-            throw new TypeError(
-                `Invalid template returned by the render() method on ${vm}. It must return an imported template (e.g.: \`import html from "./${
-                    vm.def.name
-                }.html"\`), instead, it has returned: ${toString(html)}.`
-            );
-        }
-
-        vm.cmpTemplate = html;
-
-        // Populate context with template information
-        context.tplCache = create(null);
-
-        resetStyleAttributes(vm);
-
-        const { stylesheets, stylesheetTokens } = html;
-        if (isUndefined(stylesheets) || stylesheets.length === 0) {
-            context.styleVNode = null;
-        } else if (!isUndefined(stylesheetTokens)) {
-            const { hostAttribute, shadowAttribute } = stylesheetTokens;
-            applyStyleAttributes(vm, hostAttribute, shadowAttribute);
-            // Caching style vnode so it can be reused on every render
-            context.styleVNode = evaluateCSS(vm, stylesheets, hostAttribute, shadowAttribute);
-        }
-
-        if (process.env.NODE_ENV !== 'production') {
-            // one time operation for any new template returned by render()
-            // so we can warn if the template is attempting to use a binding
-            // that is not provided by the component instance.
-            validateFields(vm, html);
-        }
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(
-            isObject(context.tplCache),
-            `vm.context.tplCache must be an object associated to ${cmpTemplate}.`
-        );
-        // validating slots in every rendering since the allocated content might change over time
-        validateSlots(vm, html);
-    }
-    // right before producing the vnodes, we clear up all internal references
-    // to custom elements from the template.
-    vm.velements = [];
-    // invoke the selected template.
-    const vnodes: VNodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
-
-    const { styleVNode } = context;
-    if (!isNull(styleVNode)) {
-        ArrayUnshift.call(vnodes, styleVNode);
-    }
+    );
 
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import Parent from 'x/dualTemplate1506';
+
+it('setting tracked value in disconnectedCallback should not throw', () => {
+    const elm = createElement('x-parent', { is: Parent });
+    document.body.appendChild(elm);
+    expect(
+        elm.shadowRoot.querySelector('x-disconnected-callback-sets-tracked-value')
+    ).not.toBeNull();
+    elm.toggleTemplate();
+
+    return Promise.resolve().then(() => {
+        expect(elm.shadowRoot.querySelector('div').textContent).toBe('simple template');
+    });
+});

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.html
@@ -1,0 +1,3 @@
+<template>
+    <div>Child Component</div>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/disconnectedCallbackSetsTrackedValue/disconnectedCallbackSetsTrackedValue.js
@@ -1,0 +1,10 @@
+import { LightningElement, track } from 'lwc';
+
+export default class Child extends LightningElement {
+    @track
+    state = true;
+
+    disconnectedCallback() {
+        this.state = false;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/dualTemplate1506.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/dualTemplate1506.js
@@ -1,0 +1,16 @@
+import { LightningElement, api, track } from 'lwc';
+import SimpleTemplate from './simpleTemplate.html';
+import TemplateWithChild from './templateWithChild.html';
+
+export default class Parent extends LightningElement {
+    @track _toggle = false;
+
+    @api
+    toggleTemplate() {
+        this._toggle = !this._toggle;
+    }
+
+    render() {
+        return this._toggle ? SimpleTemplate : TemplateWithChild;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/simpleTemplate.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/simpleTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <div>simple template</div>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/templateWithChild.html
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/x/dualTemplate1506/templateWithChild.html
@@ -1,0 +1,3 @@
+<template>
+    <x-disconnected-callback-sets-tracked-value></x-disconnected-callback-sets-tracked-value>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -70,3 +70,29 @@ it('supports returning different templates', () => {
         expect(elm.shadowRoot.textContent).toBe('Template 2');
     });
 });
+
+// The error in this test case happens in a Promise chain that is not within the control of the test.
+// Hence the error has to be caught at the top level
+if ('onunhandledrejection' in window) {
+    describe('should throw error during async rehydration', () => {
+        let listener;
+        afterEach(() => {
+            // Cleanup listener after test
+            window.removeEventListener('unhandledrejection', listener);
+        });
+        it('should throw when render() switches a valid template with an undefined value', done => {
+            const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
+            elm.template = template1;
+            document.body.appendChild(elm);
+
+            elm.template = undefined;
+            listener = event => {
+                expect(event.reason).toMatch(
+                    /Assert Violation: evaluateTemplate\(\) second argument must be an imported template instead of undefined/
+                );
+                done();
+            };
+            window.addEventListener('unhandledrejection', listener);
+        });
+    });
+}


### PR DESCRIPTION
## Details
Porting changes from https://github.com/salesforce/lwc/pull/1507

1. User land code is protected from making dangerous mutation during rendering phase.
2. Rendering a component is two steps, first the render() is invoked and then the returned template is evaluated.
3. The userland code was being protected using one global flag called `isRendering`. 
4.  In between these two steps, the engine is executing its own routine and does not need to be protected from dangerous mutations.

This PR separates the flag into two. One for render invocation and another for template evaluation.

Fixes issue https://github.com/salesforce/lwc/issues/1506

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`


If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
