### PR TITLE
refactor(engine): preliminar work to move slotting to synthetic shadow

### DIFF
--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -5,13 +5,12 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, fields, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
-import { EmptyArray, ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
+import { ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
 import {
     rerenderVM,
     createVM,
     removeVM,
     getCustomElementVM,
-    allocateInSlot,
     appendVM,
     runWithBoundaryProtection,
 } from './vm';
@@ -157,19 +156,6 @@ export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
         },
         noop
     );
-}
-
-export function allocateChildrenHook(vnode: VCustomElement) {
-    const elm = vnode.elm as HTMLElement;
-    const vm = getCustomElementVM(elm);
-    const { children } = vnode;
-    vm.aChildren = children;
-    if (isTrue(useSyntheticShadow)) {
-        // slow path
-        allocateInSlot(vm, children);
-        // every child vnode is now allocated, and the host should receive none directly, it receives them via the shadow!
-        vnode.children = EmptyArray;
-    }
 }
 
 export function createViewModelHook(vnode: VCustomElement) {


### PR DESCRIPTION
## Details

Internal refactor to move the slotting from engine (which was forking the logic to detect synthetic and do manual allocation into slot elements for any custom element) into the synthetic shadow package, this way the engine doesn't work the logic.

#### TODO

* [ ] refactor compiler api.s -> api.h
* [ ] refactor compiler to make `name` attribute in slots a `data.props.name` instead of `data.attrs.name`, this way the synthetic shadow can carry on the proper allocation.
* [ ] refactor the slotchange event now that we can trigger that without a mutation observer.

Solves https://github.com/salesforce/lwc/issues/1351

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
