### PR TITLE
fix(compiler): allow compiler to transform .mjs files

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -36,6 +36,46 @@ it('should apply transformation for valid javascript file', async () => {
     expect(pretify(code)).toBe(pretify(expected));
 });
 
+it('should apply transformation for valid .mjs file', async () => {
+    const actual = `
+        import { LightningElement } from 'lwc';
+        export default class Foo extends LightningElement {}
+    `;
+
+    const expected = `
+        import _tmpl from "./foo.html";
+        import { registerComponent as _registerComponent } from "lwc";
+        import { LightningElement } from 'lwc';
+        class Foo extends LightningElement {}
+        export default _registerComponent(Foo, {
+            tmpl: _tmpl
+        });
+    `;
+
+    const { code } = await transform(actual, 'foo.mjs', COMPILER_OPTIONS);
+    expect(pretify(code)).toBe(pretify(expected));
+});
+
+it('should apply transformation for valid .ts file', async () => {
+    const actual = `
+        import { LightningElement } from 'lwc';
+        export default class Foo extends LightningElement {}
+    `;
+
+    const expected = `
+        import _tmpl from "./foo.html";
+        import { registerComponent as _registerComponent } from "lwc";
+        import { LightningElement } from 'lwc';
+        class Foo extends LightningElement {}
+        export default _registerComponent(Foo, {
+            tmpl: _tmpl
+        });
+    `;
+
+    const { code } = await transform(actual, 'foo.ts', COMPILER_OPTIONS);
+    expect(pretify(code)).toBe(pretify(expected));
+});
+
 it('should throw when processing an invalid javascript file', async () => {
     await expect(transform(`const`, 'foo.js', COMPILER_OPTIONS)).rejects.toMatchObject({
         filename: 'foo.js',

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -77,6 +77,7 @@ export function transformFile(
             break;
 
         case '.ts':
+        case '.mjs':
         case '.js':
             transformer = scriptTransformer;
             break;


### PR DESCRIPTION
## Details

Some npm packages use `.mjs` file extension for es modules.  If my app consumes one of these `.mjs` modules then the lwc compiler throws when rollup tries to bundle because it doesn't know how to handle `.mjs`.  This change allows the compiler to treat `.mjs` just like a `.js` file.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
