### PR TITLE
test(integration-test): Increase integration test timeout

### DIFF
--- a/packages/integration-tests/scripts/wdio.conf.js
+++ b/packages/integration-tests/scripts/wdio.conf.js
@@ -47,16 +47,6 @@ exports.config = {
     specs: ['./src/**/*.spec.js'],
     suites: wdSuites,
 
-    maxInstances: 3,
-    capabilities: [],
-
-    // Specifies globally the timeout for all the `waitFor*` defined by wdio.
-    // https://webdriver.io/docs/timeouts.html#webdriverio-related-timeouts
-    waitforTimeout: 20 * 1000, // 20 seconds
-
-    connectionRetryTimeout: 2 * 60 * 1000, // 2 minutes
-    connectionRetryCount: 5,
-
     services: ['static-server'],
 
     staticServerFolders: [
@@ -65,11 +55,5 @@ exports.config = {
     ],
 
     framework: 'mocha',
-    mochaOpts: {
-        // Specify test timeout threshold time enforced by mocha.
-        // https://mochajs.org/#-timeout-ms-t-ms
-        timeout: 30 * 1000, // 30 seconds
-    },
-
     reporters: ['spec'],
 };

--- a/packages/integration-tests/scripts/wdio.conf.js
+++ b/packages/integration-tests/scripts/wdio.conf.js
@@ -50,8 +50,12 @@ exports.config = {
     maxInstances: 3,
     capabilities: [],
 
-    waitforTimeout: 10000,
-    connectionRetryTimeout: 90000,
+    // Specifies globally the timeout for all the `waitFor*` defined by wdio.
+    // https://webdriver.io/docs/timeouts.html#webdriverio-related-timeouts
+    waitforTimeout: 20 * 1000, // 20 seconds
+
+    connectionRetryTimeout: 2 * 60 * 1000, // 2 minutes
+    connectionRetryCount: 5,
 
     services: ['static-server'],
 
@@ -61,5 +65,11 @@ exports.config = {
     ],
 
     framework: 'mocha',
+    mochaOpts: {
+        // Specify test timeout threshold time enforced by mocha.
+        // https://mochajs.org/#-timeout-ms-t-ms
+        timeout: 30 * 1000, // 30 seconds
+    },
+
     reporters: ['spec'],
 };

--- a/packages/integration-tests/scripts/wdio.local.conf.js
+++ b/packages/integration-tests/scripts/wdio.local.conf.js
@@ -12,6 +12,8 @@ const baseConfig = require('./wdio.conf.js');
 const HEADLESS = process.env.HEADLESS_CHROME !== 'false';
 
 exports.config = merge(baseConfig.config, {
+    maxInstances: 5,
+
     capabilities: [
         {
             browserName: 'chrome',

--- a/packages/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/integration-tests/scripts/wdio.sauce.conf.js
@@ -130,4 +130,19 @@ exports.config = merge(baseConfig.config, {
     key: accessKey,
 
     capabilities: getCapabilities(),
+
+    maxInstances: 3,
+
+    // Specifies globally the timeout for all the `waitFor*` defined by wdio.
+    // https://webdriver.io/docs/timeouts.html#webdriverio-related-timeouts
+    waitforTimeout: 20 * 1000, // 20 seconds
+
+    connectionRetryTimeout: 2 * 60 * 1000, // 2 minutes
+    connectionRetryCount: 5,
+
+    mochaOpts: {
+        // Specify test timeout threshold time enforced by mocha.
+        // https://mochajs.org/#-timeout-ms-t-ms
+        timeout: 30 * 1000, // 30 seconds
+    },
 });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
@@ -38,7 +38,7 @@ describe('Tabbing into custom element with delegates focus', () => {
                 });
                 return active.getTagName() === 'input';
             },
-            500,
+            undefined,
             'expect input to be focused'
         );
     });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
@@ -27,7 +27,7 @@ describe('Tabbing into custom element with delegates focus', () => {
                     'integration-delegates-focus-false-negative-tab-index'
                 );
             },
-            500,
+            undefined,
             'expect integration-delegates-focus-false-negative-tab-index to be focused'
         );
 
@@ -41,7 +41,7 @@ describe('Tabbing into custom element with delegates focus', () => {
 
                 return activeFromShadow.getTagName() === 'a';
             },
-            500,
+            undefined,
             'expect anchor to be focused'
         );
     });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
@@ -31,7 +31,7 @@ describe('Tabbing into custom element with delegates focus', () => {
                 });
                 return div.getText() === 'Focus in called';
             },
-            500,
+            undefined,
             'expected focusin to have been triggered'
         );
     });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
@@ -23,7 +23,7 @@ describe('Delegate focus with tabindex 0, no tabbable elements, and no tabbable 
                 });
                 return active.getTagName().toLowerCase() === 'body';
             },
-            500,
+            undefined,
             'It should focus the body'
         );
     });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
@@ -23,7 +23,7 @@ describe('Delegate focus with tabindex 0 and no tabbable elements', () => {
 
                 return active.getText() === 'second button';
             },
-            500,
+            undefined,
             'Second button should be focused'
         );
 
@@ -37,7 +37,7 @@ describe('Delegate focus with tabindex 0 and no tabbable elements', () => {
 
                 return active.getText() === 'first button';
             },
-            500,
+            undefined,
             'First button should be focused'
         );
     });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
@@ -23,7 +23,7 @@ describe('Delegate focus with tabindex 0', () => {
 
                 return active.getTagName().toLowerCase() === 'input';
             },
-            500,
+            undefined,
             'Input should be focused'
         );
     });
@@ -39,7 +39,7 @@ describe('Delegate focus with tabindex 0', () => {
 
                 return active.getText() === 'second button';
             },
-            500,
+            undefined,
             'Second button should be focused'
         );
 
@@ -53,7 +53,7 @@ describe('Delegate focus with tabindex 0', () => {
 
                 return active.getTagName().toLowerCase() === 'input';
             },
-            500,
+            undefined,
             'Input should be focused'
         );
 
@@ -66,7 +66,7 @@ describe('Delegate focus with tabindex 0', () => {
                 });
                 return active.getText() === 'first button';
             },
-            500,
+            undefined,
             'First button should be focused'
         );
     });

--- a/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
@@ -40,7 +40,7 @@ describe('Component with a wired method', () => {
                 });
                 return todoText === 'Title:task 1 Completed:false';
             },
-            3000,
+            undefined,
             'Should update todo id'
         );
     });

--- a/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
@@ -38,7 +38,7 @@ describe('Component with a wired property', () => {
                 });
                 return todoText === 'Title:task 1 Completed:false';
             },
-            1000,
+            undefined,
             'expect todo item to be updated'
         );
     });


### PR DESCRIPTION
## Details

This PR increases all the integration tests' timeouts to increase CI stability. This PR also removes all the hardcoded `waitFor*` timeouts to use instead the globally defined `waitforTimeout`.

**GUS work item:**  W-7093447

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅