### PR TITLE
fix(module-resolver): fixes #1607 with npm module resolution

### DIFF
--- a/packages/@lwc/module-resolver/src/index.ts
+++ b/packages/@lwc/module-resolver/src/index.ts
@@ -69,7 +69,7 @@ function resolveModulesFromNpm(packageName: string): RegistryEntry[] {
         const lwcConfigFile = path.join(packageDir, LWC_CONFIG_FILE);
 
         if (fs.existsSync(lwcConfigFile)) {
-            resolvedModules = resolveModules({ rootDir: lwcConfigFile });
+            resolvedModules = resolveModules({ rootDir: path.dirname(lwcConfigFile) });
         } else {
             const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
             if (pkgJson.lwc) {


### PR DESCRIPTION
## Details

Fixes #1607 by passing in the directory name instead of the path to the actual config file.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`