### PR TITLE
refactor(engine): to rely on native custom elements for connectness

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -64,6 +64,7 @@ import {
 import { Services, invokeServiceHook } from './services';
 import { markNodeFromVNode } from './restrictions';
 import { isComponentConstructor } from './def';
+import { attemptToRegisterTagName } from './local-registry';
 
 export interface ElementCompilerData extends VNodeData {
     key: Key;
@@ -161,6 +162,7 @@ const ElementHook: Hooks = {
 const CustomElementHook: Hooks = {
     create: (vnode: VCustomElement) => {
         const { sel } = vnode;
+        attemptToRegisterTagName(sel);
         vnode.elm = document.createElement(sel);
         linkNodeToShadow(vnode);
         if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -35,6 +35,7 @@ import {
     lockDomMutation,
 } from './restrictions';
 import { getComponentDef, setElementProto } from './def';
+import { isTagNameRegistered } from './local-registry';
 
 const noop = () => void 0;
 
@@ -208,8 +209,11 @@ export function createViewModelHook(vnode: VCustomElement) {
         mode,
         owner,
     });
-    reactWhenConnected(elm, customElementConnectedHook);
-    reactWhenDisconnected(elm, customElementDisconnectedHook);
+    // Handle insertion and removal from the DOM manually when needed
+    if (!isTagNameRegistered(vnode.sel)) {
+        reactWhenConnected(elm, customElementConnectedHook);
+        reactWhenDisconnected(elm, customElementDisconnectedHook);
+    }
     if (process.env.NODE_ENV !== 'production') {
         const vm = getAssociatedVM(elm);
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);

--- a/packages/@lwc/engine/src/framework/local-registry.ts
+++ b/packages/@lwc/engine/src/framework/local-registry.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { getAssociatedVM, appendVM, removeVM, hasAttachedVM } from './vm';
+import { appendVM, removeVM, getAssociatedVMIfPresent } from './vm';
+import { isUndefined } from '@lwc/shared';
 
 const globalRegisteredNames: Set<string> = new Set();
 const isCustomElementsRegistryAvailable = typeof customElements !== 'undefined';
@@ -19,14 +20,14 @@ function attemptToDefineNewCustomElementRouter(tagName: string): boolean {
         tagName,
         class extends HTMLElement {
             connectedCallback() {
-                if (hasAttachedVM(this)) {
-                    const vm = getAssociatedVM(this);
+                const vm = getAssociatedVMIfPresent(this);
+                if (!isUndefined(vm)) {
                     appendVM(vm);
                 }
             }
             disconnectedCallback() {
-                if (hasAttachedVM(this)) {
-                    const vm = getAssociatedVM(this);
+                const vm = getAssociatedVMIfPresent(this);
+                if (!isUndefined(vm)) {
                     removeVM(vm);
                 }
             }

--- a/packages/@lwc/engine/src/framework/local-registry.ts
+++ b/packages/@lwc/engine/src/framework/local-registry.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { getAssociatedVM, appendVM, removeVM, hasAttachedVM } from './vm';
+
+const globalRegisteredNames: Set<string> = new Set();
+const isCustomElementsRegistryAvailable = typeof customElements !== 'undefined';
+
+function attemptToDefineNewCustomElementRouter(tagName: string): boolean {
+    if (customElements.get(tagName)) {
+        // someone else already defined this element
+        // TO-DO: what should we do here?
+        return false;
+    }
+    customElements.define(
+        tagName,
+        class extends HTMLElement {
+            connectedCallback() {
+                if (hasAttachedVM(this)) {
+                    const vm = getAssociatedVM(this);
+                    appendVM(vm);
+                }
+            }
+            disconnectedCallback() {
+                if (hasAttachedVM(this)) {
+                    const vm = getAssociatedVM(this);
+                    removeVM(vm);
+                }
+            }
+        }
+    );
+    globalRegisteredNames.add(tagName);
+    return true;
+}
+
+export function attemptToRegisterTagName(tagName: string): boolean {
+    if (isTagNameRegistered(tagName)) {
+        return true;
+    }
+    if (isCustomElementsRegistryAvailable) {
+        return attemptToDefineNewCustomElementRouter(tagName);
+    }
+    return false;
+}
+
+export function isTagNameRegistered(tagName: string): boolean {
+    return globalRegisteredNames.has(tagName);
+}

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -19,6 +19,7 @@ import { EmptyObject, isCircularModuleDependency, resolveCircularModuleDependenc
 import { getComponentDef, setElementProto } from './def';
 import { patchCustomElementWithRestrictions } from './restrictions';
 import { GlobalMeasurementPhase, startGlobalMeasure, endGlobalMeasure } from './performance-timing';
+import { attemptToRegisterTagName, isTagNameRegistered } from './local-registry';
 
 type ShadowDomMode = 'open' | 'closed';
 
@@ -78,6 +79,7 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
     }
 
     const mode = options.mode !== 'closed' ? 'open' : 'closed';
+    attemptToRegisterTagName(sel);
 
     // Create element with correct tagName
     const element = document.createElement(sel);
@@ -100,8 +102,10 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
     }
     // In case the element is not initialized already, we need to carry on the manual creation
     createVM(element, Ctor, { mode, isRoot: true, owner: null });
-    // Handle insertion and removal from the DOM manually
-    reactWhenConnected(element, connectedHook);
-    reactWhenDisconnected(element, disconnectedHook);
+    // Handle insertion and removal from the DOM manually when needed
+    if (!isTagNameRegistered(sel)) {
+        reactWhenConnected(element, connectedHook);
+        reactWhenDisconnected(element, disconnectedHook);
+    }
     return element;
 }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -486,10 +486,6 @@ export function isNodeFromTemplate(node: Node): boolean {
     return root instanceof ShadowRoot;
 }
 
-export function hasAttachedVM(elm: HTMLElement): boolean {
-    return !isUndefined(getHiddenField(elm, ViewModelReflection));
-}
-
 // slow path routine
 // NOTE: we should probably more this routine to the synthetic shadow folder
 // and get the allocation to be cached by in the elm instead of in the VM

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -486,6 +486,10 @@ export function isNodeFromTemplate(node: Node): boolean {
     return root instanceof ShadowRoot;
 }
 
+export function hasAttachedVM(elm: HTMLElement): boolean {
+    return !isUndefined(getHiddenField(elm, ViewModelReflection));
+}
+
 // slow path routine
 // NOTE: we should probably more this routine to the synthetic shadow folder
 // and get the allocation to be cached by in the elm instead of in the VM

--- a/packages/@lwc/node-reactions/src/api.ts
+++ b/packages/@lwc/node-reactions/src/api.ts
@@ -6,7 +6,11 @@
  */
 import { isFunction, isUndefined, assert } from '@lwc/shared';
 import { ReactionCallback } from './types';
-import { reactWhenConnected, reactWhenDisconnected } from './global/init';
+import {
+    reactWhenConnected,
+    reactWhenDisconnected,
+    isCustomElementsRegistryAvailable,
+} from './global/init';
 
 /**
  * Redirecting after dev mode assertion.
@@ -19,6 +23,10 @@ function reactWhenConnectedRedirect(elm: Element, callback: ReactionCallback) {
         // Eventually when the library can handle all types of Nodes, then this assetion will go away
         assert.invariant(elm instanceof Element, 'Expected to only register Elements');
         assert.invariant(isFunction(callback), 'Expected a callback function');
+        assert.isFalse(
+            isCustomElementsRegistryAvailable,
+            'use node-reactions in browsers that do not support custom element registry'
+        );
     }
 
     reactWhenConnected(elm, callback);
@@ -30,6 +38,10 @@ function reactWhenDisconnectedRedirect(elm: Element, callback: ReactionCallback)
         // Eventually when the library can handle all types of Nodes, then this assetion will go away
         assert.invariant(elm instanceof Element, 'Expected to only register Elements');
         assert.invariant(isFunction(callback), 'Expected a callback function');
+        assert.isFalse(
+            isCustomElementsRegistryAvailable,
+            'use node-reactions in browsers that do not support custom element registry'
+        );
     }
 
     reactWhenDisconnected(elm, callback);

--- a/packages/@lwc/node-reactions/src/global/init.ts
+++ b/packages/@lwc/node-reactions/src/global/init.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { defineProperty, isUndefined } from '@lwc/shared';
+import { defineProperty, isUndefined, isFalse } from '@lwc/shared';
 import { ReactionCallback } from '../types';
 import patchNodePrototype from '../dom-patching/node';
 import { reactWhenConnected, reactWhenDisconnected } from '../core/reactions';
@@ -24,7 +24,10 @@ const InitializationSlot = '$$node-reactions-initialized$$';
 let reactWhenConnectedCached: (elm: Element, callback: ReactionCallback) => void;
 let reactWhenDisconnectedCached: (elm: Element, callback: ReactionCallback) => void;
 
-initialize();
+export const isCustomElementsRegistryAvailable = typeof customElements !== 'undefined';
+if (isFalse(isCustomElementsRegistryAvailable)) {
+    initialize();
+}
 /**
  * Set an internal field to detect initialization
  */


### PR DESCRIPTION
## Details

Experimental branch to see if we can rely on registered custom elements for connect/disconnect detection instead of always relying on node-reactions.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
