### PR TITLE
test(synthetic-shadow): enable karma test related to #1141

### DIFF
--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -63,8 +63,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(null);
     });
 
-    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
-    xit('component (composed: true)', () => {
+    it('component (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
 
@@ -72,8 +71,7 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         assertEventStateReset(evt);
     });
 
-    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
-    xit('component (composed: false)', () => {
+    it('component (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
 

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -63,7 +63,8 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         expect(evt.target).toBe(null);
     });
 
-    it('component (composed: true)', () => {
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    xit('component (composed: true)', () => {
         const evt = new CustomEvent('test', { composed: true, bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
 
@@ -71,7 +72,8 @@ describe('Event properties post dispatch on node in a shadow tree', () => {
         assertEventStateReset(evt);
     });
 
-    it('component (composed: false)', () => {
+    // TODO [#1129]: Invoking dispatchEvent on nodes rendered by the template doesn't respect retargetting
+    xit('component (composed: false)', () => {
         const evt = new CustomEvent('test', { bubbles: true });
         nodes['x-shadow-tree'].dispatchEventComponent(evt);
 

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -97,8 +97,7 @@ describe('event propagation in simple shadow tree', () => {
         });
     });
 
-    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
-    xit('propagate event from a host element', () => {
+    it('propagate event from a host element', () => {
         const logs = dispatchEventWithLog(
             nodes['x-shadow-tree'],
             new CustomEvent('test', { composed: true, bubbles: true })

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
@@ -109,8 +109,7 @@ function testEventScopeInShadowTree(type, Ctor) {
 }
 
 function testEventScopeOnHostElement(type, Ctor) {
-    // TODO [#1141]: Event non dispatched from within a LWC shadow tree are not patched
-    xdescribe(`event scope on host element ${type}`, () => {
+    describe(`event scope on host element ${type}`, () => {
         let nodes;
         beforeEach(() => {
             nodes = createShadowTree(document.body);


### PR DESCRIPTION
Details

This PR enables tests that have been disabled becasue synthetic-shadow didn't used to patch `Event` not originating from an LWC component.

Fixes #1141.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
