### PR TITLE
build: Enforce github issue with TODO comments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -89,6 +89,8 @@
         "template-curly-spacing": "error",
         "yoda": "error",
 
+        "lwc-internal/no-invalid-todo": "error",
+
         // Want to enable if there is consent
         "no-shadow": "off", // 20 violations https://eslint.org/docs/rules/no-shadow	
         "no-use-before-define": ["off", { "functions": true, "classes": true, "variables": false }], // 215 violations https://eslint.org/docs/rules/no-use-before-define

--- a/packages/@lwc/compiler/src/bundler/bundler.ts
+++ b/packages/@lwc/compiler/src/bundler/bundler.ts
@@ -71,7 +71,7 @@ export async function bundle(options: NormalizedCompileOptions): Promise<BundleR
 
     const { outputConfig, name, namespace } = options;
 
-    // TODO: #1268 - remove format option once tests are converted to 'amd' format
+    // TODO [#1268]: remove format option once tests are converted to 'amd' format
     const format = (outputConfig as any).format || DEFAULT_FORMAT;
 
     const diagnostics: CompilerDiagnostic[] = [];

--- a/packages/@lwc/engine/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/snabbdom.ts
@@ -34,7 +34,7 @@ function isVNode(vnode: any): vnode is VNode {
 function createKeyToOldIdx(children: VNodes, beginIdx: number, endIdx: number): KeyToIndexMap {
     const map: KeyToIndexMap = {};
     let j: number, key: Key | undefined, ch;
-    // TODO: simplify this by assuming that all vnodes has keys
+    // TODO [#1637]: simplify this by assuming that all vnodes has keys
     for (j = beginIdx; j <= endIdx; ++j) {
         ch = children[j];
         if (isVNode(ch)) {
@@ -106,12 +106,7 @@ export function updateDynamicChildren(parentElm: Node, oldCh: VNodes, newCh: VNo
         } else if (sameVnode(oldStartVnode, newEndVnode)) {
             // Vnode moved right
             patchVnode(oldStartVnode, newEndVnode);
-            newEndVnode.hook.move(
-                oldStartVnode,
-                parentElm,
-                // TODO: resolve this, but using dot notation for nextSibling for now
-                (oldEndVnode.elm as Node).nextSibling
-            );
+            newEndVnode.hook.move(oldStartVnode, parentElm, (oldEndVnode.elm as Node).nextSibling);
             oldStartVnode = oldCh[++oldStartIdx];
             newEndVnode = newCh[--newEndIdx];
         } else if (sameVnode(oldEndVnode, newStartVnode)) {

--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -46,7 +46,7 @@ export interface VElement extends VNode {
     elm: Element | undefined;
     text: undefined;
     key: Key;
-    // TODO: issue #1364 - support the ability to provision a cloned StyleElement
+    // TODO [#1364]: support the ability to provision a cloned StyleElement
     // for native shadow as a perf optimization
     clonedElement?: HTMLStyleElement;
 }

--- a/packages/@lwc/engine/src/__tests__/focus.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/focus.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-// TODO: #1311 move this tests to integration
-// TODO: issue #1341 find ways to test this in browsers
+// TODO [#1311]: move this tests to integration
+// TODO [#1341]: find ways to test this in browsers
 // import { isFocusable, isTabbable } from '../focus';
 
 // fake functions for now until we can enable this test again in karma

--- a/packages/@lwc/engine/src/__tests__/traverse.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/traverse.spec.ts
@@ -8,7 +8,6 @@ import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement } from '../';
 
 describe('#childNodes', () => {
-    // TODO: issue #xxx move this test to karma, and only test this for synthetic
     it.skip('should always return an empty array for slots not rendering default content', () => {
         const hasSlotTmpl = compileTemplate(`
             <template>

--- a/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/html-element.spec.ts
@@ -37,7 +37,7 @@ describe('html-element', () => {
 
             expect(userDefinedTabIndexValue).toBe('0');
         }),
-            // TODO: #1257 - This test log multiple errors. We should fix this before migrating to expect().toLogError()
+            // TODO [#1257]: This test log multiple errors. We should fix this before migrating to expect().toLogError()
             it.skip('should log console error when user land code changes attribute via querySelector', () => {
                 jest.spyOn(assertLogger, 'logError');
 
@@ -71,7 +71,7 @@ describe('html-element', () => {
                 assertLogger.logError.mockRestore();
             });
 
-        // TODO: #1257 - This test log multiple errors. We should fix this before migrating to expect().toLogError()
+        // TODO [#1257]: This test log multiple errors. We should fix this before migrating to expect().toLogError()
         it.skip('should log console error when user land code removes attribute via querySelector', () => {
             jest.spyOn(assertLogger, 'logError');
 
@@ -105,7 +105,7 @@ describe('html-element', () => {
             assertLogger.logError.mockRestore();
         });
 
-        // TODO: #1257 - This test log multiple errors. We should fix this before migrating to expect().toLogError()
+        // TODO [#1257]: This test log multiple errors. We should fix this before migrating to expect().toLogError()
         it.skip('should log error message when attribute is set via elm.setAttribute if reflective property is defined', () => {
             jest.spyOn(assertLogger, 'logError');
 
@@ -1322,7 +1322,7 @@ describe('html-element', () => {
 
             expect(userDefinedTabIndexValue).toBe('0');
         }),
-            // TODO: #1257 - This test log multiple errors. We should fix this before migrating to expect().toLogError()
+            // TODO [#1257]: This test log multiple errors. We should fix this before migrating to expect().toLogError()
             it.skip('should log console error when user land code changes attribute via querySelector', () => {
                 jest.spyOn(assertLogger, 'logError');
 
@@ -1356,7 +1356,7 @@ describe('html-element', () => {
                 assertLogger.logError.mockRestore();
             });
 
-        // TODO: #1257 - This test log multiple errors. We should fix this before migrating to expect().toLogError()
+        // TODO [#1257]: This test log multiple errors. We should fix this before migrating to expect().toLogError()
         it.skip('should log console error when user land code removes attribute via querySelector', () => {
             jest.spyOn(assertLogger, 'logError');
 

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -139,8 +139,8 @@ const ElementHook: Hooks = {
     create: (vnode: VElement) => {
         const { data, sel, clonedElement } = vnode;
         const { ns } = data;
-        // TODO: issue #1364 - supporting the ability to inject a cloned StyleElement
-        // via a vnode this is used for style tags for native shadow
+        // TODO [#1364]: supporting the ability to inject a cloned StyleElement via a vnode this is
+        // used for style tags for native shadow
         if (isUndefined(clonedElement)) {
             vnode.elm = isUndefined(ns)
                 ? document.createElement(sel)
@@ -216,15 +216,15 @@ const CustomElementHook: Hooks = {
 };
 
 function linkNodeToShadow(vnode: VNode) {
-    // TODO: #1164 - this should eventually be done by the polyfill directly
+    // TODO [#1164]: this should eventually be done by the polyfill directly
     (vnode.elm as any).$shadowResolver$ = (vnode.owner.cmpRoot as any).$shadowResolver$;
 }
 
-// TODO: #1136 - this should be done by the compiler, adding ns to every sub-element
+// TODO [#1136]: this should be done by the compiler, adding ns to every sub-element
 function addNS(vnode: VElement) {
     const { data, children, sel } = vnode;
     data.ns = NamespaceAttributeForSVG;
-    // TODO: #1275 - review why `sel` equal `foreignObject` should get this `ns`
+    // TODO [#1275]: review why `sel` equal `foreignObject` should get this `ns`
     if (isArray(children) && sel !== 'foreignObject') {
         for (let j = 0, n = children.length; j < n; ++j) {
             const childNode = children[j];
@@ -344,7 +344,7 @@ export function s(
     }
     const vnode = h('slot', data, children);
     if (useSyntheticShadow) {
-        // TODO: #1276 - compiler should give us some sort of indicator when a vnodes collection is dynamic
+        // TODO [#1276]: compiler should give us some sort of indicator when a vnodes collection is dynamic
         sc(children);
     }
     return vnode;
@@ -415,7 +415,7 @@ export function c(
         hook: CustomElementHook,
         ctor: Ctor,
         owner: vmBeingRendered as VM,
-        mode: 'open', // TODO: #1294 - this should be defined in Ctor
+        mode: 'open', // TODO [#1294]: this should be defined in Ctor
     };
     addVNodeToChildLWC(vnode);
     return vnode;
@@ -427,7 +427,7 @@ export function i(
     factory: (value: any, index: number, first: boolean, last: boolean) => VNodes | VNode
 ): VNodes {
     const list: VNodes = [];
-    // TODO: #1276 - compiler should give us some sort of indicator when a vnodes collection is dynamic
+    // TODO [#1276]: compiler should give us some sort of indicator when a vnodes collection is dynamic
     sc(list);
     const vmBeingRendered = getVMBeingRendered();
     if (isUndefined(iterable) || iterable === null) {
@@ -525,7 +525,7 @@ export function f(items: any[]): any[] {
     }
     const len = items.length;
     const flattened: VNodes = [];
-    // TODO: #1276 - compiler should give us some sort of indicator when a vnodes collection is dynamic
+    // TODO [#1276]: compiler should give us some sort of indicator when a vnodes collection is dynamic
     sc(flattened);
     for (let j = 0; j < len; j += 1) {
         const item = items[j];

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -541,7 +541,7 @@ BaseLightningElementConstructor.prototype = {
     get classList(): DOMTokenList {
         if (process.env.NODE_ENV !== 'production') {
             const vm = getComponentVM(this);
-            // TODO: #1290 - this still fails in dev but works in production, eventually, we should just throw in all modes
+            // TODO [#1290]: this still fails in dev but works in production, eventually, we should just throw in all modes
             assert.isFalse(
                 isBeingConstructed(vm),
                 `Failed to construct ${vm}: The result must not have attributes. Adding or tampering with classname in constructor is not allowed in a web component, use connectedCallback() instead.`

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -21,7 +21,7 @@ import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 
 export type ErrorCallback = (error: any, stack: string) => void;
 export interface ComponentInterface {
-    // TODO: #1291 - complete the entire interface used by the engine
+    // TODO [#1291]: complete the entire interface used by the engine
     setAttribute(attrName: string, value: any): void;
 }
 

--- a/packages/@lwc/engine/src/framework/decorators/readonly.ts
+++ b/packages/@lwc/engine/src/framework/decorators/readonly.ts
@@ -14,7 +14,7 @@ import { reactiveMembrane } from '../membrane';
  */
 export default function readonly(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {
-        // TODO: #1292 - Remove the readonly decorator
+        // TODO [#1292]: Remove the readonly decorator
         if (arguments.length !== 1) {
             assert.fail(
                 '@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value.'

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -15,7 +15,7 @@ import decorate, { DecoratorMap } from './decorate';
 
 export interface PropDef {
     config: number;
-    type: string; // TODO: #1301 - make this an enum
+    type: string; // TODO [#1301]: make this an enum
     attr: string;
 }
 export interface WireDef {
@@ -106,7 +106,7 @@ function getTrackHash(target: ComponentConstructor, track: TrackDef | undefined)
         return EmptyObject;
     }
 
-    // TODO: #1302 - check that anything in `track` is correctly defined in the prototype
+    // TODO [#1302]: check that anything in `track` is correctly defined in the prototype
     return assign(create(null), track);
 }
 
@@ -118,7 +118,7 @@ function getWireHash(
         return;
     }
 
-    // TODO: #1302 - check that anything in `wire` is correctly defined in the prototype
+    // TODO [#1302]: check that anything in `wire` is correctly defined in the prototype
     return assign(create(null), wire);
 }
 

--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -236,7 +236,7 @@ export function getComponentDef(Ctor: any, subclassComponentName?: string): Comp
 
         let meta = getComponentRegisteredMeta(Ctor);
         if (isUndefined(meta)) {
-            // TODO: #1295 - remove this workaround after refactoring tests
+            // TODO [#1295]: remove this workaround after refactoring tests
             meta = {
                 template: undefined,
                 name: Ctor.name,

--- a/packages/@lwc/engine/src/framework/main.ts
+++ b/packages/@lwc/engine/src/framework/main.ts
@@ -9,7 +9,7 @@
 import '../polyfills/proxy-concat/main';
 import '../polyfills/aria-properties/main';
 
-// TODO: #1296 - Revisit these exports and figure out a better separation
+// TODO [#1296]: Revisit these exports and figure out a better separation
 export { createElement } from './upgrade';
 export { getComponentDef, isComponentConstructor, getComponentConstructor } from './def';
 export { BaseLightningElement as LightningElement } from './base-lightning-element';

--- a/packages/@lwc/engine/src/framework/modules/props.ts
+++ b/packages/@lwc/engine/src/framework/modules/props.ts
@@ -46,7 +46,7 @@ function update(oldVnode: VNode, vnode: VNode) {
 
         if (process.env.NODE_ENV !== 'production') {
             if (!(key in elm)) {
-                // TODO: #1297 - Move this validation to the compiler
+                // TODO [#1297]: Move this validation to the compiler
                 assert.fail(
                     `Unknown public property "${key}" of element <${sel}>. This is likely a typo on the corresponding attribute "${getAttrNameFromPropName(
                         key

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -231,7 +231,7 @@ function getShadowRootRestrictionsDescriptors(
                         sr
                     )} by adding an event listener for "${type}".`
                 );
-                // TODO: #420 - this is triggered when the component author attempts to add a listener
+                // TODO [#420]: this is triggered when the component author attempts to add a listener
                 // programmatically into its Component's shadow root
                 if (!isUndefined(options)) {
                     logError(
@@ -348,7 +348,7 @@ function getCustomElementRestrictionsDescriptors(
                         elm
                     )} by adding an event listener for "${type}".`
                 );
-                // TODO: #420 - this is triggered when the component author attempts to add a listener
+                // TODO [#420]: this is triggered when the component author attempts to add a listener
                 // programmatically into a lighting element node
                 if (!isUndefined(options)) {
                     logError(

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -63,7 +63,7 @@ function createStyleVNode(elm: HTMLStyleElement) {
         },
         EmptyArray
     );
-    // TODO: issue #1364 - supporting the ability to inject a cloned StyleElement
+    // TODO [#1364]: supporting the ability to inject a cloned StyleElement
     // forcing the diffing algo to use the cloned style for native shadow
     vnode.clonedElement = elm;
     return vnode;

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -91,7 +91,7 @@ function validateSlots(vm: VM, html: any) {
         );
 
         if (slotName !== '' && ArrayIndexOf.call(slots, slotName) === -1) {
-            // TODO: #1297 - this should never really happen because the compiler should always validate
+            // TODO [#1297]: this should never really happen because the compiler should always validate
             // eslint-disable-next-line lwc-internal/no-production-assert
             logError(
                 `Ignoring unknown provided slot name "${slotName}" in ${vm}. Check for a typo on the slot attribute.`,

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -601,12 +601,12 @@ export function isNodeFromTemplate(node: Node): boolean {
     if (isFalse(node instanceof Node)) {
         return false;
     }
-    // TODO: #1250 - skipping the shadowRoot instances itself makes no sense, we need to revisit this with locker
+    // TODO [#1250]: skipping the shadowRoot instances itself makes no sense, we need to revisit this with locker
     if (node instanceof ShadowRoot) {
         return false;
     }
     if (useSyntheticShadow) {
-        // TODO: #1252 - old behavior that is still used by some pieces of the platform, specifically, nodes inserted
+        // TODO [#1252]: old behavior that is still used by some pieces of the platform, specifically, nodes inserted
         // manually on places where `lwc:dom="manual"` directive is not used, will be considered global elements.
         if (isUndefined((node as any).$shadowResolver$)) {
             return false;
@@ -633,7 +633,7 @@ export function getComponentVM(component: ComponentInterface): VM {
 }
 
 export function getShadowRootVM(root: ShadowRoot): VM {
-    // TODO: #1299 - use a weak map instead of an internal field
+    // TODO [#1299]: use a weak map instead of an internal field
     if (process.env.NODE_ENV !== 'production') {
         const vm = getHiddenField(root, ViewModelReflection);
         assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);

--- a/packages/@lwc/errors/src/compiler/error-info/compiler.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/compiler.ts
@@ -7,7 +7,7 @@
 import { DiagnosticLevel } from '../../shared/types';
 
 /**
- * TODO: W-5678919 - implement script to determine the next available error code
+ * TODO [W-5678919]: implement script to determine the next available error code
  * In the meantime, reference and the update the value at src/compiler/error-info/index.ts
  */
 

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * TODO: W-5678919 - implement script to determine the next available error code
+ * TODO [W-5678919]: implement script to determine the next available error code
  * Next error code: 1126
  */
 

--- a/packages/@lwc/errors/src/compiler/error-info/jest-transformer.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/jest-transformer.ts
@@ -7,7 +7,7 @@
 import { DiagnosticLevel } from '../../shared/types';
 
 /**
- * TODO: W-5678919 - implement script to determine the next available error code
+ * TODO [W-5678919]: implement script to determine the next available error code
  * In the meantime, reference and the update the value at src/compiler/error-info/index.ts
  */
 

--- a/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
@@ -7,7 +7,7 @@
 import { DiagnosticLevel } from '../../shared/types';
 
 /**
- * TODO: W-5678919 - implement script to determine the next available error code
+ * TODO [W-5678919]: implement script to determine the next available error code
  * In the meantime, reference and the update the value at src/compiler/error-info/index.ts
  */
 

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -7,7 +7,7 @@
 import { DiagnosticLevel } from '../../shared/types';
 
 /**
- * TODO: W-5678919 - implement script to determine the next available error code
+ * TODO [W-5678919]: implement script to determine the next available error code
  * In the meantime, reference and the update the value at src/compiler/error-info/index.ts
  */
 

--- a/packages/@lwc/errors/src/compiler/errors.ts
+++ b/packages/@lwc/errors/src/compiler/errors.ts
@@ -19,7 +19,7 @@ export { CompilerDiagnosticOrigin, CompilerDiagnostic, CompilerError } from './u
 
 export * from './error-info';
 
-// TODO: #1289 - Can be flattened now that we're down to only 2 properties
+// TODO [#1289]: Can be flattened now that we're down to only 2 properties
 export interface ErrorConfig {
     messageArgs?: any[];
     origin?: CompilerDiagnosticOrigin;
@@ -31,7 +31,7 @@ export function generateErrorMessage(errorInfo: LWCErrorInfo, args?: any[]): str
         : errorInfo.message;
 
     if (errorInfo.url && errorInfo.url !== '') {
-        // TODO: #1289 - Add url info into message
+        // TODO [#1289]: Add url info into message
     }
 
     return `LWC${errorInfo.code}: ${message}`;
@@ -167,6 +167,6 @@ function convertErrorToDiagnostic(
     const filename = getFilename(origin, error);
     const location = getLocation(origin, error);
 
-    // TODO: #1289 - Preserve stack information
+    // TODO [#1289]: Preserve stack information
     return { code, message, level, filename, location };
 }

--- a/packages/@lwc/errors/src/compiler/utils.ts
+++ b/packages/@lwc/errors/src/compiler/utils.ts
@@ -42,7 +42,7 @@ export class CompilerError extends Error implements CompilerDiagnostic {
         const compilerError = new CompilerError(code, message, filename, location);
 
         // The stack here is misleading and doesn't point to the cause of the original error message
-        // TODO: W-5712064 - Enhance diagnostics with useful stack trace and source code
+        // TODO [W-5712064]: Enhance diagnostics with useful stack trace and source code
         compilerError.stack = undefined;
         return compilerError;
     }

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -181,7 +181,7 @@ function serializeCss(
     return buffer;
 }
 
-// TODO: #1288 - this code needs refactor, it could be simpler by using a native post-css walker
+// TODO [#1288]: this code needs refactor, it could be simpler by using a native post-css walker
 function tokenizeCssSelector(data: string): Token[] {
     data = data.replace(/( {2,})/gm, ' '); // remove when there are more than two spaces
     const tokens: Token[] = [];

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -126,7 +126,7 @@ defineProperties(Element.prototype, {
                 return innerHTMLGetter.call(this);
             }
 
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return innerHTMLGetter.call(this);
             }
@@ -147,7 +147,7 @@ defineProperties(Element.prototype, {
                 return outerHTMLGetter.call(this);
             }
 
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return outerHTMLGetter.call(this);
             }
@@ -289,7 +289,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         // element belonging to the document
         const elm = ArrayFind.call(
             nodeList,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
         return isUndefined(elm) ? null : elm;
@@ -339,7 +339,7 @@ function getFilteredArrayOfNodes<T extends Node>(
             // `context` is document.body or element belonging to the document with the patch enabled
             filtered = ArrayFilter.call(
                 unfilteredNodes,
-                // TODO: issue #1222 - remove global bypass
+                // TODO [#1222]: remove global bypass
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
             );
         } else {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -68,14 +68,14 @@ function targetGetter(this: Event): EventTarget | null {
     // Handle cases where the currentTarget is null (for async events),
     // and when an event has been added to Window
     if (!(originalCurrentTarget instanceof Node)) {
-        // TODO: issue #1511 - Special escape hatch to support legacy behavior. Should be fixed.
+        // TODO [#1511]: Special escape hatch to support legacy behavior. Should be fixed.
         // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
         if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;
         }
         return retarget(doc, composedPath);
     } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
-        // TODO: issue #1530 - If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // TODO [#1530]: If currentTarget is document or document.body (Third party libraries that have global event listeners)
         // and the originalTarget is not a keyed element, do not retarget
         if (isUndefined(getNodeOwnerKey(originalTarget as Node))) {
             return originalTarget;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -115,7 +115,7 @@ function blurPatched(this: HTMLElement) {
 
 function focusPatched(this: HTMLElement) {
     disableKeyboardFocusNavigationRoutines();
-    // TODO: #1327 - Shadow DOM semantics for focus method
+    // TODO [#1327]: Shadow DOM semantics for focus method
     focus.call(this);
     enableKeyboardFocusNavigationRoutines();
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -47,7 +47,7 @@ export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
         // `context` is document.body which is already patched.
         filtered = ArrayFilter.call(
             unfilteredNodes,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
         );
     } else {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -172,7 +172,7 @@ function parentNodeGetterPatched(this: Node): (Node & ParentNode) | null {
     if (isNull(value)) {
         return value;
     }
-    // TODO: this needs optimization, maybe implementing it based on this.assignedSlot
+    // TODO [#1635]: this needs optimization, maybe implementing it based on this.assignedSlot
     return getShadowParent(this, value);
 }
 
@@ -184,7 +184,7 @@ function parentElementGetterPatched(this: Node): Element | null {
     const parentNode = getShadowParent(this, value);
     // it could be that the parentNode is the shadowRoot, in which case
     // we need to return null.
-    // TODO: this needs optimization, maybe implementing it based on this.assignedSlot
+    // TODO [#1635]: this needs optimization, maybe implementing it based on this.assignedSlot
     return parentNode instanceof Element ? parentNode : null;
 }
 
@@ -248,7 +248,7 @@ function childNodesGetterPatched(this: Node): NodeListOf<Node & Element> {
         return createStaticNodeList(childNodes);
     }
     // nothing to do here since this does not have a synthetic shadow attached to it
-    // TODO: what about slot elements?
+    // TODO [#1636]: what about slot elements?
     return childNodesGetter.call(this);
 }
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -349,7 +349,7 @@ defineProperties(Node.prototype, {
                 return textContentGetter.call(this);
             }
 
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return textContentGetter.call(this);
             }
@@ -403,7 +403,7 @@ defineProperties(Node.prototype, {
     },
     compareDocumentPosition: {
         value(this: Node, otherNode: Node): number {
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return compareDocumentPosition.call(this, otherNode);
             }
@@ -427,7 +427,7 @@ defineProperties(Node.prototype, {
                 return contains.call(this, otherNode);
             }
 
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             if (isGlobalPatchingSkipped(this)) {
                 return contains.call(this, otherNode);
             }
@@ -448,7 +448,7 @@ defineProperties(Node.prototype, {
             }
 
             if (isTrue(deep)) {
-                // TODO: issue #1222 - remove global bypass
+                // TODO [#1222]: remove global bypass
                 if (isGlobalPatchingSkipped(this)) {
                     return cloneNode.call(this, deep);
                 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -104,7 +104,7 @@ function markElementAsPortal(elm: Element) {
     }
     // install mutation observer for portals
     MutationObserverObserve.call(portalObserver, elm, portalObserverConfig);
-    // TODO: #1253 - optimization to synchronously adopt new child nodes added
+    // TODO [#1253]: optimization to synchronously adopt new child nodes added
     // to this elm, we can do that by patching the most common operations
     // on the node itself
 }
@@ -123,7 +123,7 @@ function markElementAsPortal(elm: Element) {
  *    marked as $domManual$, setting it to false does nothing.
  *
  **/
-// TODO: #1306 - rename this to $observerConnection$
+// TODO [#1306]: rename this to $observerConnection$
 defineProperty(Element.prototype, '$domManual$', {
     set(this: Element, v: boolean) {
         this[DomManualPrivateKey] = v;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -71,7 +71,7 @@ const ShadowResolverPrivateKey = '$$ShadowResolverKey$$';
 defineProperty(Node.prototype, ShadowRootResolverKey, {
     set(this: Node, fn: ShadowRootResolver) {
         this[ShadowResolverPrivateKey] = fn;
-        // TODO: #1164 - temporary propagation of the key
+        // TODO [#1164]: temporary propagation of the key
         setNodeOwnerKey(this, (fn as any).nodeKey);
     },
     get(this: Node): string | undefined {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -85,7 +85,7 @@ defineProperty(Document.prototype, 'getElementById', {
         if (isNull(elm)) {
             return null;
         }
-        // TODO: issue #1222 - remove global bypass
+        // TODO [#1222]: remove global bypass
         return isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm) ? elm : null;
     },
     writable: true,
@@ -100,7 +100,7 @@ defineProperty(Document.prototype, 'querySelector', {
         );
         const filtered = ArrayFind.call(
             elements,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return !isUndefined(filtered) ? filtered : null;
@@ -117,7 +117,7 @@ defineProperty(Document.prototype, 'querySelectorAll', {
         );
         const filtered = ArrayFilter.call(
             elements,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticNodeList(filtered);
@@ -134,7 +134,7 @@ defineProperty(Document.prototype, 'getElementsByClassName', {
         );
         const filtered = ArrayFilter.call(
             elements,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
@@ -151,7 +151,7 @@ defineProperty(Document.prototype, 'getElementsByTagName', {
         );
         const filtered = ArrayFilter.call(
             elements,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
@@ -171,7 +171,7 @@ defineProperty(Document.prototype, 'getElementsByTagNameNS', {
         );
         const filtered = ArrayFilter.call(
             elements,
-            // TODO: issue #1222 - remove global bypass
+            // TODO [#1222]: remove global bypass
             elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
@@ -194,7 +194,7 @@ defineProperty(
             );
             const filtered = ArrayFilter.call(
                 elements,
-                // TODO: issue #1222 - remove global bypass
+                // TODO [#1222]: remove global bypass
                 elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
             return createStaticNodeList(filtered);

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
@@ -89,7 +89,7 @@ function removeEventListener(this: EventTarget, type, fnOrObj, optionsOrCapture)
     nativeRemoveEventListener.call(this, type, wrapperFn || fnOrObj, optionsOrCapture);
 }
 
-// TODO: #1305 - these patches should be on EventTarget.prototype instead of win and node prototypes
+// TODO [#1305]: these patches should be on EventTarget.prototype instead of win and node prototypes
 //       but IE doesn't support that.
 window.addEventListener = windowAddEventListener;
 window.removeEventListener = windowRemoveEventListener;

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -29,7 +29,7 @@ export function getOwnerWindow(node: Node): Window {
 
 let skipGlobalPatching: boolean;
 
-// TODO: issue #1222 - remove global bypass
+// TODO [#1222]: remove global bypass
 export function isGlobalPatchingSkipped(node: Node): boolean {
     // we lazily compute this value instead of doing it during evaluation, this helps
     // for apps that are setting this after the engine code is evaluated.

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -61,9 +61,10 @@ export function isDynamic(element: IRElement): boolean {
 }
 
 /**
- * Returns true if the passed element should be flattened
- * TODO: #1303 - Move this logic into the optimizing compiler. This kind of
- *       optimization should be done before the actual code generation.
+ * Returns true if the passed element should be flattened.
+ *
+ * TODO [#1303]: Move this logic into the optimizing compiler. This kind of optimization should be
+ * done before the actual code generation.
  */
 export function shouldFlatten(element: IRElement): boolean {
     return element.children.some(

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -192,7 +192,6 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
         let babelElement: t.Expression;
 
         // Check wether it has the special directive lwc:dynamic
-        // TODO: We should inline a isDynamicElement, but ts doesn't like it
         if (element.lwc && element.lwc.dynamic) {
             const { expression } = bindExpression(element.lwc.dynamic, element);
             babelElement = codeGen.genDynamicElement(element.tag, expression, databag, children);

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -195,7 +195,7 @@ export default function parse(source: string, state: State): TemplateParseResult
         Text: {
             enter(node: parse5.AST.Default.TextNode) {
                 // Extract the raw source to avoid HTML entity decoding done by parse5
-                // TODO: #1286 - Update parse5-with-error to match version used for jsdom (interface for ElementLocation changed)
+                // TODO [#1286]: Update parse5-with-error to match version used for jsdom (interface for ElementLocation changed)
                 const location = node.__location as parse5.MarkupData.Location;
 
                 const { startOffset, endOffset } = location;
@@ -913,7 +913,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                 }
             }
 
-            // TODO #1136 - once the template compiler emits the element namespace information to the engine we should
+            // TODO [#1136]: once the template compiler emits the element namespace information to the engine we should
             // restrict the validation of the "srcdoc" attribute on the "iframe" element only if this element is
             // part of the HTML namespace.
             if (tag === 'iframe' && attrName === 'srcdoc') {
@@ -1090,7 +1090,7 @@ export default function parse(source: string, state: State): TemplateParseResult
         );
     }
 
-    // TODO: #1286 - Update parse5-with-error to match version used for jsdom (interface for ElementLocation changed)
+    // TODO [#1286]: Update parse5-with-error to match version used for jsdom (interface for ElementLocation changed)
     function normalizeLocation(
         location?: parse5.MarkupData.Location
     ): { line: number; column: number; start: number; length: number } {

--- a/packages/@lwc/wire-service/src/property-trap.ts
+++ b/packages/@lwc/wire-service/src/property-trap.ts
@@ -7,9 +7,6 @@
 /*
  * Detects property changes by installing setter/getter overrides on the component
  * instance.
- *
- * TODO - in 216 engine will expose an 'updated' callback for services that is invoked
- * once after all property changes occur in the event loop.
  */
 
 import { ConfigListenerMetadata, ConfigContext, ReactiveParameter } from './wiring';
@@ -36,7 +33,7 @@ function invokeConfigListeners(
             }
         }
 
-        // TODO - consider read-only membrane to enforce invariant of immutable config
+        // TODO [#1634]: consider read-only membrane to enforce invariant of immutable config
         const config = Object.assign({}, statics, reactiveValues);
         listener.call(undefined, config);
     });

--- a/packages/@lwc/wire-service/src/wiring.ts
+++ b/packages/@lwc/wire-service/src/wiring.ts
@@ -254,7 +254,7 @@ export class WireEventTarget {
             this._cmp.dispatchEvent(internalDomEvent);
             return false; // canceling signal since we don't want this to propagate
         } else if (evt.type === 'WireContextEvent') {
-            // TODO: issue #1357 - remove this branch
+            // TODO [#1357]: remove this branch
             return this._cmp.dispatchEvent(evt);
         } else {
             throw new Error(`Invalid event ${evt}.`);

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -19,7 +19,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         };
     }
 
-    // TODO: #869 - Replace this custom spy with standard spyOn jasmine spy when logWarning doesn't use console.group
+    // TODO [#869]: Replace this custom spy with standard spyOn jasmine spy when logWarning doesn't use console.group
     // anymore. On IE11 console.group has a different behavior when the F12 inspector is attached to the page.
     function spyConsole() {
         var originalConsole = window.console;
@@ -62,7 +62,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         return args.map(String).join(' ');
     }
 
-    // TODO: #869 - Improve lookup logWarning doesn't use console.group anymore.
+    // TODO [#869]: Improve lookup logWarning doesn't use console.group anymore.
     function consoleDevMatcherFactory(methodName, internalMethodName) {
         return function consoleDevMatcher() {
             return {

--- a/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
+++ b/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
@@ -8,7 +8,7 @@ beforeEach(() => {
     document.body.focus();
 });
 
-// TODO: #1327 - enable after patching focus method
+// TODO [#1327]: enable after patching focus method
 xit('should focus the first internally focusable element (delegatesFocus=true)', () => {
     const elm = createElement('x-focus', { is: DelegatesFocusTrue });
     document.body.appendChild(elm);
@@ -26,7 +26,7 @@ it('should not focus the first internally focusable element (delegatesFocus=fals
     expect(elm.shadowRoot.activeElement).toBeNull();
 });
 
-// TODO: #1329 - enable after fixing bug where the custom element does not gain focus
+// TODO [#1329]: enable after fixing bug where the custom element does not gain focus
 xit('should focus the host element (delegatesFocus=false, tabIndex=-1)', () => {
     const container = createElement('x-container', { is: Container });
     document.body.appendChild(container);

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -1,4 +1,4 @@
-// TODO [#1284] Import this from the lwc module once we move validation from compiler to linter
+// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
 const { isNodeFromTemplate } = LWC;
 
 import { createElement } from 'lwc';
@@ -48,7 +48,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     const div = document.createElement('div');
     elm.shadowRoot.querySelector('div').appendChild(div);
 
-    // TODO [#1253] optimization to synchronously adopt new child nodes added
+    // TODO [#1253]: optimization to synchronously adopt new child nodes added
     // to this elm, we can do that by patching the most common operations
     // on the node itself
     if (!process.env.NATIVE_SHADOW) {
@@ -61,7 +61,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     });
 });
 
-// TODO [#1252] old behavior that is still used by some pieces of the platform
+// TODO [#1252]: old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
 if (!process.env.NATIVE_SHADOW) {
     it('should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"', () => {

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -1,4 +1,4 @@
-// TODO: #1284 - Import this from the lwc module once we move validation from compiler to linter
+// TODO [#1284] Import this from the lwc module once we move validation from compiler to linter
 const { isNodeFromTemplate } = LWC;
 
 import { createElement } from 'lwc';
@@ -48,7 +48,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     const div = document.createElement('div');
     elm.shadowRoot.querySelector('div').appendChild(div);
 
-    // TODO: #1253 - optimization to synchronously adopt new child nodes added
+    // TODO [#1253] optimization to synchronously adopt new child nodes added
     // to this elm, we can do that by patching the most common operations
     // on the node itself
     if (!process.env.NATIVE_SHADOW) {
@@ -61,7 +61,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     });
 });
 
-// TODO: #1252 - old behavior that is still used by some pieces of the platform
+// TODO [#1252] old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
 if (!process.env.NATIVE_SHADOW) {
     it('should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"', () => {

--- a/packages/integration-karma/test/api/readonly/index.spec.js
+++ b/packages/integration-karma/test/api/readonly/index.spec.js
@@ -21,7 +21,7 @@ it('it should return a wrapped object', () => {
     expect(wrapObj).not.toBe(obj);
 });
 
-// TODO: salesforce/observable-membrane#28 - ReadOnly membrane doesn't throw when mutating a value on JavascriptCore
+// TODO [salesforce/observable-membrane#28]: ReadOnly membrane doesn't throw when mutating a value on JavascriptCore
 xit('should throw when trying to mutate an object property', () => {
     const wrapObj = readonly({ foo: true });
 

--- a/packages/integration-karma/test/api/registerTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/registerTemplate/index.spec.js
@@ -1,4 +1,4 @@
-// TODO: #1284 - Import this from the lwc module once we move validation from compiler to linter
+// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
 const { registerTemplate } = LWC;
 
 import { createElement } from 'lwc';

--- a/packages/integration-karma/test/component/LightningElement.addEventListener/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.addEventListener/index.spec.js
@@ -25,7 +25,7 @@ it('should be able to attach an event listener on the host element', () => {
     expect(args[0].type).toBe('click');
 });
 
-// TODO: #1043 inconsistent restriction between native shadow and synthetic shadow
+// TODO [#1043]: inconsistent restriction between native shadow and synthetic shadow
 xit('should warn when adding multiple times the same event handler', () => {
     const elm = createElement('x-same-event-handler', { is: SameEventHandler });
 
@@ -41,7 +41,7 @@ xit('should warn when adding multiple times the same event handler', () => {
     );
 });
 
-// TODO: #1043 inconsistent restriction between native shadow and synthetic shadow
+// TODO [#1043]: inconsistent restriction between native shadow and synthetic shadow
 xit('should warn when passing a 3rd parameter to the event handler', () => {
     const elm = createElement('x-event-handler-options', { is: EventHandlerOptions });
 
@@ -57,7 +57,7 @@ xit('should warn when passing a 3rd parameter to the event handler', () => {
     );
 });
 
-// TODO: #1072 - Inconsistent error type thrown between dev and prod
+// TODO [#1072]: Inconsistent error type thrown between dev and prod
 xit('should throw an error if event handler is not a function', () => {
     const elm = createElement('x-event-handler', { is: EventHandler });
 

--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -23,7 +23,7 @@ testDispatchEvent('Event', 'test', new Event('test'));
 testDispatchEvent('CustomEvent', 'testcustom', new CustomEvent('testcustom'));
 testDispatchEvent('FocusEvent', 'testfocus', new CustomEvent('testfocus'));
 
-// TODO: #1072 - LightningElement.addEventListener throws 2 different type of errors in dev and prod
+// TODO [#1072]: LightningElement.addEventListener throws 2 different type of errors in dev and prod
 xit('should throw an error if the parameter is not an instance of Event', () => {
     const elm = createElement('x-test', { is: Test });
     document.body.appendChild(elm);

--- a/packages/integration-karma/test/component/LightningElement.removeEventListener/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.removeEventListener/index.spec.js
@@ -32,7 +32,7 @@ it('should not throw when invoking in the different lifecycle hooks', () => {
     }).not.toThrow();
 });
 
-// TODO: #1043 inconsistent restriction between native shadow and synthetic shadow
+// TODO [#1043]: inconsistent restriction between native shadow and synthetic shadow
 xit('should log an error message when removing a non existing event handler', () => {
     const elm = createElement('x-non-existing-event-listener', { is: NonExistingEventListener });
 

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -8,7 +8,7 @@ function testInvalidTemplate(type, template) {
         const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
         elm.template = template;
 
-        // TODO: #1109 - Inconsistent error message for render lifecycle method
+        // TODO [#1109]: Inconsistent error message for render lifecycle method
         // Once the error is fixed, we should add the error message to the assertion.
         expect(() => {
             document.body.appendChild(elm);

--- a/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
@@ -3,13 +3,13 @@ import { createElement } from 'lwc';
 import Anonymous from 'x/anonymous';
 import Named from 'x/named';
 
-// TODO: #1033 with the transformation done by the compiler, the class name is removed, producing "[object undefined]"
+// TODO [#1033]: with the transformation done by the compiler, the class name is removed, producing "[object undefined]"
 xit('should rely on the constructor name', () => {
     const elm = createElement('x-named', { is: Named });
     expect(elm.getToString()).toBe('[object MyFancyComponent]');
 });
 
-// TODO: #1033 open issue return "[object ]" on Safari
+// TODO [#1033]: open issue return "[object ]" on Safari
 xit('should fallback to BaseLightningElement if constructor has no name', () => {
     const elm = createElement('x-anonymous', { is: Anonymous });
     expect(elm.getToString()).toBe('[object BaseLightningElement]');

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -41,7 +41,7 @@ describe('properties', () => {
         });
     });
 
-    // TODO: salesforce/observable-membrane#28 - ReadOnly membrane doesn't throw when mutating a value on JavascriptCore
+    // TODO [salesforce/observable-membrane#28]: ReadOnly membrane doesn't throw when mutating a value on JavascriptCore
     xit('throws an error when attempting a property of a public property', () => {
         const elm = createElement('x-mutate', { is: Mutate });
         elm.publicProp = { x: 0 };

--- a/packages/integration-karma/test/events/window-event-listener/index.spec.js
+++ b/packages/integration-karma/test/events/window-event-listener/index.spec.js
@@ -5,7 +5,7 @@ describe('Event Target on window event listener', () => {
     // The composed-event-click-polyfill doesn't work when native Shadow DOM is enabled on Safari 12.0.0 (it has been fixed
     // with Safari 12.0.1). The polyfill only patches the event javascript wrapper and doesn't have any effect on how Webkit
     // make the event bubbles.
-    // TODO: #1277 - Enable this test again once Sauce Labs supports Safari version >= 12.0.1 (also delete corresponding integration test)
+    // TODO [#1277]: Enable this test again once Sauce Labs supports Safari version >= 12.0.1 (also delete corresponding integration test)
     xit('should return correct target', function() {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/polyfills/click-event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/click-event-composed/index.spec.js
@@ -15,7 +15,7 @@ it('should set the composed property to true when invoking click() on an element
     elm.click();
 
     expect(clickEvent instanceof Event).toBe(true);
-    // TODO: #1278 - remove this condition again once Sauce Labs supports Safari version >= 12.0.0
+    // TODO [#1278]: remove this condition again once Sauce Labs supports Safari version >= 12.0.0
     if (!process.env.NATIVE_SHADOW) {
         expect(clickEvent.composed).toBe(true);
     }
@@ -24,7 +24,7 @@ it('should set the composed property to true when invoking click() on an element
 // The composed-event-click-polyfill doesn't work when native Shadow DOM is enabled on Safari 12.0.0 (it has been fixed
 // with Safari 12.0.1). The polyfill only patches the event javascript wrapper and doesn't have any effect on how Webkit
 // make the event bubbles.
-// TODO: #1278 - Enable this test again once Sauce Labs supports Safari version >= 12.0.0
+// TODO [#1278]: Enable this test again once Sauce Labs supports Safari version >= 12.0.0
 xit('should let the event bubble throws the shadow root when invoking click() on an element in the shadow', () => {
     let clickEvent;
 

--- a/packages/integration-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/document-properties/index.spec.js
@@ -52,7 +52,7 @@ describe('dynamic nodes', () => {
         });
     });
     if (!process.env.NATIVE_SHADOW) {
-        // TODO: #1252 - old behavior that is still used by some pieces of the platform
+        // TODO [#1252]: old behavior that is still used by some pieces of the platform
         // that is only useful in synthetic mode where elements inserted manually without lwc:dom="manual"
         // are still considered global elements
         it('if parent node does not have lwc:dom="manual", child node is accessible', () => {

--- a/packages/integration-karma/test/polyfills/event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/event-composed/index.spec.js
@@ -1,10 +1,10 @@
-// TODO: #938 - Standard event composed flag should not be set if the event is created manually.
+// TODO [#938]: Standard event composed flag should not be set if the event is created manually.
 xit('should not set composed to true if the event is not trusted', () => {
     const clickEvent = new Event('click');
     expect(clickEvent.composed).toBe(false);
 });
 
-// TODO: #938 - Standard event composed flag should not be set if the event is created manually.
+// TODO [#938]: Standard event composed flag should not be set if the event is created manually.
 xit('should respect when the event composed flag is set during construction', () => {
     const composedClickEvent = new Event('click', { composed: true });
     expect(composedClickEvent.composed).toBe(true);

--- a/packages/integration-karma/test/polyfills/html-collection/index.spec.js
+++ b/packages/integration-karma/test/polyfills/html-collection/index.spec.js
@@ -7,7 +7,7 @@ describe('HTMLCollection', () => {
             const elm = createElement('x-test', { is: XTest });
             document.body.appendChild(elm);
             // custom element
-            // TODO: #1231 - Add this assertion back once we patch getElementsByTagName
+            // TODO [#1231]: Add this assertion back once we patch getElementsByTagName
             // expect(elm.getElementsByTagName(`p`).length).toBe(0);
             expect(elm.getElementsByTagName(`p`) instanceof HTMLCollection).toBe(true);
             expect(elm.getElementsByTagName(`p`) + '').toBe('[object HTMLCollection]');
@@ -62,7 +62,7 @@ describe('HTMLCollection', () => {
             const elm = createElement('x-test', { is: XTest });
             document.body.appendChild(elm);
             // custom element
-            // TODO: #1231 - Add this assertion back once we patch getElementsByClassName
+            // TODO [#1231]: Add this assertion back once we patch getElementsByClassName
             // expect(elm.getElementsByClassName(`foo`).length).toBe(0);
             expect(elm.getElementsByClassName(`foo`) instanceof HTMLCollection).toBe(true);
             expect(elm.getElementsByClassName(`foo`) + '').toBe('[object HTMLCollection]');
@@ -89,7 +89,7 @@ describe('HTMLCollection', () => {
             const elm = createElement('x-test', { is: XTest });
             document.body.appendChild(elm);
             // custom element
-            // TODO: #1231 - Add this assertion back once we patch children
+            // TODO [#1231]: Add this assertion back once we patch children
             // expect(elm.children.length).toBe(3);
             expect(elm.children instanceof HTMLCollection).toBe(true);
             expect(elm.children + '').toBe('[object HTMLCollection]');

--- a/packages/integration-karma/test/shadow-dom/Element-properties/Element.innerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Element-properties/Element.innerHTML.spec.js
@@ -29,7 +29,7 @@ describe('Element.innerHTML - get', () => {
 });
 
 describe('Element.innerHTML - set', () => {
-    // TODO - #990 No error is thrown when invoking innerHTML on the host element
+    // TODO [#990]: No error is thrown when invoking innerHTML on the host element
     xit('should throw when invoking setter on the host element', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Element-properties/Element.outerHTML.spec.js
@@ -29,7 +29,7 @@ describe('Element.outerHTML - get', () => {
 });
 
 describe('Element.outerHTML - set', () => {
-    // TODO - #991 Add error type to the .toThrowError(<type>) matcher once the issue is fixed.
+    // TODO [#991]: Add error type to the .toThrowError(<type>) matcher once the issue is fixed.
     xit('should throw when invoking setter on the host element', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
@@ -39,7 +39,7 @@ describe('Element.outerHTML - set', () => {
         }).toThrowError();
     });
 
-    // TODO - #991 Add error type to the .toThrowError(<type>) matcher once the issue is fixed.
+    // TODO [#991]: Add error type to the .toThrowError(<type>) matcher once the issue is fixed.
     xit('should log an error when invoking setter for an element in the shadow', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -7,7 +7,7 @@ import XParentWithDynamicChild from 'x/parentWithDynamicChild';
 // The composed-event-click-polyfill doesn't work when native Shadow DOM is enabled on Safari 12.0.0 (it has been fixed
 // with Safari 12.0.1). The polyfill only patches the event javascript wrapper and doesn't have any effect on how Webkit
 // make the event bubbles.
-// TODO: #1278 - Enable this test again once Sauce Labs supports Safari version >= 12.0.0
+// TODO [#1278]: Enable this test again once Sauce Labs supports Safari version >= 12.0.0
 if (!process.env.NATIVE_SHADOW) {
     it('Async event target should be root node', function() {
         const elm = createElement('x-async-event-target', { is: XAsyncEventTarget });
@@ -35,7 +35,7 @@ it('parent should receive composed event with correct target', function() {
 // The composed-event-click-polyfill doesn't work when native Shadow DOM is enabled on Safari 12.0.0 (it has been fixed
 // with Safari 12.0.1). The polyfill only patches the event javascript wrapper and doesn't have any effect on how Webkit
 // make the event bubbles.
-// TODO: #1278 - Enable this test again once Sauce Labs supports Safari version >= 12.0.0
+// TODO [#1278]: Enable this test again once Sauce Labs supports Safari version >= 12.0.0
 if (!process.env.NATIVE_SHADOW) {
     describe('event.target on document event listener', () => {
         let actual;

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
@@ -17,7 +17,7 @@ beforeEach(() => {
     child = parent.shadowRoot.querySelector('x-child');
 });
 
-// TODO: #1282 - This test fails on Safari 12.0.0 but passes locally with 12.1.1 (expected 0 to be 1)
+// TODO [#1282]: This test fails on Safari 12.0.0 but passes locally with 12.1.1 (expected 0 to be 1)
 xit('should fire slotchange on initial render', () => {
     return waitForSlotChange().then(() => {
         expect(child.getSlotChangeCount()).toBe(1);

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.cloneNode.spec.js
@@ -18,7 +18,7 @@ function testCloneNodeShadowRoot(deep) {
         expect(clone.shadowRoot === null || clone.shadowRoot === undefined).toBe(true);
     });
 
-    // TODO: #1065 - Node.cloneNode should throw an error in all modes
+    // TODO [#1065]: Node.cloneNode should throw an error in all modes
     xit(`should throw when invoking cloneNode on a shadowRoot with deep=${deep}`, () => {
         const elm = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
@@ -19,7 +19,7 @@ describe('Node.isConnected', () => {
         expect(elm.shadowRoot.isConnected).toBe(true);
     });
 
-    // TODO - #987 Node.isConnected returns false when the node comes from the shadow tree in IE11
+    // TODO [#987]: Node.isConnected returns false when the node comes from the shadow tree in IE11
     xit('should return true if the component is connected in the DOM', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
@@ -28,7 +28,7 @@ describe('Node.textContent - getter', () => {
 });
 
 describe('Node.textContent - setter', () => {
-    // TODO - #990 no error is thrown when invoking textContent on the host element
+    // TODO [#990]: no error is thrown when invoking textContent on the host element
     xit('should throw when invoking setter on the host element', () => {
         const elm = createElement('x-test', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.childElementCount.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.childElementCount.spec.js
@@ -5,7 +5,7 @@ import Text from 'x/text';
 import Slotted from 'x/slotted';
 
 describe('ParentNode.childElementCount', () => {
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the number of children elements', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
@@ -20,7 +20,7 @@ describe('ParentNode.childElementCount', () => {
         expect(elm.shadowRoot.childElementCount).toBe(0);
     });
 
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the right number of elements for content children', () => {
         const elm = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.children.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.children.spec.js
@@ -5,7 +5,7 @@ import Text from 'x/text';
 import Slotted from 'x/slotted';
 
 describe('ParentNode.children', () => {
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return all the element children', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
@@ -26,7 +26,7 @@ describe('ParentNode.children', () => {
         expect(children.length).toBe(0);
     });
 
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the right elements for slotted children', () => {
         const elm = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.firstElementChild.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.firstElementChild.spec.js
@@ -5,7 +5,7 @@ import Text from 'x/text';
 import Slotted from 'x/slotted';
 
 describe('ParentNode.firstElementChild', () => {
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the first element child', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
@@ -20,7 +20,7 @@ describe('ParentNode.firstElementChild', () => {
         expect(elm.shadowRoot.firstElementChild).toBe(null);
     });
 
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the right elements for slotted children', () => {
         const elm = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.lastElementChild.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ParentNode-properties/ParentNode.lastElementChild.spec.js
@@ -5,7 +5,7 @@ import Text from 'x/text';
 import Slotted from 'x/slotted';
 
 describe('ParentNode.lastElementChild', () => {
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the last element child', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
@@ -20,7 +20,7 @@ describe('ParentNode.lastElementChild', () => {
         expect(elm.shadowRoot.lastElementChild).toBe(null);
     });
 
-    // TODO: #977 - in test mode the children doesn't return the right set of values
+    // TODO [#977]: in test mode the children doesn't return the right set of values
     xit('should return the right elements for slotted children', () => {
         const elm = createElement('x-slotted', { is: Slotted });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
@@ -2,7 +2,7 @@ import { LightningElement } from 'lwc';
 import { createElement } from 'lwc';
 
 describe('ShadowRoot.delegatesFocus', () => {
-    // TODO - #985 delegatedFocus is only implemented the native ShadowRoot by Blink
+    // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
     xit('ShadowRoot.delegatesFocus should be false by default', () => {
         class NoDelegatesFocus extends LightningElement {}
 
@@ -12,7 +12,7 @@ describe('ShadowRoot.delegatesFocus', () => {
         expect(elm.shadowRoot.delegatesFocus).toBe(false);
     });
 
-    // TODO - #985 delegatedFocus is only implemented the native ShadowRoot by Blink
+    // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
     xit('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
         class DelegatesFocus extends LightningElement {
             static delegatesFocus = true;

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.innerHTML.spec.js
@@ -13,7 +13,7 @@ describe('ShadowRoot.innerHTML', () => {
         );
     });
 
-    // TODO - #991 No error is thrown when invoking
+    // TODO [#991]: No error is thrown when invoking
     xit('should throw an error when invoking setter on the shadowRoot', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -27,7 +27,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         nodes = createShadowTree(document.body);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes.span.dispatchEvent(evt);
@@ -36,7 +36,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(nodes['x-shadow-tree']);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes.span.dispatchEvent(evt);
@@ -45,7 +45,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(null);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element added via lwc:dom="manual" (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['span-manual'].dispatchEvent(evt);
@@ -54,7 +54,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(nodes['x-shadow-tree']);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element added via lwc:dom="manual" (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['span-manual'].dispatchEvent(evt);
@@ -63,7 +63,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(null);
     });
 
-    // TODO: #1141 - Event non dispatched from within a LWC shadow tree are not patched
+    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
     xit('component (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
@@ -72,7 +72,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         assertEventStateReset(evt);
     });
 
-    // TODO: #1141 - Event non dispatched from within a LWC shadow tree are not patched
+    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
     xit('component (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
@@ -96,7 +96,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         nodes = createNestedShadowTree(document.body);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes.span.dispatchEvent(evt);
@@ -105,7 +105,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         expect(evt.target).toBe(nodes['x-nested-shadow-tree']);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes.span.dispatchEvent(evt);
@@ -114,7 +114,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         expect(evt.target).toBe(null);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element added via lwc:dom="manual" (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['span-manual'].dispatchEvent(evt);
@@ -123,7 +123,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         assertEventStateReset(evt);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('element added via lwc:dom="manual" (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['span-manual'].dispatchEvent(evt);
@@ -132,7 +132,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         expect(evt.target).toBe(null);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('component (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
@@ -141,7 +141,7 @@ describe('Event properties post dispatch on node in a nested shadow tree', () =>
         assertEventStateReset(evt);
     });
 
-    // TODO: #1129 - Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
     xit('component (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -97,7 +97,7 @@ describe('event propagation in simple shadow tree', () => {
         });
     });
 
-    // TODO: #1141 - Event non dispatched from within a LWC shadow tree are not patched
+    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
     xit('propagate event from a host element', () => {
         const logs = dispatchEventWithLog(
             nodes['x-shadow-tree'],

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
@@ -46,7 +46,7 @@ function testEventScopeInShadowTree(type, Ctor) {
             expect(logs).toEqual([[nodes.span, nodes.span, composedPath]]);
         });
 
-        // TODO: #960 - Non composed events leaks out of the shadow tree
+        // TODO [#960]: Non composed events leaks out of the shadow tree
         xit('{ bubble: true }', () => {
             const evt = new Ctor('test', { bubbles: true });
             const logs = dispatchEventWithLog(nodes.span, evt);
@@ -59,7 +59,7 @@ function testEventScopeInShadowTree(type, Ctor) {
             ]);
         });
 
-        // TODO: #1138 - Composed and non-bubbling events doesn't invoke host event listeners
+        // TODO [#1138]: Composed and non-bubbling events doesn't invoke host event listeners
         xit('{ composed: true }', () => {
             const evt = new Ctor('test', { composed: true });
             const logs = dispatchEventWithLog(nodes.span, evt);
@@ -80,7 +80,7 @@ function testEventScopeInShadowTree(type, Ctor) {
             ]);
         });
 
-        // TODO: #1139 - Event constructor doesn't support composed in compat mode
+        // TODO [#1139]: Event constructor doesn't support composed in compat mode
         xit('{ bubble: true, composed: true }', () => {
             const evt = new Ctor('test', { bubbles: true, composed: true });
 
@@ -109,7 +109,7 @@ function testEventScopeInShadowTree(type, Ctor) {
 }
 
 function testEventScopeOnHostElement(type, Ctor) {
-    // TODO: #1141 - Event non dispatched from within a LWC shadow tree are not patched
+    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
     xdescribe(`event scope on host element ${type}`, () => {
         let nodes;
         beforeEach(() => {

--- a/packages/integration-karma/test/template/directive-for-each/index.spec.js
+++ b/packages/integration-karma/test/template/directive-for-each/index.spec.js
@@ -58,12 +58,12 @@ function iterator() {
 }
 testForEach('Iterator', { [Symbol.iterator]: iterator });
 
-// TODO: #1285 - revisit
+// TODO [#1285]: revisit
 xit('should throw an error when the passing a non iterable', () => {
     const elm = createElement('x-test', { is: XTest });
     elm.items = {};
 
-    // TODO: #1283 - Improve this error message. The vm should not be exposed and the message is not helpful.
+    // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
     expect(() => document.body.appendChild(elm)).toThrowError(
         /Invalid template iteration for value `\[object Object\]` in \[object:vm undefined \(\d+\)\]. It must be an array-like object and not `null` nor `undefined`./
     );

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
@@ -12,7 +12,7 @@ describe('Focus event while sequential focus navigation', () => {
         browser.url(URL);
     });
 
-    // TODO: #1243 - Fix bug where shadow tree receives focus event when it should be skipped
+    // TODO [#1243]: Fix bug where shadow tree receives focus event when it should be skipped
     describe.skip('delegatesFocus: true, tabindex: -1', () => {
         beforeEach(() => {
             // Reset counters
@@ -82,7 +82,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
     });
 
-    // TODO: #1244 - Fix bug where host does not receive focus event when it should
+    // TODO [#1244]: Fix bug where host does not receive focus event when it should
     describe.skip('delegatesFocus: true, tabindex: none', () => {
         beforeEach(() => {
             // Reset counters
@@ -225,7 +225,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
     });
 
-    // TODO: #1243 - Fix bug where shadow tree receives focus event when it should be skipped
+    // TODO [#1243]: Fix bug where shadow tree receives focus event when it should be skipped
     describe.skip('delegatesFocus: false, tabindex: -1', () => {
         beforeEach(() => {
             // Reset counters
@@ -368,7 +368,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
     });
 
-    // TODO: #1244 - Fix bug where host does not receive focus event when it should
+    // TODO [#1244]: Fix bug where host does not receive focus event when it should
     describe.skip('delegatesFocus: false, tabindex: none', () => {
         beforeEach(() => {
             // Reset counters

--- a/packages/integration-tests/src/components/events/test-window-event-listener/window-event-listener.spec.js
+++ b/packages/integration-tests/src/components/events/test-window-event-listener/window-event-listener.spec.js
@@ -16,7 +16,7 @@ describe('Event Target on window event listener', () => {
     // The composed-event-click-polyfill doesn't work when native Shadow DOM is enabled on Safari 12.0.0 (it has been fixed
     // with Safari 12.0.1). The polyfill only patches the event javascript wrapper and doesn't have any effect on how Webkit
     // make the event bubbles.
-    // TODO: #1277 - Remove this test and enable the corresponding integration-karma test once Sauce Labs supports Safari version >= 12.0.1
+    // TODO [#1277]: Remove this test and enable the corresponding integration-karma test once Sauce Labs supports Safari version >= 12.0.1
     it('should return correct target', function() {
         browser.execute(function() {
             document

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-append-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-append-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/tableComponent';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table-component/append/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-clear-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-clear-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/tableComponent';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table-component/clear/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-create-10k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-create-10k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/tableComponent';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table-component/create/10k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-create-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-create-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/tableComponent';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table-component/create/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-update-10th-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-component/tablecmp-update-10th-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/tableComponent';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table-component/update-10th/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-append-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-append-1k.benchmark.js
@@ -8,7 +8,7 @@ import { buildCustomElementConstructor } from 'lwc';
 import Table from 'benchmark/tableComponent';
 import Row from 'benchmark/tableComponentRow';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 customElements.define('benchmark-table-component', buildCustomElementConstructor(Table));

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-clear-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-clear-1k.benchmark.js
@@ -8,7 +8,7 @@ import { buildCustomElementConstructor } from 'lwc';
 import Table from 'benchmark/tableComponent';
 import Row from 'benchmark/tableComponentRow';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 customElements.define('benchmark-table-component', buildCustomElementConstructor(Table));

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-create-10k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-create-10k.benchmark.js
@@ -8,7 +8,7 @@ import { buildCustomElementConstructor } from 'lwc';
 import Table from 'benchmark/tableComponent';
 import Row from 'benchmark/tableComponentRow';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 customElements.define('benchmark-table-component', buildCustomElementConstructor(Table));

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-create-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-create-1k.benchmark.js
@@ -8,7 +8,7 @@ import { buildCustomElementConstructor } from 'lwc';
 import Table from 'benchmark/tableComponent';
 import Row from 'benchmark/tableComponentRow';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 customElements.define('benchmark-table-component', buildCustomElementConstructor(Table));

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-update-10th-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table-wc/wc-update-10th-1k.benchmark.js
@@ -8,7 +8,7 @@ import { buildCustomElementConstructor } from 'lwc';
 import Table from 'benchmark/tableComponent';
 import Row from 'benchmark/tableComponentRow';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 customElements.define('benchmark-table-component', buildCustomElementConstructor(Table));

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-append-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-append-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/table';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table/append/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-clear-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-clear-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/table';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table/clear/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-create-10k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-create-10k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/table';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table/create/10k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-create-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-create-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/table';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table/create/1k`, () => {

--- a/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-update-10th-1k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/benchmark-table/table-update-10th-1k.benchmark.js
@@ -8,7 +8,7 @@
 import { createElement } from 'lwc';
 import Table from 'benchmark/table';
 
-import { Store } from '../../tableStore';
+import Store from '../../tableStore';
 import { insertTableComponent, destroyTableComponent } from '../../utils';
 
 benchmark(`benchmark-table/update-10th/1k`, () => {

--- a/packages/perf-benchmarks/src/tableStore.js
+++ b/packages/perf-benchmarks/src/tableStore.js
@@ -66,8 +66,7 @@ function _random(max) {
     return Math.round(Math.random() * 1000) % max;
 }
 
-// TODO export as default class when compiler handles it
-export class Store {
+export default class Store {
     constructor() {
         this.data = [];
         this.selected = undefined;

--- a/scripts/eslint-plugin/index.js
+++ b/scripts/eslint-plugin/index.js
@@ -8,10 +8,12 @@
 
 const noExtendGlobalConstructor = require('./rules/no-extend-global-constructor');
 const noProductionAssert = require('./rules/no-production-assert');
+const noInvalidTodo = require('./rules/no-invalid-todo');
 
 module.exports = {
     rules: {
         'no-extend-global-constructor': noExtendGlobalConstructor,
         'no-production-assert': noProductionAssert,
+        'no-invalid-todo': noInvalidTodo,
     },
 };

--- a/scripts/eslint-plugin/rules/no-invalid-todo.js
+++ b/scripts/eslint-plugin/rules/no-invalid-todo.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const TODO_REGEX = /\*?\s+(TODO|todo)/;
+const VALID_TODO_REGEX = /\*?\s+(TODO|todo) \[((#\d+)|(\S+\/\S+#\d+)|(W-\d+))\]:/;
+
+/**
+ * This eslint rule checks that all the TODO comments contains a reference to a git issue or a GUS
+ * bug.
+ *
+ * Valid comment formats:
+ *   - `// TODO [#1234]: This is a todo`
+ *   - `// TODO [salesforce/observable-membrane#1234]: This is a todo`
+ *   - `// TODO [W-123456]: this is a todo`
+ */
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Restrict usage of TODO in comments.',
+        },
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        function checkComment(comment) {
+            const { value } = comment;
+
+            const isTodo = value.match(TODO_REGEX);
+            const isValidTodo = value.match(VALID_TODO_REGEX);
+
+            if (isTodo && !isValidTodo) {
+                context.report({
+                    node: comment,
+                    message:
+                        'Invalid TODO comment format, the git issue reference is probably missing.',
+                });
+            }
+        }
+
+        return {
+            Program() {
+                const comments = sourceCode.getAllComments();
+
+                for (const comment of comments) {
+                    checkComment(comment);
+                }
+            },
+        };
+    },
+};


### PR DESCRIPTION
## Details

* Add new internal linting rule: `lwc-internal/no-invalid-todo`. This new linting rule enforce the presence of a github issue or a GUS work item number right along with the `TODO`.
* Align alll the existing `TODO`s to the new syntax.

Fixes #1307

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
