### PR TITLE
fix(synthetic-shadow): make isNodeShadowed to only check owner key

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -119,16 +119,13 @@ defineProperties(Element.prototype, {
     innerHTML: {
         get(this: Element): string {
             if (!featureFlags.ENABLE_ELEMENT_PATCH) {
-                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
+                if (isNodeShadowed(this) || isHostElement(this)) {
                     return innerHTMLGetterPatched.call(this);
                 }
 
                 return innerHTMLGetter.call(this);
             }
 
-            if (isNodeShadowed(this) || isHostElement(this)) {
-                return innerHTMLGetterPatched.call(this);
-            }
             // TODO: issue #1222 - remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return innerHTMLGetter.call(this);
@@ -144,15 +141,12 @@ defineProperties(Element.prototype, {
     outerHTML: {
         get(this: Element): string {
             if (!featureFlags.ENABLE_ELEMENT_PATCH) {
-                if (!isUndefined(getNodeOwnerKey(this)) || isHostElement(this)) {
+                if (isNodeShadowed(this) || isHostElement(this)) {
                     return outerHTMLGetterPatched.call(this);
                 }
                 return outerHTMLGetter.call(this);
             }
 
-            if (isNodeShadowed(this) || isHostElement(this)) {
-                return outerHTMLGetterPatched.call(this);
-            }
             // TODO: issue #1222 - remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return outerHTMLGetter.call(this);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -352,7 +352,7 @@ defineProperties(Node.prototype, {
     },
     parentNode: {
         get(this: Node): (Node & ParentNode) | null {
-            if (isNodeShadowed(this)) {
+            if (!isUndefined(getNodeOwnerKey(this))) {
                 return parentNodeGetterPatched.call(this);
             }
             return parentNodeGetter.call(this);
@@ -362,7 +362,7 @@ defineProperties(Node.prototype, {
     },
     parentElement: {
         get(this: Node): Element | null {
-            if (isNodeShadowed(this)) {
+            if (!isUndefined(getNodeOwnerKey(this))) {
                 return parentElementGetterPatched.call(this);
             }
             return parentElementGetter.call(this);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -110,11 +110,7 @@ defineProperties(HTMLSlotElement.prototype, {
         ) {
             // super.addEventListener - but that doesn't work with typescript
             HTMLElement.prototype.addEventListener.call(this, type, listener, options);
-            if (
-                isNodeShadowed(this) &&
-                type === 'slotchange' &&
-                !getHiddenField(this, SlotChangeKey)
-            ) {
+            if (type === 'slotchange' && !getHiddenField(this, SlotChangeKey)) {
                 setHiddenField(this, SlotChangeKey, true);
                 if (!observer) {
                     observer = initSlotObserver();

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
@@ -15,11 +15,11 @@ import {
 } from '../../env/element';
 import { eventTargetGetter } from '../../env/dom';
 import { patchEvent } from '../../faux-shadow/events';
-import { isNodeShadowed } from '../../faux-shadow/node';
+import { isNodeDeepShadowed } from '../../faux-shadow/node';
 
 function doesEventNeedsPatch(e: Event): boolean {
     const originalTarget = eventTargetGetter.call(e);
-    return originalTarget instanceof Node && isNodeShadowed(originalTarget);
+    return originalTarget instanceof Node && isNodeDeepShadowed(originalTarget);
 }
 
 function getEventListenerWrapper(fnOrObj): EventListener | null {


### PR DESCRIPTION
## Details

Previously, `isNodeShadowed` was expensive because it traverses up trying to find an owner key. This issue surfaced when calling `node.parentNode` on a node without ownerKey, it would traverse all the way up to the document.

For most of our use cases, we only need to check the presence of an ownerKey in a node. Only the `doesEventNeedsPatch` logic requires to verify if those nodes that might or might not have owner keys are in a shadow.

- `parentNode` and `parentElement` justification:
Given that `parentNode` and `parentElement` are traversal apis that look up just one level, we can make the compromise and directly check for `ownerKey` presence, if it is present we need to return the patched parentNode.

Given a node, these are the relevant scenarios:
An element,
1. Is not part of any shadow.
2. Is part of an lwc component, and rendered by the engine (it will have ownerKey)
3. Is appended as part of a `lwc:dom manual`: it may be that it does not have ownerKey because the MO hasn't kicked in, but in this case, we can return the parentNode.
4. Is manually appended as a direct child of an LWC component's shadowRoot: well, you shouldn't do this, this element wont have ownerKey, `parentNode` will return the host element instead of the ShadowRoot.
5. Is manually appended on the slot. Again, you shouldn't do this, and you will get the incorrect `parentNode`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`