### PR TITLE
fix(synthetic-shadow): use native mutation observer for portal elements

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -105,6 +105,13 @@ export function getShadowRoot(elm: HTMLElement): SyntheticShadowRootInterface {
     return getInternalSlot(elm).shadowRoot;
 }
 
+// Intentionally adding Node here as possible the first argument
+// since this check is harmless for nodes as well, and it speeds up things
+// to avoid casting before calling this method in few places.
+export function isHostElement(elm: Element | Node): boolean {
+    return !isUndefined(getInternalField(elm, InternalSlot));
+}
+
 export function hasSyntheticShadow(elm: HTMLElement): boolean {
     return !isUndefined(getInternalField(elm, InternalSlot));
 }

--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -14,6 +14,7 @@ import './polyfills/event-composed/main';
 import './polyfills/custom-event-composed/main';
 import './polyfills/focus-event-composed/main';
 import './polyfills/iframe-content-window/main';
+import './polyfills/mutation-observer/main';
 
 // Internal Patches
 import './faux-shadow/portal';


### PR DESCRIPTION
## Details
 (Backport of #1596)
use native mutation observer for elements marked as lwc:dom=manual.
It also adds a performance optimization by not listening to the whole subtree.





## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
