### PR TITLE
refactor(engine): VM access and assertions in the engine

### DIFF
--- a/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/vm.spec.ts
@@ -4,13 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { fields } from '@lwc/shared';
 import { compileTemplate } from 'test-utils';
 import { createElement, LightningElement, registerDecorators } from '../main';
-import { ViewModelReflection } from '../utils';
-import { getComponentVM } from '../vm';
-
-const { getHiddenField } = fields;
+import { getAssociatedVM } from '../vm';
 
 const emptyTemplate = compileTemplate(`<template></template>`);
 
@@ -19,7 +15,7 @@ describe('vm', () => {
         it('should have idx>0 (creation index) during construction', () => {
             class MyComponent1 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent1 });
-            const hiddenFields = getHiddenField(elm, ViewModelReflection);
+            const hiddenFields = getAssociatedVM(elm);
             expect(hiddenFields.idx).toBeGreaterThan(0);
         });
 
@@ -27,7 +23,7 @@ describe('vm', () => {
             class MyComponent2 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent2 });
             document.body.appendChild(elm);
-            const hiddenFields = getHiddenField(elm, ViewModelReflection);
+            const hiddenFields = getAssociatedVM(elm);
             expect(hiddenFields.idx).toBeGreaterThan(0);
         });
 
@@ -35,7 +31,7 @@ describe('vm', () => {
             class MyComponent3 extends LightningElement {}
             const elm = createElement('x-foo', { is: MyComponent3 });
             document.body.appendChild(elm);
-            const hiddenFields = getHiddenField(elm, ViewModelReflection);
+            const hiddenFields = getAssociatedVM(elm);
             expect(hiddenFields.idx).toBeGreaterThan(0);
             document.body.removeChild(elm);
             expect(hiddenFields.idx).toBeGreaterThan(0);
@@ -47,7 +43,7 @@ describe('vm', () => {
             class ChildComponent4 extends LightningElement {
                 constructor() {
                     super();
-                    vm2 = getComponentVM(this);
+                    vm2 = getAssociatedVM(this);
                 }
             }
 
@@ -64,7 +60,7 @@ describe('vm', () => {
             class MyComponent4 extends LightningElement {
                 constructor() {
                     super();
-                    vm1 = getComponentVM(this);
+                    vm1 = getAssociatedVM(this);
                 }
                 render() {
                     return html;
@@ -84,7 +80,7 @@ describe('vm', () => {
             class ChildComponent5 extends LightningElement {
                 constructor() {
                     super();
-                    vm2 = getComponentVM(this);
+                    vm2 = getAssociatedVM(this);
                 }
                 render() {
                     counter++;
@@ -105,7 +101,7 @@ describe('vm', () => {
             class MyComponent5 extends LightningElement {
                 constructor() {
                     super();
-                    vm1 = getComponentVM(this);
+                    vm1 = getAssociatedVM(this);
                 }
                 render() {
                     return html;

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -32,7 +32,7 @@ import {
     EmptyObject,
     useSyntheticShadow,
 } from './utils';
-import { getCustomElementVM, runConnectedCallback, SlotSet, VM, VMState } from './vm';
+import { getAssociatedVM, runConnectedCallback, SlotSet, VM, VMState } from './vm';
 import { ComponentConstructor } from './component';
 import {
     VNode,
@@ -197,7 +197,7 @@ const CustomElementHook: Hooks = {
     },
     insert: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
         insertNodeHook(vnode, parentNode, referenceNode);
-        const vm = getCustomElementVM(vnode.elm as HTMLElement);
+        const vm = getAssociatedVM(vnode.elm!);
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(vm.state === VMState.created, `${vm} cannot be recycled.`);
         }

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -199,7 +199,6 @@ const CustomElementHook: Hooks = {
         insertNodeHook(vnode, parentNode, referenceNode);
         const vm = getCustomElementVM(vnode.elm as HTMLElement);
         if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             assert.isTrue(vm.state === VMState.created, `${vm} cannot be recycled.`);
         }
         runConnectedCallback(vm);

--- a/packages/@lwc/engine/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine/src/framework/base-bridge-element.ts
@@ -20,7 +20,7 @@ import {
     seal,
     setPrototypeOf,
 } from '@lwc/shared';
-import { getCustomElementVM } from './vm';
+import { getAssociatedVM } from './vm';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { reactiveMembrane } from './membrane';
 
@@ -35,7 +35,7 @@ function createGetter(key: string) {
     let fn = cachedGetterByKey[key];
     if (isUndefined(fn)) {
         fn = cachedGetterByKey[key] = function(this: HTMLElement): any {
-            const vm = getCustomElementVM(this);
+            const vm = getAssociatedVM(this);
             const { getHook } = vm;
             return getHook(vm.component, key);
         };
@@ -47,7 +47,7 @@ function createSetter(key: string) {
     let fn = cachedSetterByKey[key];
     if (isUndefined(fn)) {
         fn = cachedSetterByKey[key] = function(this: HTMLElement, newValue: any): any {
-            const vm = getCustomElementVM(this);
+            const vm = getAssociatedVM(this);
             const { setHook } = vm;
             newValue = reactiveMembrane.getReadOnlyProxy(newValue);
             setHook(vm.component, key, newValue);
@@ -58,7 +58,7 @@ function createSetter(key: string) {
 
 function createMethodCaller(methodName: string): (...args: any[]) => any {
     return function(this: HTMLElement): any {
-        const vm = getCustomElementVM(this);
+        const vm = getAssociatedVM(this);
         const { callHook, component } = vm;
         const fn = component[methodName];
         return callHook(vm.component, fn, ArraySlice.call(arguments));

--- a/packages/@lwc/engine/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine/src/framework/base-bridge-element.ts
@@ -8,7 +8,6 @@
  * This module is responsible for creating the base bridge class BaseBridgeElement
  * that represents the HTMLElement extension used for any LWC inserted in the DOM.
  */
-import { assert } from '@lwc/shared';
 import {
     ArraySlice,
     create,
@@ -21,15 +20,9 @@ import {
     seal,
     setPrototypeOf,
 } from '@lwc/shared';
-import { getCustomElementVM, VM } from './vm';
+import { getCustomElementVM } from './vm';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { reactiveMembrane } from './membrane';
-
-export function prepareForPropUpdate(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-}
 
 // A bridge descriptor is a descriptor whose job is just to get the component instance
 // from the element instance, and get the value or set a new value on the component.

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -247,7 +247,7 @@ export interface LightningElement {
 function BaseLightningElementConstructor(this: LightningElement) {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
-        throw new ReferenceError();
+        throw new ReferenceError('Invalid Constructor');
     }
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -17,7 +17,6 @@ import {
     assert,
     create,
     defineProperties,
-    fields,
     freeze,
     getOwnPropertyNames,
     isFalse,
@@ -35,9 +34,9 @@ import {
     getComponentAsString,
     getTemplateReactiveObserver,
 } from './component';
-import { ViewModelReflection, EmptyObject } from './utils';
+import { EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
-import { getComponentVM, VM } from './vm';
+import { getAssociatedVM, VM, associateVM } from './vm';
 import { valueObserved, valueMutated } from '../libs/mutation-tracker';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';
@@ -45,8 +44,6 @@ import { unlockAttribute, lockAttribute } from './attributes';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 
 const GlobalEvent = Event; // caching global reference to avoid poisoning
-
-const { setHiddenField } = fields;
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -79,7 +76,7 @@ function createBridgeToElementDescriptor(
         enumerable,
         configurable,
         get(this: ComponentInterface) {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
                     const name = vm.elm.constructor.name;
@@ -94,7 +91,7 @@ function createBridgeToElementDescriptor(
             return get.call(vm.elm);
         },
         set(this: ComponentInterface, newValue: any) {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
@@ -130,7 +127,7 @@ function createBridgeToElementDescriptor(
 }
 
 function getLinkedElement(cmp: ComponentInterface): HTMLElement {
-    return getComponentVM(cmp).elm;
+    return getAssociatedVM(cmp).elm;
 }
 
 interface ComponentHooks {
@@ -284,9 +281,9 @@ function BaseLightningElementConstructor(this: LightningElement) {
     };
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM
-    setHiddenField(component, ViewModelReflection, vm);
-    setHiddenField(cmpRoot, ViewModelReflection, vm);
-    setHiddenField(elm, ViewModelReflection, vm);
+    associateVM(component, vm as VM);
+    associateVM(cmpRoot, vm as VM);
+    associateVM(elm, vm as VM);
     // VM is now initialized
     (vm as VM).cmpRoot = cmpRoot;
     if (process.env.NODE_ENV !== 'production') {
@@ -301,7 +298,7 @@ BaseLightningElementConstructor.prototype = {
     constructor: BaseLightningElementConstructor,
     dispatchEvent(event: Event): boolean {
         const elm = getLinkedElement(this);
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
 
         if (process.env.NODE_ENV !== 'production') {
             if (arguments.length === 0) {
@@ -346,7 +343,7 @@ BaseLightningElementConstructor.prototype = {
         listener: EventListener,
         options?: boolean | AddEventListenerOptions
     ) {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
             const vmBeingRendered = getVMBeingRendered();
             assert.invariant(
@@ -370,7 +367,7 @@ BaseLightningElementConstructor.prototype = {
         listener: EventListener,
         options?: boolean | AddEventListenerOptions
     ) {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         const wrappedListener = getWrappedComponentsListener(vm, listener);
         vm.elm.removeEventListener(type, wrappedListener, options);
     },
@@ -378,7 +375,7 @@ BaseLightningElementConstructor.prototype = {
         const elm = getLinkedElement(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
-                isBeingConstructed(getComponentVM(this)),
+                isBeingConstructed(getAssociatedVM(this)),
                 `Failed to construct '${getComponentAsString(
                     this
                 )}': The result must not have attributes.`
@@ -410,7 +407,7 @@ BaseLightningElementConstructor.prototype = {
         const elm = getLinkedElement(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
-                isBeingConstructed(getComponentVM(this)),
+                isBeingConstructed(getAssociatedVM(this)),
                 `Failed to construct '${getComponentAsString(
                     this
                 )}': The result must not have attributes.`
@@ -443,7 +440,7 @@ BaseLightningElementConstructor.prototype = {
     getBoundingClientRect(): ClientRect {
         const elm = getLinkedElement(this);
         if (process.env.NODE_ENV !== 'production') {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             assert.isFalse(
                 isBeingConstructed(vm),
                 `this.getBoundingClientRect() should not be called during the construction of the custom element for ${getComponentAsString(
@@ -460,7 +457,7 @@ BaseLightningElementConstructor.prototype = {
     // querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
     // querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
     querySelector<E extends Element = Element>(selectors: string): E | null {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
                 isBeingConstructed(vm),
@@ -480,7 +477,7 @@ BaseLightningElementConstructor.prototype = {
     // querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>,
     // querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>,
     querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E> {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
                 isBeingConstructed(vm),
@@ -498,7 +495,7 @@ BaseLightningElementConstructor.prototype = {
      * match the provided tagName.
      */
     getElementsByTagName(tagNameOrWildCard: string): HTMLCollectionOf<Element> {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
                 isBeingConstructed(vm),
@@ -516,7 +513,7 @@ BaseLightningElementConstructor.prototype = {
      * match the provide classnames.
      */
     getElementsByClassName(names: string): HTMLCollectionOf<Element> {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
             assert.isFalse(
                 isBeingConstructed(vm),
@@ -531,7 +528,7 @@ BaseLightningElementConstructor.prototype = {
 
     get classList(): DOMTokenList {
         if (process.env.NODE_ENV !== 'production') {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             // TODO [#1290]: this still fails in dev but works in production, eventually, we should just throw in all modes
             assert.isFalse(
                 isBeingConstructed(vm),
@@ -541,7 +538,7 @@ BaseLightningElementConstructor.prototype = {
         return getLinkedElement(this).classList;
     },
     get template(): ShadowRoot {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         return vm.cmpRoot;
     },
     get shadowRoot(): ShadowRoot | null {
@@ -550,11 +547,11 @@ BaseLightningElementConstructor.prototype = {
         return null;
     },
     render(): Template {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         return vm.def.template;
     },
     toString(): string {
-        const vm = getComponentVM(this);
+        const vm = getAssociatedVM(this);
         return `[object ${vm.def.name}]`;
     },
 };

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -36,7 +36,7 @@ import {
 } from './component';
 import { EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
-import { getAssociatedVM, VM, associateVM } from './vm';
+import { associateVM, getAssociatedVM, VM } from './vm';
 import { valueObserved, valueMutated } from '../libs/mutation-tracker';
 import { dispatchEvent } from '../env/dom';
 import { patchComponentWithRestrictions, patchShadowRootWithRestrictions } from './restrictions';

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -247,7 +247,7 @@ export interface LightningElement {
 function BaseLightningElementConstructor(this: LightningElement) {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
-        throw new ReferenceError('Invalid Constructor');
+        throw new ReferenceError('Illegal constructor');
     }
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -80,9 +80,6 @@ function createBridgeToElementDescriptor(
         configurable,
         get(this: ComponentInterface) {
             const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-            }
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
                     const name = vm.elm.constructor.name;
@@ -99,7 +96,6 @@ function createBridgeToElementDescriptor(
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
                     !isInvokingRender,
@@ -257,7 +253,6 @@ function BaseLightningElementConstructor(this: LightningElement) {
         throw new ReferenceError();
     }
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue('cmpProps' in vmBeingConstructed, `${vmBeingConstructed} is not a vm.`);
         assert.invariant(
             vmBeingConstructed.elm instanceof HTMLElement,
             `Component creation requires a DOM element to be associated to ${vmBeingConstructed}.`
@@ -354,7 +349,6 @@ BaseLightningElementConstructor.prototype = {
         const vm = getComponentVM(this);
         if (process.env.NODE_ENV !== 'production') {
             const vmBeingRendered = getVMBeingRendered();
-            assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
             assert.invariant(
                 !isInvokingRender,
                 `${vmBeingRendered}.render() method has side effects on the state of ${vm} by adding an event listener for "${type}".`
@@ -377,9 +371,6 @@ BaseLightningElementConstructor.prototype = {
         options?: boolean | AddEventListenerOptions
     ) {
         const vm = getComponentVM(this);
-        if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-        }
         const wrappedListener = getWrappedComponentsListener(vm, listener);
         vm.elm.removeEventListener(type, wrappedListener, options);
     },
@@ -551,9 +542,6 @@ BaseLightningElementConstructor.prototype = {
     },
     get template(): ShadowRoot {
         const vm = getComponentVM(this);
-        if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-        }
         return vm.cmpRoot;
     },
     get shadowRoot(): ShadowRoot | null {
@@ -567,9 +555,6 @@ BaseLightningElementConstructor.prototype = {
     },
     toString(): string {
         const vm = getComponentVM(this);
-        if (process.env.NODE_ENV !== 'production') {
-            assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-        }
         return `[object ${vm.def.name}]`;
     },
 };

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -12,7 +12,7 @@ import {
     invokeEventListener,
 } from './invoker';
 import { invokeServiceHook, Services } from './services';
-import { VM, getComponentVM, UninitializedVM, scheduleRehydration } from './vm';
+import { VM, getAssociatedVM, UninitializedVM, scheduleRehydration } from './vm';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { tagNameGetter } from '../env/element';
 import { ReactiveObserver } from '../libs/mutation-tracker';
@@ -159,6 +159,6 @@ export function getComponentAsString(component: ComponentInterface): string {
     if (process.env.NODE_ENV === 'production') {
         throw new ReferenceError();
     }
-    const vm = getComponentVM(component);
+    const vm = getAssociatedVM(component);
     return `<${StringToLowerCase.call(tagNameGetter.call(vm.elm))}>`;
 }

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -57,13 +57,6 @@ export function getComponentRegisteredMeta(Ctor: ComponentConstructor): Componen
 }
 
 export function createComponent(uninitializedVm: UninitializedVM, Ctor: ComponentConstructor) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(
-            uninitializedVm && 'cmpProps' in uninitializedVm,
-            `${uninitializedVm} is not a vm.`
-        );
-    }
-
     // create the component instance
     invokeComponentConstructor(uninitializedVm, Ctor);
 
@@ -76,14 +69,11 @@ export function createComponent(uninitializedVm: UninitializedVM, Ctor: Componen
 }
 
 export function linkComponent(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    // wiring service
     const {
         def: { wire },
     } = vm;
-    if (wire) {
+
+    if (!isUndefined(wire)) {
         const { wiring } = Services;
         if (wiring) {
             invokeServiceHook(vm, wiring);
@@ -113,7 +103,6 @@ export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
 
 export function renderComponent(vm: VM): VNodes {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.invariant(vm.isDirty, `${vm} is not dirty.`);
     }
 
@@ -133,7 +122,6 @@ export function renderComponent(vm: VM): VNodes {
 
 export function markComponentAsDirty(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         const vmBeingRendered = getVMBeingRendered();
         assert.isFalse(
             vm.isDirty,
@@ -154,9 +142,6 @@ export function markComponentAsDirty(vm: VM) {
 const cmpEventListenerMap: WeakMap<EventListener, EventListener> = new WeakMap();
 
 export function getWrappedComponentsListener(vm: VM, listener: EventListener): EventListener {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     if (!isFunction(listener)) {
         throw new TypeError(); // avoiding problems with non-valid listeners
     }

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -68,9 +68,6 @@ function createPublicPropertyDescriptor(
     return {
         get(this: ComponentInterface): any {
             const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-            }
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
                     const name = vm.elm.constructor.name;
@@ -90,7 +87,6 @@ function createPublicPropertyDescriptor(
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
                     !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
@@ -173,15 +169,14 @@ function createPublicAccessorDescriptor(
     return {
         get(this: ComponentInterface): any {
             if (process.env.NODE_ENV !== 'production') {
-                const vm = getComponentVM(this);
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
+                // Assert that the this value is an actual Component with an associated VM.
+                getComponentVM(this);
             }
             return get.call(this);
         },
         set(this: ComponentInterface, newValue: any) {
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
                     !isInvokingRender,

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -10,7 +10,7 @@ import { logError } from '../../shared/assert';
 import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { valueObserved, valueMutated, ReactiveObserver } from '../../libs/mutation-tracker';
 import { ComponentInterface, ComponentConstructor } from '../component';
-import { getComponentVM, rerenderVM } from '../vm';
+import { getAssociatedVM, rerenderVM } from '../vm';
 import { getDecoratorsRegisteredMeta } from './register';
 import { addCallbackToNextTick } from '../utils';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
@@ -67,7 +67,7 @@ function createPublicPropertyDescriptor(
 ): PropertyDescriptor {
     return {
         get(this: ComponentInterface): any {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
                     const name = vm.elm.constructor.name;
@@ -84,7 +84,7 @@ function createPublicPropertyDescriptor(
             return vm.cmpProps[key];
         },
         set(this: ComponentInterface, newValue: any) {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(
@@ -170,12 +170,12 @@ function createPublicAccessorDescriptor(
         get(this: ComponentInterface): any {
             if (process.env.NODE_ENV !== 'production') {
                 // Assert that the this value is an actual Component with an associated VM.
-                getComponentVM(this);
+                getAssociatedVM(this);
             }
             return get.call(this);
         },
         set(this: ComponentInterface, newValue: any) {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -7,7 +7,7 @@
 import { assert, isFalse, isUndefined, toString } from '@lwc/shared';
 import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
 import { isInvokingRender } from '../invoker';
-import { getComponentVM } from '../vm';
+import { getAssociatedVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { ComponentConstructor, ComponentInterface } from '../component';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
@@ -62,12 +62,12 @@ export function createTrackedPropertyDescriptor(
 ): PropertyDescriptor {
     return {
         get(this: ComponentInterface): any {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             valueObserved(this, key);
             return vm.cmpTrack[key];
         },
         set(this: ComponentInterface, newValue: any) {
-            const vm = getComponentVM(this);
+            const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 assert.invariant(

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -63,9 +63,6 @@ export function createTrackedPropertyDescriptor(
     return {
         get(this: ComponentInterface): any {
             const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-            }
             valueObserved(this, key);
             return vm.cmpTrack[key];
         },
@@ -73,7 +70,6 @@ export function createTrackedPropertyDescriptor(
             const vm = getComponentVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
                 assert.invariant(
                     !isInvokingRender,
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(

--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -53,8 +53,7 @@ import {
     TrackDef,
 } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
-import { getAssociatedIfPresent } from './vm';
-
+import { getAssociatedVMIfPresent } from './vm';
 
 export interface ComponentDef extends DecoratorMeta {
     name: string;
@@ -270,7 +269,7 @@ export function getComponentConstructor(elm: HTMLElement): ComponentConstructor 
     let ctor: ComponentConstructor | null = null;
 
     if (elm instanceof HTMLElement) {
-        const vm = getAssociatedIfPresent(elm);
+        const vm = getAssociatedVMIfPresent(elm);
 
         if (!isUndefined(vm)) {
             ctor = vm.def.ctor;

--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -19,7 +19,6 @@ import {
     assign,
     create,
     defineProperties,
-    fields,
     freeze,
     getOwnPropertyNames,
     getPrototypeOf,
@@ -29,11 +28,7 @@ import {
     setPrototypeOf,
 } from '@lwc/shared';
 import { getAttrNameFromPropName } from './attributes';
-import {
-    resolveCircularModuleDependency,
-    isCircularModuleDependency,
-    ViewModelReflection,
-} from './utils';
+import { resolveCircularModuleDependency, isCircularModuleDependency } from './utils';
 import {
     ComponentConstructor,
     ErrorCallback,
@@ -58,6 +53,8 @@ import {
     TrackDef,
 } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
+import { getAssociatedIfPresent } from './vm';
+
 
 export interface ComponentDef extends DecoratorMeta {
     name: string;
@@ -72,7 +69,6 @@ export interface ComponentDef extends DecoratorMeta {
 }
 
 const CtorToDefMap: WeakMap<any, ComponentDef> = new WeakMap();
-const { getHiddenField } = fields;
 
 function getCtorProto(Ctor: any, subclassComponentName: string): ComponentConstructor {
     let proto: ComponentConstructor | null = getPrototypeOf(Ctor);
@@ -272,12 +268,15 @@ export function getComponentDef(Ctor: any, subclassComponentName?: string): Comp
  */
 export function getComponentConstructor(elm: HTMLElement): ComponentConstructor | null {
     let ctor: ComponentConstructor | null = null;
+
     if (elm instanceof HTMLElement) {
-        const vm = getHiddenField(elm, ViewModelReflection);
+        const vm = getAssociatedIfPresent(elm);
+
         if (!isUndefined(vm)) {
             ctor = vm.def.ctor;
         }
     }
+
     return ctor;
 }
 

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -193,9 +193,7 @@ export function createViewModelHook(vnode: VCustomElement) {
         mode,
         owner,
     });
-    const vm = getCustomElementVM(elm);
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             isArray(vnode.children),
             `Invalid vnode for a custom element, it must have children defined.`
@@ -234,7 +232,6 @@ export function createChildrenHook(vnode: VElement) {
 export function rerenderCustomElmHook(vnode: VCustomElement) {
     const vm = getCustomElementVM(vnode.elm as HTMLElement);
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             isArray(vnode.children),
             `Invalid vnode for a custom element, it must have children defined.`

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -10,11 +10,11 @@ import {
     rerenderVM,
     createVM,
     removeVM,
-    getCustomElementVM,
+    getAssociatedVM,
     allocateInSlot,
     appendVM,
     runWithBoundaryProtection,
-    getAssociatedIfPresent,
+    getAssociatedVMIfPresent,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
@@ -141,7 +141,7 @@ export function updateElmHook(oldVnode: VElement, vnode: VElement) {
 }
 
 export function insertCustomElmHook(vnode: VCustomElement) {
-    const vm = getCustomElementVM(vnode.elm as HTMLElement);
+    const vm = getAssociatedVM(vnode.elm!);
     appendVM(vm);
 }
 
@@ -160,8 +160,7 @@ export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
 }
 
 export function allocateChildrenHook(vnode: VCustomElement) {
-    const elm = vnode.elm as HTMLElement;
-    const vm = getCustomElementVM(elm);
+    const vm = getAssociatedVM(vnode.elm!);
     const { children } = vnode;
     vm.aChildren = children;
     if (isTrue(useSyntheticShadow)) {
@@ -174,7 +173,7 @@ export function allocateChildrenHook(vnode: VCustomElement) {
 
 export function createViewModelHook(vnode: VCustomElement) {
     const elm = vnode.elm as HTMLElement;
-    if (!isUndefined(getAssociatedIfPresent(elm))) {
+    if (!isUndefined(getAssociatedVMIfPresent(elm))) {
         // There is a possibility that a custom element is registered under tagName,
         // in which case, the initialization is already carry on, and there is nothing else
         // to do here since this hook is called right after invoking `document.createElement`.
@@ -230,7 +229,7 @@ export function createChildrenHook(vnode: VElement) {
 }
 
 export function rerenderCustomElmHook(vnode: VCustomElement) {
-    const vm = getCustomElementVM(vnode.elm as HTMLElement);
+    const vm = getAssociatedVM(vnode.elm!);
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(
             isArray(vnode.children),
@@ -258,7 +257,7 @@ export function removeElmHook(vnode: VElement) {
     for (let j = 0, len = children.length; j < len; ++j) {
         const ch = children[j];
         if (!isNull(ch)) {
-            ch.hook.remove(ch, elm as HTMLElement);
+            ch.hook.remove(ch, elm!);
         }
     }
 }
@@ -266,7 +265,7 @@ export function removeElmHook(vnode: VElement) {
 export function removeCustomElmHook(vnode: VCustomElement) {
     // for custom elements we don't have to go recursively because the removeVM routine
     // will take care of disconnecting any child VM attached to its shadow as well.
-    removeVM(getCustomElementVM(vnode.elm as HTMLElement));
+    removeVM(getAssociatedVM(vnode.elm!));
 }
 
 // Using a WeakMap instead of a WeakSet because this one works in IE11 :(

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, fields, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
-import { EmptyArray, ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
+import { assert, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
+import { EmptyArray, EmptyObject, useSyntheticShadow } from './utils';
 import {
     rerenderVM,
     createVM,
@@ -14,6 +14,7 @@ import {
     allocateInSlot,
     appendVM,
     runWithBoundaryProtection,
+    getAssociatedIfPresent,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
@@ -34,7 +35,6 @@ import {
 import { getComponentDef, setElementProto } from './def';
 
 const noop = () => void 0;
-const { getHiddenField } = fields;
 
 function observeElementChildNodes(elm: Element) {
     (elm as any).$domManual$ = true;
@@ -174,7 +174,7 @@ export function allocateChildrenHook(vnode: VCustomElement) {
 
 export function createViewModelHook(vnode: VCustomElement) {
     const elm = vnode.elm as HTMLElement;
-    if (!isUndefined(getHiddenField(elm, ViewModelReflection))) {
+    if (!isUndefined(getAssociatedIfPresent(elm))) {
         // There is a possibility that a custom element is registered under tagName,
         // in which case, the initialization is already carry on, and there is nothing else
         // to do here since this hook is called right after invoking `document.createElement`.

--- a/packages/@lwc/engine/src/framework/invoker.ts
+++ b/packages/@lwc/engine/src/framework/invoker.ts
@@ -17,9 +17,6 @@ export let isInvokingRender: boolean = false;
 
 export let vmBeingConstructed: UninitializedVM | null = null;
 export function isBeingConstructed(vm: VM): boolean {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpProps' in vm, `${vm} is not a vm.`);
-    }
     return vmBeingConstructed === vm;
 }
 
@@ -48,9 +45,6 @@ export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, arg
 
 export function invokeComponentConstructor(vm: UninitializedVM, Ctor: ComponentConstructor) {
     const vmBeingConstructedInception = vmBeingConstructed;
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpProps' in vm, `${vm} is not a vm.`);
-    }
     const { context } = vm;
     const ctx = currentContext;
     establishContext(context);

--- a/packages/@lwc/engine/src/framework/modules/context.ts
+++ b/packages/@lwc/engine/src/framework/modules/context.ts
@@ -6,9 +6,9 @@
  */
 import { assign, isUndefined } from '@lwc/shared';
 import { getAssociatedVMIfPresent } from '../vm';
-import { VNode } from '../../3rdparty/snabbdom/types';
+import { VElement } from '../../3rdparty/snabbdom/types';
 
-function createContext(vnode: VNode) {
+function createContext(vnode: VElement) {
     const {
         data: { context },
     } = vnode;

--- a/packages/@lwc/engine/src/framework/modules/context.ts
+++ b/packages/@lwc/engine/src/framework/modules/context.ts
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assign, fields, isUndefined } from '@lwc/shared';
+import { assign, isUndefined } from '@lwc/shared';
+import { getAssociatedIfPresent } from '../vm';
 import { VNode } from '../../3rdparty/snabbdom/types';
-import { ViewModelReflection } from '../utils';
-import { VM } from '../vm';
-
-const { getHiddenField } = fields;
 
 function createContext(vnode: VNode) {
     const {
@@ -20,8 +17,8 @@ function createContext(vnode: VNode) {
         return;
     }
 
-    const elm = vnode.elm as Element;
-    const vm: VM = getHiddenField(elm, ViewModelReflection);
+    const elm = vnode.elm as HTMLElement;
+    const vm = getAssociatedIfPresent(elm);
 
     if (!isUndefined(vm)) {
         assign(vm.context, context);

--- a/packages/@lwc/engine/src/framework/modules/context.ts
+++ b/packages/@lwc/engine/src/framework/modules/context.ts
@@ -17,7 +17,7 @@ function createContext(vnode: VNode) {
         return;
     }
 
-    const elm = vnode.elm as HTMLElement;
+    const elm = vnode.elm!;
     const vm = getAssociatedVMIfPresent(elm);
 
     if (!isUndefined(vm)) {

--- a/packages/@lwc/engine/src/framework/modules/context.ts
+++ b/packages/@lwc/engine/src/framework/modules/context.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assign, isUndefined } from '@lwc/shared';
-import { getAssociatedIfPresent } from '../vm';
+import { getAssociatedVMIfPresent } from '../vm';
 import { VNode } from '../../3rdparty/snabbdom/types';
 
 function createContext(vnode: VNode) {
@@ -18,7 +18,7 @@ function createContext(vnode: VNode) {
     }
 
     const elm = vnode.elm as HTMLElement;
-    const vm = getAssociatedIfPresent(elm);
+    const vm = getAssociatedVMIfPresent(elm);
 
     if (!isUndefined(vm)) {
         assign(vm.context, context);

--- a/packages/@lwc/engine/src/framework/modules/props.ts
+++ b/packages/@lwc/engine/src/framework/modules/props.ts
@@ -4,13 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, fields, isUndefined, keys } from '@lwc/shared';
-import { ViewModelReflection } from '../utils';
-import { prepareForPropUpdate } from '../base-bridge-element';
+import { assert, isUndefined, keys } from '@lwc/shared';
 import { VNode } from '../../3rdparty/snabbdom/types';
 import { getAttrNameFromPropName } from '../attributes';
-
-const { getHiddenField } = fields;
 
 function isLiveBindingProp(sel: string, key: string): boolean {
     // For special whitelisted properties, we check against the actual property value on the DOM element instead of
@@ -36,9 +32,7 @@ function update(oldVnode: VNode, vnode: VNode) {
     }
 
     const elm = vnode.elm as Element;
-    const vm = getHiddenField(elm, ViewModelReflection);
     const isFirstPatch = isUndefined(oldProps);
-    const isCustomElement = !isUndefined(vm);
     const { sel } = vnode;
 
     for (const key in props) {
@@ -60,9 +54,6 @@ function update(oldVnode: VNode, vnode: VNode) {
             isFirstPatch ||
             cur !== (isLiveBindingProp(sel as string, key) ? elm[key] : (oldProps as any)[key])
         ) {
-            if (isCustomElement) {
-                prepareForPropUpdate(vm); // this is just in case the vnode is actually a custom element
-            }
             elm[key] = cur;
         }
     }

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, ArrayReduce, isFalse } from '@lwc/shared';
+import { ArrayReduce, isFalse } from '@lwc/shared';
 import { ComponentInterface } from './component';
-import { getComponentVM } from './vm';
+import { getAssociatedVM } from './vm';
 import { valueMutated, valueObserved } from '../libs/mutation-tracker';
 
 export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): PropertyDescriptorMap {
@@ -24,19 +24,12 @@ export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): Proper
 function createObservedFieldPropertyDescriptor(key: PropertyKey): PropertyDescriptor {
     return {
         get(this: ComponentInterface): any {
-            const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
-            }
+            const vm = getAssociatedVM(this);
             valueObserved(this, key);
             return vm.cmpTrack[key];
         },
         set(this: ComponentInterface, newValue: any) {
-            const vm = getComponentVM(this);
-            if (process.env.NODE_ENV !== 'production') {
-                assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a valid vm.`);
-            }
-
+            const vm = getAssociatedVM(this);
             if (newValue !== vm.cmpTrack[key]) {
                 vm.cmpTrack[key] = newValue;
                 if (isFalse(vm.isDirty)) {

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -24,7 +24,7 @@ import { logError } from '../shared/assert';
 import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
 import { isBeingConstructed, isInvokingRender } from './invoker';
-import { getShadowRootVM, getComponentVM } from './vm';
+import { getAssociatedVM } from './vm';
 import { isUpdatingTemplate, getVMBeingRendered } from './template';
 
 function generateDataDescriptor(options: PropertyDescriptor): PropertyDescriptor {
@@ -246,7 +246,7 @@ function getShadowRootRestrictionsDescriptors(
         }),
         querySelector: generateDataDescriptor({
             value(this: ShadowRoot) {
-                const vm = getShadowRootVM(this);
+                const vm = getAssociatedVM(this);
                 assert.isFalse(
                     isBeingConstructed(vm),
                     `this.template.querySelector() cannot be called during the construction of the custom element for ${vm} because no content has been rendered yet.`
@@ -258,7 +258,7 @@ function getShadowRootRestrictionsDescriptors(
         }),
         querySelectorAll: generateDataDescriptor({
             value(this: ShadowRoot) {
-                const vm = getShadowRootVM(this);
+                const vm = getAssociatedVM(this);
                 assert.isFalse(
                     isBeingConstructed(vm),
                     `this.template.querySelectorAll() cannot be called during the construction of the custom element for ${vm} because no content has been rendered yet.`
@@ -402,7 +402,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(proto: object): Pro
                 } else if (attribute) {
                     msg.push(`Instead access it via \`this.getAttribute("${attribute}")\`.`);
                 }
-                logError(msg.join('\n'), getComponentVM(this).elm);
+                logError(msg.join('\n'), getAssociatedVM(this).elm);
             },
             set() {
                 const { readOnly } = globalHTMLProperties[propName];

--- a/packages/@lwc/engine/src/framework/services.ts
+++ b/packages/@lwc/engine/src/framework/services.ts
@@ -67,7 +67,6 @@ export function register(service: ServiceDef) {
 
 export function invokeServiceHook(vm: VM, cbs: ServiceCallback[]) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             isArray(cbs) && cbs.length > 0,
             `Optimize invokeServiceHook() to be invoked only when needed`

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -108,13 +108,11 @@ function collectStylesheets(stylesheets, hostSelector, shadowSelector, isNative,
 }
 
 export function evaluateCSS(
-    vm: VM,
     stylesheets: StylesheetFactory[],
     hostAttribute: string,
     shadowAttribute: string
 ): VNode | null {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(isArray(stylesheets), `Invalid stylesheets.`);
     }
 

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -123,7 +123,6 @@ function validateFields(vm: VM, html: Template) {
 
 export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             isFunction(html),
             `evaluateTemplate() second argument must be an imported template instead of ${toString(
@@ -182,7 +181,6 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
                         applyStyleAttributes(vm, hostAttribute, shadowAttribute);
                         // Caching style vnode so it can be reused on every render
                         context.styleVNode = evaluateCSS(
-                            vm,
                             stylesheets,
                             hostAttribute,
                             shadowAttribute

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -18,9 +18,9 @@ import {
     createVM,
     removeRootVM,
     appendRootVM,
-    getCustomElementVM,
+    getAssociatedVM,
     VMState,
-    getAssociatedIfPresent,
+    getAssociatedVMIfPresent,
 } from './vm';
 import { ComponentConstructor } from './component';
 import { EmptyObject, isCircularModuleDependency, resolveCircularModuleDependency } from './utils';
@@ -109,7 +109,7 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
 
     // Create element with correct tagName
     const element = document.createElement(sel);
-    if (!isUndefined(getAssociatedIfPresent(element))) {
+    if (!isUndefined(getAssociatedVMIfPresent(element))) {
         // There is a possibility that a custom element is registered under tagName,
         // in which case, the initialization is already carry on, and there is nothing else
         // to do here.
@@ -130,7 +130,7 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
     createVM(element, Ctor, { mode, isRoot: true, owner: null });
     // Handle insertion and removal from the DOM manually
     setHiddenField(element, ConnectingSlot, () => {
-        const vm = getCustomElementVM(element);
+        const vm = getAssociatedVM(element);
         startGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
         if (vm.state === VMState.connected) {
             // usually means moving the element from one place to another, which is observable via life-cycle hooks
@@ -140,7 +140,7 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
         endGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
     });
     setHiddenField(element, DisconnectingSlot, () => {
-        const vm = getCustomElementVM(element);
+        const vm = getAssociatedVM(element);
         removeRootVM(vm);
     });
     return element;

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -14,14 +14,16 @@ import {
     isUndefined,
     toString,
 } from '@lwc/shared';
-import { createVM, removeRootVM, appendRootVM, getCustomElementVM, VMState } from './vm';
-import { ComponentConstructor } from './component';
 import {
-    EmptyObject,
-    isCircularModuleDependency,
-    resolveCircularModuleDependency,
-    ViewModelReflection,
-} from './utils';
+    createVM,
+    removeRootVM,
+    appendRootVM,
+    getCustomElementVM,
+    VMState,
+    getAssociatedIfPresent,
+} from './vm';
+import { ComponentConstructor } from './component';
+import { EmptyObject, isCircularModuleDependency, resolveCircularModuleDependency } from './utils';
 import { getComponentDef, setElementProto } from './def';
 import { patchCustomElementWithRestrictions } from './restrictions';
 import { GlobalMeasurementPhase, startGlobalMeasure, endGlobalMeasure } from './performance-timing';
@@ -35,7 +37,9 @@ function callNodeSlot(node: Node, slot: symbol): Node {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(node, `callNodeSlot() should not be called for a non-object`);
     }
-    const fn = getHiddenField(node, slot);
+
+    const fn = getHiddenField(node, slot) as Function | undefined;
+
     if (!isUndefined(fn)) {
         fn();
     }
@@ -105,7 +109,7 @@ export function createElement(sel: string, options: CreateElementOptions): HTMLE
 
     // Create element with correct tagName
     const element = document.createElement(sel);
-    if (!isUndefined(getHiddenField(element, ViewModelReflection))) {
+    if (!isUndefined(getAssociatedIfPresent(element))) {
         // There is a possibility that a custom element is registered under tagName,
         // in which case, the initialization is already carry on, and there is nothing else
         // to do here.

--- a/packages/@lwc/engine/src/framework/utils.ts
+++ b/packages/@lwc/engine/src/framework/utils.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayPush, create, fields, hasOwnProperty, isFunction, seal } from '@lwc/shared';
-const { createFieldName } = fields;
+import { ArrayPush, create, hasOwnProperty, isFunction, seal } from '@lwc/shared';
 
 type Callback = () => void;
 
@@ -14,7 +13,6 @@ export const SPACE_CHAR = 32;
 
 export const EmptyObject = seal(create(null));
 export const EmptyArray = seal([]);
-export const ViewModelReflection = createFieldName('ViewModel', 'engine');
 
 function flushCallbackQueue() {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -251,8 +251,7 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
     linkComponent(initializedVm);
 }
 
-// function assertIsVM(obj: any): asserts obj is VM {
-function assertIsVM(obj: any): void {
+function assertIsVM(obj: any): asserts obj is VM {
     if (!isObject(obj) || !('cmpRoot' in obj)) {
         throw new TypeError(`${obj} is not a VM.`);
     }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -117,7 +117,7 @@ export interface VM extends UninitializedVM {
     oar: Record<PropertyKey, ReactiveObserver>;
 }
 
-type VMAssociable = Node | LightningElement | ComponentInterface;
+type VMAssociable = ShadowRoot | LightningElement | ComponentInterface;
 
 let idx: number = 0;
 

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -139,33 +139,21 @@ function getHook(cmp: ComponentInterface, prop: PropertyKey): any {
 }
 
 export function rerenderVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     rehydrate(vm);
 }
 
 export function appendRootVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     runConnectedCallback(vm);
     rehydrate(vm);
 }
 
 export function appendVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     rehydrate(vm);
 }
 
 // just in case the component comes back, with this we guarantee re-rendering it
 // while preventing any attempt to rehydration until after reinsertion.
 function resetComponentStateWhenRemoved(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { state } = vm;
     if (state !== VMState.disconnected) {
         const { oar, tro } = vm;
@@ -186,7 +174,6 @@ function resetComponentStateWhenRemoved(vm: VM) {
 // old vnode.children is removed from the DOM.
 export function removeVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             vm.state === VMState.connected || vm.state === VMState.disconnected,
             `${vm} must have been connected.`
@@ -197,9 +184,6 @@ export function removeVM(vm: VM) {
 
 // this method is triggered by the removal of a root element from the DOM.
 export function removeRootVM(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     resetComponentStateWhenRemoved(vm);
 }
 
@@ -267,7 +251,6 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
 
 function rehydrate(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(
             vm.elm instanceof HTMLElement,
             `rehydration can only happen after ${vm} was patched the first time.`
@@ -280,9 +263,6 @@ function rehydrate(vm: VM) {
 }
 
 function patchShadowRoot(vm: VM, newCh: VNodes) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { cmpRoot, children: oldCh } = vm;
     vm.children = newCh; // caching the new children collection
     if (newCh.length > 0 || oldCh.length > 0) {
@@ -322,9 +302,6 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
 }
 
 function runRenderedCallback(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { rendered } = Services;
     if (rendered) {
         invokeServiceHook(vm, rendered);
@@ -381,9 +358,6 @@ function flushRehydrationQueue() {
 }
 
 export function runConnectedCallback(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { state } = vm;
     if (state === VMState.connected) {
         return; // nothing to do since it was already connected
@@ -410,7 +384,6 @@ export function runConnectedCallback(vm: VM) {
 
 function runDisconnectedCallback(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.isTrue(vm.state !== VMState.disconnected, `${vm} must be inserted.`);
     }
     if (isFalse(vm.isDirty)) {
@@ -441,9 +414,6 @@ function runDisconnectedCallback(vm: VM) {
 }
 
 function runShadowChildNodesDisconnectedCallback(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { velements: vCustomElementCollection } = vm;
     // reporting disconnection for every child in inverse order since they are inserted in reserved order
     for (let i = vCustomElementCollection.length - 1; i >= 0; i -= 1) {
@@ -462,9 +432,6 @@ function runShadowChildNodesDisconnectedCallback(vm: VM) {
 }
 
 function runLightChildNodesDisconnectedCallback(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     const { aChildren: adoptedChildren } = vm;
     recursivelyDisconnectChildren(adoptedChildren);
 }
@@ -497,9 +464,6 @@ function recursivelyDisconnectChildren(vnodes: VNodes) {
 // of an error, in which case the children VNodes might not be representing the current
 // state of the DOM
 export function resetShadowRoot(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     vm.children = EmptyArray;
     ShadowRootInnerHTMLSetter.call(vm.cmpRoot, '');
     // disconnecting any known custom element inside the shadow of the this vm
@@ -507,9 +471,6 @@ export function resetShadowRoot(vm: VM) {
 }
 
 export function scheduleRehydration(vm: VM) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     if (!vm.isScheduled) {
         vm.isScheduled = true;
         if (rehydrateQueue.length === 0) {
@@ -517,14 +478,6 @@ export function scheduleRehydration(vm: VM) {
         }
         ArrayPush.call(rehydrateQueue, vm);
     }
-}
-
-function getErrorBoundaryVMFromOwnElement(vm: VM): VM | undefined {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
-    const { elm } = vm;
-    return getErrorBoundaryVM(elm);
 }
 
 const { getHiddenField } = fields;
@@ -646,7 +599,6 @@ export function getShadowRootVM(root: ShadowRoot): VM {
 // and get the allocation to be cached by in the elm instead of in the VM
 export function allocateInSlot(vm: VM, children: VNodes) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
         assert.invariant(
             isObject(vm.cmpSlots),
             `When doing manual allocation, there must be a cmpSlots object available.`
@@ -702,10 +654,8 @@ export function runWithBoundaryProtection(
     job: () => void,
     post: () => void
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.isTrue(vm && 'cmpRoot' in vm, `${vm} is not a vm.`);
-    }
     let error;
+
     pre();
     try {
         job();
@@ -715,9 +665,7 @@ export function runWithBoundaryProtection(
         post();
         if (!isUndefined(error)) {
             error.wcStack = error.wcStack || getErrorComponentStack(vm.elm);
-            const errorBoundaryVm = isNull(owner)
-                ? undefined
-                : getErrorBoundaryVMFromOwnElement(owner);
+            const errorBoundaryVm = isNull(owner) ? undefined : getErrorBoundaryVM(owner.elm);
             if (isUndefined(errorBoundaryVm)) {
                 throw error; // eslint-disable-line no-unsafe-finally
             }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -572,15 +572,37 @@ function assertIsVM(obj: any): void {
     }
 }
 
-type AssociableWithVM = Node | LightningElement | ComponentInterface;
+type VMAssociable = Node | LightningElement | ComponentInterface;
 
+/**
+ * An internal field used to associate objects the engine manipulates with view models.
+ */
 const ViewModelReflection = createFieldName('ViewModel', 'engine');
 
-export function associateVM(obj: AssociableWithVM, vm: VM): void {
+/**
+ * Associate an object with a view model.
+ */
+export function associateVM(obj: VMAssociable, vm: VM): void {
     setHiddenField(obj, ViewModelReflection, vm);
 }
 
-export function getAssociatedVMIfPresent(obj: AssociableWithVM): VM | undefined {
+/**
+ * Returns the view model associated with the passed object.
+ */
+export function getAssociatedVM(obj: VMAssociable): VM {
+    const vm = getHiddenField(obj, ViewModelReflection);
+
+    if (process.env.NODE_ENV !== 'production') {
+        assertIsVM(vm);
+    }
+
+    return vm as VM;
+}
+
+/**
+ * Returns the view model associated with the passed object if present, or return undefined.
+ */
+export function getAssociatedVMIfPresent(obj: VMAssociable): VM | undefined {
     const maybeVm = getHiddenField(obj, ViewModelReflection);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -590,16 +612,6 @@ export function getAssociatedVMIfPresent(obj: AssociableWithVM): VM | undefined 
     }
 
     return maybeVm as VM | undefined;
-}
-
-export function getAssociatedVM(obj: AssociableWithVM): VM {
-    const vm = getHiddenField(obj, ViewModelReflection);
-
-    if (process.env.NODE_ENV !== 'production') {
-        assertIsVM(vm);
-    }
-
-    return vm as VM;
 }
 
 // slow path routine

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -121,7 +121,7 @@ type VMAssociable = Node | LightningElement | ComponentInterface;
 
 let idx: number = 0;
 
-/** The internal slot used to associated the different objects the engine manipulates with the VM */
+/** The internal slot used to associate different objects the engine manipulates with the VM */
 const ViewModelReflection = createFieldName('ViewModel', 'engine');
 
 function callHook(
@@ -252,12 +252,12 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
 }
 
 function assertIsVM(obj: any): asserts obj is VM {
-    if (!isObject(obj) || !('cmpRoot' in obj)) {
+    if (isNull(obj) || !isObject(obj) || !('cmpRoot' in obj)) {
         throw new TypeError(`${obj} is not a VM.`);
     }
 }
 
-export function associateVM(obj: VMAssociable, vm: VM): void {
+export function associateVM(obj: VMAssociable, vm: VM) {
     setHiddenField(obj, ViewModelReflection, vm);
 }
 

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -6,7 +6,7 @@
  */
 import { ArrayMap, getOwnPropertyNames, isNull, isObject, isUndefined } from '@lwc/shared';
 import { ComponentConstructor } from './component';
-import { createVM, appendRootVM, removeRootVM, getCustomElementVM, CreateVMInit } from './vm';
+import { createVM, appendRootVM, removeRootVM, getAssociatedVM, CreateVMInit } from './vm';
 import { EmptyObject } from './utils';
 import { getComponentDef } from './def';
 import { getPropNameFromAttrName, isAttributeLocked } from './attributes';
@@ -50,11 +50,11 @@ export function buildCustomElementConstructor(
             }
         }
         connectedCallback() {
-            const vm = getCustomElementVM(this);
+            const vm = getAssociatedVM(this);
             appendRootVM(vm);
         }
         disconnectedCallback() {
-            const vm = getCustomElementVM(this);
+            const vm = getAssociatedVM(this);
             removeRootVM(vm);
         }
         attributeChangedCallback(attrName, oldValue, newValue) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,27 +36,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
-  integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.2.2"
-    "@babel/helpers" "^7.2.0"
-    "@babel/parser" "^7.2.2"
-    "@babel/template" "^7.2.2"
-    "@babel/traverse" "^7.2.2"
-    "@babel/types" "^7.2.2"
-    convert-source-map "^1.1.0"
-    debug "^4.1.0"
-    json5 "^2.1.0"
-    lodash "^4.17.10"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.7.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.5.tgz#ae1323cd035b5160293307f50647e83f8ba62f7e"
   integrity sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==
@@ -379,15 +359,6 @@
     "@babel/traverse" "^7.1.5"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.2.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
-  integrity sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==
-  dependencies:
-    "@babel/template" "^7.1.2"
-    "@babel/traverse" "^7.1.5"
-    "@babel/types" "^7.3.0"
-
 "@babel/helpers@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.7.4.tgz#62c215b9e6c712dadc15a9a0dcab76c92a940302"
@@ -406,22 +377,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.3.tgz#32f5df65744b70888d17872ec106b02434ba1489"
-  integrity sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
-  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
-
-"@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
-  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
-
-"@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
   version "7.7.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.5.tgz#cbf45321619ac12d83363fcf9c94bb67fa646d71"
   integrity sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
@@ -705,7 +661,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.7.4"
 
-"@babel/template@^7.0.0", "@babel/template@^7.2.2":
+"@babel/template@^7.0.0":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
   integrity sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==
@@ -741,7 +697,7 @@
     "@babel/parser" "^7.7.4"
     "@babel/types" "^7.7.4"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.2.2":
+"@babel/traverse@^7.0.0":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
   integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==


### PR DESCRIPTION
## Details

This PR refactors the View Model access and assertions in the engine:
- uniformize access to the VM in the engine: 
  - make `ViewModelReflection` internal to `vm.ts`
  - replace all the VM accessors with the following APIs: `associateVM`, `getAssociatedVM` and `getAssociatedVMIfPresent`
- remove all the inline VM assertions, all the assertions are now done directly in `getAssociatedVM`.
- improve `fields.ts` typing to make it more Typescript ideomatic.
- forced upgraded to `@babel/core` (directly in the `yarn.lock`) to enable support for typescript assertion functions support in jest.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
