### PR TITLE
fix: ease restriction for using object and embed in template

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-embed-tag/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-embed-tag/actual.html
@@ -1,5 +1,4 @@
 <template>
-    <embed src="loading2.swf" type="application/x-shockwave-flash"> 
     <math>
         <embed src="loading2.swf" type="application/x-shockwave-flash"> 
     </math>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-embed-tag/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-embed-tag/metadata.json
@@ -1,24 +1,13 @@
 {
     "warnings": [
         {
-            "code": 1051,
-            "message": "LWC1051: Forbidden tag found in template: '<embed>' tag is not allowed.",
-            "level": 1,
-            "location": {
-                "line": 2,
-                "column": 5,
-                "start": 15,
-                "length": 63
-            }
-        },
-        {
             "code": 1050,
             "message": "LWC1050: Forbidden MathML namespace tag found in template: '<embed>' tag is not allowed within <math>",
             "level": 1,
             "location": {
-                "line": 4,
+                "line": 3,
                 "column": 9,
-                "start": 99,
+                "start": 30,
                 "length": 69
             }
         }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-object-tag/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-object-tag/actual.html
@@ -1,5 +1,4 @@
 <template>
-    <object data="example.html"></object>
     <math>
         <object data="example.html"></object>
     </math>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-object-tag/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/forbidden-object-tag/metadata.json
@@ -1,24 +1,13 @@
 {
     "warnings": [
         {
-            "code": 1051,
-            "message": "LWC1051: Forbidden tag found in template: '<object>' tag is not allowed.",
-            "level": 1,
-            "location": {
-                "line": 2,
-                "column": 5,
-                "start": 15,
-                "length": 37
-            }
-        },
-        {
             "code": 1050,
             "message": "LWC1050: Forbidden MathML namespace tag found in template: '<object>' tag is not allowed within <math>",
             "level": 1,
             "location": {
-                "line": 4,
+                "line": 3,
                 "column": 9,
-                "start": 72,
+                "start": 30,
                 "length": 37
             }
         }

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -226,15 +226,7 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     'aria-valuetext': 'ariaValueText',
 };
 
-export const HTML_TAG_BLACKLIST = new Set([
-    'base',
-    'embed',
-    'link',
-    'meta',
-    'object',
-    'script',
-    'title',
-]);
+export const HTML_TAG_BLACKLIST = new Set(['base', 'link', 'meta', 'script', 'title']);
 
 export const HTML_ATTRIBUTES_REVERSE_LOOKUP: {
     [attr: string]: string[];


### PR DESCRIPTION
## Details
Easing the restriction for usage of `<embed>` and `<object>` tag in a template. It will only be prevented inside of a `<math>` tag.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
