### PR TITLE
fix(synthetic-shadow): use native mutation observer for portal elements

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -15,7 +15,6 @@ import {
 } from './shadow-root';
 import { setShadowToken, getShadowToken } from './shadow-token';
 
-const MO = MutationObserver;
 const DomManualPrivateKey = '$$DomManualKey$$';
 
 // Resolver function used when a node is removed from within a portal
@@ -58,7 +57,7 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
 }
 
 function initPortalObserver() {
-    return new MO(mutations => {
+    return new MutationObserver(mutations => {
         forEach.call(mutations, mutation => {
             /**
              * This routine will process all nodes added or removed from elm (which is marked as a portal)

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -30,7 +30,6 @@ let portalObserver: MutationObserver | undefined;
 
 const portalObserverConfig: MutationObserverInit = {
     childList: true,
-    subtree: false,
 };
 
 function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string | undefined) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined, forEach, defineProperty, isTrue } from '@lwc/shared';
-import { getInternalChildNodes } from './node';
-import { compareDocumentPosition } from '../env/node';
+import { childNodesGetter, compareDocumentPosition } from '../env/node';
 import { MutationObserver, MutationObserverObserve } from '../env/mutation-observer';
 import {
     setShadowRootResolver,
@@ -51,10 +50,9 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
             MutationObserverObserve.call(portalObserver, node, portalObserverConfig);
         }
         // recursively patching all children as well
-        const childNodes = getInternalChildNodes(node);
+        const childNodes = childNodesGetter.call(node);
         for (let i = 0, len = childNodes.length; i < len; i += 1) {
-            const child = childNodes[i];
-            adoptChildNode(child, fn, shadowToken);
+            adoptChildNode(childNodes[i], fn, shadowToken);
         }
     }
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -38,13 +38,18 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
         return; // nothing to do here, it is already correctly patched
     }
     setShadowRootResolver(node, fn);
-    // Root LWC elements can't contain slots, therefore we stop listening mutations.
-    if (node instanceof Element && !isHostElement(node)) {
+    if (node instanceof Element) {
+        setShadowToken(node, shadowToken);
+
+        if (isHostElement(node)) {
+            // Root LWC elements can't get content slotted into them, therefore we don't observe their children.
+            return;
+        }
+
         if (isUndefined(previousNodeShadowResolver)) {
             // we only care about Element without shadowResolver (no MO.observe has been called)
             MutationObserverObserve.call(portalObserver, node, portalObserverConfig);
         }
-        setShadowToken(node, shadowToken);
         // recursively patching all children as well
         const childNodes = getInternalChildNodes(node);
         for (let i = 0, len = childNodes.length; i < len; i += 1) {


### PR DESCRIPTION
elements marked as lwc:dom=manual.

It also adds a performance optimization by not listening to the whole subtree.



## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
