### PR TITLE
feat: inline import of the compat and prod libraries

### DIFF
--- a/packages/@lwc/compiler/src/rollup-plugins/compat.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/compat.ts
@@ -5,18 +5,18 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Plugin } from 'rollup';
-import * as babel from '@babel/core';
-import * as presetCompat from 'babel-preset-compat';
-
-import { BABEL_CONFIG_BASE } from '../babel-plugins';
 import { NormalizedOutputConfig } from '../options';
 
-const BABEL_CONFIG_CONFIG = {
-    ...BABEL_CONFIG_BASE,
-    presets: [[presetCompat, { proxy: true }]],
-};
-
 export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
+    // [perf optimization] inline these imports to prevent node-tool from parsing unused libs until compiling for 'compat'
+    const babel = require('@babel/core');
+    const { BABEL_CONFIG_BASE } = require('../babel-plugins');
+    const presetCompat = require('babel-preset-compat');
+
+    const BABEL_CONFIG_CONFIG = {
+        ...BABEL_CONFIG_BASE,
+        presets: [[presetCompat, { proxy: true }]],
+    };
     const config = Object.assign({}, BABEL_CONFIG_CONFIG, { sourceMaps: sourcemap });
 
     return {

--- a/packages/@lwc/compiler/src/rollup-plugins/compat.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/compat.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Plugin } from 'rollup';
-import babel from '@babel/core';
+import * as babel from '@babel/core';
 
 import { BABEL_CONFIG_BASE } from '../babel-plugins';
 import { NormalizedOutputConfig } from '../options';
@@ -18,6 +18,7 @@ export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
         ...BABEL_CONFIG_BASE,
         presets: [[presetCompat, { proxy: true }]],
     };
+
     const config = Object.assign({}, BABEL_CONFIG_CONFIG, { sourceMaps: sourcemap });
 
     return {

--- a/packages/@lwc/compiler/src/rollup-plugins/compat.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/compat.ts
@@ -5,12 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Plugin } from 'rollup';
+import babel from '@babel/core';
+
+import { BABEL_CONFIG_BASE } from '../babel-plugins';
 import { NormalizedOutputConfig } from '../options';
 
 export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
-    // [perf optimization] inline these imports to prevent node-tool from parsing unused libs until compiling for 'compat'
-    const babel = require('@babel/core');
-    const { BABEL_CONFIG_BASE } = require('../babel-plugins');
+    // Inlining the `babel-preset-compat` module require to only pay the parsing and evaluation cost for needed modules
     const presetCompat = require('babel-preset-compat');
 
     const BABEL_CONFIG_CONFIG = {

--- a/packages/@lwc/compiler/src/rollup-plugins/minify.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/minify.ts
@@ -14,6 +14,7 @@ import { NormalizedOutputConfig } from '../options';
 export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
     // Inlining the `terser` module require to only pay the parsing and evaluation cost for needed modules
     const { minify } = require('terser');
+
     return {
         name: 'lwc-minify',
 

--- a/packages/@lwc/compiler/src/rollup-plugins/minify.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/minify.ts
@@ -12,7 +12,7 @@ import { NormalizedOutputConfig } from '../options';
  * Rollup plugin applying minification to the generated bundle.
  */
 export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
-    // [perf optimization] inline the import to prevent node-tool from parsing unused lib until compiling for 'prod'.
+    // Inlining the `terser` module require to only pay the parsing and evaluation cost for needed modules
     const { minify } = require('terser');
     return {
         name: 'lwc-minify',

--- a/packages/@lwc/compiler/src/rollup-plugins/minify.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/minify.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { minify } from 'terser';
 import { Plugin } from 'rollup';
 
 import { NormalizedOutputConfig } from '../options';
@@ -13,6 +12,8 @@ import { NormalizedOutputConfig } from '../options';
  * Rollup plugin applying minification to the generated bundle.
  */
 export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
+    // [perf optimization] inline the import to prevent node-tool from parsing unused lib until compiling for 'prod'.
+    const { minify } = require('terser');
     return {
         name: 'lwc-minify',
 

--- a/packages/@lwc/style-compiler/src/transform.ts
+++ b/packages/@lwc/style-compiler/src/transform.ts
@@ -8,7 +8,6 @@ import postcss from 'postcss';
 
 import serialize from './serialize';
 import postcssLwc from './postcss-lwc-plugin';
-import postcssMinify from './postcss-minify-plugins';
 
 export interface Config {
     /** CSS custom properties configuration */
@@ -47,6 +46,7 @@ export function transform(src: string, id: string, config: Config = {}): { code:
     ];
 
     if (minify) {
+        const postcssMinify = require('./postcss-minify-plugins');
         // It's important to run the postcss minification plugins before the LWC one because we
         // need to clone the CSS declarations and they shouldn't be mangled by the minifier.
         plugins = [...postcssMinify(), ...plugins];

--- a/packages/@lwc/style-compiler/src/transform.ts
+++ b/packages/@lwc/style-compiler/src/transform.ts
@@ -46,7 +46,7 @@ export function transform(src: string, id: string, config: Config = {}): { code:
     ];
 
     if (minify) {
-        const postcssMinify = require('./postcss-minify-plugins');
+        const postcssMinify = require('./postcss-minify-plugins').default;
         // It's important to run the postcss minification plugins before the LWC one because we
         // need to clone the CSS declarations and they shouldn't be mangled by the minifier.
         plugins = [...postcssMinify(), ...plugins];


### PR DESCRIPTION
## Details
inline imports of cssnano and babel-compat libraries until they are required for 'compat' or 'prod' compilation.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
