### PR TITLE
fix(synthetic-shadow): fixes contains in ie11

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/env/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/node.ts
@@ -27,8 +27,9 @@ const {
     removeChild,
     replaceChild,
     hasChildNodes,
-    contains,
 } = Node.prototype;
+
+const { contains } = HTMLElement.prototype;
 
 const firstChildGetter: (this: Node) => ChildNode | null = getOwnPropertyDescriptor(
     Node.prototype,

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -378,6 +378,17 @@ if (!process.env.NATIVE_SHADOW) {
                         Node.DOCUMENT_POSITION_CONTAINED_BY
                 ).toBeGreaterThan(0);
             });
+
+            it('should preserve contains behavior', () => {
+                expect(elementOutsideLWC.contains(lwcElementInsideShadow)).toBe(true);
+
+                expect(rootLwcElement.contains(elementOutsideLWC)).toBe(false);
+                expect(lwcElementInsideShadow.contains(divManuallyApendedToShadow)).toBe(true);
+
+                expect(divManuallyApendedToShadow.contains(elementOutsideLWC)).toBe(false);
+
+                expect(cmpShadow.contains(slottedNode)).toBe(true);
+            });
         });
     });
 }


### PR DESCRIPTION
# Details

In ie11 contains is in HTMLElement.prototype, instead of Node.prototype. This commit fixes it by taking the native contains HTMLElement.prototype; is fine since HTMLElement inherits from Node.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`