### PR TITLE
build: make build requirements more friendly to new contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 env_default: &env_default
   working_directory: ~/lwc
   docker:
-    - image: circleci/node:10.16.3-browsers
+    - image: circleci/node:12.13.1-browsers
 
 env_perf: &env_perf
   <<: *env_default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Before you start, familiarize yourself with [Lightning Web Components](https://l
 
 ## Requirements
 
- * Node >= 10.13.0
+ * Node >= 10
  * Yarn >= 1.6
 
 ## Installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,10 @@ Before you start, familiarize yourself with [Lightning Web Components](https://l
 
 ## Requirements
 
- * Node >= 10
- * Yarn >= 1.6
+ * [Node](https://nodejs.org/) >= 10
+ * [Yarn](https://yarnpkg.com/) >= 1.6
+
+This project uses [Volta](https://volta.sh/) to ensure that all the contributors share the same version of `Node` and `Yarn` for development. If you are considering making frequent contributions to this project, we recommend installing this tool as well.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -91,12 +91,11 @@
     "packages/perf-benchmarks"
   ],
   "engines": {
-    "node": ">=10.16.3 <10.17.0",
-    "yarn": ">=1.17.3 <1.18.0"
+    "node": ">=10"
   },
   "volta": {
-    "node": "10.16.3",
-    "yarn": "1.17.3"
+    "node": "12.13.1",
+    "yarn": "1.19.2"
   },
   "resolutions": {
     "jsdom": "^15.2.1",


### PR DESCRIPTION
## Details

One of the main issue new contributors faces when they want to pull and build the repository is that they need to have a specific version of `node` and `yarn`. Since most of the developers don't have a version manager installed it hurts external developers contribute to this repository.

* Upgrade node version to latest LTS version for the CI.
* Remove `yarn` version enforcement in `package.json`.
* Make `node` version enforcement less strict.
* Add a mention about `volta` in the `CONTRIBUTING.md`

Fixes #1593

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? 🤷‍♂
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
