### PR TITLE
fix(engine): move @lwc/features to dependencies of @lwc/engine

### DIFF
--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -16,10 +16,10 @@
         "types/"
     ],
     "dependencies": {
+        "@lwc/features": "1.1.0",
         "observable-membrane": "0.26.1"
     },
     "devDependencies": {
-        "@lwc/features": "1.1.0",
         "@lwc/shared": "1.1.0",
         "@lwc/template-compiler": "1.1.0"
     },


### PR DESCRIPTION
## Details

`@lwc/engine/src/framework/main.ts` re-exports functions from `@lwc/features` package.  However, the package.json lists that as just a dev dependency so when my LWC app updates to lwc/engine 1.1 it fails to build because it can't find `@lwc/features` in my node_modules.  This PR moves `@lwc/features` to be a runtime dependency so that consumers of engine don't have to explicitly `npm i @lwc/features`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added?  ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
