### PR TITLE
refactor(engine): remove Event instanceof check on dispatchEvent

### DIFF
--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -23,18 +23,15 @@ import {
     isObject,
     isNull,
 } from '@lwc/shared';
-<<<<<<< HEAD
-import { logError } from '../shared/logger';
-import { ComponentInterface } from './component';
-=======
-import { logError } from '../shared/assert';
+
 import { LightningElement } from './base-lightning-element';
-import { ComponentInterface, getComponentAsString } from './component';
->>>>>>> a843dc01... refactor(engine): move dispatchEvent check to restrictions
+import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
 import { isBeingConstructed, isInvokingRender } from './invoker';
 import { getAssociatedVM, getAssociatedVMIfPresent } from './vm';
 import { isUpdatingTemplate, getVMBeingRendered } from './template';
+import { logError } from '../shared/logger';
+import { getComponentTag } from '../shared/format';
 
 function generateDataDescriptor(options: PropertyDescriptor): PropertyDescriptor {
     return assign(
@@ -413,8 +410,8 @@ function getLightningElementPrototypeRestrictionsDescriptors(
 
                 assert.isFalse(
                     isBeingConstructed(vm),
-                    `this.dispatchEvent() should not be called during the construction of the custom element for ${getComponentAsString(
-                        this
+                    `this.dispatchEvent() should not be called during the construction of the custom element for ${getComponentTag(
+                        vm
                     )} because no one is listening just yet.`
                 );
 
@@ -423,11 +420,10 @@ function getLightningElementPrototypeRestrictionsDescriptors(
 
                     if (isString(type) && !/^[a-z][a-z0-9_]*$/.test(type)) {
                         logError(
-                            `Invalid event type "${type}" dispatched in element ${getComponentAsString(
-                                vm.component
-                            )}. ` +
-                                'Event name must start with a lowercase letter and followed only lowercase letters, numbers, and underscores',
-                            vm.elm
+                            `Invalid event type "${type}" dispatched in element ${getComponentTag(
+                                vm
+                            )}. Event name must start with a lowercase letter and followed only lowercase letters, numbers, and underscores`,
+                            vm
                         );
                     }
                 }

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -19,7 +19,6 @@ import {
     isUndefined,
     setPrototypeOf,
     toString,
-    isString,
     isObject,
     isNull,
 } from '@lwc/shared';
@@ -418,7 +417,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(
                 if (!isNull(event) && isObject(event)) {
                     const { type } = event;
 
-                    if (isString(type) && !/^[a-z][a-z0-9_]*$/.test(type)) {
+                    if (!/^[a-z][a-z0-9_]*$/.test(type)) {
                         logError(
                             `Invalid event type "${type}" dispatched in element ${getComponentTag(
                                 vm

--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -47,7 +47,7 @@ it('should throw when event is dispatched during construction', function() {
         createElement('x-test', { is: Test });
     }).toThrowErrorDev(
         Error,
-        /this.dispatchEvent\(\) should not be called during the construction of the custom element for <x-test> because no one is listening for the event "event" just yet/
+        /this.dispatchEvent\(\) should not be called during the construction of the custom element for <x-test> because no one is listening just yet/
     );
 });
 


### PR DESCRIPTION
## Details

In the process of implementing SSR (#910), to start decoupling the engine from the DOM. This PR remove the `instanceof Event` check in `LigthningElement.prototype.dispatchEvent`. The same check is run by the browser when invoking the `EventTarget.prototype.dispatchEvent` method.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
