### PR TITLE
fix(synthetic-shadow): addEventListener for custom elements

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { defineProperties } from '@lwc/shared';
 import {
     windowRemoveEventListener as nativeWindowRemoveEventListener,
     windowAddEventListener as nativeWindowAddEventListener,
@@ -93,5 +94,22 @@ function removeEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture)
 window.addEventListener = windowAddEventListener;
 window.removeEventListener = windowRemoveEventListener;
 
-Node.prototype.addEventListener = addEventListener;
-Node.prototype.removeEventListener = removeEventListener;
+// IE11 doesn't have EventTarget, so we have to patch it conditionally:
+
+const protoToBePatched =
+    typeof EventTarget !== 'undefined' ? EventTarget.prototype : Node.prototype;
+
+defineProperties(protoToBePatched, {
+    addEventListener: {
+        value: addEventListener,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+    },
+    removeEventListener: {
+        value: removeEventListener,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+    },
+});


### PR DESCRIPTION
is not being used.


## Details
This PR fixes:
The (add/remove)EventListenerPatched listener from https://github.com/salesforce/lwc/blob/master/packages/%40lwc/synthetic-shadow/src/faux-shadow/event-target.ts#L28 . is not being used. This is due that the event-target polyfill is adding one patched `addEventListener` to the `Node.prototype`, and `faux-shadow/event-target.ts` is adding it to the `EventTarget`.

Node inherits from EventTarget, so whenever you ask for `addEventListener` the patch defined in Node.prototype always win.

This PR fixes it by always patching EventTarget when is available

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`