### PR TITLE
refactor(engine): improving the diffing algo for slotted elements

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -162,7 +162,6 @@ export function allocateChildrenHook(vnode: VCustomElement, vm: VM) {
     // In case #2, we will always get a fresh VCustomElement.
     const children = vnode.aChildren || vnode.children;
 
-    vm.aChildren = children;
     if (isTrue(vm.renderer.syntheticShadow)) {
         // slow path
         allocateInSlot(vm, children);
@@ -171,6 +170,8 @@ export function allocateChildrenHook(vnode: VCustomElement, vm: VM) {
         // every child vnode is now allocated, and the host should receive none directly, it receives them via the shadow!
         vnode.children = EmptyArray;
     }
+    // storing the new children collection for disconnection purposes
+    vm.aChildren = children;
 }
 
 export function createViewModelHook(elm: HTMLElement, vnode: VCustomElement) {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -676,8 +676,8 @@ export function allocateInSlot(vm: VM, children: VNodes) {
             const oldVNode = aChildren[i];
             if (!isNull(oldVNode) && !isUndefined(oldVNode.elm)) {
                 const newVNode = children[i];
-                ArrayPush.call(slottedNewChildren, oldVNode);
-                ArrayPush.call(slottedOldChildren, newVNode);
+                ArrayPush.call(slottedOldChildren, oldVNode);
+                ArrayPush.call(slottedNewChildren, newVNode);
             }
         }
         updateStaticChildren(vm.elm, slottedOldChildren, slottedNewChildren);

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -663,7 +663,7 @@ export function allocateInSlot(vm: VM, children: VNodes) {
                 }
             }
         }
-        // If we to this point in the algo, it means that the allocation children
+        // If we reach to this point in the algo, it means that the allocation children
         // collection identical, no new nodes or removal, and all existing vnodes
         // have the same identity (key). We can just simply diff those vnodes directly
         // to avoid marking the vm as dirty, which will cause a full rehydration

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -607,7 +607,8 @@ function hasDifferentIdentities(a: VNode | null, b: VNode | null): boolean {
         // replace or insertion
         return true;
     }
-    // keys must be different otherwise they represent the same element
+    // if keys are different, it means the vnodes are representing a different element
+    // if the keys are the same, it means the vnodes are representing the same element
     return a.key !== b.key;
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -598,6 +598,19 @@ function getErrorBoundaryVM(vm: VM): VM | undefined {
     }
 }
 
+function hasDifferentIdentities(a: VNode | null, b: VNode | null): boolean {
+    if (a === b) {
+        // cached vnodes or null will qualify here
+        return false;
+    }
+    if (isNull(a) || isNull(b)) {
+        // replace or insertion
+        return true;
+    }
+    // keys must be different otherwise they represent the same element
+    return a.key !== b.key;
+}
+
 // slow path routine
 // NOTE: we should probably more this routine to the synthetic shadow folder
 // and get the allocation to be cached by in the elm instead of in the VM
@@ -644,12 +657,29 @@ export function allocateInSlot(vm: VM, children: VNodes) {
             const oldVNodes = oldSlots[key];
             const vnodes = cmpSlots[key];
             for (let j = 0, a = cmpSlots[key].length; j < a; j += 1) {
-                if (oldVNodes[j] !== vnodes[j]) {
+                if (hasDifferentIdentities(oldVNodes[j], vnodes[j])) {
                     markComponentAsDirty(vm);
                     return;
                 }
             }
         }
+        // If we to this point in the algo, it means that the allocation children
+        // collection identical, no new nodes or removal, and all existing vnodes
+        // have the same identity (key). We can just simply diff those vnodes directly
+        // to avoid marking the vm as dirty, which will cause a full rehydration
+        // just to allocate the exact same things.
+        const { aChildren } = vm;
+        const slottedNewChildren: VNodes = [];
+        const slottedOldChildren: VNodes = [];
+        for (let i = 0, len = children.length; i < len; i += 1) {
+            const oldVNode = aChildren[i];
+            if (!isNull(oldVNode) && !isUndefined(oldVNode.elm)) {
+                const newVNode = children[i];
+                ArrayPush.call(slottedNewChildren, oldVNode);
+                ArrayPush.call(slottedOldChildren, newVNode);
+            }
+        }
+        updateStaticChildren(vm.elm, slottedOldChildren, slottedNewChildren);
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -674,7 +674,7 @@ export function allocateInSlot(vm: VM, children: VNodes) {
         const slottedOldChildren: VNodes = [];
         for (let i = 0, len = children.length; i < len; i += 1) {
             const oldVNode = aChildren[i];
-            if (!isNull(oldVNode) && !isUndefined(oldVNode.elm)) {
+            if (!isNull(oldVNode) && !isUndefined(oldVNode) && !isUndefined(oldVNode.elm)) {
                 const newVNode = children[i];
                 ArrayPush.call(slottedOldChildren, oldVNode);
                 ArrayPush.call(slottedNewChildren, newVNode);

--- a/packages/integration-karma/test/rendering/slot/index.spec.js
+++ b/packages/integration-karma/test/rendering/slot/index.spec.js
@@ -1,0 +1,68 @@
+import { createElement } from 'lwc';
+import Container from 'x/container';
+
+describe('slot diffing algorithm', () => {
+    it('should not re-render child component when parent component is re-rendered and api attributes does not change', function() {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+
+        return Promise.resolve()
+            .then(() => {
+                const xChild = elm.shadowRoot.querySelector('x-child');
+
+                expect(xChild.getRenderedTimes()).toBe(1);
+                elm.reRenderElementInShadow();
+                return Promise.resolve();
+            })
+            .then(() => {
+                const xChild = elm.shadowRoot.querySelector('x-child');
+
+                expect(xChild.getRenderedTimes()).toBe(1);
+            });
+    });
+
+    it('should not re-render child component when slot change', function() {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+
+        return Promise.resolve()
+            .then(() => {
+                elm.updateElementInDefaultSlot();
+                elm.updateElementInNamedSlot();
+
+                return Promise.resolve();
+            })
+            .then(() => {
+                const xChild = elm.shadowRoot.querySelector('x-child');
+
+                expect(xChild.getRenderedTimes()).toBe(1);
+
+                expect(elm.shadowRoot.querySelector('p.default-slot').textContent).toBe('1');
+                expect(elm.shadowRoot.querySelector('p.named-slot').textContent).toBe('1');
+            });
+    });
+
+    it('should trigger slot change in child', function() {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+
+        return Promise.resolve()
+            .then(() => {
+                elm.updateElementInDefaultSlot();
+                elm.updateElementInNamedSlot();
+
+                return Promise.resolve();
+            })
+            .then(() => {
+                const xChild = elm.shadowRoot.querySelector('x-child');
+                const { defaultCalledTimes, namedCalledTimes } = xChild.getSlotChangeEventCalls();
+
+                expect(defaultCalledTimes).toBe(1);
+                expect(namedCalledTimes).toBe(1);
+
+                expect(elm.shadowRoot.querySelector('p.default-slot').textContent).toEqual('1');
+                expect(elm.shadowRoot.querySelector('p.named-slot').textContent).toEqual('1');
+                expect(xChild.getRenderedTimes()).toBe(1);
+            });
+    });
+});

--- a/packages/integration-karma/test/rendering/slot/index.spec.js
+++ b/packages/integration-karma/test/rendering/slot/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('slot diffing algorithm', () => {
-    it('should not re-render child component when parent component is re-rendered and api attributes does not change', function() {
+    it('should not re-render child component when parent component is re-rendered and api attributes does not change', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
@@ -21,7 +21,7 @@ describe('slot diffing algorithm', () => {
             });
     });
 
-    it('should not re-render child component when slot change', function() {
+    it('should not re-render child component when slot change', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
@@ -42,7 +42,7 @@ describe('slot diffing algorithm', () => {
             });
     });
 
-    it('should trigger slot change in child', function(done) {
+    it('should trigger slot change in child', function (done) {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/rendering/slot/index.spec.js
+++ b/packages/integration-karma/test/rendering/slot/index.spec.js
@@ -42,27 +42,26 @@ describe('slot diffing algorithm', () => {
             });
     });
 
-    it('should trigger slot change in child', function() {
+    it('should trigger slot change in child', function(done) {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
-        return Promise.resolve()
-            .then(() => {
-                elm.updateElementInDefaultSlot();
-                elm.updateElementInNamedSlot();
+        elm.updateElementInDefaultSlot();
+        elm.updateElementInNamedSlot();
 
-                return Promise.resolve();
-            })
-            .then(() => {
-                const xChild = elm.shadowRoot.querySelector('x-child');
-                const { defaultCalledTimes, namedCalledTimes } = xChild.getSlotChangeEventCalls();
+        // Need the setTimeout because on IE11 the slotchange is not guarantied to be triggered in the next tick.
+        setTimeout(() => {
+            const xChild = elm.shadowRoot.querySelector('x-child');
+            const { defaultCalledTimes, namedCalledTimes } = xChild.getSlotChangeEventCalls();
 
-                expect(defaultCalledTimes).toBe(1);
-                expect(namedCalledTimes).toBe(1);
+            expect(defaultCalledTimes).toBe(1);
+            expect(namedCalledTimes).toBe(1);
 
-                expect(elm.shadowRoot.querySelector('p.default-slot').textContent).toEqual('1');
-                expect(elm.shadowRoot.querySelector('p.named-slot').textContent).toEqual('1');
-                expect(xChild.getRenderedTimes()).toBe(1);
-            });
+            expect(elm.shadowRoot.querySelector('p.default-slot').textContent).toEqual('1');
+            expect(elm.shadowRoot.querySelector('p.named-slot').textContent).toEqual('1');
+            expect(xChild.getRenderedTimes()).toBe(1);
+
+            done();
+        }, 10);
     });
 });

--- a/packages/integration-karma/test/rendering/slot/x/child/child.html
+++ b/packages/integration-karma/test/rendering/slot/x/child/child.html
@@ -1,0 +1,4 @@
+<template>
+    <slot onslotchange={handleDefaultSlotChangeEvent}></slot>
+    <slot name="namedSlot" onslotchange={handleNamedSlotChangeEvent}></slot>
+</template>

--- a/packages/integration-karma/test/rendering/slot/x/child/child.js
+++ b/packages/integration-karma/test/rendering/slot/x/child/child.js
@@ -1,0 +1,31 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Child extends LightningElement {
+    renderedCallbackCalls = 0;
+    slotChangeEventCalls = {
+        defaultCalledTimes: 0,
+        namedCalledTimes: 0,
+    };
+
+    @api
+    getRenderedTimes() {
+        return this.renderedCallbackCalls;
+    }
+
+    @api
+    getSlotChangeEventCalls() {
+        return this.slotChangeEventCalls;
+    }
+
+    handleDefaultSlotChangeEvent() {
+        this.slotChangeEventCalls.defaultCalledTimes++;
+    }
+
+    handleNamedSlotChangeEvent() {
+        this.slotChangeEventCalls.namedCalledTimes++;
+    }
+
+    renderedCallback() {
+        this.renderedCallbackCalls++;
+    }
+}

--- a/packages/integration-karma/test/rendering/slot/x/container/container.html
+++ b/packages/integration-karma/test/rendering/slot/x/container/container.html
@@ -1,0 +1,8 @@
+<template>
+    {counter}
+    <button onclick={increaseCounter}>increaseCounter</button>
+    <x-child>
+        <p class="default-slot">{defaultSlotCounter}</p>
+        <p slot="namedSlot" class="named-slot">{namedSlotCounter}</p>
+    </x-child>
+</template>

--- a/packages/integration-karma/test/rendering/slot/x/container/container.js
+++ b/packages/integration-karma/test/rendering/slot/x/container/container.js
@@ -1,0 +1,22 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Container extends LightningElement {
+    counter = 0;
+    defaultSlotCounter = 0;
+    namedSlotCounter = 0;
+
+    @api
+    reRenderElementInShadow() {
+        this.counter++;
+    }
+
+    @api
+    updateElementInDefaultSlot() {
+        this.defaultSlotCounter++;
+    }
+
+    @api
+    updateElementInNamedSlot() {
+        this.namedSlotCounter++;
+    }
+}


### PR DESCRIPTION
## Details

In the following example:

```html
<template>
    <p>{counter}</p>
    <c-child>
        <button />
    </c-child>
</template>
````

every time the counter is updated, `<c-child>` will get rehydrated for no reason. this is due to the slotting process (in this case the `<button />` passed into `<c-child>`).

this change attempts to optimize that so it doesn't get rerendered.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.