### PR TITLE
fix(synthetic-shadow): querySelectors not returning

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -7,9 +7,13 @@
 import { isHostElement } from './shadow-root';
 import { getAllMatches, getNodeOwner, getAllSlottedMatches } from './traverse';
 import { ArrayFilter, ArraySlice, isNull, isUndefined } from '@lwc/shared';
-import { getNodeKey, getNodeOwnerKey } from './node';
+import { getNodeKey, getNodeNearestOwnerKey, getNodeOwnerKey } from './node';
 import { isGlobalPatchingSkipped } from '../shared/utils';
 
+/**
+ * This methods filters out elements that are not in the same shadow root of context.
+ * It does not enforce shadow dom semantics if $context is not managed by LWC
+ */
 export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
     context: Element,
     unfilteredNodes: Array<T>
@@ -33,7 +37,11 @@ export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
                 filtered = getAllMatches(owner, unfilteredNodes);
             }
         } else {
-            filtered = ArrayFilter.call(unfilteredNodes, elm => getNodeOwnerKey(elm) === ownerKey);
+            // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
+            filtered = ArrayFilter.call(
+                unfilteredNodes,
+                elm => getNodeNearestOwnerKey(elm) === ownerKey
+            );
         }
     } else if (context instanceof HTMLBodyElement) {
         // `context` is document.body which is already patched.

--- a/packages/integration-karma/test/shadow-dom/Element-properties/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Element-properties/index.spec.js
@@ -3,6 +3,7 @@ import { createElement } from 'lwc';
 import Slotted from 'x/slotted';
 import Nested from 'x/nested';
 import NestedFallback from 'x/nestedFallback';
+import TestWithDiv from 'x/testWithDiv';
 
 describe('Element.querySelector', () => {
     it('should return null if no Element match', () => {
@@ -20,6 +21,20 @@ describe('Element.querySelector', () => {
 
         const slotted1 = elm.shadowRoot.firstChild.firstChild;
         expect(elm.shadowRoot.querySelector('.slotted')).toBe(slotted1);
+    });
+
+    it('should return matching elements when are manually inserted in same shadow', () => {
+        const elm = createElement('x-test-with-div', { is: TestWithDiv });
+        document.body.appendChild(elm);
+
+        const divInsideShadow = elm.shadowRoot.querySelector('div');
+        const manuallyInsertedElement = document.createElement('span');
+
+        divInsideShadow.appendChild(manuallyInsertedElement);
+
+        const qsResult = divInsideShadow.querySelector('span');
+
+        expect(qsResult).toBe(manuallyInsertedElement);
     });
 });
 
@@ -52,6 +67,56 @@ describe('Element.querySelectorAll', () => {
         expect(nodeList.length).toBe(2);
         expect(nodeList[0]).toBe(slotted1);
         expect(nodeList[1]).toBe(slotted2);
+    });
+
+    it('should return matching elements when are manually inserted in same shadow', () => {
+        const elm = createElement('x-test-with-div', { is: TestWithDiv });
+        document.body.appendChild(elm);
+
+        const divInsideShadow = elm.shadowRoot.querySelector('div');
+        const manuallyInsertedElement = document.createElement('span');
+
+        divInsideShadow.appendChild(manuallyInsertedElement);
+
+        const qsResult = divInsideShadow.querySelectorAll('span');
+
+        expect(qsResult.length).toBe(1);
+        expect(qsResult[0]).toBe(manuallyInsertedElement);
+    });
+});
+
+describe('Element.getElementsByTagName', () => {
+    it('should return matching elements when are manually inserted in same shadow', () => {
+        const elm = createElement('x-test-with-div', { is: TestWithDiv });
+        document.body.appendChild(elm);
+
+        const divInsideShadow = elm.shadowRoot.querySelector('div');
+        const manuallyInsertedElement = document.createElement('span');
+
+        divInsideShadow.appendChild(manuallyInsertedElement);
+
+        const qsResult = divInsideShadow.getElementsByTagName('span');
+
+        expect(qsResult.length).toBe(1);
+        expect(qsResult[0]).toBe(manuallyInsertedElement);
+    });
+});
+
+describe('Element.getElementsByClassName', () => {
+    it('should return matching elements when are manually inserted in same shadow', () => {
+        const elm = createElement('x-test-with-div', { is: TestWithDiv });
+        document.body.appendChild(elm);
+
+        const divInsideShadow = elm.shadowRoot.querySelector('div');
+        const manuallyInsertedElement = document.createElement('span');
+        manuallyInsertedElement.className = 'test-class';
+
+        divInsideShadow.appendChild(manuallyInsertedElement);
+
+        const qsResult = divInsideShadow.getElementsByClassName('test-class');
+
+        expect(qsResult.length).toBe(1);
+        expect(qsResult[0]).toBe(manuallyInsertedElement);
     });
 });
 


### PR DESCRIPTION
manually inserted nodes in same shadow tree

## Details
This PR makes `querySelector`, `querySelectorAll`, `getElementsBy*` to include manually inserted elements in the same shadow of the query context.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`