### PR TITLE
fix(compiler): decorated props duplicated in fields (#1641)

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -408,7 +408,7 @@ describe('Transform property', () => {
                     }
                   },
                   publicMethods: ["m1"],
-                  fields: ["privateProp", "ctor"]
+                  fields: ["privateProp"]
                 });
 
                 export default _registerComponent(Text, {

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -35,7 +35,14 @@ module.exports = function postProcess({ types: t }) {
 
     function collectObservedFields(body, decoratedProperties) {
         const mappers = {
-            ObjectExpression: ({ properties }) => properties.map(({ key: { name } }) => name),
+            ObjectExpression: ({ properties }) =>
+                properties.map(({ key }) => {
+                    if (t.isIdentifier(key)) {
+                        return key.name;
+                    } else if (t.isStringLiteral(key)) {
+                        return key.value;
+                    }
+                }),
             ArrayExpression: ({ elements }) => elements.map(({ value }) => value),
         };
 
@@ -49,6 +56,8 @@ module.exports = function postProcess({ types: t }) {
                 path =>
                     t.isClassProperty(path.node) &&
                     !isLWCNode(path.node) &&
+                    !path.node.static &&
+                    t.isIdentifier(path.node.key) &&
                     !(decoratedIdentifiers.indexOf(path.node.key.name) >= 0)
             )
             .map(path => path.node.key.name);

--- a/packages/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/integration-karma/test/component/observed-fields/index.spec.js
@@ -115,4 +115,19 @@ describe('observed-fields', () => {
             expect(elm.shadowRoot.querySelector('.inherited-value').textContent).toBe('mutated');
         });
     });
+
+    it('should allow decorated reserved words as field names', () => {
+        const elm = createElement('x-simple', { is: Simple });
+        elm.static = 'static value';
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe('static value');
+        elm.static = 'static value modified';
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
+                'static value modified'
+            );
+        });
+    });
 });

--- a/packages/integration-karma/test/component/observed-fields/x/simple/simple.html
+++ b/packages/integration-karma/test/component/observed-fields/x/simple/simple.html
@@ -3,4 +3,5 @@
     <p class="expando-value">{expandoField}</p>
     <p class="inherited-value">{inheritedValue}</p>
     <p class="complex-value">{complexValue.name}-{complexValue.lastName}</p>
+    <p class="static-value">{static}</p>
 </template>

--- a/packages/integration-karma/test/component/observed-fields/x/simple/simple.js
+++ b/packages/integration-karma/test/component/observed-fields/x/simple/simple.js
@@ -5,6 +5,7 @@ class BaseKlass extends LightningElement {
 }
 
 export default class Simple extends BaseKlass {
+    @api static;
     @track trackedField;
     simpleValue = 'initial';
     complexValue = {


### PR DESCRIPTION
# Details
cherrypicks 90269c6182dfaedc4d3d34a19dc2aa7e0b42c55b (#1641)

When having a decorated property named as a reserved word (ex: static) the engine will throw an error at runtime (Cannot redefine property: static)

* fix(compiler): dont observe mutation in fields defined with bracket notation

* fix(compiler): dont observe mutations in static fields

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
