### PR TITLE
fix(compiler): decorated props duplicated in fields

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -408,7 +408,7 @@ describe('Transform property', () => {
                     }
                   },
                   publicMethods: ["m1"],
-                  fields: ["privateProp", "ctor"]
+                  fields: ["privateProp"]
                 });
 
                 export default _registerComponent(Text, {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -79,6 +79,59 @@ describe('observed fields', () => {
     );
 
     pluginTest(
+        'should not add reserved words to fields when is a reserved word decorated with @api, @track or @wire',
+        `
+        import { api, wire, track, createElement } from 'lwc';
+        export default class Test {
+            interface;
+            @api static;
+            @track for;
+            @wire(createElement) function;
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators } from "lwc";
+                import _tmpl from "./test.html";
+                import { registerComponent as _registerComponent } from "lwc";
+                import { createElement } from "lwc";
+                
+                class Test {
+                  constructor() {
+                    this.interface = void 0;
+                    this.static = void 0;
+                    this.for = void 0;
+                    this.function = void 0;
+                  }
+                }
+                
+                _registerDecorators(Test, {
+                  publicProps: {
+                    static: {
+                      config: 0
+                    }
+                  },
+                  wire: {
+                    function: {
+                      adapter: createElement
+                    }
+                  },
+                  track: {
+                    for: 1
+                  },
+                  fields: ["interface"]
+                });
+                
+                export default _registerComponent(Test, {
+                  tmpl: _tmpl
+                });
+                `,
+            },
+        }
+    );
+
+    pluginTest(
         'should transform export default that is not a class',
         `
         const DATA_FROM_NETWORK = [

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -132,12 +132,53 @@ describe('observed fields', () => {
     );
 
     pluginTest(
-        'should not observe changes in a field when is defined in bracket notation',
+        'should not observe changes in computed fields',
+        `
+        import { api, wire, track, createElement } from 'lwc';
+        const PREFIX = 'prefix';
+        export default class Test {
+            interface;
+            ['a'] = 0;
+            [\`\${PREFIX}Field\`] = 'prefixed field';
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators } from "lwc";
+                import _tmpl from "./test.html";
+                import { registerComponent as _registerComponent } from "lwc";
+                import { createElement } from "lwc";
+                const PREFIX = "prefix";
+                
+                class Test {
+                  constructor() {
+                    this.interface = void 0;
+                    this["a"] = 0;
+                    this[\`\${PREFIX}Field\`] = "prefixed field";
+                  }
+                }
+                
+                _registerDecorators(Test, {
+                  fields: ["interface"]
+                });
+                
+                export default _registerComponent(Test, {
+                  tmpl: _tmpl
+                });
+                `,
+            },
+        }
+    );
+
+    pluginTest(
+        'should not observe changes in a static fields',
         `
         import { api, wire, track, createElement } from 'lwc';
         export default class Test {
             interface;
-            ['a'] = 0;
+            static foo = 3;
+            static baz = 1;
         }
     `,
         {
@@ -151,9 +192,11 @@ describe('observed fields', () => {
                 class Test {
                   constructor() {
                     this.interface = void 0;
-                    this["a"] = 0;
                   }
                 }
+                
+                Test.foo = 3;
+                Test.baz = 1;
                 
                 _registerDecorators(Test, {
                   fields: ["interface"]

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -79,7 +79,7 @@ describe('observed fields', () => {
     );
 
     pluginTest(
-        'should not add reserved words to fields when is a reserved word decorated with @api, @track or @wire',
+        'should not process reserved words as field when decorated with @api, @track or @wire',
         `
         import { api, wire, track, createElement } from 'lwc';
         export default class Test {
@@ -120,6 +120,42 @@ describe('observed fields', () => {
                   track: {
                     for: 1
                   },
+                  fields: ["interface"]
+                });
+                
+                export default _registerComponent(Test, {
+                  tmpl: _tmpl
+                });
+                `,
+            },
+        }
+    );
+
+    pluginTest(
+        'should not observe changes in a field when is defined in bracket notation',
+        `
+        import { api, wire, track, createElement } from 'lwc';
+        export default class Test {
+            interface;
+            ['a'] = 0;
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators } from "lwc";
+                import _tmpl from "./test.html";
+                import { registerComponent as _registerComponent } from "lwc";
+                import { createElement } from "lwc";
+                
+                class Test {
+                  constructor() {
+                    this.interface = void 0;
+                    this["a"] = 0;
+                  }
+                }
+                
+                _registerDecorators(Test, {
                   fields: ["interface"]
                 });
                 

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -56,6 +56,7 @@ module.exports = function postProcess({ types: t }) {
                 path =>
                     t.isClassProperty(path.node) &&
                     !isLWCNode(path.node) &&
+                    !path.node.static &&
                     t.isIdentifier(path.node.key) &&
                     !(decoratedIdentifiers.indexOf(path.node.key.name) >= 0)
             )

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -56,6 +56,7 @@ module.exports = function postProcess({ types: t }) {
                 path =>
                     t.isClassProperty(path.node) &&
                     !isLWCNode(path.node) &&
+                    t.isIdentifier(path.node.key) &&
                     !(decoratedIdentifiers.indexOf(path.node.key.name) >= 0)
             )
             .map(path => path.node.key.name);

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -35,7 +35,14 @@ module.exports = function postProcess({ types: t }) {
 
     function collectObservedFields(body, decoratedProperties) {
         const mappers = {
-            ObjectExpression: ({ properties }) => properties.map(({ key: { name } }) => name),
+            ObjectExpression: ({ properties }) =>
+                properties.map(({ key }) => {
+                    if (t.isIdentifier(key)) {
+                        return key.name;
+                    } else if (t.isStringLiteral(key)) {
+                        return key.value;
+                    }
+                }),
             ArrayExpression: ({ elements }) => elements.map(({ value }) => value),
         };
 

--- a/packages/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/integration-karma/test/component/observed-fields/index.spec.js
@@ -115,4 +115,19 @@ describe('observed-fields', () => {
             expect(elm.shadowRoot.querySelector('.inherited-value').textContent).toBe('mutated');
         });
     });
+
+    it('should allow decorated reserved words as field names', () => {
+        const elm = createElement('x-simple', { is: Simple });
+        elm.static = 'static value';
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe('static value');
+        elm.static = 'static value modified';
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
+                'static value modified'
+            );
+        });
+    });
 });

--- a/packages/integration-karma/test/component/observed-fields/x/simple/simple.html
+++ b/packages/integration-karma/test/component/observed-fields/x/simple/simple.html
@@ -3,4 +3,5 @@
     <p class="expando-value">{expandoField}</p>
     <p class="inherited-value">{inheritedValue}</p>
     <p class="complex-value">{complexValue.name}-{complexValue.lastName}</p>
+    <p class="static-value">{static}</p>
 </template>

--- a/packages/integration-karma/test/component/observed-fields/x/simple/simple.js
+++ b/packages/integration-karma/test/component/observed-fields/x/simple/simple.js
@@ -5,6 +5,7 @@ class BaseKlass extends LightningElement {
 }
 
 export default class Simple extends BaseKlass {
+    @api static;
     @track trackedField;
     simpleValue = 'initial';
     complexValue = {


### PR DESCRIPTION
## Details
This pr fixes: when having a decorated property named as a reserved word (ex: static) the engine will throw an error at runtime (Cannot redefine property: static)

```js
import { LightningElement, api } from 'lwc';

export default class Foo extends LightningElement {
    @api static;
}
```
The problem is that the compiler is adding the decorated field `static` to both `publicProps` (correct) and `fields` (incorrect).

```js
    lwc.registerDecorators(Foo, {
      publicProps: {
        "static": {
          config: 0
        }
      },
      fields: ["static"]
    });
```
## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`