### PR TITLE
Caridy/ravi/master/node reactions review native

### DIFF
--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -20,6 +20,7 @@
     },
     "devDependencies": {
         "@lwc/features": "1.0.2",
+        "@lwc/node-reactions": "1.0.2",
         "@lwc/shared": "1.0.2",
         "@lwc/template-compiler": "1.0.2"
     },

--- a/packages/@lwc/engine/scripts/jest/test-utils.js
+++ b/packages/@lwc/engine/scripts/jest/test-utils.js
@@ -34,6 +34,7 @@ function compileTemplate(source, config = {}) {
 function stripNodeReactionsMarker(str) {
     return str.replace(/ data-node-reactions(="")*/gm, '');
 }
+
 module.exports = {
     compileTemplate,
     stripNodeReactionsMarker,

--- a/packages/@lwc/engine/scripts/jest/test-utils.js
+++ b/packages/@lwc/engine/scripts/jest/test-utils.js
@@ -27,6 +27,14 @@ function compileTemplate(source, config = {}) {
     return registerTemplate(templateFactory(modules));
 }
 
+/**
+ * Strip out data markers added by @lwc/node-reactions
+ * @param {string} str
+ */
+function stripNodeReactionsMarker(str) {
+    return str.replace(/ data-node-reactions(="")*/gm, '');
+}
 module.exports = {
     compileTemplate,
+    stripNodeReactionsMarker,
 };

--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -46,15 +46,11 @@ export interface VElement extends VNode {
     elm: Element | undefined;
     text: undefined;
     key: Key;
-    // TODO: issue #1364 - support the ability to provision a cloned StyleElement
-    // for native shadow as a perf optimization
-    clonedElement?: HTMLStyleElement;
 }
 
 export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
-    clonedElement?: undefined;
 }
 
 export interface VComment extends VNode {

--- a/packages/@lwc/engine/src/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/events.spec.ts
@@ -182,8 +182,8 @@ describe('events', () => {
             divWithClickHandler.addEventListener('click', function(event) {
                 target = event.target;
             });
-            document.body.appendChild(divWithClickHandler);
             divWithClickHandler.appendChild(elm);
+            document.body.appendChild(divWithClickHandler);
 
             const div = elm.shadowRoot.querySelector('div');
             div.click();

--- a/packages/@lwc/engine/src/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/events.spec.ts
@@ -182,8 +182,8 @@ describe('events', () => {
             divWithClickHandler.addEventListener('click', function(event) {
                 target = event.target;
             });
-            divWithClickHandler.appendChild(elm);
             document.body.appendChild(divWithClickHandler);
+            divWithClickHandler.appendChild(elm);
 
             const div = elm.shadowRoot.querySelector('div');
             div.click();

--- a/packages/@lwc/engine/src/env/dom.ts
+++ b/packages/@lwc/engine/src/env/dom.ts
@@ -11,12 +11,7 @@ const ShadowRootHostGetter: (this: ShadowRoot) => Element | null = getOwnPropert
     'host'
 )!.get!;
 
-const ShadowRootInnerHTMLSetter: (this: ShadowRoot, s: string) => void = getOwnPropertyDescriptor(
-    ShadowRoot.prototype,
-    'innerHTML'
-)!.set!;
-
 const dispatchEvent =
     'EventTarget' in window ? EventTarget.prototype.dispatchEvent : Node.prototype.dispatchEvent; // IE11
 
-export { dispatchEvent, ShadowRootHostGetter, ShadowRootInnerHTMLSetter };
+export { dispatchEvent, ShadowRootHostGetter };

--- a/packages/@lwc/engine/src/env/node.ts
+++ b/packages/@lwc/engine/src/env/node.ts
@@ -6,8 +6,6 @@
  */
 import { getOwnPropertyDescriptor, hasOwnProperty } from '@lwc/shared';
 
-const { appendChild, insertBefore, removeChild, replaceChild } = Node.prototype;
-
 const parentNodeGetter: (this: Node) => Element | null = getOwnPropertyDescriptor(
     Node.prototype,
     'parentNode'
@@ -22,10 +20,6 @@ const parentElementGetter: (this: Node) => Element | null = hasOwnProperty.call(
 
 export {
     // Node.prototype
-    appendChild,
-    insertBefore,
     parentElementGetter,
     parentNodeGetter,
-    removeChild,
-    replaceChild,
 };

--- a/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { compileTemplate, stripNodeReactionsMarker } from 'test-utils';
 import { fields } from '@lwc/shared';
-import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement, registerDecorators } from '../main';
 import { ViewModelReflection } from '../utils';
 import { getComponentVM } from '../vm';
@@ -201,9 +201,9 @@ describe('vm', () => {
                 // at this point, if we are reusing the h1 and h2 from the default content
                 // of the slots in c-child, they will have an extraneous attribute on them,
                 // which will be a problem.
-                expect(parentTemplate.querySelector('c-child').outerHTML).toBe(
-                    `<c-child><h1 slot="">slotted</h1><h2 slot="foo"></h2></c-child>`
-                );
+                expect(
+                    stripNodeReactionsMarker(parentTemplate.querySelector('c-child').outerHTML)
+                ).toBe(`<c-child><h1 slot="">slotted</h1><h2 slot="foo"></h2></c-child>`);
             });
         });
     });

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -46,10 +46,8 @@ import {
 } from '../3rdparty/snabbdom/types';
 import {
     createViewModelHook,
-    insertCustomElmHook,
     fallbackElmHook,
     rerenderCustomElmHook,
-    removeElmHook,
     createChildrenHook,
     updateNodeHook,
     insertNodeHook,
@@ -60,7 +58,6 @@ import {
     updateCustomElmHook,
     updateChildrenHook,
     allocateChildrenHook,
-    removeCustomElmHook,
     markAsDynamicChildren,
 } from './hooks';
 import { Services, invokeServiceHook } from './services';
@@ -136,17 +133,11 @@ const CommentHook: Hooks = {
 // Custom Element that is inserted via a template.
 const ElementHook: Hooks = {
     create: (vnode: VElement) => {
-        const { data, sel, clonedElement } = vnode;
+        const { data, sel } = vnode;
         const { ns } = data;
-        // TODO: issue #1364 - supporting the ability to inject a cloned StyleElement
-        // via a vnode this is used for style tags for native shadow
-        if (isUndefined(clonedElement)) {
-            vnode.elm = isUndefined(ns)
-                ? document.createElement(sel)
-                : document.createElementNS(ns, sel);
-        } else {
-            vnode.elm = clonedElement;
-        }
+        vnode.elm = isUndefined(ns)
+            ? document.createElement(sel)
+            : document.createElementNS(ns, sel);
         linkNodeToShadow(vnode);
         if (process.env.NODE_ENV !== 'production') {
             markNodeFromVNode(vnode.elm as Element);
@@ -162,13 +153,8 @@ const ElementHook: Hooks = {
         insertNodeHook(vnode, parentNode, referenceNode);
         createChildrenHook(vnode);
     },
-    move: (vnode: VElement, parentNode: Node, referenceNode: Node | null) => {
-        insertNodeHook(vnode, parentNode, referenceNode);
-    },
-    remove: (vnode: VElement, parentNode: Node) => {
-        removeNodeHook(vnode, parentNode);
-        removeElmHook(vnode);
-    },
+    move: insertNodeHook,
+    remove: removeNodeHook,
 };
 
 const CustomElementHook: Hooks = {
@@ -197,15 +183,9 @@ const CustomElementHook: Hooks = {
     insert: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
         insertNodeHook(vnode, parentNode, referenceNode);
         createChildrenHook(vnode);
-        insertCustomElmHook(vnode);
     },
-    move: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
-        insertNodeHook(vnode, parentNode, referenceNode);
-    },
-    remove: (vnode: VCustomElement, parentNode: Node) => {
-        removeNodeHook(vnode, parentNode);
-        removeCustomElmHook(vnode);
-    },
+    move: insertNodeHook,
+    remove: removeNodeHook,
 };
 
 function linkNodeToShadow(vnode: VNode) {
@@ -226,10 +206,6 @@ function addNS(vnode: VElement) {
             }
         }
     }
-}
-
-function addVNodeToChildLWC(vnode: VCustomElement) {
-    ArrayPush.call((vmBeingRendered as VM).velements, vnode);
 }
 
 // [h]tml node
@@ -408,7 +384,6 @@ export function c(
         owner: vmBeingRendered as VM,
         mode: 'open', // TODO: #1294 - this should be defined in Ctor
     };
-    addVNodeToChildLWC(vnode);
     return vnode;
 }
 

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -63,6 +63,7 @@ import {
 import { Services, invokeServiceHook } from './services';
 import { markNodeFromVNode } from './restrictions';
 import { isComponentConstructor } from './def';
+import { attemptToRegisterTagName } from './local-registry';
 
 export interface ElementCompilerData extends VNodeData {
     key: Key;
@@ -160,6 +161,7 @@ const ElementHook: Hooks = {
 const CustomElementHook: Hooks = {
     create: (vnode: VCustomElement) => {
         const { sel } = vnode;
+        attemptToRegisterTagName(sel);
         vnode.elm = document.createElement(sel);
         linkNodeToShadow(vnode);
         if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -168,8 +168,8 @@ export function allocateChildrenHook(vnode: VCustomElement) {
     }
 }
 
-function customElementConnectedHook(this: HTMLElement) {
-    const vm = getCustomElementVM(this);
+function customElementConnectedHook(elm: HTMLElement) {
+    const vm = getCustomElementVM(elm);
     if (process.env.NODE_ENV !== 'production') {
         // Either the vm was just created or the node is being moved to another subtree
         assert.isTrue(
@@ -180,8 +180,8 @@ function customElementConnectedHook(this: HTMLElement) {
     appendVM(vm);
 }
 
-function customElementDisconnectedHook(this: HTMLElement) {
-    const vm = getCustomElementVM(this);
+function customElementDisconnectedHook(elm: HTMLElement) {
+    const vm = getCustomElementVM(elm);
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm.state === VMState.connected, `${vm} should be connected.`);
     }

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, fields, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
+import { assert, fields, isArray, isTrue, isUndefined } from '@lwc/shared';
+import { reactWhenConnected, reactWhenDisconnected } from '@lwc/node-reactions';
 import { EmptyArray, ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
 import {
     rerenderVM,
@@ -14,6 +15,7 @@ import {
     allocateInSlot,
     appendVM,
     runWithBoundaryProtection,
+    VMState,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
@@ -140,11 +142,6 @@ export function updateElmHook(oldVnode: VElement, vnode: VElement) {
     modComputedStyle.update(oldVnode, vnode);
 }
 
-export function insertCustomElmHook(vnode: VCustomElement) {
-    const vm = getCustomElementVM(vnode.elm as HTMLElement);
-    appendVM(vm);
-}
-
 export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
     const { children, owner } = vnode;
     const fn = hasDynamicChildren(children) ? updateDynamicChildren : updateStaticChildren;
@@ -163,7 +160,6 @@ export function allocateChildrenHook(vnode: VCustomElement) {
     const elm = vnode.elm as HTMLElement;
     const vm = getCustomElementVM(elm);
     const { children } = vnode;
-    vm.aChildren = children;
     if (isTrue(useSyntheticShadow)) {
         // slow path
         allocateInSlot(vm, children);
@@ -193,15 +189,32 @@ export function createViewModelHook(vnode: VCustomElement) {
         mode,
         owner,
     });
-    const vm = getCustomElementVM(elm);
+    reactWhenConnected(elm, function(this: HTMLElement) {
+        const vm = getCustomElementVM(this);
+        if (process.env.NODE_ENV !== 'production') {
+            // Either the vm was just created or the node is being moved to another subtree
+            assert.isTrue(
+                vm.state === VMState.created || vm.state === VMState.disconnected,
+                `${vm} cannot be connected.`
+            );
+        }
+        appendVM(vm);
+    });
+    reactWhenDisconnected(elm, function(this: HTMLElement) {
+        const vm = getCustomElementVM(this);
+        if (process.env.NODE_ENV !== 'production') {
+            assert.isTrue(vm.state === VMState.connected, `${vm} should be connected.`);
+        }
+        removeVM(vm);
+    });
     if (process.env.NODE_ENV !== 'production') {
+        const vm = getCustomElementVM(elm);
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             isArray(vnode.children),
             `Invalid vnode for a custom element, it must have children defined.`
         );
-    }
-    if (process.env.NODE_ENV !== 'production') {
+
         patchCustomElementWithRestrictions(elm, EmptyObject);
     }
 }
@@ -251,25 +264,6 @@ export function updateCustomElmHook(oldVnode: VCustomElement, vnode: VCustomElem
     modProps.update(oldVnode, vnode);
     modComputedClassName.update(oldVnode, vnode);
     modComputedStyle.update(oldVnode, vnode);
-}
-
-export function removeElmHook(vnode: VElement) {
-    // this method only needs to search on child vnodes from template
-    // to trigger the remove hook just in case some of those children
-    // are custom elements.
-    const { children, elm } = vnode;
-    for (let j = 0, len = children.length; j < len; ++j) {
-        const ch = children[j];
-        if (!isNull(ch)) {
-            ch.hook.remove(ch, elm as HTMLElement);
-        }
-    }
-}
-
-export function removeCustomElmHook(vnode: VCustomElement) {
-    // for custom elements we don't have to go recursively because the removeVM routine
-    // will take care of disconnecting any child VM attached to its shadow as well.
-    removeVM(getCustomElementVM(vnode.elm as HTMLElement));
 }
 
 // Using a WeakMap instead of a WeakSet because this one works in IE11 :(

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -34,6 +34,7 @@ import {
     lockDomMutation,
 } from './restrictions';
 import { getComponentDef, setElementProto } from './def';
+import { isTagNameRegistered } from './local-registry';
 
 const noop = () => void 0;
 const { getHiddenField } = fields;
@@ -209,8 +210,11 @@ export function createViewModelHook(vnode: VCustomElement) {
         mode,
         owner,
     });
-    reactWhenConnected(elm, customElementConnectedHook);
-    reactWhenDisconnected(elm, customElementDisconnectedHook);
+    // Handle insertion and removal from the DOM manually when needed
+    if (!isTagNameRegistered(vnode.sel)) {
+        reactWhenConnected(elm, customElementConnectedHook);
+        reactWhenDisconnected(elm, customElementDisconnectedHook);
+    }
     if (process.env.NODE_ENV !== 'production') {
         const vm = getCustomElementVM(elm);
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);

--- a/packages/@lwc/engine/src/framework/local-registry.ts
+++ b/packages/@lwc/engine/src/framework/local-registry.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { getCustomElementVM, appendVM, removeVM, hasAttachedVM } from './vm';
+
+const globalRegisteredNames: Set<string> = new Set();
+const isCustomElementsRegistryAvailable = typeof customElements !== 'undefined';
+
+function attemptToDefineNewCustomElementRouter(tagName: string): boolean {
+    if (customElements.get(tagName)) {
+        // someone else already defined this element
+        // TODO: what should we do here?
+        return false;
+    }
+    customElements.define(
+        tagName,
+        class extends HTMLElement {
+            connectedCallback() {
+                if (hasAttachedVM(this)) {
+                    const vm = getCustomElementVM(this);
+                    appendVM(vm);
+                }
+            }
+            disconnectedCallback() {
+                if (hasAttachedVM(this)) {
+                    const vm = getCustomElementVM(this);
+                    removeVM(vm);
+                }
+            }
+        }
+    );
+    globalRegisteredNames.add(tagName);
+    return true;
+}
+
+export function attemptToRegisterTagName(tagName: string): boolean {
+    if (isTagNameRegistered(tagName)) {
+        return true;
+    }
+    if (isCustomElementsRegistryAvailable) {
+        return attemptToDefineNewCustomElementRouter(tagName);
+    }
+    return false;
+}
+
+export function isTagNameRegistered(tagName: string): boolean {
+    return globalRegisteredNames.has(tagName);
+}

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, create, emptyString, forEach, isArray, isUndefined } from '@lwc/shared';
-import { VNode } from '../3rdparty/snabbdom/types';
-
-import * as api from './api';
-import { EmptyArray, useSyntheticShadow } from './utils';
+import { assert, create, emptyString, forEach, isArray, isNull, isUndefined } from '@lwc/shared';
+import { useSyntheticShadow } from './utils';
 import { VM } from './vm';
 import { removeAttribute, setAttribute } from '../env/element';
 /**
@@ -20,6 +17,20 @@ export type StylesheetFactory = (
     shadowSelector: string,
     nativeShadow: boolean
 ) => string;
+
+export interface StylesheetTokens {
+    /**
+     * HTML attribute that need to be applied to the host element. This attribute is used for the
+     * `:host` pseudo class CSS selector.
+     */
+    hostAttribute: string;
+
+    /**
+     * HTML attribute that need to the applied to all the element that the template produces.
+     * This attribute is used for style encapsulation when the engine runs with synthetic shadow.
+     */
+    shadowAttribute: string;
+}
 
 const CachedStyleFragments: Record<string, DocumentFragment> = create(null);
 
@@ -55,25 +66,11 @@ function insertGlobalStyle(styleContent: string) {
     }
 }
 
-function createStyleVNode(elm: HTMLStyleElement) {
-    const vnode = api.h(
-        'style',
-        {
-            key: 'style', // special key
-        },
-        EmptyArray
-    );
-    // TODO: issue #1364 - supporting the ability to inject a cloned StyleElement
-    // forcing the diffing algo to use the cloned style for native shadow
-    vnode.clonedElement = elm;
-    return vnode;
-}
-
 /**
  * Reset the styling token applied to the host element.
  */
-export function resetStyleAttributes(vm: VM): void {
-    const { context, elm } = vm;
+export function resetStyle(vm: VM): void {
+    const { context, elm, cmpRoot } = vm;
 
     // Remove the style attribute currently applied to the host element.
     const oldHostAttribute = context.hostAttribute;
@@ -83,18 +80,40 @@ export function resetStyleAttributes(vm: VM): void {
 
     // Reset the scoping attributes associated to the context.
     context.hostAttribute = context.shadowAttribute = undefined;
+
+    // removing style tag if present
+    if (!isNull(context.styleVNode) && !isUndefined(context.styleVNode)) {
+        cmpRoot.removeChild(context.styleVNode);
+        context.styleVNode = null;
+    }
 }
 
 /**
  * Apply/Update the styling token applied to the host element.
  */
-export function applyStyleAttributes(vm: VM, hostAttribute: string, shadowAttribute: string): void {
-    const { context, elm } = vm;
+export function applyStyle(
+    vm: VM,
+    stylesheets: StylesheetFactory[],
+    stylesheetTokens: StylesheetTokens
+): void {
+    const { context, elm, cmpRoot } = vm;
+    const { hostAttribute, shadowAttribute } = stylesheetTokens;
     // Remove the style attribute currently applied to the host element.
     setAttribute.call(elm, hostAttribute, '');
 
     context.hostAttribute = hostAttribute;
     context.shadowAttribute = shadowAttribute;
+
+    // Caching style vnode so it can be removed when needed
+    const styleElm = (context.styleVNode = evaluateCSS(
+        vm,
+        stylesheets,
+        hostAttribute,
+        shadowAttribute
+    ));
+    if (!isNull(styleElm)) {
+        cmpRoot.appendChild(styleElm);
+    }
 }
 
 function collectStylesheets(stylesheets, hostSelector, shadowSelector, isNative, aggregatorFn) {
@@ -107,12 +126,12 @@ function collectStylesheets(stylesheets, hostSelector, shadowSelector, isNative,
     });
 }
 
-export function evaluateCSS(
+function evaluateCSS(
     vm: VM,
     stylesheets: StylesheetFactory[],
     hostAttribute: string,
     shadowAttribute: string
-): VNode | null {
+): HTMLStyleElement | null {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(isArray(stylesheets), `Invalid stylesheets.`);
@@ -136,6 +155,6 @@ export function evaluateCSS(
             buffer += textContent;
         });
 
-        return createStyleVNode(getCachedStyleElement(buffer));
+        return getCachedStyleElement(buffer);
     }
 }

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -6,7 +6,6 @@
  */
 import {
     ArrayIndexOf,
-    ArrayUnshift,
     assert,
     create,
     forEach,
@@ -22,15 +21,10 @@ import { VNode, VNodes } from '../3rdparty/snabbdom/types';
 import * as api from './api';
 import { RenderAPI } from './api';
 import { Context } from './context';
-import { SlotSet, VM, resetShadowRoot } from './vm';
+import { SlotSet, VM } from './vm';
 import { EmptyArray } from './utils';
 import { isTemplateRegistered, registerTemplate } from './secure-template';
-import {
-    evaluateCSS,
-    StylesheetFactory,
-    applyStyleAttributes,
-    resetStyleAttributes,
-} from './stylesheet';
+import { StylesheetFactory, applyStyle, resetStyle, StylesheetTokens } from './stylesheet';
 
 export { registerTemplate };
 export interface Template {
@@ -47,19 +41,7 @@ export interface Template {
      */
     ids?: string[];
 
-    stylesheetTokens?: {
-        /**
-         * HTML attribute that need to be applied to the host element. This attribute is used for the
-         * `:host` pseudo class CSS selector.
-         */
-        hostAttribute: string;
-
-        /**
-         * HTML attribute that need to the applied to all the element that the template produces.
-         * This attribute is used for style encapsulation when the engine runs with synthetic shadow.
-         */
-        shadowAttribute: string;
-    };
+    stylesheetTokens?: StylesheetTokens;
 }
 const EmptySlots: SlotSet = create(null);
 
@@ -110,6 +92,28 @@ function validateFields(vm: VM, html: Template) {
     });
 }
 
+// This is a super optimized mechanism to remove the content of the shadowRoot
+// without having to go into snabbdom. This assumes that nodes are present and
+// connected, otherwise it throws, and will be captured by outer control, the
+// main goal is to do this clean up as fast as possible.
+function resetTemplate(vm: VM) {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+    }
+    // removing all tracked childNodes
+    const { children, cmpRoot } = vm;
+    for (let i = 0, len = children.length; i < len; i += 1) {
+        const vnode = children[i];
+        if (!isNull(vnode)) {
+            const { elm } = vnode;
+            // the vnode must have elm defined, and must be connected
+            cmpRoot.removeChild(elm as Node);
+        }
+    }
+    vm.children = EmptyArray;
+    // intentionally leaving out any manually inserted node in the shadowRoot
+}
+
 export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
@@ -128,7 +132,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         if (!isUndefined(cmpTemplate)) {
             // It is important to reset the content to avoid reusing similar elements generated from a different
             // template, because they could have similar IDs, and snabbdom just rely on the IDs.
-            resetShadowRoot(vm);
+            resetTemplate(vm);
+            resetStyle(vm);
         }
 
         // Check that the template was built by the compiler
@@ -145,16 +150,9 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         // Populate context with template information
         context.tplCache = create(null);
 
-        resetStyleAttributes(vm);
-
         const { stylesheets, stylesheetTokens } = html;
-        if (isUndefined(stylesheets) || stylesheets.length === 0) {
-            context.styleVNode = null;
-        } else if (!isUndefined(stylesheetTokens)) {
-            const { hostAttribute, shadowAttribute } = stylesheetTokens;
-            applyStyleAttributes(vm, hostAttribute, shadowAttribute);
-            // Caching style vnode so it can be reused on every render
-            context.styleVNode = evaluateCSS(vm, stylesheets, hostAttribute, shadowAttribute);
+        if (!isUndefined(stylesheetTokens) && !isUndefined(stylesheets) && stylesheets.length > 0) {
+            applyStyle(vm, stylesheets, stylesheetTokens);
         }
 
         if (process.env.NODE_ENV !== 'production') {
@@ -173,16 +171,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         // validating slots in every rendering since the allocated content might change over time
         validateSlots(vm, html);
     }
-    // right before producing the vnodes, we clear up all internal references
-    // to custom elements from the template.
-    vm.velements = [];
     // invoke the selected template.
     const vnodes: VNodes = html.call(undefined, api, component, cmpSlots, context.tplCache!);
-
-    const { styleVNode } = context;
-    if (!isNull(styleVNode)) {
-        ArrayUnshift.call(vnodes, styleVNode);
-    }
 
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -107,7 +107,7 @@ function resetTemplate(vm: VM) {
         if (!isNull(vnode)) {
             const { elm } = vnode;
             // the vnode must have elm defined, and must be connected
-            cmpRoot.removeChild(elm as Node);
+            cmpRoot.removeChild(elm!);
         }
     }
     vm.children = EmptyArray;

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -26,8 +26,8 @@ interface CreateElementOptions {
     mode?: ShadowDomMode;
 }
 
-function connectedHook(this: HTMLElement) {
-    const vm = getCustomElementVM(this);
+function connectedHook(elm: HTMLElement) {
+    const vm = getCustomElementVM(elm);
     startGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(
@@ -39,8 +39,8 @@ function connectedHook(this: HTMLElement) {
     endGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
 }
 
-function disconnectedHook(this: HTMLElement) {
-    const vm = getCustomElementVM(this);
+function disconnectedHook(elm: HTMLElement) {
+    const vm = getCustomElementVM(elm);
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm.state === VMState.connected, `${vm} should be connected.`);
     }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -554,6 +554,10 @@ export function isNodeFromTemplate(node: Node): boolean {
     return root instanceof ShadowRoot;
 }
 
+export function hasAttachedVM(elm: HTMLElement): boolean {
+    return !isUndefined(getHiddenField(elm, ViewModelReflection));
+}
+
 export function getCustomElementVM(elm: HTMLElement): VM {
     if (process.env.NODE_ENV !== 'production') {
         const vm = getHiddenField(elm, ViewModelReflection);

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -159,7 +159,7 @@ function reset(vm: VM) {
     const { state } = vm;
     if (state !== VMState.disconnected) {
         const { oar, tro } = vm;
-        // Making sure that any observing record will not trigger the rehydrated on this vm
+        // Making sure that any observing record will not trigger the rehydration on this vm
         tro.reset();
         // Making sure that any observing accessor record will not trigger the setter to be reinvoked
         for (const key in oar) {
@@ -167,8 +167,8 @@ function reset(vm: VM) {
         }
     }
     if (isFalse(vm.isDirty)) {
-        // this guarantees that if the component is reused/reinserted,
-        // it will be re-rendered because we are disconnecting the reactivity
+        // this guarantees that if the component is reused/reinserted, it will be re-rendered.
+        // it should be re-rendered because we are disconnecting the reactivity
         // linking, so mutations are not automatically reflected on the state
         // of disconnected components.
         vm.isDirty = true;

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -11,7 +11,6 @@ import {
     assert,
     create,
     fields,
-    isArray,
     isFalse,
     isNull,
     isObject,
@@ -37,9 +36,9 @@ import {
 } from './utils';
 import { invokeServiceHook, Services } from './services';
 import { invokeComponentCallback } from './invoker';
-import { ShadowRootInnerHTMLSetter, ShadowRootHostGetter } from '../env/dom';
+import { ShadowRootHostGetter } from '../env/dom';
 
-import { VNodeData, VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
+import { VNodeData, VNodes } from '../3rdparty/snabbdom/types';
 import { Template } from './template';
 import { ComponentDef } from './def';
 import { ComponentInterface } from './component';
@@ -83,9 +82,6 @@ export interface UninitializedVM {
     data: VNodeData;
     /** Shadow Children List */
     children: VNodes;
-    /** Adopted Children List */
-    aChildren: VNodes;
-    velements: VCustomElement[];
     cmpProps: any;
     cmpSlots: SlotSet;
     cmpTrack: any;
@@ -145,18 +141,10 @@ export function rerenderVM(vm: VM) {
     rehydrate(vm);
 }
 
-export function appendRootVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    runConnectedCallback(vm);
-    rehydrate(vm);
-}
-
+// this method is triggered by the insertion of a element into the DOM.
 export function appendVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-        assert.isTrue(vm.state === VMState.created, `${vm} cannot be recycled.`);
     }
     runConnectedCallback(vm);
     rehydrate(vm);
@@ -164,7 +152,7 @@ export function appendVM(vm: VM) {
 
 // just in case the component comes back, with this we guarantee re-rendering it
 // while preventing any attempt to rehydration until after reinsertion.
-function resetComponentStateWhenRemoved(vm: VM) {
+function reset(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
     }
@@ -177,15 +165,17 @@ function resetComponentStateWhenRemoved(vm: VM) {
         for (const key in oar) {
             oar[key].reset();
         }
-        runDisconnectedCallback(vm);
-        // Spec: https://dom.spec.whatwg.org/#concept-node-remove (step 14-15)
-        runShadowChildNodesDisconnectedCallback(vm);
-        runLightChildNodesDisconnectedCallback(vm);
+    }
+    if (isFalse(vm.isDirty)) {
+        // this guarantees that if the component is reused/reinserted,
+        // it will be re-rendered because we are disconnecting the reactivity
+        // linking, so mutations are not automatically reflected on the state
+        // of disconnected components.
+        vm.isDirty = true;
     }
 }
 
-// this method is triggered by the diffing algo only when a vnode from the
-// old vnode.children is removed from the DOM.
+// this method is triggered by the removal of a element from the DOM.
 export function removeVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
@@ -194,15 +184,8 @@ export function removeVM(vm: VM) {
             `${vm} must have been connected.`
         );
     }
-    resetComponentStateWhenRemoved(vm);
-}
-
-// this method is triggered by the removal of a root element from the DOM.
-export function removeRootVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    resetComponentStateWhenRemoved(vm);
+    reset(vm);
+    runDisconnectedCallback(vm);
 }
 
 export interface CreateVMInit {
@@ -243,8 +226,6 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
         setHook,
         getHook,
         children: EmptyArray,
-        aChildren: EmptyArray,
-        velements: EmptyArray,
         // Perf optimization to preserve the shape of this obj
         cmpTemplate: undefined,
         component: undefined,
@@ -415,13 +396,6 @@ function runDisconnectedCallback(vm: VM) {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(vm.state !== VMState.disconnected, `${vm} must be inserted.`);
     }
-    if (isFalse(vm.isDirty)) {
-        // this guarantees that if the component is reused/reinserted,
-        // it will be re-rendered because we are disconnecting the reactivity
-        // linking, so mutations are not automatically reflected on the state
-        // of disconnected components.
-        vm.isDirty = true;
-    }
     vm.state = VMState.disconnected;
     // reporting disconnection
     const { disconnected } = Services;
@@ -442,70 +416,32 @@ function runDisconnectedCallback(vm: VM) {
     }
 }
 
-function runShadowChildNodesDisconnectedCallback(vm: VM) {
+// For error boundary recovery, some vnodes might not
+// have the `elm` defined, and there is no guarantee
+// that it was inserted. This routine just attempt to
+// remove all possible nodes by ignoring errors.
+function resetShadowRootAfterError(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
     }
-    const { velements: vCustomElementCollection } = vm;
-    // reporting disconnection for every child in inverse order since they are inserted in reserved order
-    for (let i = vCustomElementCollection.length - 1; i >= 0; i -= 1) {
-        const elm = vCustomElementCollection[i].elm;
-        // There are two cases where the element could be undefined:
-        // * when there is an error during the construction phase, and an
-        //   error boundary picks it, there is a possibility that the VCustomElement
-        //   is not properly initialized, and therefore is should be ignored.
-        // * when slotted custom element is not used by the element where it is slotted
-        //   into it, as a result, the custom element was never initialized.
-        if (!isUndefined(elm)) {
-            const childVM = getCustomElementVM(elm as HTMLElement);
-            resetComponentStateWhenRemoved(childVM);
-        }
-    }
-}
-
-function runLightChildNodesDisconnectedCallback(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    const { aChildren: adoptedChildren } = vm;
-    recursivelyDisconnectChildren(adoptedChildren);
-}
-
-/**
- * The recursion doesn't need to be a complete traversal of the vnode graph,
- * instead it can be partial, when a custom element vnode is found, we don't
- * need to continue into its children because by attempting to disconnect the
- * custom element itself will trigger the removal of anything slotted or anything
- * defined on its shadow.
- */
-function recursivelyDisconnectChildren(vnodes: VNodes) {
-    for (let i = 0, len = vnodes.length; i < len; i += 1) {
-        const vnode: VCustomElement | VNode | null = vnodes[i];
-        if (!isNull(vnode) && isArray(vnode.children) && !isUndefined(vnode.elm)) {
-            // vnode is a VElement with children
-            if (isUndefined((vnode as any).ctor)) {
-                // it is a VElement, just keep looking (recursively)
-                recursivelyDisconnectChildren(vnode.children);
-            } else {
-                // it is a VCustomElement, disconnect it and ignore its children
-                resetComponentStateWhenRemoved(getCustomElementVM(vnode.elm as HTMLElement));
+    const { children, cmpRoot } = vm;
+    for (let i = 0, len = children.length; i < len; i += 1) {
+        const vnode = children[i];
+        if (!isNull(vnode)) {
+            const { elm } = vnode;
+            if (!isUndefined(elm)) {
+                // the concern here is that this routine might
+                // throw and we have one flow that does not
+                // have protection (recovering from error boundary)
+                try {
+                    cmpRoot.removeChild(elm);
+                } catch (e) {
+                    // ignore any error to complete the clean up
+                }
             }
         }
     }
-}
-
-// This is a super optimized mechanism to remove the content of the shadowRoot
-// without having to go into snabbdom. Especially useful when the reset is a consequence
-// of an error, in which case the children VNodes might not be representing the current
-// state of the DOM
-export function resetShadowRoot(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     vm.children = EmptyArray;
-    ShadowRootInnerHTMLSetter.call(vm.cmpRoot, '');
-    // disconnecting any known custom element inside the shadow of the this vm
-    runShadowChildNodesDisconnectedCallback(vm);
 }
 
 export function scheduleRehydration(vm: VM) {
@@ -723,7 +659,7 @@ export function runWithBoundaryProtection(
             if (isUndefined(errorBoundaryVm)) {
                 throw error; // eslint-disable-line no-unsafe-finally
             }
-            resetShadowRoot(vm); // remove offenders
+            resetShadowRootAfterError(vm); // remove offenders
 
             if (process.env.NODE_ENV !== 'production') {
                 startMeasure('errorCallback', errorBoundaryVm);

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayMap, getOwnPropertyNames, isNull, isObject, isUndefined } from '@lwc/shared';
+import { ArrayMap, assert, getOwnPropertyNames, isNull, isObject, isUndefined } from '@lwc/shared';
 import { ComponentConstructor } from './component';
-import { createVM, appendRootVM, removeRootVM, getCustomElementVM, CreateVMInit } from './vm';
+import { createVM, getCustomElementVM, CreateVMInit, removeVM, appendVM, VMState } from './vm';
 import { EmptyObject } from './utils';
 import { getComponentDef } from './def';
 import { getPropNameFromAttrName, isAttributeLocked } from './attributes';
@@ -50,12 +50,21 @@ export function buildCustomElementConstructor(
             }
         }
         connectedCallback() {
-            const vm = getCustomElementVM(this);
-            appendRootVM(vm);
+            const vm = getCustomElementVM(this as HTMLElement);
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(
+                    vm.state === VMState.created || vm.state === VMState.disconnected,
+                    `${vm} should be new or disconnected.`
+                );
+            }
+            appendVM(vm);
         }
         disconnectedCallback() {
-            const vm = getCustomElementVM(this);
-            removeRootVM(vm);
+            const vm = getCustomElementVM(this as HTMLElement);
+            if (process.env.NODE_ENV !== 'production') {
+                assert.isTrue(vm.state === VMState.connected, `${vm} should be connected.`);
+            }
+            removeVM(vm);
         }
         attributeChangedCallback(attrName, oldValue, newValue) {
             if (oldValue === newValue) {

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -50,7 +50,7 @@ export function buildCustomElementConstructor(
             }
         }
         connectedCallback() {
-            const vm = getCustomElementVM(this as HTMLElement);
+            const vm = getCustomElementVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(
                     vm.state === VMState.created || vm.state === VMState.disconnected,
@@ -60,7 +60,7 @@ export function buildCustomElementConstructor(
             appendVM(vm);
         }
         disconnectedCallback() {
-            const vm = getCustomElementVM(this as HTMLElement);
+            const vm = getCustomElementVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(vm.state === VMState.connected, `${vm} should be connected.`);
             }

--- a/packages/@lwc/node-reactions/.eslintrc
+++ b/packages/@lwc/node-reactions/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "env": {
+        "browser": true
+    },
+
+    "globals": {
+        "process": true,
+        "global": true
+    }
+}

--- a/packages/@lwc/node-reactions/README.md
+++ b/packages/@lwc/node-reactions/README.md
@@ -1,0 +1,3 @@
+Usage:
+reactWhenConnected(element, callback);
+reactWhenDisconnected(element, callback);

--- a/packages/@lwc/node-reactions/README.md
+++ b/packages/@lwc/node-reactions/README.md
@@ -1,3 +1,28 @@
-Usage:
+# node-reactions
+
+node-reactions is a library, tailor made for lwc engine to react to lifecycle events of a DOM node. In the current state, the library allow a subscriber to react to a DOM node being connected and disconnected from the document.
+Note: In its current state node-reactions is not meant to be used outside of the @lwc/engine package.
+
+## APIs
+
 reactWhenConnected(element, callback);
 reactWhenDisconnected(element, callback);
+
+## Example usage
+
+```js
+const element = document.createElement('lwc-foo');
+reactWhenConnected(element, function(element, reactionType) {
+    console.log(element.isConnected); // true
+    console.log(element.tagName); // lwc-foo
+    console.log(reactionType); // 1 (which indicates connected)
+});
+document.body.appendChild(element);
+```
+
+## Caveats
+
+This library assumes certain DOM APIs to be available(or polyfilled). Here is the list of APIs:
+
+1. [Node.isConnected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected)
+2. [Element.shadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot)

--- a/packages/@lwc/node-reactions/jest.config.js
+++ b/packages/@lwc/node-reactions/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const BASE_CONFIG = require('../../../scripts/jest/base.config');
+
+module.exports = {
+    ...BASE_CONFIG,
+
+    displayName: 'lwc-node-reactions',
+
+    roots: ['<rootDir>/src'],
+
+    // Override global threshold for the package. As we increase the test coverage we should increase
+    // the threshold as well.
+    coverageThreshold: {
+        global: {
+            ...BASE_CONFIG.coverageThreshold.global,
+            branches: 50,
+            functions: 60,
+            lines: 86,
+        },
+    },
+};

--- a/packages/@lwc/node-reactions/jest.config.js
+++ b/packages/@lwc/node-reactions/jest.config.js
@@ -12,15 +12,4 @@ module.exports = {
     displayName: 'lwc-node-reactions',
 
     roots: ['<rootDir>/src'],
-
-    // Override global threshold for the package. As we increase the test coverage we should increase
-    // the threshold as well.
-    coverageThreshold: {
-        global: {
-            ...BASE_CONFIG.coverageThreshold.global,
-            branches: 50,
-            functions: 60,
-            lines: 86,
-        },
-    },
 };

--- a/packages/@lwc/node-reactions/package.json
+++ b/packages/@lwc/node-reactions/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@lwc/node-reactions",
+    "version": "1.0.2",
+    "description": "Node Reactions utility to detect synchronous mutations of the DOM",
+    "license": "MIT",
+    "main": "dist/node-reactions.cjs.js",
+    "module": "dist/node-reactions.js",
+    "typings": "dist/types/index.d.ts",
+    "scripts": {
+        "clean": "rm -rf dist/",
+        "test": "jest",
+        "build": "tsc  --emitDeclarationOnly && rollup --config ./scripts/rollup/rollup.config.js"
+    },
+    "files": [
+        "dist/"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "@lwc/shared": "1.0.2"
+    }
+}

--- a/packages/@lwc/node-reactions/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/node-reactions/scripts/rollup/rollup.config.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const path = require('path');
+const typescript = require('rollup-plugin-typescript');
+
+const { version } = require('../../package.json');
+const entry = path.resolve(__dirname, '../../src/index.ts');
+const targetDirectory = path.resolve(__dirname, '../../dist');
+const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
+const footer = `/** version: ${version} */`;
+
+function generateTargetName({ format }) {
+    return ['node-reactions', format === 'cjs' ? '.cjs' : '', '.js'].join('');
+}
+
+function rollupConfig({ format }) {
+    return {
+        input: entry,
+        output: {
+            file: path.join(targetDirectory, generateTargetName({ format })),
+            name: 'NodeReactions',
+            format,
+            banner,
+            footer,
+        },
+        plugins: [typescript({ target: 'es2017', typescript: require('typescript') })],
+    };
+}
+
+module.exports = [rollupConfig({ format: 'es' }), rollupConfig({ format: 'cjs' })];

--- a/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
+++ b/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { reactWhenConnected, reactWhenDisconnected } from '../index';
+
+describe('patches', () => {
+    describe('appendChild()', () => {
+        it('should be detected as connection', () => {
+            const elm = document.createElement('div');
+            let connected = false;
+            reactWhenConnected(elm, function() {
+                connected = true;
+            });
+            document.body.appendChild(elm);
+            expect(connected).toBe(true);
+        });
+    });
+
+    describe('insertBefore()', () => {
+        it('should be detected as connection', () => {
+            const elm = document.createElement('div');
+            let connected = false;
+            reactWhenConnected(elm, function() {
+                connected = true;
+            });
+            document.body.insertBefore(elm, null);
+            expect(connected).toBe(true);
+        });
+    });
+
+    describe('replaceChild()', () => {
+        it('should be detected as connection', () => {
+            const anchor = document.createElement('a');
+            const elm = document.createElement('div');
+            let connected = false;
+            reactWhenConnected(elm, function() {
+                connected = true;
+            });
+            document.body.appendChild(anchor);
+            document.body.replaceChild(elm, anchor);
+            expect(connected).toBe(true);
+        });
+    });
+
+    describe('removeChild()', () => {
+        it('should be detected as disconnection', () => {
+            const elm = document.createElement('div');
+            let disconnected = false;
+            reactWhenDisconnected(elm, function() {
+                disconnected = true;
+            });
+            document.body.appendChild(elm);
+            document.body.removeChild(elm);
+            expect(disconnected).toBe(true);
+        });
+    });
+});

--- a/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
+++ b/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
@@ -13,7 +13,7 @@ describe('patches', () => {
             const elm = document.createElement('div');
             let connected = false;
             let actualReactionType;
-            reactWhenConnected(elm, function(reactionType) {
+            reactWhenConnected(elm, function(element, reactionType) {
                 connected = true;
                 actualReactionType = reactionType;
             });
@@ -28,7 +28,7 @@ describe('patches', () => {
             const elm = document.createElement('div');
             let connected = false;
             let actualReactionType;
-            reactWhenConnected(elm, function(reactionType) {
+            reactWhenConnected(elm, function(element, reactionType) {
                 connected = true;
                 actualReactionType = reactionType;
             });
@@ -44,7 +44,7 @@ describe('patches', () => {
             const elm = document.createElement('div');
             let connected = false;
             let actualReactionType;
-            reactWhenConnected(elm, function(reactionType) {
+            reactWhenConnected(elm, function(element, reactionType) {
                 connected = true;
                 actualReactionType = reactionType;
             });
@@ -60,7 +60,7 @@ describe('patches', () => {
             const elm = document.createElement('div');
             let disconnected = false;
             let actualReactionType;
-            reactWhenDisconnected(elm, function(reactionType) {
+            reactWhenDisconnected(elm, function(element, reactionType) {
                 disconnected = true;
                 actualReactionType = reactionType;
             });

--- a/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
+++ b/packages/@lwc/node-reactions/src/__tests__/Node-methods.spec.ts
@@ -12,11 +12,14 @@ describe('patches', () => {
         it('should be detected as connection', () => {
             const elm = document.createElement('div');
             let connected = false;
-            reactWhenConnected(elm, function() {
+            let actualReactionType;
+            reactWhenConnected(elm, function(reactionType) {
                 connected = true;
+                actualReactionType = reactionType;
             });
             document.body.appendChild(elm);
             expect(connected).toBe(true);
+            expect(actualReactionType).toBe(1);
         });
     });
 
@@ -24,11 +27,14 @@ describe('patches', () => {
         it('should be detected as connection', () => {
             const elm = document.createElement('div');
             let connected = false;
-            reactWhenConnected(elm, function() {
+            let actualReactionType;
+            reactWhenConnected(elm, function(reactionType) {
                 connected = true;
+                actualReactionType = reactionType;
             });
             document.body.insertBefore(elm, null);
             expect(connected).toBe(true);
+            expect(actualReactionType).toBe(1);
         });
     });
 
@@ -37,12 +43,15 @@ describe('patches', () => {
             const anchor = document.createElement('a');
             const elm = document.createElement('div');
             let connected = false;
-            reactWhenConnected(elm, function() {
+            let actualReactionType;
+            reactWhenConnected(elm, function(reactionType) {
                 connected = true;
+                actualReactionType = reactionType;
             });
             document.body.appendChild(anchor);
             document.body.replaceChild(elm, anchor);
             expect(connected).toBe(true);
+            expect(actualReactionType).toBe(1);
         });
     });
 
@@ -50,12 +59,15 @@ describe('patches', () => {
         it('should be detected as disconnection', () => {
             const elm = document.createElement('div');
             let disconnected = false;
-            reactWhenDisconnected(elm, function() {
+            let actualReactionType;
+            reactWhenDisconnected(elm, function(reactionType) {
                 disconnected = true;
+                actualReactionType = reactionType;
             });
             document.body.appendChild(elm);
             document.body.removeChild(elm);
             expect(disconnected).toBe(true);
+            expect(actualReactionType).toBe(2);
         });
     });
 });

--- a/packages/@lwc/node-reactions/src/api.ts
+++ b/packages/@lwc/node-reactions/src/api.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined, assert } from '@lwc/shared';
+import { isFunction, isUndefined, assert } from '@lwc/shared';
 import { ReactionCallback } from './types';
 import { reactWhenConnected, reactWhenDisconnected } from './global/init';
 
@@ -16,8 +16,9 @@ import { reactWhenConnected, reactWhenDisconnected } from './global/init';
 function reactWhenConnectedRedirect(elm: Element, callback: ReactionCallback) {
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(!isUndefined(elm), 'Missing required node param');
-        assert.invariant(!isUndefined(callback), 'Missing callback');
+        // Eventually when the library can handle all types of Nodes, then this assetion will go away
         assert.invariant(elm instanceof Element, 'Expected to only register Elements');
+        assert.invariant(isFunction(callback), 'Expected a callback function');
     }
 
     reactWhenConnected(elm, callback);
@@ -26,8 +27,9 @@ function reactWhenConnectedRedirect(elm: Element, callback: ReactionCallback) {
 function reactWhenDisconnectedRedirect(elm: Element, callback: ReactionCallback) {
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(!isUndefined(elm), 'Missing required node param');
-        assert.invariant(!isUndefined(callback), 'Missing callback');
+        // Eventually when the library can handle all types of Nodes, then this assetion will go away
         assert.invariant(elm instanceof Element, 'Expected to only register Elements');
+        assert.invariant(isFunction(callback), 'Expected a callback function');
     }
 
     reactWhenDisconnected(elm, callback);

--- a/packages/@lwc/node-reactions/src/api.ts
+++ b/packages/@lwc/node-reactions/src/api.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isUndefined, assert } from '@lwc/shared';
+import { ReactionCallback } from './types';
+import { reactWhenConnected, reactWhenDisconnected } from './global/init';
+
+/**
+ * Redirecting after dev mode assertion.
+ * In prod mode, the browser should be able to optimize this
+ */
+
+function reactWhenConnectedRedirect(elm: Element, callback: ReactionCallback) {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.invariant(!isUndefined(elm), 'Missing required node param');
+        assert.invariant(!isUndefined(callback), 'Missing callback');
+        assert.invariant(elm instanceof Element, 'Expected to only register Elements');
+    }
+
+    reactWhenConnected(elm, callback);
+}
+
+function reactWhenDisconnectedRedirect(elm: Element, callback: ReactionCallback) {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.invariant(!isUndefined(elm), 'Missing required node param');
+        assert.invariant(!isUndefined(callback), 'Missing callback');
+        assert.invariant(elm instanceof Element, 'Expected to only register Elements');
+    }
+
+    reactWhenDisconnected(elm, callback);
+}
+
+export {
+    reactWhenConnectedRedirect as reactWhenConnected,
+    reactWhenDisconnectedRedirect as reactWhenDisconnected,
+};

--- a/packages/@lwc/node-reactions/src/core/reaction-queue.ts
+++ b/packages/@lwc/node-reactions/src/core/reaction-queue.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { forEach, ArrayPush } from '@lwc/shared';
+import { ReactionRecord } from '../types';
+
+export function queueReactionRecord(
+    reactionQueue: ReactionRecord[],
+    reactionList: ReactionRecord[]
+) {
+    ArrayPush.apply(reactionQueue, reactionList);
+}
+
+export function flushQueue(reactionQueue: ReactionRecord[]) {
+    forEach.call(reactionQueue, (entry: ReactionRecord) =>
+        entry.callback.call(entry.element, entry.type)
+    );
+}

--- a/packages/@lwc/node-reactions/src/core/reaction-queue.ts
+++ b/packages/@lwc/node-reactions/src/core/reaction-queue.ts
@@ -16,6 +16,6 @@ export function queueReactionRecord(
 
 export function flushQueue(reactionQueue: ReactionRecord[]) {
     forEach.call(reactionQueue, (entry: ReactionRecord) =>
-        entry.callback.call(entry.element, entry.type)
+        entry.callback.call(undefined, entry.element, entry.type)
     );
 }

--- a/packages/@lwc/node-reactions/src/core/reactions.ts
+++ b/packages/@lwc/node-reactions/src/core/reactions.ts
@@ -61,10 +61,9 @@ export function isRegisteredNode(node: Node): boolean {
  * 2. The root, has to have children or is a registered element
  *  2a. Assumption here is that all custom elements are registered
  */
-export function isQualifyingElement(elmOrDocFrag: Node): boolean {
+export function isQualifyingElement(elmOrDocFrag: Node | undefined | null): boolean {
     return (
         elmOrDocFrag != null &&
-        // TODO: Can we substitute with an instanceof check?
         // duck-typing to detect if node is an element or a document fragment, instead of the expensive instanceOf
         'childElementCount' in elmOrDocFrag &&
         ((elmOrDocFrag as Element | DocumentFragment).childElementCount > 0 ||
@@ -72,6 +71,6 @@ export function isQualifyingElement(elmOrDocFrag: Node): boolean {
     );
 }
 
-export function isQualifyingHost(node: Node): boolean {
+export function isQualifyingHost(node: Node | undefined | null): boolean {
     return node != null && isRegisteredNode(node);
 }

--- a/packages/@lwc/node-reactions/src/core/reactions.ts
+++ b/packages/@lwc/node-reactions/src/core/reactions.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { ArrayPush, fields, isTrue, isUndefined } from '@lwc/shared';
+import { ReactionCallback, ReactionRecord } from '../types';
+const { getHiddenField, setHiddenField, createFieldName } = fields;
+
+export const marker = 'data-node-reactions';
+const ConnectedRecordsLookup = createFieldName('connected-records-lookup', 'node-reactions');
+const DisconnectedRecordsLookup = createFieldName('disconnected-records-lookup', 'node-reactions');
+export const RegisteredFlag = createFieldName('registered-node', 'node-reactions');
+const { setAttribute } = Element.prototype;
+
+export function reactWhenConnected(element: Element, callback: ReactionCallback) {
+    const reactionRecord: ReactionRecord = { element, callback, type: 1 };
+
+    const reactionRecords: ReactionRecord[] = getHiddenField(element, ConnectedRecordsLookup);
+    if (isUndefined(reactionRecords)) {
+        setHiddenField(element, ConnectedRecordsLookup, [reactionRecord]);
+        setHiddenField(element, RegisteredFlag, true);
+        setAttribute.call(element, marker, '');
+        return;
+    }
+    ArrayPush.call(reactionRecords, reactionRecord);
+}
+
+export function reactWhenDisconnected(element: Element, callback: ReactionCallback) {
+    const reactionRecord: ReactionRecord = { element, callback, type: 2 };
+    const reactionRecords: ReactionRecord[] = getHiddenField(element, DisconnectedRecordsLookup);
+    if (isUndefined(reactionRecords)) {
+        setHiddenField(element, DisconnectedRecordsLookup, [reactionRecord]);
+        setHiddenField(element, RegisteredFlag, true);
+        setAttribute.call(element, marker, '');
+        return;
+    }
+    ArrayPush.call(reactionRecords, reactionRecord);
+}
+
+export function getDisconnectedRecordsForElement(elm: Element): ReactionRecord[] | undefined {
+    return getHiddenField(elm, DisconnectedRecordsLookup);
+}
+
+export function getConnectedRecordsForElement(elm: Element): ReactionRecord[] | undefined {
+    return getHiddenField(elm, ConnectedRecordsLookup);
+}
+
+/**
+ * For perf reasons, instead of running an instanceof to disambiguate the type, we just look up the field.
+ */
+export function isRegisteredNode(node: Node): boolean {
+    return isTrue(getHiddenField(node, RegisteredFlag));
+}
+
+/**
+ * Is a given node qualified for reactions?
+ * Conditions to satisfy
+ * 1. The root, has to be an element or document fragment
+ * 2. The root, has to have children or is a registered element
+ *  2a. Assumption here is that all custom elements are registered
+ */
+export function isQualifyingElement(elmOrDocFrag: Node): boolean {
+    return (
+        elmOrDocFrag != null &&
+        // TODO: Can we substitute with an instanceof check?
+        // duck-typing to detect if node is an element or a document fragment, instead of the expensive instanceOf
+        'childElementCount' in elmOrDocFrag &&
+        ((elmOrDocFrag as Element | DocumentFragment).childElementCount > 0 ||
+            isRegisteredNode(elmOrDocFrag))
+    );
+}
+
+export function isQualifyingHost(node: Node): boolean {
+    return node != null && isRegisteredNode(node);
+}

--- a/packages/@lwc/node-reactions/src/core/traverse.ts
+++ b/packages/@lwc/node-reactions/src/core/traverse.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, forEach, isUndefined } from '@lwc/shared';
+import { assert, isUndefined } from '@lwc/shared';
 import { ReactionRecord, QualifyingReactionTypes } from '../types';
 import {
     getConnectedRecordsForElement,
@@ -58,15 +58,17 @@ function queueReactionsForShadowRoot(
  * Process nodes in a NodeList of marked elements
  */
 function queueReactionsForNodeList(
-    nodeList: NodeList,
+    nodeList: NodeListOf<Element>,
     reactionTypes: QualifyingReactionTypes,
     reactionQueue: ReactionRecord[]
 ) {
-    forEach.call(nodeList, node => {
-        queueReactionsForSingleElement(node, reactionTypes, reactionQueue);
+    const length = nodeList.length;
+    for (let i = 0; i < length; i++) {
+        const element = nodeList[i];
+        queueReactionsForSingleElement(element, reactionTypes, reactionQueue);
         // If node has a shadow tree, process its shadow tree
-        queueReactionsForShadowRoot((node as Element).shadowRoot!, reactionTypes, reactionQueue);
-    });
+        queueReactionsForShadowRoot(element.shadowRoot!, reactionTypes, reactionQueue);
+    }
 }
 
 /**
@@ -74,7 +76,7 @@ function queueReactionsForNodeList(
  */
 export default function queueReactionsForSubtree(
     rootElm: Element | DocumentFragment,
-    nodeList: NodeList,
+    nodeList: NodeListOf<Element>,
     reactionTypes: QualifyingReactionTypes,
     reactionQueue: ReactionRecord[]
 ) {

--- a/packages/@lwc/node-reactions/src/core/traverse.ts
+++ b/packages/@lwc/node-reactions/src/core/traverse.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { assert, forEach, isUndefined } from '@lwc/shared';
+import { ReactionRecord, QualifyingReactionTypes } from '../types';
+import {
+    getConnectedRecordsForElement,
+    getDisconnectedRecordsForElement,
+    marker,
+} from './reactions';
+import { queueReactionRecord } from './reaction-queue';
+
+/**
+ * Queue qualifying reaction callbacks for a single node.
+ * If the node is a host element, this method will only queue callbacks for the host element.
+ * It does not process the host's shadow tree.
+ */
+function queueReactionsForSingleElement(
+    elm: Element,
+    reactionTypes: QualifyingReactionTypes,
+    reactionQueue: ReactionRecord[]
+) {
+    // Disconnected callback has to be processed before connected callback
+    if (reactionTypes & 2) {
+        const reactionRecords = getDisconnectedRecordsForElement(elm);
+        if (!isUndefined(reactionRecords)) {
+            queueReactionRecord(reactionQueue, reactionRecords);
+        }
+    }
+    if (reactionTypes & 1) {
+        const reactionRecords = getConnectedRecordsForElement(elm);
+        if (!isUndefined(reactionRecords)) {
+            queueReactionRecord(reactionQueue, reactionRecords);
+        }
+    }
+}
+
+const ShadowRootQuerySelectorAll = ShadowRoot.prototype.querySelectorAll;
+/**
+ * Process nodes in a shadow tree
+ */
+function queueReactionsForShadowRoot(
+    sr: ShadowRoot,
+    reactionTypes: QualifyingReactionTypes,
+    reactionQueue: ReactionRecord[]
+) {
+    queueReactionsForNodeList(
+        ShadowRootQuerySelectorAll.call(sr, `[${marker}]`),
+        reactionTypes,
+        reactionQueue
+    );
+}
+
+/**
+ * Process nodes in a NodeList of marked elements
+ */
+function queueReactionsForNodeList(
+    nodeList: NodeList,
+    reactionTypes: QualifyingReactionTypes,
+    reactionQueue: ReactionRecord[]
+) {
+    forEach.call(nodeList, node => {
+        queueReactionsForSingleElement(node, reactionTypes, reactionQueue);
+        // If node has a shadow tree, process its shadow tree
+        queueReactionsForShadowRoot((node as Element).shadowRoot!, reactionTypes, reactionQueue);
+    });
+}
+
+/**
+ * Traverse and queue reactions for a sub tree
+ */
+export default function queueReactionsForSubtree(
+    rootElm: Element | DocumentFragment,
+    nodeList: NodeList,
+    reactionTypes: QualifyingReactionTypes,
+    reactionQueue: ReactionRecord[]
+) {
+    if (process.env.NODE_ENV !== 'production') {
+        assert.invariant(!isUndefined(rootElm), `Expected a dom node but received undefined`);
+    }
+
+    // Process root node first
+    queueReactionsForSingleElement(rootElm as any, reactionTypes, reactionQueue);
+
+    // If root node has a shadow tree, process its shadow tree
+    const sr = (rootElm as any).shadowRoot;
+    if (sr != null) {
+        // coerce to null, shadowRoot of docFrag will be undefined
+        queueReactionsForShadowRoot(sr, reactionTypes, reactionQueue);
+    }
+    // Process all registered nodes in subtree in pre-order
+    queueReactionsForNodeList(nodeList, reactionTypes, reactionQueue);
+}

--- a/packages/@lwc/node-reactions/src/dom-patching/node.ts
+++ b/packages/@lwc/node-reactions/src/dom-patching/node.ts
@@ -24,7 +24,6 @@ export default function() {
             configurable: true,
             value: function(this: Node, aChild: Node) {
                 if (!isQualifyingHost(aChild)) {
-                    // invoke with apply to preserve native behavior of missing arguments, invalid types etc
                     return appendChild.call(this, aChild);
                 }
 
@@ -110,7 +109,7 @@ export default function() {
 
                 // Process oldChild
                 let qualifiedReactionTypesForOldChild: QualifyingReactionTypes = 0;
-                let qualifyingOldChildren: undefined | NodeList;
+                let qualifyingOldChildren: undefined | NodeListOf<Element>;
                 // Is the parent node whose subtree is being modified, a connected node?
                 const parentIsConnected = isConnectedGetter.call(this);
                 if (oldChildIsQualified && parentIsConnected) {
@@ -123,7 +122,7 @@ export default function() {
                 // Process newChild
                 let qualifiedReactionTypesForNewChild: QualifyingReactionTypes = 0;
                 // pre fetch the new child's subtree(works for both Element and DocFrag)
-                let qualifyingNewChildren: undefined | NodeList;
+                let qualifyingNewChildren: undefined | NodeListOf<Element>;
                 if (newChildIsQualified) {
                     // If newChild was connected, call disconnectedCallback
                     if (isConnectedGetter.call(newChild)) {
@@ -147,7 +146,7 @@ export default function() {
                 if (qualifiedReactionTypesForOldChild & 2) {
                     queueReactionsForSubtree(
                         oldChild as Element,
-                        qualifyingOldChildren!,
+                        qualifyingOldChildren as NodeListOf<Element>,
                         qualifiedReactionTypesForOldChild,
                         reactionQueue
                     );
@@ -155,7 +154,7 @@ export default function() {
                 if (qualifiedReactionTypesForNewChild > 0) {
                     queueReactionsForSubtree(
                         newChild as Element | DocumentFragment,
-                        qualifyingNewChildren!,
+                        qualifyingNewChildren as NodeListOf<Element>,
                         qualifiedReactionTypesForNewChild,
                         reactionQueue
                     );

--- a/packages/@lwc/node-reactions/src/dom-patching/node.ts
+++ b/packages/@lwc/node-reactions/src/dom-patching/node.ts
@@ -23,7 +23,7 @@ export default function() {
             enumerable: true,
             configurable: true,
             value: function(this: Node, aChild: Node) {
-                if (!isQualifyingHost(aChild)) {
+                if (!isQualifyingElement(aChild)) {
                     return appendChild.call(this, aChild);
                 }
 

--- a/packages/@lwc/node-reactions/src/dom-patching/node.ts
+++ b/packages/@lwc/node-reactions/src/dom-patching/node.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { getOwnPropertyDescriptor, defineProperties } from '@lwc/shared';
+import { ReactionRecord, QualifyingReactionTypes } from '../types';
+import queueReactionsForSubtree from '../core/traverse';
+import { flushQueue } from '../core/reaction-queue';
+import { isQualifyingElement, isQualifyingHost, marker } from '../core/reactions';
+
+export default function() {
+    // caching few DOM APIs
+    const { appendChild, insertBefore, removeChild, replaceChild } = Node.prototype;
+
+    const isConnectedGetter = getOwnPropertyDescriptor(Node.prototype, 'isConnected')!.get!;
+
+    defineProperties(Node.prototype, {
+        appendChild: {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: function(this: Node, aChild: Node) {
+                // Performance optimization: Only check if the node being added is a registered node.
+                // We made this decision because appendChild is on the critical path and cannot
+                // subject every node to the expensive check that isQualifyingElement() performs
+                if (!isQualifyingHost(aChild)) {
+                    // invoke with apply to preserve native behavior of missing arguments, invalid types etc
+                    return appendChild.call(this, aChild);
+                }
+
+                let qualifiedReactionTypes: QualifyingReactionTypes = 0;
+                if (isConnectedGetter.call(aChild)) {
+                    qualifiedReactionTypes = qualifiedReactionTypes | 2;
+                }
+                // Get the children before appending
+                const qualifyingChildren = (aChild as Element | DocumentFragment).querySelectorAll(
+                    `[${marker}]`
+                );
+
+                // DOM Operation
+                const result = appendChild.call(this, aChild);
+
+                if (isConnectedGetter.call(this)) {
+                    qualifiedReactionTypes = qualifiedReactionTypes | 1;
+                }
+                if (qualifiedReactionTypes > 0) {
+                    const reactionQueue: ReactionRecord[] = [];
+                    queueReactionsForSubtree(
+                        aChild as Element | DocumentFragment,
+                        qualifyingChildren,
+                        qualifiedReactionTypes,
+                        reactionQueue
+                    );
+                    flushQueue(reactionQueue);
+                }
+                return result;
+            },
+        },
+        insertBefore: {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: function(this: Node, newNode: Node, referenceNode: Node) {
+                // Performance optimization: Only check if the node being added is a registered node.
+                // We made this decision because insertBefore is on the critical path and cannot
+                // subject every node to the expensive check that isQualifyingElement() performs
+                if (!isQualifyingHost(newNode)) {
+                    return insertBefore.call(this, newNode, referenceNode);
+                }
+
+                let qualifiedReactionTypes: QualifyingReactionTypes = 0;
+                if (isConnectedGetter.call(newNode)) {
+                    qualifiedReactionTypes = qualifiedReactionTypes | 2;
+                }
+                const qualifyingChildren = (newNode as Element | DocumentFragment).querySelectorAll(
+                    `[${marker}]`
+                );
+
+                // DOM Operation
+                const result = insertBefore.call(this, newNode, referenceNode);
+
+                if (isConnectedGetter.call(this)) {
+                    // Short circuit and check if parent is connected
+                    qualifiedReactionTypes = qualifiedReactionTypes | 1;
+                }
+                if (qualifiedReactionTypes > 0) {
+                    const reactionQueue: ReactionRecord[] = [];
+                    queueReactionsForSubtree(
+                        newNode as Element | DocumentFragment,
+                        qualifyingChildren,
+                        qualifiedReactionTypes,
+                        reactionQueue
+                    );
+                    flushQueue(reactionQueue);
+                }
+                return result;
+            },
+        },
+        replaceChild: {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: function(this: Node, newChild: Node, oldChild: Node) {
+                const oldChildIsQualified = isQualifyingElement(oldChild);
+                const newChildIsQualified = isQualifyingElement(newChild);
+                // If both oldChild and newChild are non qualifying elements, exit early
+                if (!oldChildIsQualified && !newChildIsQualified) {
+                    return replaceChild.call(this, newChild, oldChild);
+                }
+
+                // Process oldChild
+                let qualifiedReactionTypesForOldChild: QualifyingReactionTypes = 0;
+                let qualifyingOldChildren: undefined | NodeList;
+                // Is the parent node whose subtree is being modified, a connected node?
+                const parentIsConnected = isConnectedGetter.call(this);
+                if (oldChildIsQualified && parentIsConnected) {
+                    qualifiedReactionTypesForOldChild = qualifiedReactionTypesForOldChild | 2;
+                    qualifyingOldChildren = (oldChild as
+                        | Element
+                        | DocumentFragment).querySelectorAll(`[${marker}]`);
+                }
+
+                // Process newChild
+                let qualifiedReactionTypesForNewChild: QualifyingReactionTypes = 0;
+                // pre fetch the new child's subtree(works for both Element and DocFrag)
+                let qualifyingNewChildren: undefined | NodeList;
+                if (newChildIsQualified) {
+                    // If newChild was connected, call disconnectedCallback
+                    if (isConnectedGetter.call(newChild)) {
+                        qualifiedReactionTypesForNewChild = qualifiedReactionTypesForNewChild | 2;
+                    }
+                    // If newChild will be connected, call connectedCallback
+                    if (parentIsConnected) {
+                        qualifiedReactionTypesForNewChild = qualifiedReactionTypesForNewChild | 1;
+                    }
+                    if (qualifiedReactionTypesForNewChild > 0) {
+                        qualifyingNewChildren = (newChild as
+                            | Element
+                            | DocumentFragment).querySelectorAll(`[${marker}]`);
+                    }
+                }
+
+                // DOM Operation
+                const result = replaceChild.call(this, newChild, oldChild);
+
+                const reactionQueue: ReactionRecord[] = [];
+                if (qualifiedReactionTypesForOldChild & 2) {
+                    queueReactionsForSubtree(
+                        oldChild as Element,
+                        qualifyingOldChildren!,
+                        qualifiedReactionTypesForOldChild,
+                        reactionQueue
+                    );
+                }
+                if (qualifiedReactionTypesForNewChild > 0) {
+                    queueReactionsForSubtree(
+                        newChild as Element | DocumentFragment,
+                        qualifyingNewChildren!,
+                        qualifiedReactionTypesForNewChild,
+                        reactionQueue
+                    );
+                }
+                flushQueue(reactionQueue);
+                return result;
+            },
+        },
+        removeChild: {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: function(this: Node, child: Node) {
+                // If child is connected and it is a qualifying element, process reaction records
+                if (isConnectedGetter.call(this) && isQualifyingElement(child)) {
+                    const qualifyingChildren = (child as
+                        | Element
+                        | DocumentFragment).querySelectorAll(`[${marker}]`);
+                    const qualifiedReactionTypes: QualifyingReactionTypes = 2;
+
+                    // DOM operation
+                    const result = removeChild.call(this, child);
+                    const reactionQueue: ReactionRecord[] = [];
+                    queueReactionsForSubtree(
+                        child as Element | DocumentFragment,
+                        qualifyingChildren,
+                        qualifiedReactionTypes,
+                        reactionQueue
+                    );
+                    flushQueue(reactionQueue);
+                    return result;
+                }
+                return removeChild.call(this, child);
+            },
+        },
+    });
+}

--- a/packages/@lwc/node-reactions/src/dom-patching/node.ts
+++ b/packages/@lwc/node-reactions/src/dom-patching/node.ts
@@ -23,9 +23,6 @@ export default function() {
             enumerable: true,
             configurable: true,
             value: function(this: Node, aChild: Node) {
-                // Performance optimization: Only check if the node being added is a registered node.
-                // We made this decision because appendChild is on the critical path and cannot
-                // subject every node to the expensive check that isQualifyingElement() performs
                 if (!isQualifyingHost(aChild)) {
                     // invoke with apply to preserve native behavior of missing arguments, invalid types etc
                     return appendChild.call(this, aChild);

--- a/packages/@lwc/node-reactions/src/global/README.md
+++ b/packages/@lwc/node-reactions/src/global/README.md
@@ -1,0 +1,2 @@
+Note:
+Modules in this folder contain stateful information. This is important when working with unit test environments. Jest for example shares DOM prototypes across test suites. Care must be taken to avoid repeatedly patching prototypes.

--- a/packages/@lwc/node-reactions/src/global/init.ts
+++ b/packages/@lwc/node-reactions/src/global/init.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { defineProperty, isUndefined } from '@lwc/shared';
+import { ReactionCallback } from '../types';
+import patchNodePrototype from '../dom-patching/node';
+import { reactWhenConnected, reactWhenDisconnected } from '../core/reactions';
+
+const {
+    prototype: { constructor: DocumentConstructor },
+} = Document;
+
+/**
+ * Path the DOM APIs and start monitoring dom mutations
+ */
+function patchDomApi() {
+    patchNodePrototype();
+}
+
+const InitializationSlot = '$$node-reactions-initialized$$';
+let reactWhenConnectedCached: (elm: Element, callback: ReactionCallback) => void;
+let reactWhenDisconnectedCached: (elm: Element, callback: ReactionCallback) => void;
+
+initialize();
+/**
+ * Set an internal field to detect initialization
+ */
+export function initialize() {
+    let init = (DocumentConstructor as any)[InitializationSlot];
+    if (isUndefined(init)) {
+        patchDomApi();
+        init = () => {
+            return {
+                connected: reactWhenConnected,
+                disconnected: reactWhenDisconnected,
+            };
+        };
+        // Defined as an arrow function to avoid anybody walking the prototype chain from
+        // accidentally discovering the cached apis
+        defineProperty(DocumentConstructor, InitializationSlot, { value: init });
+    }
+    const cachedApis = init();
+    reactWhenConnectedCached = cachedApis.connected;
+    reactWhenDisconnectedCached = cachedApis.disconnected;
+}
+
+export {
+    reactWhenConnectedCached as reactWhenConnected,
+    reactWhenDisconnectedCached as reactWhenDisconnected,
+};

--- a/packages/@lwc/node-reactions/src/global/init.ts
+++ b/packages/@lwc/node-reactions/src/global/init.ts
@@ -28,7 +28,7 @@ initialize();
 /**
  * Set an internal field to detect initialization
  */
-export function initialize() {
+function initialize() {
     let init = (DocumentConstructor as any)[InitializationSlot];
     if (isUndefined(init)) {
         patchDomApi();

--- a/packages/@lwc/node-reactions/src/index.ts
+++ b/packages/@lwc/node-reactions/src/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import './global/init';
+export { reactWhenConnected, reactWhenDisconnected } from './api';

--- a/packages/@lwc/node-reactions/src/types.ts
+++ b/packages/@lwc/node-reactions/src/types.ts
@@ -7,7 +7,7 @@
 
 export type ReactionType = 1 /* connected */ | 2 /* disconnected */;
 
-export type ReactionCallback = (this: Element, reactionType: ReactionType) => void;
+export type ReactionCallback = (element: Element, reactionType: ReactionType) => void;
 
 export interface ReactionRecord {
     type: ReactionType;

--- a/packages/@lwc/node-reactions/src/types.ts
+++ b/packages/@lwc/node-reactions/src/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export type ReactionType = 1 /* connected */ | 2 /* disconnected */;
+
+export type ReactionCallback = (this: Element, reactionType: ReactionType) => void;
+
+export interface ReactionRecord {
+    type: ReactionType;
+    callback: ReactionCallback;
+    element: Element;
+}
+
+export type QualifyingReactionTypes = number; /* 0: none, 1: connected, 2: disconnected */

--- a/packages/@lwc/node-reactions/tsconfig.json
+++ b/packages/@lwc/node-reactions/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist/commonjs",
+        "declarationDir": "dist/types"
+    },
+    "include": ["src/"]
+}

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -25,6 +25,7 @@ import {
     cloneNode,
     hasChildNodes,
     contains,
+    isConnected,
     parentElementGetter,
     lastChildGetter,
     firstChildGetter,
@@ -426,6 +427,13 @@ defineProperties(Node.prototype, {
         enumerable: true,
         configurable: true,
         writable: true,
+    },
+    isConnected: {
+        enumerable: true,
+        configurable: true,
+        get(this: Node) {
+            return isConnected.call(this);
+        },
     },
 });
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -33,10 +33,6 @@ import {
     parentElementGetter,
     textContextSetter,
     isConnected,
-    removeChild,
-    insertBefore,
-    replaceChild,
-    appendChild,
     COMMENT_NODE,
 } from '../env/node';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
@@ -269,7 +265,7 @@ const NodePatchDescriptors = {
             newChild: T,
             refChild: Node | null
         ): T {
-            insertBefore.call(getHost(this), newChild, refChild);
+            Node.prototype.insertBefore.call(getHost(this), newChild, refChild);
             return newChild;
         },
     },
@@ -278,7 +274,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value<T extends Node>(this: SyntheticShadowRootInterface, oldChild: T): T {
-            removeChild.call(getHost(this), oldChild);
+            Node.prototype.removeChild.call(getHost(this), oldChild);
             return oldChild;
         },
     },
@@ -287,7 +283,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value<T extends Node>(this: SyntheticShadowRootInterface, newChild: T): T {
-            appendChild.call(getHost(this), newChild);
+            Node.prototype.appendChild.call(getHost(this), newChild);
             return newChild;
         },
     },
@@ -296,7 +292,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value<T extends Node>(this: SyntheticShadowRootInterface, newChild: Node, oldChild: T): T {
-            replaceChild.call(getHost(this), newChild, oldChild);
+            Node.prototype.replaceChild.call(getHost(this), newChild, oldChild);
             return oldChild;
         },
     },

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/index.spec.js
@@ -3,6 +3,7 @@ import { createElement } from 'lwc';
 import Test from 'x/test';
 import ConnectedCallbackThrow from 'x/connectedCallbackThrow';
 import XSlottedParent from 'x/slottedParent';
+import XParent from 'x/parent';
 
 function testConnectSlot(name, fn) {
     it(`should invoke the connectedCallback the root element is added in the DOM via ${name}`, () => {
@@ -63,5 +64,43 @@ describe('addEventListner in `connectedCallback`', () => {
             expect(elm.eventHandled).toBe(true);
             expect(elm.shadowRoot.querySelector('p').textContent).toBe('Was clicked: true');
         });
+    });
+});
+
+describe('connectedCallback for host with slots', () => {
+    let parentConnectSpy;
+    let slotAcceptingChildSpy;
+    let acceptedSlotContentSpy;
+    let parent;
+    let container;
+
+    beforeEach(() => {
+        parentConnectSpy = jasmine.createSpy();
+        slotAcceptingChildSpy = jasmine.createSpy();
+        acceptedSlotContentSpy = jasmine.createSpy();
+        parent = createElement('x-parent', { is: XParent });
+        parent.connect = parentConnectSpy;
+
+        document.body.appendChild(parent);
+        parentConnectSpy.calls.reset();
+
+        parent.shadowRoot.querySelector('x-accepting-slots').connect = slotAcceptingChildSpy;
+        parent.shadowRoot.querySelector('x-test').connect = acceptedSlotContentSpy;
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    it('should invoke connectedCallback on appendChild', () => {
+        container.appendChild(parent);
+        expect(parentConnectSpy).toHaveBeenCalledTimes(1);
+        expect(slotAcceptingChildSpy).toHaveBeenCalledTimes(1);
+        expect(acceptedSlotContentSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke connectedCallback on insertBefore', () => {
+        container.insertBefore(parent, null);
+        expect(parentConnectSpy).toHaveBeenCalledTimes(1);
+        expect(slotAcceptingChildSpy).toHaveBeenCalledTimes(1);
+        expect(acceptedSlotContentSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/x/acceptingSlots/acceptingSlots.html
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/x/acceptingSlots/acceptingSlots.html
@@ -1,0 +1,5 @@
+<template>
+    <slot>
+        <div class="default"></div>
+    </slot>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/x/acceptingSlots/acceptingSlots.js
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/x/acceptingSlots/acceptingSlots.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class AcceptingSlots extends LightningElement {
+    @api connect;
+
+    connectedCallback() {
+        this.connect && this.connect();
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/x/parent/parent.html
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/x/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <x-accepting-slots>
+        <x-test></x-test>
+    </x-accepting-slots>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/x/parent/parent.js
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/x/parent/parent.js
@@ -1,9 +1,9 @@
 import { LightningElement, api } from 'lwc';
 
-export default class Test extends LightningElement {
+export default class SlottedParent extends LightningElement {
     @api connect;
 
     connectedCallback() {
-        this.connect && this.connect(this);
+        this.connect();
     }
 }

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
@@ -87,6 +87,7 @@ describe('disconnectedCallback for host with slots', () => {
     let parentDisconnectSpy;
     let slotIgnoringChildSpy;
     let slotAcceptingChildSpy;
+    let acceptedSlotContentSpy;
     let parent;
 
     beforeAll(() => {
@@ -101,11 +102,13 @@ describe('disconnectedCallback for host with slots', () => {
         parentDisconnectSpy = jasmine.createSpy();
         slotIgnoringChildSpy = jasmine.createSpy();
         slotAcceptingChildSpy = jasmine.createSpy();
+        acceptedSlotContentSpy = jasmine.createSpy();
         parent = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(parent);
         parent.disconnect = parentDisconnectSpy;
         parent.shadowRoot.querySelector('x-accepting-slots').disconnect = slotAcceptingChildSpy;
         parent.shadowRoot.querySelector('x-ignoring-slots').disconnect = slotIgnoringChildSpy;
+        parent.shadowRoot.querySelector('x-test.slotted').disconnect = acceptedSlotContentSpy;
     });
 
     it('should invoke disconnectedCallback on host and all children components', () => {
@@ -113,6 +116,7 @@ describe('disconnectedCallback for host with slots', () => {
         expect(parentDisconnectSpy).toHaveBeenCalledTimes(1);
         expect(slotAcceptingChildSpy).toHaveBeenCalledTimes(1);
         expect(slotIgnoringChildSpy).toHaveBeenCalledTimes(1);
+        expect(acceptedSlotContentSpy).toHaveBeenCalledTimes(1);
     });
 
     /**
@@ -131,14 +135,11 @@ describe('disconnectedCallback for host with slots', () => {
     });
 
     it('should invoke disconnectedCallback on child that has rendered slot content', () => {
-        const slotContent = parent.shadowRoot.querySelector('x-test.slotted');
-        const slotContentDisconnectSpy = jasmine.createSpy();
-        slotContent.disconnect = slotContentDisconnectSpy;
         parent.hideChildAcceptsSlots = true;
         return Promise.resolve(() => {
             expect(parentDisconnectSpy).not.toHaveBeenCalled();
             expect(slotAcceptingChildSpy).toHaveBeenCalledTimes(1);
-            expect(slotContentDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(acceptedSlotContentSpy).toHaveBeenCalledTimes(1);
             expect(slotIgnoringChildSpy).not.toHaveBeenCalled();
         });
     });

--- a/packages/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/track/index.spec.js
@@ -114,7 +114,7 @@ describe('array mutations', () => {
         });
     });
 
-    it('rerenders the component if an item is removed via Array.prototype.pop', () => {
+    it('rerenders the component if an item is removed via Array.prototype.unshift', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -132,7 +132,7 @@ it('should call children component lifecycle hooks when a public property change
     });
 });
 
-xit('should call parent and children lifecycle hooks in correct order when parent reconnected', () => {
+it('should call parent and children lifecycle hooks in correct order when parent reconnected', () => {
     const elm = createElement('x-parent', { is: Parent });
 
     document.body.appendChild(elm);
@@ -140,13 +140,12 @@ xit('should call parent and children lifecycle hooks in correct order when paren
 
     resetTimingBuffer();
     document.body.appendChild(elm);
+    // child:renderedCallback is not invoked because the elements are reused by the diffing algo
     expect(window.timingBuffer).toEqual([
         'parent:connectedCallback',
-        'child:connectedCallback',
-        'child:renderedCallback',
-        'child:connectedCallback',
-        'child:renderedCallback',
         'parent:renderedCallback',
+        'child:connectedCallback',
+        'child:connectedCallback',
     ]);
 });
 
@@ -164,21 +163,34 @@ describe('should invoke the component lifecycle hooks in the right order for a s
             'child:disconnectedCallback',
         ]);
     });
-    // TODO: In native shadow mode, accepting-slot:renderedCallback is invoked before child:constructor
-    xit('appending parent to the DOM', () => {
+    it('appending parent to the DOM', () => {
         const elm = createElement('x-slotted-parent', { is: SlottedParent });
         resetTimingBuffer();
         document.body.appendChild(elm);
-
-        expect(window.timingBuffer).toEqual([
-            'slotted-parent:connectedCallback',
-            'accepting-slot:constructor',
-            'accepting-slot:connectedCallback',
-            'child:constructor',
-            'child:connectedCallback',
-            'child:renderedCallback',
-            'accepting-slot:renderedCallback',
-            'slotted-parent:renderedCallback',
-        ]);
+        if (process.env.NATIVE_SHADOW) {
+            expect(window.timingBuffer).toEqual([
+                // In native shadow mode, accepting-slot:renderedCallback is invoked before child:constructor
+                'slotted-parent:connectedCallback',
+                'accepting-slot:constructor',
+                'accepting-slot:connectedCallback',
+                'accepting-slot:renderedCallback',
+                'child:constructor',
+                'child:connectedCallback',
+                'child:renderedCallback',
+                'slotted-parent:renderedCallback',
+            ]);
+        } else {
+            // The difference in behavior is due to the way we handle slotted content in synthetic-shadow mode
+            expect(window.timingBuffer).toEqual([
+                'slotted-parent:connectedCallback',
+                'accepting-slot:constructor',
+                'accepting-slot:connectedCallback',
+                'child:constructor',
+                'child:connectedCallback',
+                'child:renderedCallback',
+                'accepting-slot:renderedCallback',
+                'slotted-parent:renderedCallback',
+            ]);
+        }
     });
 });

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/acceptingSlots/acceptingSlots.html
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/acceptingSlots/acceptingSlots.html
@@ -1,0 +1,5 @@
+<template>
+    <slot>
+        <div class="default"></div>
+    </slot>
+</template>

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/acceptingSlots/acceptingSlots.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/acceptingSlots/acceptingSlots.js
@@ -1,0 +1,20 @@
+import { LightningElement } from 'lwc';
+
+export default class AcceptingSlots extends LightningElement {
+    constructor() {
+        super();
+        window.timingBuffer.push('accepting-slot:constructor');
+    }
+
+    connectedCallback() {
+        window.timingBuffer.push('accepting-slot:connectedCallback');
+    }
+
+    disconnectedCallback() {
+        window.timingBuffer.push('accepting-slot:disconnectedCallback');
+    }
+
+    renderedCallback() {
+        window.timingBuffer.push('accepting-slot:renderedCallback');
+    }
+}

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/slottedParent/slottedParent.html
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/slottedParent/slottedParent.html
@@ -1,0 +1,5 @@
+<template>
+    <x-accepting-slots>
+        <x-child></x-child>
+    </x-accepting-slots>
+</template>

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/slottedParent/slottedParent.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/slottedParent/slottedParent.js
@@ -1,0 +1,20 @@
+import { LightningElement } from 'lwc';
+
+export default class SlottedParent extends LightningElement {
+    constructor() {
+        super();
+        window.timingBuffer.push('slotted-parent:constructor');
+    }
+
+    connectedCallback() {
+        window.timingBuffer.push('slotted-parent:connectedCallback');
+    }
+
+    disconnectedCallback() {
+        window.timingBuffer.push('slotted-parent:disconnectedCallback');
+    }
+
+    renderedCallback() {
+        window.timingBuffer.push('slotted-parent:renderedCallback');
+    }
+}

--- a/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
@@ -2,13 +2,17 @@ import { createElement } from 'lwc';
 
 import Test from 'x/test';
 
+function stripDataMarker(str) {
+    // Strip the node-reactions marker
+    return str.replace(/ data-node-reactions(="")*/gm, '');
+}
 describe('Element.outerHTML - get', () => {
     it('should enforce the shadow DOM semantic - x-test', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        expect(elm.outerHTML).toBe('<x-test></x-test>');
-        expect(elm.shadowRoot.querySelector('x-container').outerHTML).toBe(
+        expect(stripDataMarker(elm.outerHTML)).toBe('<x-test></x-test>');
+        expect(stripDataMarker(elm.shadowRoot.querySelector('x-container').outerHTML)).toBe(
             '<x-container><div>Slotted Text<input name="slotted"></div></x-container>'
         );
         expect(elm.shadowRoot.querySelector('div').outerHTML).toBe(

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
@@ -4,6 +4,11 @@ import Slotted from 'x/slotted';
 import Container from 'x/container';
 import ComplexCloneNode from 'x/complexCloneNode';
 
+function stripDataMarker(str) {
+    // Strip the node-reactions marker
+    return str.replace(/ data-node-reactions(="")*/gm, '');
+}
+
 function testCloneNodeShadowRoot(deep) {
     it(`should not clone the associated shadowRoot when cloning an element with deep=${deep}`, () => {
         const elm = createElement('x-slotted', { is: Slotted });
@@ -42,7 +47,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(false);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should not clone slotted content', () => {
@@ -51,7 +56,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode(false);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
     });
 
@@ -62,7 +67,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode();
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should not clone slotted content', () => {
@@ -71,7 +76,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode();
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
 
         it('should not clone children of parent node with vanilla html', () => {
@@ -91,7 +96,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(true);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should clone slotted content', () => {
@@ -100,7 +105,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode(true);
             expect(clone.childNodes.length).toBe(1);
-            expect(clone.outerHTML).toBe(
+            expect(stripDataMarker(clone.outerHTML)).toBe(
                 '<x-container><div class="slotted">Slotted Text</div></x-container>'
             );
         });
@@ -111,7 +116,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('div').cloneNode(true);
             expect(clone.childNodes.length).toBe(2);
-            expect(clone.outerHTML).toBe(
+            expect(stripDataMarker(clone.outerHTML)).toBe(
                 '<div>A<x-container><x-container>B</x-container><div><x-container>C</x-container></div></x-container></div>'
             );
         });
@@ -122,7 +127,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(true);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripDataMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
 
         it('should clone children of parent node with vanilla html', () => {

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
@@ -2,12 +2,19 @@ import { createElement } from 'lwc';
 
 import Test from 'x/test';
 
+function stripDataMarker(str) {
+    // Strip the node-reactions marker
+    return str.replace(/ data-node-reactions(="")*/gm, '');
+}
+
 describe('ShadowRoot.innerHTML', () => {
     it('get - should enforce the shadow DOM semantic', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        expect(elm.shadowRoot.innerHTML).toBe('<x-container><div>Slotted Text</div></x-container>');
+        expect(stripDataMarker(elm.shadowRoot.innerHTML)).toBe(
+            '<x-container><div>Slotted Text</div></x-container>'
+        );
         expect(elm.shadowRoot.querySelector('x-container').shadowRoot.innerHTML).toBe(
             '<div>Before[<slot></slot>]After</div>'
         );

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -162,7 +162,9 @@ function doEventsBubbleToDocFrag() {
 describe('event propagation in disconnected tree', () => {
     it('propagate event from a child element in a document fragment', () => {
         const fragment = document.createDocumentFragment();
-        const nodes = createShadowTree(fragment);
+        const nodes = createShadowTree(document.body);
+        // Add to body and then move to fragment because lwc element is not hydrated until it is connected to the document
+        fragment.appendChild(nodes['x-shadow-tree']);
         const logs = dispatchEventWithLog(
             nodes.span,
             new CustomEvent('test', { composed: true, bubbles: true })


### PR DESCRIPTION
## Details
Experimental branch to see if we can rely on registered custom elements for connect/disconnect detection instead of always relying on node-reactions.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
