### PR TITLE
fix(synthetic-shadow): do not patch lwc root elements

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -7,9 +7,7 @@
 import {
     ArrayFilter,
     ArrayFind,
-    ArrayPush,
     ArraySlice,
-    assert,
     defineProperties,
     defineProperty,
     getOwnPropertyDescriptor,
@@ -28,9 +26,9 @@ import {
     getNodeOwner,
     getAllMatches,
     getFilteredChildNodes,
-    isSlotElement,
-    isNodeOwnedBy,
     getFirstMatch,
+    getAllSlottedMatches,
+    getFirstSlottedMatch,
 } from './traverse';
 import {
     childrenGetter,
@@ -43,17 +41,7 @@ import {
 } from '../env/element';
 import { createStaticNodeList } from '../shared/static-node-list';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
-import {
-    getNodeKey,
-    getNodeNearestOwnerKey,
-    getInternalChildNodes,
-    hasMountedChildren,
-} from './node';
-import {
-    compareDocumentPosition,
-    DOCUMENT_POSITION_CONTAINS,
-    parentElementGetter,
-} from '../env/node';
+import { getNodeKey, getInternalChildNodes, hasMountedChildren } from './node';
 import {
     innerHTMLSetter,
     getElementsByClassName as elementGetElementsByClassName,
@@ -65,17 +53,13 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { arrayFromCollection, isGlobalPatchingSkipped } from '../shared/utils';
 import { getNodeOwnerKey, isNodeShadowed } from '../faux-shadow/node';
 import { assignedSlotGetterPatched } from './slot';
+import { getNonPatchedFilteredCollectionResult } from './no-patch-utils';
 
-const {
-    DISABLE_ELEMENT_PATCH,
-    ENABLE_NODE_LIST_PATCH,
-    ENABLE_HTML_COLLECTIONS_PATCH,
-} = getInitializedFeatureFlags();
+const { DISABLE_ELEMENT_PATCH, ENABLE_NODE_LIST_PATCH } = getInitializedFeatureFlags();
 
 function getInitializedFeatureFlags() {
     let DISABLE_ELEMENT_PATCH;
     let ENABLE_NODE_LIST_PATCH;
-    let ENABLE_HTML_COLLECTIONS_PATCH;
 
     if (featureFlags.ENABLE_ELEMENT_PATCH) {
         DISABLE_ELEMENT_PATCH = false;
@@ -89,117 +73,10 @@ function getInitializedFeatureFlags() {
         ENABLE_NODE_LIST_PATCH = false;
     }
 
-    if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-        ENABLE_HTML_COLLECTIONS_PATCH = true;
-    } else {
-        ENABLE_HTML_COLLECTIONS_PATCH = false;
-    }
-
     return {
         DISABLE_ELEMENT_PATCH,
         ENABLE_NODE_LIST_PATCH,
-        ENABLE_HTML_COLLECTIONS_PATCH,
     };
-}
-
-// when finding a slot in the DOM, we can fold it if it is contained
-// inside another slot.
-function foldSlotElement(slot: HTMLElement) {
-    let parent = parentElementGetter.call(slot);
-    while (!isNull(parent) && isSlotElement(parent)) {
-        slot = parent as HTMLElement;
-        parent = parentElementGetter.call(slot);
-    }
-    return slot;
-}
-
-function isNodeSlotted(host: Element, node: Node): boolean {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            host instanceof HTMLElement,
-            `isNodeSlotted() should be called with a host as the first argument instead of ${host}`
-        );
-        assert.invariant(
-            node instanceof Node,
-            `isNodeSlotted() should be called with a node as the second argument instead of ${node}`
-        );
-        assert.invariant(
-            compareDocumentPosition.call(node, host) & DOCUMENT_POSITION_CONTAINS,
-            `isNodeSlotted() should never be called with a node that is not a child node of ${host}`
-        );
-    }
-    const hostKey = getNodeKey(host);
-    // this routine assumes that the node is coming from a different shadow (it is not owned by the host)
-    // just in case the provided node is not an element
-    let currentElement = node instanceof Element ? node : parentElementGetter.call(node);
-    while (!isNull(currentElement) && currentElement !== host) {
-        const elmOwnerKey = getNodeNearestOwnerKey(currentElement);
-        const parent = parentElementGetter.call(currentElement);
-        if (elmOwnerKey === hostKey) {
-            // we have reached an element inside the host's template, and only if
-            // that element is an slot, then the node is considered slotted
-            return isSlotElement(currentElement);
-        } else if (parent === host) {
-            return false;
-        } else if (!isNull(parent) && getNodeNearestOwnerKey(parent) !== elmOwnerKey) {
-            // we are crossing a boundary of some sort since the elm and its parent
-            // have different owner key. for slotted elements, this is possible
-            // if the parent happens to be a slot.
-            if (isSlotElement(parent)) {
-                /**
-                 * the slot parent might be allocated inside another slot, think of:
-                 * <x-root> (<--- root element)
-                 *    <x-parent> (<--- own by x-root)
-                 *       <x-child> (<--- own by x-root)
-                 *           <slot> (<--- own by x-child)
-                 *               <slot> (<--- own by x-parent)
-                 *                  <div> (<--- own by x-root)
-                 *
-                 * while checking if x-parent has the div slotted, we need to traverse
-                 * up, but when finding the first slot, we skip that one in favor of the
-                 * most outer slot parent before jumping into its corresponding host.
-                 */
-                currentElement = getNodeOwner(foldSlotElement(parent as HTMLElement));
-                if (!isNull(currentElement)) {
-                    if (currentElement === host) {
-                        // the slot element is a top level element inside the shadow
-                        // of a host that was allocated into host in question
-                        return true;
-                    } else if (getNodeNearestOwnerKey(currentElement) === hostKey) {
-                        // the slot element is an element inside the shadow
-                        // of a host that was allocated into host in question
-                        return true;
-                    }
-                }
-            } else {
-                return false;
-            }
-        } else {
-            currentElement = parent;
-        }
-    }
-    return false;
-}
-
-function getAllSlottedMatches(host: Element, nodeList: NodeList | Node[]): Array<Node & Element> {
-    const filteredAndPatched = [];
-    for (let i = 0, len = nodeList.length; i < len; i += 1) {
-        const node = nodeList[i];
-        if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
-            ArrayPush.call(filteredAndPatched, node);
-        }
-    }
-    return filteredAndPatched;
-}
-
-function getFirstSlottedMatch(host: Element, nodeList: Element[]): Element | null {
-    for (let i = 0, len = nodeList.length; i < len; i += 1) {
-        const node = nodeList[i] as Element;
-        if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
-            return node;
-        }
-    }
-    return null;
 }
 
 function innerHTMLGetterPatched(this: Element): string {
@@ -506,15 +383,16 @@ defineProperties(Element.prototype, {
     },
     getElementsByClassName: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [string])
             );
 
-            const filteredResults = getFilteredNodeListQueryResult(
-                this,
-                elements,
-                ENABLE_HTML_COLLECTIONS_PATCH
-            );
+            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                filteredResults = getFilteredNodeListQueryResult(this, elements, true);
+            } else {
+                filteredResults = getNonPatchedFilteredCollectionResult(this, elements);
+            }
 
             return createStaticHTMLCollection(filteredResults);
         },
@@ -524,15 +402,16 @@ defineProperties(Element.prototype, {
     },
     getElementsByTagName: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
             );
 
-            const filteredResults = getFilteredNodeListQueryResult(
-                this,
-                elements,
-                ENABLE_HTML_COLLECTIONS_PATCH
-            );
+            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                filteredResults = getFilteredNodeListQueryResult(this, elements, true);
+            } else {
+                filteredResults = getNonPatchedFilteredCollectionResult(this, elements);
+            }
 
             return createStaticHTMLCollection(filteredResults);
         },
@@ -542,6 +421,7 @@ defineProperties(Element.prototype, {
     },
     getElementsByTagNameNS: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByTagNameNS.apply(this, ArraySlice.call(arguments) as [
                     string,
@@ -549,11 +429,11 @@ defineProperties(Element.prototype, {
                 ])
             );
 
-            const filteredResults = getFilteredNodeListQueryResult(
-                this,
-                elements,
-                ENABLE_HTML_COLLECTIONS_PATCH
-            );
+            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                filteredResults = getFilteredNodeListQueryResult(this, elements, true);
+            } else {
+                filteredResults = getNonPatchedFilteredCollectionResult(this, elements);
+            }
 
             return createStaticHTMLCollection(filteredResults);
         },

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -57,6 +57,11 @@ import { getNonPatchedFilteredArrayOfNodes } from './no-patch-utils';
 
 const { DISABLE_ELEMENT_PATCH, ENABLE_NODE_LIST_PATCH } = getInitializedFeatureFlags();
 
+enum ShadowDomSemantic {
+    Disabled = 0,
+    Enabled,
+}
+
 function getInitializedFeatureFlags() {
     let DISABLE_ELEMENT_PATCH;
     let ENABLE_NODE_LIST_PATCH;
@@ -307,7 +312,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
 function getFilteredArrayOfNodes<T extends Node>(
     context: Element,
     unfilteredNodes: T[],
-    isShadowSemanticEnforced: boolean
+    shadowDomSemantic: ShadowDomSemantic
 ): T[] {
     let filtered: T[];
     if (isHostElement(context)) {
@@ -325,7 +330,7 @@ function getFilteredArrayOfNodes<T extends Node>(
     } else if (isNodeShadowed(context)) {
         // element inside a shadowRoot
         const ownerKey = getNodeOwnerKey(context);
-        if (!isUndefined(ownerKey) || isShadowSemanticEnforced) {
+        if (!isUndefined(ownerKey) || shadowDomSemantic === ShadowDomSemantic.Enabled) {
             // The patch is enabled or `context` is an element rendered by lwc
             filtered = ArrayFilter.call(unfilteredNodes, elm => getNodeOwnerKey(elm) === ownerKey);
         } else {
@@ -333,7 +338,7 @@ function getFilteredArrayOfNodes<T extends Node>(
             filtered = ArraySlice.call(unfilteredNodes);
         }
     } else {
-        if (context instanceof HTMLBodyElement || isShadowSemanticEnforced) {
+        if (context instanceof HTMLBodyElement || shadowDomSemantic === ShadowDomSemantic.Enabled) {
             // `context` is document.body or element belonging to the document with the patch enabled
             filtered = ArrayFilter.call(
                 unfilteredNodes,
@@ -372,9 +377,17 @@ defineProperties(Element.prototype, {
             let filteredResults;
 
             if (featureFlags.ENABLE_NODE_LIST_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(this, nodeList, true);
+                filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    nodeList,
+                    ShadowDomSemantic.Enabled
+                );
             } else {
-                filteredResults = getFilteredArrayOfNodes(this, nodeList, false);
+                filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    nodeList,
+                    ShadowDomSemantic.Disabled
+                );
             }
 
             return createStaticNodeList(filteredResults);
@@ -391,7 +404,11 @@ defineProperties(Element.prototype, {
             );
 
             if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(this, elements, true);
+                filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    elements,
+                    ShadowDomSemantic.Enabled
+                );
             } else {
                 filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }
@@ -410,7 +427,11 @@ defineProperties(Element.prototype, {
             );
 
             if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(this, elements, true);
+                filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    elements,
+                    ShadowDomSemantic.Enabled
+                );
             } else {
                 filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }
@@ -432,7 +453,11 @@ defineProperties(Element.prototype, {
             );
 
             if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(this, elements, true);
+                filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    elements,
+                    ShadowDomSemantic.Enabled
+                );
             } else {
                 filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -58,7 +58,7 @@ import { getNonPatchedFilteredArrayOfNodes } from './no-patch-utils';
 const { DISABLE_ELEMENT_PATCH, ENABLE_NODE_LIST_PATCH } = getInitializedFeatureFlags();
 
 enum ShadowDomSemantic {
-    Disabled = 0,
+    Disabled,
     Enabled,
 }
 
@@ -374,21 +374,13 @@ defineProperties(Element.prototype, {
             const nodeList = arrayFromCollection(
                 elementQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [string])
             );
-            let filteredResults;
+            let shadowDomSemantic = ShadowDomSemantic.Disabled;
 
             if (featureFlags.ENABLE_NODE_LIST_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(
-                    this,
-                    nodeList,
-                    ShadowDomSemantic.Enabled
-                );
-            } else {
-                filteredResults = getFilteredArrayOfNodes(
-                    this,
-                    nodeList,
-                    ShadowDomSemantic.Disabled
-                );
+                shadowDomSemantic = ShadowDomSemantic.Enabled;
             }
+
+            const filteredResults = getFilteredArrayOfNodes(this, nodeList, shadowDomSemantic);
 
             return createStaticNodeList(filteredResults);
         },

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import { isHostElement } from './shadow-root';
 import { getAllMatches, getNodeOwner, getAllSlottedMatches } from './traverse';
 import { ArrayFilter, ArraySlice, isNull, isUndefined } from '@lwc/shared';

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -17,8 +17,9 @@ export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
     let filtered: T[];
 
     const ownerKey = getNodeOwnerKey(context);
+
+    // a node inside a shadow.
     if (!isUndefined(ownerKey)) {
-        // a node inside a shadow.
         if (isHostElement(context)) {
             // element with shadowRoot attached
             const owner = getNodeOwner(context);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -1,0 +1,41 @@
+import { isHostElement } from './shadow-root';
+import { getAllMatches, getNodeOwner, getAllSlottedMatches } from './traverse';
+import { ArrayFilter, ArraySlice, isNull, isUndefined } from '@lwc/shared';
+import { getNodeKey, getNodeOwnerKey } from './node';
+import { isGlobalPatchingSkipped } from '../shared/utils';
+
+export function getNonPatchedFilteredCollectionResult(context: Element, nodeList): Element[] {
+    let filtered: Element[];
+
+    const ownerKey = getNodeOwnerKey(context);
+    if (!isUndefined(ownerKey)) {
+        // a node inside a shadow.
+        if (isHostElement(context)) {
+            // element with shadowRoot attached
+            const owner = getNodeOwner(context);
+            if (isNull(owner)) {
+                filtered = [];
+            } else if (getNodeKey(context)) {
+                // it is a custom element, and we should then filter by slotted elements
+                filtered = getAllSlottedMatches(context, nodeList);
+            } else {
+                // regular element, we should then filter by ownership
+                filtered = getAllMatches(owner, nodeList);
+            }
+        } else {
+            filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
+        }
+    } else if (context instanceof HTMLBodyElement) {
+        // `context` is document.body which is already patched.
+        filtered = ArrayFilter.call(
+            nodeList,
+            // TODO: issue #1222 - remove global bypass
+            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
+        );
+    } else {
+        // `context` is outside the lwc boundary, return unfiltered list.
+        filtered = ArraySlice.call(nodeList);
+    }
+
+    return filtered;
+}

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -10,8 +10,11 @@ import { ArrayFilter, ArraySlice, isNull, isUndefined } from '@lwc/shared';
 import { getNodeKey, getNodeOwnerKey } from './node';
 import { isGlobalPatchingSkipped } from '../shared/utils';
 
-export function getNonPatchedFilteredCollectionResult(context: Element, nodeList): Element[] {
-    let filtered: Element[];
+export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
+    context: Element,
+    unfilteredNodes: Array<T>
+): Array<T> {
+    let filtered: T[];
 
     const ownerKey = getNodeOwnerKey(context);
     if (!isUndefined(ownerKey)) {
@@ -23,24 +26,24 @@ export function getNonPatchedFilteredCollectionResult(context: Element, nodeList
                 filtered = [];
             } else if (getNodeKey(context)) {
                 // it is a custom element, and we should then filter by slotted elements
-                filtered = getAllSlottedMatches(context, nodeList);
+                filtered = getAllSlottedMatches(context, unfilteredNodes);
             } else {
                 // regular element, we should then filter by ownership
-                filtered = getAllMatches(owner, nodeList);
+                filtered = getAllMatches(owner, unfilteredNodes);
             }
         } else {
-            filtered = ArrayFilter.call(nodeList, elm => getNodeOwnerKey(elm) === ownerKey);
+            filtered = ArrayFilter.call(unfilteredNodes, elm => getNodeOwnerKey(elm) === ownerKey);
         }
     } else if (context instanceof HTMLBodyElement) {
         // `context` is document.body which is already patched.
         filtered = ArrayFilter.call(
-            nodeList,
+            unfilteredNodes,
             // TODO: issue #1222 - remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
         );
     } else {
         // `context` is outside the lwc boundary, return unfiltered list.
-        filtered = ArraySlice.call(nodeList);
+        filtered = ArraySlice.call(unfilteredNodes);
     }
 
     return filtered;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -421,6 +421,9 @@ defineProperties(Node.prototype, {
     contains: {
         value(this: Node, otherNode: Node): boolean {
             if (DISABLE_NODE_PATCH) {
+                if (otherNode == null) {
+                    return false;
+                }
                 const ownerKey = getNodeOwnerKey(this);
                 if (!isUndefined(ownerKey) || isHostElement(this)) {
                     return containsPatched.call(this, otherNode);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -420,6 +420,15 @@ defineProperties(Node.prototype, {
     },
     contains: {
         value(this: Node, otherNode: Node): boolean {
+            if (DISABLE_NODE_PATCH) {
+                const ownerKey = getNodeOwnerKey(this);
+                if (!isUndefined(ownerKey) || isHostElement(this)) {
+                    return containsPatched.call(this, otherNode);
+                }
+
+                return contains.call(this, otherNode);
+            }
+
             // TODO: issue #1222 - remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return contains.call(this, otherNode);
@@ -432,6 +441,15 @@ defineProperties(Node.prototype, {
     },
     cloneNode: {
         value(this: Node, deep?: boolean): Node {
+            if (DISABLE_NODE_PATCH) {
+                const ownerKey = getNodeOwnerKey(this);
+                if (!isUndefined(ownerKey) || isHostElement(this)) {
+                    return cloneNodePatched.call(this, deep);
+                }
+
+                return cloneNode.call(this, deep);
+            }
+
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return cloneNodePatched.call(this, deep);
             }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -150,10 +150,10 @@ export function shadowRootChildNodes(root: SyntheticShadowRootInterface): Array<
     return getAllMatches(elm, arrayFromCollection(childNodesGetter.call(elm)));
 }
 
-export function getAllSlottedMatches(
+export function getAllSlottedMatches<T extends Node>(
     host: Element,
     nodeList: NodeList | Node[]
-): Array<Node & Element> {
+): Array<T> {
     const filteredAndPatched = [];
     for (let i = 0, len = nodeList.length; i < len; i += 1) {
         const node = nodeList[i];
@@ -174,7 +174,7 @@ export function getFirstSlottedMatch(host: Element, nodeList: Element[]): Elemen
     return null;
 }
 
-export function getAllMatches(owner: Element, nodeList: Node[]): Array<Element & Node> {
+export function getAllMatches<T extends Node>(owner: Element, nodeList: Node[]): Array<T> {
     const filteredAndPatched = [];
     for (let i = 0, len = nodeList.length; i < len; i += 1) {
         const node = nodeList[i];

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -181,9 +181,8 @@ if (!process.env.NATIVE_SHADOW) {
 
             it('should preserve behavior for getElementsByTagName', () => {
                 expect(elementOutsideLWC.getElementsByTagName('p').length).toBe(8);
-                // f
-                // limiting this may be tricky! but pushing it forward
-                // expect(rootLwcElement.getElementsByTagName('p').length).toBe(8);
+                // This is an exception: not patching root lwc elements
+                expect(rootLwcElement.getElementsByTagName('p').length).toBe(8);
 
                 // f, same, restricting this.
                 // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
@@ -201,8 +200,8 @@ if (!process.env.NATIVE_SHADOW) {
 
             it('should preserve behavior for getElementsByClassName', () => {
                 expect(elementOutsideLWC.getElementsByClassName('slotted').length).toBe(2);
-                // f: inside shadow.
-                // expect(rootLwcElement.getElementsByClassName('slotted').length).toBe(2);
+                // This is an exception: not patching root lwc elements
+                expect(rootLwcElement.getElementsByClassName('slotted').length).toBe(2);
 
                 // f: inside shadow
                 // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');


### PR DESCRIPTION
when using collections

## Details
This PR ensures that when Patch flag is disabled for Collections (`getElementsByTagName`, `getElementsByClassName` and `getElementsByTagNameNS`) LWC root elements return unfiltered results.

Ex:

```
lwc-root-element
   #shadowRoot
      lwc-cmp
         #shadowRoot
            button
```

Before:
```js
(lwc-root-element).getElementsByTagName('button') // returned an empty collection.
(lwc-cmp).getElementsByTagName('button') // returned an empty collection.
```

With this change:
```js
(lwc-root-element).getElementsByTagName('button') // returns a collection with the button.
(lwc-cmp).getElementsByTagName('button') // returns an empty collection.
```


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
