### PR TITLE
perf(synthetic-shadow): optimize the Mutation Observer polyfill

### DIFF
--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -146,7 +146,7 @@ export function rerenderVM(vm: VM) {
 }
 
 function addHostAttribute(elm: HTMLElement) {
-    (elm as any).$lwcHostToken$;
+    (elm as any).$lwcHostToken$ = '';
 }
 
 export function appendRootVM(vm: VM) {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -145,10 +145,15 @@ export function rerenderVM(vm: VM) {
     rehydrate(vm);
 }
 
+function addHostAttribute(elm: HTMLElement) {
+    (elm as any).$lwcHostToken$;
+}
+
 export function appendRootVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
     }
+    addHostAttribute(vm.elm);
     runConnectedCallback(vm);
     rehydrate(vm);
 }
@@ -158,6 +163,7 @@ export function appendVM(vm: VM) {
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(vm.state === VMState.created, `${vm} cannot be recycled.`);
     }
+    addHostAttribute(vm.elm);
     runConnectedCallback(vm);
     rehydrate(vm);
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { defineProperty, isNull } from '@lwc/shared';
+import { defineProperty } from '@lwc/shared';
 import { getAttribute, setAttribute } from '../env/element';
 
 /*
@@ -19,8 +19,8 @@ const HostTokenAttributeName = 'lwc:host';
  * Patching HTMLElement.prototype.$lwcHostToken$ to add a custom attribute to host elements
  */
 defineProperty(HTMLElement.prototype, '$lwcHostToken$', {
-    get(this: HTMLElement): boolean {
-        return !isNull(getAttribute.call(this, HostTokenAttributeName));
+    get(this: HTMLElement): string | null {
+        return getAttribute.call(this, HostTokenAttributeName);
     },
     set(this: HTMLElement, value: string) {
         setAttribute.call(this, HostTokenAttributeName, value);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { defineProperty } from '@lwc/shared';
+import { setAttribute } from '../env/element';
+
+/*
+ * Using a simple custom attribute is faster based on perf results:
+ * Setting attribute: https://jsperf.com/attribute-vs-data-attribute/1
+ * matches(selector): https://jsperf.com/matches-attribute-vs-data-attribute/1
+ * querySelector(): https://jsperf.com/query-by-attribute-vs-data-attribute/1
+ **/
+export const HostTokenAttributeName = 'lwc-host';
+
+/**
+ * Patching HTMLElement.prototype.$lwcHostToken$ to add a custom attribute to host elements
+ */
+defineProperty(HTMLElement.prototype, '$lwcHostToken$', {
+    get(this: HTMLElement) {
+        setAttribute.call(this, HostTokenAttributeName, '');
+    },
+    configurable: true,
+});

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/lwc-host.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { defineProperty } from '@lwc/shared';
-import { setAttribute } from '../env/element';
+import { defineProperty, isNull } from '@lwc/shared';
+import { getAttribute, setAttribute } from '../env/element';
 
 /*
  * Using a simple custom attribute is faster based on perf results:
@@ -13,14 +13,17 @@ import { setAttribute } from '../env/element';
  * matches(selector): https://jsperf.com/matches-attribute-vs-data-attribute/1
  * querySelector(): https://jsperf.com/query-by-attribute-vs-data-attribute/1
  **/
-export const HostTokenAttributeName = 'lwc-host';
+const HostTokenAttributeName = 'lwc:host';
 
 /**
  * Patching HTMLElement.prototype.$lwcHostToken$ to add a custom attribute to host elements
  */
 defineProperty(HTMLElement.prototype, '$lwcHostToken$', {
-    get(this: HTMLElement) {
-        setAttribute.call(this, HostTokenAttributeName, '');
+    get(this: HTMLElement): boolean {
+        return !isNull(getAttribute.call(this, HostTokenAttributeName));
+    },
+    set(this: HTMLElement, value: string) {
+        setAttribute.call(this, HostTokenAttributeName, value);
     },
     configurable: true,
 });

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -44,13 +44,21 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { retarget } from '../3rdparty/polymer/retarget';
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { getInternalChildNodes, setNodeKey, setNodeOwnerKey } from './node';
-import { innerHTMLSetter } from '../env/element';
+import { innerHTMLSetter, setAttribute } from '../env/element';
 import { getOwnerDocument } from '../shared/utils';
 
 const { getHiddenField, setHiddenField, createFieldName } = fields;
 const ShadowRootResolverKey = '$shadowResolver$';
 const InternalSlot = createFieldName('shadowRecord', 'synthetic-shadow');
 const { createDocumentFragment } = document;
+
+/*
+ * Using a simple custom attribute is faster based on perf results:
+ * Setting attribute: https://jsperf.com/attribute-vs-data-attribute/1
+ * matches(selector): https://jsperf.com/matches-attribute-vs-data-attribute/1
+ * querySelector(): https://jsperf.com/query-by-attribute-vs-data-attribute/1
+ **/
+export const HostMarkerAttribute = 'lwc-host';
 
 interface ShadowRootRecord {
     mode: 'open' | 'closed';
@@ -138,6 +146,7 @@ export function attachShadow(elm: Element, options: ShadowRootInit): SyntheticSh
     const x = (shadowResolver.nodeKey = uid++);
     setNodeKey(elm, x);
     setShadowRootResolver(sr, shadowResolver);
+    setAttribute.call(elm, HostMarkerAttribute, '');
     // correcting the proto chain
     setPrototypeOf(sr, SyntheticShadowRoot.prototype);
     return sr;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -44,21 +44,13 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { retarget } from '../3rdparty/polymer/retarget';
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { getInternalChildNodes, setNodeKey, setNodeOwnerKey } from './node';
-import { innerHTMLSetter, setAttribute } from '../env/element';
+import { innerHTMLSetter } from '../env/element';
 import { getOwnerDocument } from '../shared/utils';
 
 const { getHiddenField, setHiddenField, createFieldName } = fields;
 const ShadowRootResolverKey = '$shadowResolver$';
 const InternalSlot = createFieldName('shadowRecord', 'synthetic-shadow');
 const { createDocumentFragment } = document;
-
-/*
- * Using a simple custom attribute is faster based on perf results:
- * Setting attribute: https://jsperf.com/attribute-vs-data-attribute/1
- * matches(selector): https://jsperf.com/matches-attribute-vs-data-attribute/1
- * querySelector(): https://jsperf.com/query-by-attribute-vs-data-attribute/1
- **/
-export const HostMarkerAttribute = 'lwc-host';
 
 interface ShadowRootRecord {
     mode: 'open' | 'closed';
@@ -146,7 +138,6 @@ export function attachShadow(elm: Element, options: ShadowRootInit): SyntheticSh
     const x = (shadowResolver.nodeKey = uid++);
     setNodeKey(elm, x);
     setShadowRootResolver(sr, shadowResolver);
-    setAttribute.call(elm, HostMarkerAttribute, '');
     // correcting the proto chain
     setPrototypeOf(sr, SyntheticShadowRoot.prototype);
     return sr;

--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -34,3 +34,4 @@ import './faux-shadow/slot';
 import './faux-shadow/event-target';
 import './faux-shadow/portal';
 import './faux-shadow/shadow-token';
+import './faux-shadow/lwc-host';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -21,7 +21,6 @@ import { matches } from '../../env/element';
 import { isAnElement } from '../../shared/utils';
 import { getNodeKey, getNodeNearestOwnerKey } from '../../faux-shadow/node';
 import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
-import { HostTokenAttributeName } from '../../faux-shadow/lwc-host';
 
 const OriginalMutationObserver = MutationObserver;
 const {
@@ -78,7 +77,7 @@ function retargetMutationRecord(originalRecord: MutationRecord): MutationRecord 
 
 // Descendant selector with a * is as performant as a selector with tag name
 // https://jsperf.com/matches-selector-optimization/1
-const ShadowedElementSelector = `[${HostTokenAttributeName}] *`;
+const ShadowedElementSelector = '[lwc\\:host] *';
 /**
  * Is the given node an element and not inside a shadow?
  */

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -14,14 +14,14 @@ import {
     defineProperty,
     forEach,
     isFalse,
-    isTrue,
     isNull,
     isUndefined,
 } from '@lwc/shared';
-import { getNodeKey, getNodeNearestOwnerKey } from '../../faux-shadow/node';
-import { SyntheticShadowRoot, HostMarkerAttribute } from '../../faux-shadow/shadow-root';
 import { matches } from '../../env/element';
 import { isAnElement } from '../../shared/utils';
+import { getNodeKey, getNodeNearestOwnerKey } from '../../faux-shadow/node';
+import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
+import { HostTokenAttributeName } from '../../faux-shadow/lwc-host';
 
 const OriginalMutationObserver = MutationObserver;
 const {
@@ -78,10 +78,9 @@ function retargetMutationRecord(originalRecord: MutationRecord): MutationRecord 
 
 // Descendant selector with a * is as performant as a selector with tag name
 // https://jsperf.com/matches-selector-optimization/1
-const ShadowedElementSelector = `[${HostMarkerAttribute}] *`;
+const ShadowedElementSelector = `[${HostTokenAttributeName}] *`;
 /**
  * Is the given node an element and not inside a shadow?
- * @param node
  */
 function isNonShadowedElement(node: Node): boolean {
     // If the target is an element and it is not the descendant of a host element
@@ -178,7 +177,7 @@ function filterMutationRecords(
                 // First, check if the target is not the descendant of a lwc host element.
                 // If it is not, return record as-is.
                 // If it is, then ascend the tree starting from target and check if observer is qualified
-                if (isTrue(isNonShadowedElement(target)) || isQualifiedObserver(observer, target)) {
+                if (isNonShadowedElement(target) || isQualifiedObserver(observer, target)) {
                     ArrayPush.call(filteredSet, record);
                 }
             }

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -59,3 +59,13 @@ export function arrayFromCollection<T extends Node, K extends Element>(
     }
     return cloned;
 }
+
+/**
+ * Is the given node an element?
+ * Duct-typing to detect if a node has a specific property. This is faster than the instanceOf Element check
+ * https://jsperf.com/duck-typing-vs-instanceof-lwc
+ * @param node
+ */
+export function isAnElement(node: Node): boolean {
+    return 'childElementCount' in node;
+}

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -66,7 +66,7 @@ export function arrayFromCollection<T extends Node, K extends Element>(
  * https://jsperf.com/duck-typing-vs-instanceof-lwc
  * @param node
  */
-export function isAnElement(node: Node): boolean {
+export function isAnElement(node: Node): node is Element {
     // Any property that is specifically in Element interface. Using 'matches' property.
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
     return 'matches' in node;

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -67,5 +67,7 @@ export function arrayFromCollection<T extends Node, K extends Element>(
  * @param node
  */
 export function isAnElement(node: Node): boolean {
-    return 'childElementCount' in node;
+    // Any property that is specifically in Element interface. Using 'matches' property.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+    return 'matches' in node;
 }

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -330,11 +330,16 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         register = {};
     }
 
+    function stripHostMarker(str) {
+        return str.replace(/ lwc-host(="")/gm, '');
+    }
+
     return {
         registerForLoad: registerForLoad,
         clearRegister: clearRegister,
         load: load,
         extractDataIds: extractDataIds,
         extractShadowDataIds: extractShadowDataIds,
+        stripHostMarker: stripHostMarker,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -331,7 +331,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
     }
 
     function stripHostMarker(str) {
-        return str.replace(/ lwc-host(="")/gm, '');
+        return str.replace(/ lwc:host(="")/gm, '');
     }
 
     return {

--- a/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { stripHostMarker } from 'test-utils';
 
 import Test from 'x/test';
 
@@ -7,8 +8,8 @@ describe('Element.outerHTML - get', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        expect(elm.outerHTML).toBe('<x-test></x-test>');
-        expect(elm.shadowRoot.querySelector('x-container').outerHTML).toBe(
+        expect(stripHostMarker(elm.outerHTML)).toBe('<x-test></x-test>');
+        expect(stripHostMarker(elm.shadowRoot.querySelector('x-container').outerHTML)).toBe(
             '<x-container><div>Slotted Text<input name="slotted"></div></x-container>'
         );
         expect(elm.shadowRoot.querySelector('div').outerHTML).toBe(

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { stripHostMarker } from 'test-utils';
 
 import Slotted from 'x/slotted';
 import Container from 'x/container';
@@ -42,7 +43,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(false);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should not clone slotted content', () => {
@@ -51,7 +52,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode(false);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
     });
 
@@ -62,7 +63,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode();
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should not clone slotted content', () => {
@@ -71,7 +72,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode();
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
 
         it('should not clone children of parent node with vanilla html', () => {
@@ -91,7 +92,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(true);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-slotted></x-slotted>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-slotted></x-slotted>');
         });
 
         it('should clone slotted content', () => {
@@ -100,7 +101,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('x-container').cloneNode(true);
             expect(clone.childNodes.length).toBe(1);
-            expect(clone.outerHTML).toBe(
+            expect(stripHostMarker(clone.outerHTML)).toBe(
                 '<x-container><div class="slotted">Slotted Text</div></x-container>'
             );
         });
@@ -111,7 +112,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.shadowRoot.querySelector('div').cloneNode(true);
             expect(clone.childNodes.length).toBe(2);
-            expect(clone.outerHTML).toBe(
+            expect(stripHostMarker(clone.outerHTML)).toBe(
                 '<div>A<x-container><x-container>B</x-container><div><x-container>C</x-container></div></x-container></div>'
             );
         });
@@ -122,7 +123,7 @@ describe('Node.cloneNode', () => {
 
             const clone = elm.cloneNode(true);
             expect(clone.childNodes.length).toBe(0);
-            expect(clone.outerHTML).toBe('<x-container></x-container>');
+            expect(stripHostMarker(clone.outerHTML)).toBe('<x-container></x-container>');
         });
 
         it('should clone children of parent node with vanilla html', () => {
@@ -131,7 +132,7 @@ describe('Node.cloneNode', () => {
             document.body.appendChild(table);
             const clone = table.cloneNode(true);
             expect(clone.childNodes.length).toBe(1);
-            expect(clone.outerHTML).toBe(
+            expect(stripHostMarker(clone.outerHTML)).toBe(
                 '<table><tbody><tr><th>Cat</th></tr><tr><th>Dog</th></tr></tbody></table>'
             );
         });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { stripHostMarker } from 'test-utils';
 
 import Test from 'x/test';
 
@@ -7,7 +8,9 @@ describe('ShadowRoot.innerHTML', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        expect(elm.shadowRoot.innerHTML).toBe('<x-container><div>Slotted Text</div></x-container>');
+        expect(stripHostMarker(elm.shadowRoot.innerHTML)).toBe(
+            '<x-container><div>Slotted Text</div></x-container>'
+        );
         expect(elm.shadowRoot.querySelector('x-container').shadowRoot.innerHTML).toBe(
             '<div>Before[<slot></slot>]After</div>'
         );

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { stripHostMarker } from 'test-utils';
 
 import Container from 'x/container';
 import ParentSpecialized from 'x/parentSpecialized';
@@ -67,28 +68,28 @@ if (!process.env.NATIVE_SHADOW) {
 
         describe('Element.prototype API', () => {
             it('should keep behavior for innerHTML', () => {
-                expect(elementOutsideLWC.innerHTML.length).toBe(455);
+                expect(stripHostMarker(elementOutsideLWC.innerHTML).length).toBe(455);
                 expect(rootLwcElement.innerHTML.length).toBe(0);
                 expect(lwcElementInsideShadow.innerHTML.length).toBe(0);
 
-                expect(divManuallyApendedToShadow.innerHTML.length).toBe(176); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
+                expect(stripHostMarker(divManuallyApendedToShadow.innerHTML).length).toBe(176); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
 
-                expect(cmpShadow.innerHTML.length).toBe(99);
+                expect(stripHostMarker(cmpShadow.innerHTML).length).toBe(99);
 
                 expect(slottedComponent.innerHTML.length).toBe(46);
                 expect(slottedNode.innerHTML.length).toBe(19);
             });
 
             it('should keep behavior for outerHTML', () => {
-                expect(elementOutsideLWC.outerHTML.length).toBe(466);
-                expect(rootLwcElement.outerHTML.length).toBe(27);
-                expect(lwcElementInsideShadow.outerHTML.length).toBe(27);
+                expect(stripHostMarker(elementOutsideLWC.outerHTML).length).toBe(466);
+                expect(stripHostMarker(rootLwcElement.outerHTML).length).toBe(27);
+                expect(stripHostMarker(lwcElementInsideShadow.outerHTML).length).toBe(27);
 
-                expect(divManuallyApendedToShadow.outerHTML.length).toBe(206); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
+                expect(stripHostMarker(divManuallyApendedToShadow.outerHTML).length).toBe(206); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
 
                 expect(cmpShadow.outerHTML).toBe(undefined);
 
-                expect(slottedComponent.outerHTML.length).toBe(73);
+                expect(stripHostMarker(slottedComponent.outerHTML).length).toBe(73);
                 expect(slottedNode.outerHTML.length).toBe(46);
             });
 


### PR DESCRIPTION
## Details
The polyfill should only be filtering mutations that occur inside an lwc element's shadow tree. This PR updates the polyfill implementation to first check if the mutation target is descendant of a host before considering the expensive filtering operation. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
