### PR TITLE
docs(engine): fix jsdoc example of using buildCustomElementConstructor

### DIFF
--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -21,7 +21,7 @@ import { patchCustomElementWithRestrictions } from './restrictions';
  *      import { buildCustomElementConstructor } from 'lwc';
  *      import Foo from 'ns/foo';
  *      const WC = buildCustomElementConstructor(Foo);
- *      customElements.define('x-foo', Foo);
+ *      customElements.define('x-foo', WC);
  *      const elm = document.createElement('x-foo');
  *
  */


### PR DESCRIPTION
## Details

The jsdoc comment that demonstrates how to use `buildCustomElementConstructor` has an error in it, this PR fixes it.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
