### PR TITLE
refactor(shared): Make fields tree-shakeable

### DIFF
--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -7,12 +7,15 @@
 import {
     assert,
     assign,
-    fields,
     isFunction,
     isNull,
     isObject,
     isUndefined,
     toString,
+    HiddenField,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
 } from '@lwc/shared';
 import {
     createVM,
@@ -29,16 +32,17 @@ import { patchCustomElementWithRestrictions } from './restrictions';
 import { GlobalMeasurementPhase, startGlobalMeasure, endGlobalMeasure } from './performance-timing';
 import { appendChild, insertBefore, replaceChild, removeChild } from '../env/node';
 
-const { createFieldName, getHiddenField, setHiddenField } = fields;
-const ConnectingSlot = createFieldName('connecting', 'engine');
-const DisconnectingSlot = createFieldName('disconnecting', 'engine');
+type NodeSlot = () => {};
 
-function callNodeSlot(node: Node, slot: symbol): Node {
+const ConnectingSlot = createHiddenField<NodeSlot>('connecting', 'engine');
+const DisconnectingSlot = createHiddenField<NodeSlot>('disconnecting', 'engine');
+
+function callNodeSlot(node: Node, slot: HiddenField<NodeSlot>): Node {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(node, `callNodeSlot() should not be called for a non-object`);
     }
 
-    const fn = getHiddenField(node, slot) as Function | undefined;
+    const fn = getHiddenField(node, slot);
 
     if (!isUndefined(fn)) {
         fn();

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -10,7 +10,6 @@ import {
     ArrayUnshift,
     assert,
     create,
-    fields,
     isArray,
     isFalse,
     isNull,
@@ -18,6 +17,9 @@ import {
     isTrue,
     isUndefined,
     keys,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
 } from '@lwc/shared';
 import { getComponentDef } from './def';
 import {
@@ -50,8 +52,6 @@ import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from '../libs/mutation-tracker';
 import { LightningElement } from './base-lightning-element';
 import { getComponentTag } from '../shared/format';
-
-const { createFieldName, getHiddenField, setHiddenField } = fields;
 
 export interface SlotSet {
     [key: string]: VNodes;
@@ -121,7 +121,7 @@ type VMAssociable = ShadowRoot | LightningElement | ComponentInterface;
 let idx: number = 0;
 
 /** The internal slot used to associate different objects the engine manipulates with the VM */
-const ViewModelReflection = createFieldName('ViewModel', 'engine');
+const ViewModelReflection = createHiddenField<VM>('ViewModel', 'engine');
 
 function callHook(
     cmp: ComponentInterface | undefined,
@@ -267,7 +267,7 @@ export function getAssociatedVM(obj: VMAssociable): VM {
         assertIsVM(vm);
     }
 
-    return vm as VM;
+    return vm!;
 }
 
 export function getAssociatedVMIfPresent(obj: VMAssociable): VM | undefined {

--- a/packages/@lwc/shared/src/index.ts
+++ b/packages/@lwc/shared/src/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as assert from './assert';
-import * as fields from './fields';
 
 export * from './language';
-export { assert, fields };
+export * from './fields';
+export { assert };

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -10,7 +10,9 @@ import {
     ArrayReverse,
     ArraySlice,
     assert,
-    fields,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
     isNull,
     isUndefined,
     toString,
@@ -43,8 +45,6 @@ import {
 import { isDelegatingFocus } from './shadow-root';
 import { arrayFromCollection, getOwnerDocument, getOwnerWindow } from '../shared/utils';
 
-const { createFieldName, getHiddenField, setHiddenField } = fields;
-
 const TabbableElementsQuery = `
     button:not([tabindex="-1"]):not([disabled]),
     [contenteditable]:not([tabindex="-1"]),
@@ -57,7 +57,10 @@ const TabbableElementsQuery = `
     [tabindex="0"]
 `;
 
-const DidAddMouseDownListener = createFieldName('DidAddMouseDownListener', 'synthetic-shadow');
+const DidAddMouseDownListener = createHiddenField<boolean>(
+    'DidAddMouseDownListener',
+    'synthetic-shadow'
+);
 
 function isVisible(element: HTMLElement): boolean {
     const { width, height } = getBoundingClientRect.call(element);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -10,11 +10,13 @@ import {
     create,
     defineProperties,
     defineProperty,
-    fields,
     isNull,
     isTrue,
     isUndefined,
     setPrototypeOf,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
 } from '@lwc/shared';
 import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import {
@@ -47,9 +49,8 @@ import { getInternalChildNodes, setNodeKey, setNodeOwnerKey } from './node';
 import { innerHTMLSetter } from '../env/element';
 import { getOwnerDocument } from '../shared/utils';
 
-const { getHiddenField, setHiddenField, createFieldName } = fields;
 const ShadowRootResolverKey = '$shadowResolver$';
-const InternalSlot = createFieldName('shadowRecord', 'synthetic-shadow');
+const InternalSlot = createHiddenField<ShadowRootRecord>('shadowRecord', 'synthetic-shadow');
 const { createDocumentFragment } = document;
 
 interface ShadowRootRecord {
@@ -60,7 +61,7 @@ interface ShadowRootRecord {
 }
 
 function getInternalSlot(root: SyntheticShadowRootInterface | Element): ShadowRootRecord {
-    const record: ShadowRootRecord | undefined = getHiddenField(root, InternalSlot);
+    const record = getHiddenField(root, InternalSlot);
     if (isUndefined(record)) {
         throw new TypeError();
     }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -8,7 +8,6 @@ import {
     assert,
     ArrayIndexOf,
     ArrayPush,
-    fields,
     forEach,
     isUndefined,
     isTrue,
@@ -16,6 +15,9 @@ import {
     isNull,
     ArrayReduce,
     defineProperties,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
 } from '@lwc/shared';
 import { getAttribute, setAttribute } from '../env/element';
 import { dispatchEvent } from '../env/dom';
@@ -38,9 +40,8 @@ import { arrayFromCollection } from '../shared/utils';
 // https://dom.spec.whatwg.org/#garbage-collection
 let observer;
 
-const { createFieldName, getHiddenField, setHiddenField } = fields;
 const observerConfig: MutationObserverInit = { childList: true };
-const SlotChangeKey = createFieldName('slotchange', 'synthetic-shadow');
+const SlotChangeKey = createHiddenField<boolean>('slotchange', 'synthetic-shadow');
 
 function initSlotObserver() {
     return new MutationObserver(mutations => {

--- a/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayMap, create, defineProperty, fields, forEach, setPrototypeOf } from '@lwc/shared';
-const { createFieldName, getHiddenField, setHiddenField } = fields;
+import {
+    ArrayMap,
+    create,
+    defineProperty,
+    forEach,
+    setPrototypeOf,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
+} from '@lwc/shared';
 
-const Items = createFieldName('items');
+const Items = createHiddenField<Element[]>('StaticHTMLCollectionItems', 'synthetic-shadow');
 
 function isValidHTMLCollectionName(name) {
     return name !== 'length' && isNaN(name);
@@ -38,7 +46,7 @@ StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
         enumerable: true,
         configurable: true,
         get() {
-            return getHiddenField(this, Items).length;
+            return getHiddenField(this, Items)!.length;
         },
     },
     // https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key
@@ -50,7 +58,7 @@ StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
             if (isValidHTMLCollectionName(name) && this[name]) {
                 return this[name];
             }
-            const items = getHiddenField(this, Items);
+            const items = getHiddenField(this, Items)!;
             // Note: loop in reverse so that the first named item matches the named property
             for (let len = items.length - 1; len >= 0; len -= 1) {
                 const item = items[len];
@@ -104,7 +112,7 @@ StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
             let nextIndex = 0;
             return {
                 next: () => {
-                    const items = getHiddenField(this, Items);
+                    const items = getHiddenField(this, Items)!;
                     return nextIndex < items.length
                         ? {
                               value: items[nextIndex++],

--- a/packages/@lwc/synthetic-shadow/src/shared/static-node-list.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/static-node-list.ts
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayMap, create, defineProperty, fields, forEach, setPrototypeOf } from '@lwc/shared';
-const { createFieldName, getHiddenField, setHiddenField } = fields;
+import {
+    ArrayMap,
+    create,
+    defineProperty,
+    forEach,
+    setPrototypeOf,
+    createHiddenField,
+    getHiddenField,
+    setHiddenField,
+} from '@lwc/shared';
 
-const Items = createFieldName('items', 'synthetic-shadow');
+const Items = createHiddenField<Node[]>('StaticNodeListItems', 'synthetic-shadow');
 
 function StaticNodeList() {
     throw new TypeError('Illegal constructor');
@@ -31,7 +39,8 @@ StaticNodeList.prototype = create(NodeList.prototype, {
         enumerable: true,
         configurable: true,
         get() {
-            return getHiddenField(this, Items).length;
+            const items = getHiddenField(this, Items)!;
+            return items.length;
         },
     },
 
@@ -76,7 +85,7 @@ StaticNodeList.prototype = create(NodeList.prototype, {
             let nextIndex = 0;
             return {
                 next: () => {
-                    const items = getHiddenField(this, Items);
+                    const items = getHiddenField(this, Items)!;
                     return nextIndex < items.length
                         ? {
                               value: items[nextIndex++],


### PR DESCRIPTION
## Details

This PR makes the shared field method tree-shakeable by exporting directly the methods out of the `@lwc/shared`. This PR also makes the field methods type-safe.

```js
import { createHiddenField, setHiddenField, getHiddenField } from '@lwc/shared';

const stringField = createHiddenField<string>('string', 'namespace');

setHiddenField({}, stringField, null);
// ^ Argument of type 'null' is not assignable to parameter of type 'string'.

getHiddenField({}, stringField).toLowerCase()
// ^ Object is possibly 'undefined'.
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅