### PR TITLE
refactor(engine): fix def.ts import order

### DIFF
--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -42,6 +42,22 @@ import {
 } from './component';
 import { createObservedFieldsDescriptorMap } from './observed-fields';
 import { Template } from './template';
+import { HTMLElementOriginalDescriptors } from './html-properties';
+import { BaseLightningElement } from './base-lightning-element';
+import {
+    BaseBridgeElement,
+    HTMLBridgeElementFactory,
+    HTMLElementConstructor,
+} from './base-bridge-element';
+import {
+    getDecoratorsRegisteredMeta,
+    DecoratorMeta,
+    PropsDef,
+    WireHash,
+    MethodDef,
+    TrackDef,
+} from './decorators/register';
+import { defaultEmptyTemplate } from './secure-template';
 
 export interface ComponentDef extends DecoratorMeta {
     name: string;
@@ -270,23 +286,6 @@ export function getComponentConstructor(elm: HTMLElement): ComponentConstructor 
 export function setElementProto(elm: HTMLElement, def: ComponentDef) {
     setPrototypeOf(elm, def.bridge.prototype);
 }
-
-import { HTMLElementOriginalDescriptors } from './html-properties';
-import { BaseLightningElement } from './base-lightning-element';
-import {
-    BaseBridgeElement,
-    HTMLBridgeElementFactory,
-    HTMLElementConstructor,
-} from './base-bridge-element';
-import {
-    getDecoratorsRegisteredMeta,
-    DecoratorMeta,
-    PropsDef,
-    WireHash,
-    MethodDef,
-    TrackDef,
-} from './decorators/register';
-import { defaultEmptyTemplate } from './secure-template';
 
 // Typescript is inferring the wrong function type for this particular
 // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972


### PR DESCRIPTION
## Details

- Groups the imports in `def.ts` at the top of the module 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅