### PR TITLE
refactor(synthetic-shadow): inline the global patch feature flags

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -9,12 +9,6 @@ export type FeatureFlagLookup = { [name: string]: FeatureFlagValue };
 
 const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
-
-    // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
-    ENABLE_ELEMENT_PATCH: null,
-    ENABLE_NODE_LIST_PATCH: null,
-    ENABLE_HTML_COLLECTIONS_PATCH: null,
-    ENABLE_NODE_PATCH: null,
 };
 export default featureFlagLookup;
 

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -9,6 +9,12 @@ export type FeatureFlagLookup = { [name: string]: FeatureFlagValue };
 
 const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
+
+    // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
+    ENABLE_ELEMENT_PATCH: null,
+    ENABLE_NODE_LIST_PATCH: null,
+    ENABLE_HTML_COLLECTIONS_PATCH: null,
+    ENABLE_NODE_PATCH: null,
 };
 export default featureFlagLookup;
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -397,21 +397,21 @@ defineProperties(Element.prototype, {
     },
     getElementsByClassName: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [string])
-            );
+            ) as Element[];
 
-            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(
-                    this,
-                    elements,
-                    ShadowDomSemantic.Enabled
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
                 );
-            } else {
-                filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }
 
+            const filteredResults = getFilteredArrayOfNodes(
+                this,
+                elements,
+                ShadowDomSemantic.Enabled
+            );
             return createStaticHTMLCollection(filteredResults);
         },
         writable: true,
@@ -420,21 +420,21 @@ defineProperties(Element.prototype, {
     },
     getElementsByTagName: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
-            );
+            ) as Element[];
 
-            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(
-                    this,
-                    elements,
-                    ShadowDomSemantic.Enabled
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
                 );
-            } else {
-                filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }
 
+            const filteredResults = getFilteredArrayOfNodes(
+                this,
+                elements,
+                ShadowDomSemantic.Enabled
+            );
             return createStaticHTMLCollection(filteredResults);
         },
         writable: true,
@@ -443,24 +443,24 @@ defineProperties(Element.prototype, {
     },
     getElementsByTagNameNS: {
         value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            let filteredResults;
             const elements = arrayFromCollection(
                 elementGetElementsByTagNameNS.apply(this, ArraySlice.call(arguments) as [
                     string,
                     string
                 ])
-            );
+            ) as Element[];
 
-            if (featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
-                filteredResults = getFilteredArrayOfNodes(
-                    this,
-                    elements,
-                    ShadowDomSemantic.Enabled
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
                 );
-            } else {
-                filteredResults = getNonPatchedFilteredArrayOfNodes(this, elements);
             }
 
+            const filteredResults = getFilteredArrayOfNodes(
+                this,
+                elements,
+                ShadowDomSemantic.Enabled
+            );
             return createStaticHTMLCollection(filteredResults);
         },
         writable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -15,6 +15,7 @@ import {
     isNull,
     isUndefined,
 } from '@lwc/shared';
+import featureFlags from '@lwc/features';
 import {
     attachShadow,
     getShadowRoot,
@@ -57,6 +58,7 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { arrayFromCollection, isGlobalPatchingSkipped } from '../shared/utils';
 import { getNodeOwnerKey, isNodeShadowed } from '../faux-shadow/node';
 import { assignedSlotGetterPatched } from './slot';
+import { getNonPatchedFilteredArrayOfNodes } from './no-patch-utils';
 
 enum ShadowDomSemantic {
     Disabled,
@@ -116,6 +118,14 @@ function lastElementChildGetterPatched(this: ParentNode) {
 defineProperties(Element.prototype, {
     innerHTML: {
         get(this: Element): string {
+            if (!featureFlags.ENABLE_ELEMENT_PATCH) {
+                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
+                    return innerHTMLGetterPatched.call(this);
+                }
+
+                return innerHTMLGetter.call(this);
+            }
+
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return innerHTMLGetterPatched.call(this);
             }
@@ -133,6 +143,13 @@ defineProperties(Element.prototype, {
     },
     outerHTML: {
         get(this: Element): string {
+            if (!featureFlags.ENABLE_ELEMENT_PATCH) {
+                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
+                    return outerHTMLGetterPatched.call(this);
+                }
+                return outerHTMLGetter.call(this);
+            }
+
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return outerHTMLGetterPatched.call(this);
             }
@@ -253,6 +270,11 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
             const elm = ArrayFind.call(nodeList, elm => getNodeNearestOwnerKey(elm) === ownerKey);
             return isUndefined(elm) ? null : elm;
         } else {
+            if (!featureFlags.ENABLE_NODE_LIST_PATCH) {
+                // `this` is a manually inserted element inside a shadowRoot, return the first element.
+                return nodeList.length === 0 ? null : nodeList[0];
+            }
+
             // Element is inside a shadow but we dont know which one. Use the
             // "nearest" owner key to filter by ownership.
             const contextNearestOwnerKey = getNodeNearestOwnerKey(this);
@@ -263,6 +285,13 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
             return isUndefined(elm) ? null : elm;
         }
     } else {
+        if (!featureFlags.ENABLE_NODE_LIST_PATCH) {
+            if (!(this instanceof HTMLBodyElement)) {
+                const elm = nodeList[0];
+                return isUndefined(elm) ? null : elm;
+            }
+        }
+
         // element belonging to the document
         const elm = ArrayFind.call(
             nodeList,
@@ -348,6 +377,16 @@ defineProperties(Element.prototype, {
             const nodeList = arrayFromCollection(
                 elementQuerySelectorAll.apply(this, ArraySlice.call(arguments) as [string])
             );
+
+            if (!featureFlags.ENABLE_NODE_LIST_PATCH) {
+                const filteredResults = getFilteredArrayOfNodes(
+                    this,
+                    nodeList,
+                    ShadowDomSemantic.Disabled
+                );
+                return createStaticNodeList(filteredResults);
+            }
+
             return createStaticNodeList(
                 getFilteredArrayOfNodes(this, nodeList, ShadowDomSemantic.Enabled)
             );
@@ -361,6 +400,13 @@ defineProperties(Element.prototype, {
             const elements = arrayFromCollection(
                 elementGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [string])
             ) as Element[];
+
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            }
+
             const filteredResults = getFilteredArrayOfNodes(
                 this,
                 elements,
@@ -377,6 +423,13 @@ defineProperties(Element.prototype, {
             const elements = arrayFromCollection(
                 elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
             ) as Element[];
+
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            }
+
             const filteredResults = getFilteredArrayOfNodes(
                 this,
                 elements,
@@ -396,6 +449,13 @@ defineProperties(Element.prototype, {
                     string
                 ])
             ) as Element[];
+
+            if (!featureFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            }
+
             const filteredResults = getFilteredArrayOfNodes(
                 this,
                 elements,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -60,7 +60,7 @@ import { getNodeOwnerKey, isNodeShadowed } from '../faux-shadow/node';
 import { assignedSlotGetterPatched } from './slot';
 import { getNonPatchedFilteredArrayOfNodes } from './no-patch-utils';
 
-const { DISABLE_ELEMENT_PATCH, ENABLE_NODE_LIST_PATCH } = getInitializedFeatureFlags();
+const { ENABLE_NODE_LIST_PATCH } = getInitializedFeatureFlags();
 
 enum ShadowDomSemantic {
     Disabled,
@@ -68,14 +68,7 @@ enum ShadowDomSemantic {
 }
 
 function getInitializedFeatureFlags() {
-    let DISABLE_ELEMENT_PATCH;
     let ENABLE_NODE_LIST_PATCH;
-
-    if (featureFlags.ENABLE_ELEMENT_PATCH) {
-        DISABLE_ELEMENT_PATCH = false;
-    } else {
-        DISABLE_ELEMENT_PATCH = true;
-    }
 
     if (featureFlags.ENABLE_NODE_LIST_PATCH) {
         ENABLE_NODE_LIST_PATCH = true;
@@ -84,7 +77,6 @@ function getInitializedFeatureFlags() {
     }
 
     return {
-        DISABLE_ELEMENT_PATCH,
         ENABLE_NODE_LIST_PATCH,
     };
 }
@@ -142,7 +134,7 @@ function lastElementChildGetterPatched(this: ParentNode) {
 defineProperties(Element.prototype, {
     innerHTML: {
         get(this: Element): string {
-            if (DISABLE_ELEMENT_PATCH) {
+            if (!featureFlags.ENABLE_ELEMENT_PATCH) {
                 if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
                     return innerHTMLGetterPatched.call(this);
                 }
@@ -167,7 +159,7 @@ defineProperties(Element.prototype, {
     },
     outerHTML: {
         get(this: Element): string {
-            if (DISABLE_ELEMENT_PATCH) {
+            if (!featureFlags.ENABLE_ELEMENT_PATCH) {
                 if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
                     return outerHTMLGetterPatched.call(this);
                 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -15,7 +15,6 @@ import {
     isTrue,
     isUndefined,
 } from '@lwc/shared';
-import featureFlags from '@lwc/features';
 import {
     parentNodeGetter,
     textContextSetter,
@@ -329,14 +328,6 @@ defineProperties(Node.prototype, {
     },
     textContent: {
         get(this: Node): string {
-            if (!featureFlags.ENABLE_NODE_PATCH) {
-                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
-                    return textContentGetterPatched.call(this);
-                }
-
-                return textContentGetter.call(this);
-            }
-
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return textContentGetterPatched.call(this);
             }
@@ -406,18 +397,6 @@ defineProperties(Node.prototype, {
     },
     contains: {
         value(this: Node, otherNode: Node): boolean {
-            if (!featureFlags.ENABLE_NODE_PATCH) {
-                if (otherNode == null) {
-                    return false;
-                }
-                const ownerKey = getNodeOwnerKey(this);
-                if (!isUndefined(ownerKey) || isHostElement(this)) {
-                    return containsPatched.call(this, otherNode);
-                }
-
-                return contains.call(this, otherNode);
-            }
-
             // TODO: issue #1222 - remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return contains.call(this, otherNode);
@@ -430,15 +409,6 @@ defineProperties(Node.prototype, {
     },
     cloneNode: {
         value(this: Node, deep?: boolean): Node {
-            if (!featureFlags.ENABLE_NODE_PATCH) {
-                const ownerKey = getNodeOwnerKey(this);
-                if (!isUndefined(ownerKey) || isHostElement(this)) {
-                    return cloneNodePatched.call(this, deep);
-                }
-
-                return cloneNode.call(this, deep);
-            }
-
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return cloneNodePatched.call(this, deep);
             }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -15,6 +15,7 @@ import {
     isTrue,
     isUndefined,
 } from '@lwc/shared';
+import featureFlags from '@lwc/features';
 import {
     parentNodeGetter,
     textContextSetter,
@@ -328,6 +329,14 @@ defineProperties(Node.prototype, {
     },
     textContent: {
         get(this: Node): string {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
+                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
+                    return textContentGetterPatched.call(this);
+                }
+
+                return textContentGetter.call(this);
+            }
+
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return textContentGetterPatched.call(this);
             }
@@ -397,6 +406,18 @@ defineProperties(Node.prototype, {
     },
     contains: {
         value(this: Node, otherNode: Node): boolean {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
+                if (otherNode == null) {
+                    return false;
+                }
+                const ownerKey = getNodeOwnerKey(this);
+                if (!isUndefined(ownerKey) || isHostElement(this)) {
+                    return containsPatched.call(this, otherNode);
+                }
+
+                return contains.call(this, otherNode);
+            }
+
             // TODO: issue #1222 - remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return contains.call(this, otherNode);
@@ -409,6 +430,15 @@ defineProperties(Node.prototype, {
     },
     cloneNode: {
         value(this: Node, deep?: boolean): Node {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
+                const ownerKey = getNodeOwnerKey(this);
+                if (!isUndefined(ownerKey) || isHostElement(this)) {
+                    return cloneNodePatched.call(this, deep);
+                }
+
+                return cloneNode.call(this, deep);
+            }
+
             if (isNodeShadowed(this) || isHostElement(this)) {
                 return cloneNodePatched.call(this, deep);
             }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -44,26 +44,12 @@ import { getShadowRoot, isHostElement, getIE11FakeShadowRootPlaceholder } from '
 import { createStaticNodeList } from '../shared/static-node-list';
 import { isGlobalPatchingSkipped } from '../shared/utils';
 
-const { DISABLE_NODE_PATCH } = getInitializedFeatureFlags();
-
 // DO NOT CHANGE this:
 // these two values need to be in sync with engine
 const OwnerKey = '$$OwnerKey$$';
 const OwnKey = '$$OwnKey$$';
 
 export const hasNativeSymbolsSupport = Symbol('x').toString() === 'Symbol(x)';
-
-function getInitializedFeatureFlags() {
-    let DISABLE_NODE_PATCH;
-
-    if (featureFlags.ENABLE_NODE_PATCH) {
-        DISABLE_NODE_PATCH = false;
-    } else {
-        DISABLE_NODE_PATCH = true;
-    }
-
-    return { DISABLE_NODE_PATCH };
-}
 
 export function getNodeOwnerKey(node: Node): number | undefined {
     return node[OwnerKey];
@@ -343,7 +329,7 @@ defineProperties(Node.prototype, {
     },
     textContent: {
         get(this: Node): string {
-            if (DISABLE_NODE_PATCH) {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
                 if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
                     return textContentGetterPatched.call(this);
                 }
@@ -420,7 +406,7 @@ defineProperties(Node.prototype, {
     },
     contains: {
         value(this: Node, otherNode: Node): boolean {
-            if (DISABLE_NODE_PATCH) {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
                 if (otherNode == null) {
                     return false;
                 }
@@ -444,7 +430,7 @@ defineProperties(Node.prototype, {
     },
     cloneNode: {
         value(this: Node, deep?: boolean): Node {
-            if (DISABLE_NODE_PATCH) {
+            if (!featureFlags.ENABLE_NODE_PATCH) {
                 const ownerKey = getNodeOwnerKey(this);
                 if (!isUndefined(ownerKey) || isHostElement(this)) {
                     return cloneNodePatched.call(this, deep);


### PR DESCRIPTION
## Details

Inlining these feature flags allows us to use them as compile-time flags. Usage of these feature flags was also inverted in some places to make it easier to remove them when the time comes.

Example of flag removal after these changes:
https://github.com/salesforce/lwc/commit/8bb68e12869b91b49570d2f67dc859e6ff5b13fd

Example of flag removal before these changes:
https://github.com/salesforce/lwc/compare/8d64bfcf4da9f933dae647236fdf807d165b91ba...8bb68e1

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`