### PR TITLE
test(integration): remove host and port from integration tests

### DIFF
--- a/packages/integration-tests/scripts/wdio.conf.js
+++ b/packages/integration-tests/scripts/wdio.conf.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 
+const port = process.env.PORT || 4567;
 const suiteFolders = path.resolve(__dirname, '../', 'src/components');
 
 /*
@@ -47,6 +48,8 @@ exports.config = {
     specs: ['./src/**/*.spec.js'],
     suites: wdSuites,
 
+    baseUrl: `http://localhost:${port}`,
+
     maxInstances: 3,
     capabilities: [],
 
@@ -55,6 +58,7 @@ exports.config = {
 
     services: ['static-server'],
 
+    staticServerPort: port,
     staticServerFolders: [
         { mount: '/', path: './public' },
         ...suites.flatMap(suite => suite.specs),

--- a/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused.spec.js
@@ -10,8 +10,7 @@ const assert = require('assert');
 // the previous sibling to the custom element
 
 describe('Delegates focus', () => {
-    const URL =
-        'http://localhost:4567/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused';
+    const URL = '/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex/delegate-focus-click-input-in-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex/delegate-focus-click-input-in-negative-tabindex.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 describe('Delegates focus', () => {
-    const URL = 'http://localhost:4567/delegate-focus-click-input-in-negative-tabindex';
+    const URL = '/delegate-focus-click-input-in-negative-tabindex';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-click-shadow-input-negative-tab-index';
+    const URL = '/delegates-focus-click-shadow-input-negative-tab-index';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 
-const URL = 'http://localhost:4567/delegates-focus-click-target-natively-non-focusable';
+const URL = '/delegates-focus-click-target-natively-non-focusable';
 
 describe('when the click target is natively non-focusable', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
@@ -6,7 +6,7 @@
  */
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-false-negative-tab-index';
+    const URL = '/delegates-focus-false-negative-tab-index';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-false/delegates-focus-false.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-false/delegates-focus-false.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-false';
+    const URL = '/delegates-focus-false';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-host-element/delegates-focus-focus-method-on-host-element.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-host-element/delegates-focus-focus-method-on-host-element.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 
-const URL = 'http://localhost:4567/delegates-focus-focus-method-on-host-element';
+const URL = '/delegates-focus-focus-method-on-host-element';
 
 describe('Invoking the focus method of a host element', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-internal-element/delegates-focus-focus-method-on-internal-element.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-internal-element/delegates-focus-focus-method-on-internal-element.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 
-const URL = 'http://localhost:4567/delegates-focus-focus-method-on-internal-element';
+const URL = '/delegates-focus-focus-method-on-internal-element';
 
 describe('Invoking the focus method on an element inside a shadow tree', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-next-sibling/delegates-focus-from-next-sibling.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-next-sibling/delegates-focus-from-next-sibling.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-from-previous-sibling';
+    const URL = '/delegates-focus-from-previous-sibling';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-previous-sibling/delegates-focus-from-previous-sibling.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-previous-sibling/delegates-focus-from-previous-sibling.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-from-previous-sibling';
+    const URL = '/delegates-focus-from-previous-sibling';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
@@ -6,7 +6,7 @@
  */
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-negative-tabindex-focusin-handler';
+    const URL = '/delegates-focus-negative-tabindex-focusin-handler';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-nested-focusable-custom-elements/delegates-focus-click-shadow-input-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-nested-focusable-custom-elements/delegates-focus-click-shadow-input-negative-tab-index.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-nested-focusable-custom-elements';
+    const URL = '/delegates-focus-nested-focusable-custom-elements';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-next-sibling-visibility-false/delegates-focus-next-sibling-visibility-false.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-next-sibling-visibility-false/delegates-focus-next-sibling-visibility-false.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element proceeding an invisible button', () => {
-    const URL = 'http://localhost:4567/delegates-focus-next-sibling-visibility-false';
+    const URL = '/delegates-focus-next-sibling-visibility-false';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('focus delegation when clicking on form element label', () => {
-    const URL = 'http://localhost:4567/delegates-focus-non-focusable-click-target';
+    const URL = '/delegates-focus-non-focusable-click-target';
 
     beforeEach(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-slot/delegates-focus-slot.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-slot/delegates-focus-slot.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus-slot';
+    const URL = '/delegates-focus-slot';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 describe('Delegate focus with tabindex 0, no tabbable elements, and no tabbable elements after', () => {
-    const URL =
-        'http://localhost:4567/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements';
+    const URL = '/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 describe('Delegate focus with tabindex 0 and no tabbable elements', () => {
-    const URL = 'http://localhost:4567/delegates-focus-tab-index-zero-no-focusable-elements';
+    const URL = '/delegates-focus-tab-index-zero-no-focusable-elements';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 describe('Delegate focus with tabindex 0', () => {
-    const URL = 'http://localhost:4567/delegates-focus-tab-index-zero/';
+    const URL = '/delegates-focus-tab-index-zero/';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus/delegates-focus.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus/delegates-focus.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Tabbing into custom element with delegates focus', () => {
-    const URL = 'http://localhost:4567/delegates-focus';
+    const URL = '/delegates-focus';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/accessibility/test-related-target/related-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-related-target/related-target.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/related-target';
+const URL = '/related-target';
 
 function getRootEvents() {
     return browser.execute(function() {

--- a/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-negative/tab-navigation-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-negative/tab-navigation-tabindex-negative.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tab-navigation-tabindex-negative';
+const URL = '/tab-navigation-tabindex-negative';
 
 describe('Tab navigation when tabindex -1', () => {
     before(() => {

--- a/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-zero/tab-navigation-tabindex-zero.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-zero/tab-navigation-tabindex-zero.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tab-navigation-tabindex-zero';
+const URL = '/tab-navigation-tabindex-zero';
 
 describe('Tab navigation when tabindex 0', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-disabled-button-after-negative-tabindex/disabled-button-after-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-disabled-button-after-negative-tabindex/disabled-button-after-negative-tabindex.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 describe('when disabled button comes after a component that is delegating focus with tabindex -1', () => {
-    const URL = 'http://localhost:4567/disabled-button-after-negative-tabindex';
+    const URL = '/disabled-button-after-negative-tabindex';
 
     beforeEach(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/focus-event-while-navigating';
+const URL = '/focus-event-while-navigating';
 
 describe('Focus event while sequential focus navigation', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-span-after-negative-tabindex/focusable-span-after-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-span-after-negative-tabindex/focusable-span-after-negative-tabindex.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 describe('Delegates focus', () => {
-    const URL = 'http://localhost:4567/focusable-span-after-negative-tabindex';
+    const URL = '/focusable-span-after-negative-tabindex';
 
     beforeEach(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-issue-1031/issue-1031.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-issue-1031/issue-1031.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/issue-1031';
+const URL = '/issue-1031';
 
 describe('issue #1031', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-manual-delegation/manual-delegation.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-manual-delegation/manual-delegation.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/manual-delegation';
+const URL = '/manual-delegation';
 
 describe('Tab navigation when component passes tabindex attribute to an internal element', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-shift-tab-into-negative-tabindex/shift-tab-into-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-shift-tab-into-negative-tabindex/shift-tab-into-negative-tabindex.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/shift-tab-into-negative-tabindex';
+const URL = '/shift-tab-into-negative-tabindex';
 
 describe('Delegates focus', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-negative-after-inside-click';
+const URL = '/tabindex-negative-after-inside-click';
 
 describe('Tab navigation when tabindex -1 after inside click', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-internal/tabindex-negative-internal.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-internal/tabindex-negative-internal.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-negative-internal';
+const URL = '/tabindex-negative-internal';
 
 describe('Internal tab navigation when tabindex -1', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/tabindex-negative.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-negative';
+const URL = '/tabindex-negative';
 
 describe('Tab navigation when tabindex -1', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-none/tabindex-none.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-none/tabindex-none.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-none';
+const URL = '/tabindex-none';
 
 describe('Tab navigation without tabindex', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-toggle';
+const URL = '/tabindex-toggle';
 
 describe('Tab navigation without tabindex', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-after-inside-click/tabindex-zero-after-inside-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-after-inside-click/tabindex-zero-after-inside-click.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-zero-after-inside-click';
+const URL = '/tabindex-zero-after-inside-click';
 
 describe('Tab navigation when tabindex 0 after inside click', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-zero-internal-tabindex-negative';
+const URL = '/tabindex-zero-internal-tabindex-negative';
 
 describe('Tab navigation when tabindex 0', () => {
     beforeEach(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal/tabindex-zero-internal.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal/tabindex-zero-internal.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-zero-internal';
+const URL = '/tabindex-zero-internal';
 
 describe('Internal tab navigation when tabindex 0', () => {
     before(() => {

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero/tabindex-zero.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero/tabindex-zero.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/tabindex-zero';
+const URL = '/tabindex-zero';
 
 describe('Tab navigation when tabindex 0', () => {
     before(() => {

--- a/packages/integration-tests/src/components/document/test-shadow-access/shadow-access.spec.js
+++ b/packages/integration-tests/src/components/document/test-shadow-access/shadow-access.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const assert = require('assert');
-const URL = 'http://localhost:4567/shadow-access';
+const URL = '/shadow-access';
 
 describe('document.prototype query methods', () => {
     before(() => {

--- a/packages/integration-tests/src/components/dom/test-element-from-point/element-from-point.spec.js
+++ b/packages/integration-tests/src/components/dom/test-element-from-point/element-from-point.spec.js
@@ -6,7 +6,7 @@
  */
 
 describe('shadow root element from point should return correct element', () => {
-    const URL = 'http://localhost:4567/element-from-point/';
+    const URL = '/element-from-point/';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-change-event-composed/change-event-composed.spec.js
+++ b/packages/integration-tests/src/components/events/test-change-event-composed/change-event-composed.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Composed change event', () => {
-    const URL = 'http://localhost:4567/change-event-composed/';
+    const URL = '/change-event-composed/';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-focusin-composed-true/focusin-composed-true.spec.js
+++ b/packages/integration-tests/src/components/events/test-focusin-composed-true/focusin-composed-true.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Composed focusin event', () => {
-    const URL = 'http://localhost:4567/focusin-composed-true';
+    const URL = '/focusin-composed-true';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-focusout-composed-true/focusout-composed-true.spec.js
+++ b/packages/integration-tests/src/components/events/test-focusout-composed-true/focusout-composed-true.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Composed focusout event', () => {
-    const URL = 'http://localhost:4567/focusout-composed-true';
+    const URL = '/focusout-composed-true';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-retarget-body-related-target/retarget-body-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-body-related-target/retarget-body-related-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Retarget relatedTarget', () => {
-    const URL = 'http://localhost:4567/retarget-body-related-target';
+    const URL = '/retarget-body-related-target';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-retarget-null-related-target/retarget-null-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-null-related-target/retarget-null-related-target.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 describe('Retarget relatedTarget', () => {
-    const URL = 'http://localhost:4567/retarget-null-related-target';
+    const URL = '/retarget-null-related-target';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Retarget relatedTarget', () => {
-    const URL = 'http://localhost:4567/retarget-related-target';
+    const URL = '/retarget-related-target';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-retarget-slotted-custom-element-related-target/retarget-slotted-custom-element-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-slotted-custom-element-related-target/retarget-slotted-custom-element-related-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Retarget relatedTarget', () => {
-    const URL = 'http://localhost:4567/retarget-slotted-custom-element-related-target';
+    const URL = '/retarget-slotted-custom-element-related-target';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-retarget-slotted-input-related-target/retarget-slotted-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-slotted-input-related-target/retarget-slotted-related-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Retarget relatedTarget', () => {
-    const URL = 'http://localhost:4567/retarget-slotted-input-related-target';
+    const URL = '/retarget-slotted-input-related-target';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-slotted-event-target/slotted-event-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-slotted-event-target/slotted-event-target.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Event target in slot elements', () => {
-    const URL = 'http://localhost:4567/slotted-event-target/';
+    const URL = '/slotted-event-target/';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/events/test-window-event-listener/window-event-listener.spec.js
+++ b/packages/integration-tests/src/components/events/test-window-event-listener/window-event-listener.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Event Target on window event listener', () => {
-    const URL = 'http://localhost:4567/window-event-listener/';
+    const URL = '/window-event-listener/';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/rendering/test-compat-expando/compat-expando.spec.js
+++ b/packages/integration-tests/src/components/rendering/test-compat-expando/compat-expando.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 describe('Testing component: compat-simple', () => {
-    const COMPAT_SIMPLE_URL = 'http://localhost:4567/compat-expando';
+    const COMPAT_SIMPLE_URL = '/compat-expando';
 
     it('page load', () => {
         browser.url(COMPAT_SIMPLE_URL);

--- a/packages/integration-tests/src/components/rendering/test-simple-tree-grid/simple-tree-grid.spec.js
+++ b/packages/integration-tests/src/components/rendering/test-simple-tree-grid/simple-tree-grid.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Testing component: simple-list-container', () => {
-    const URL = 'http://localhost:4567/simple-tree-grid';
+    const URL = '/simple-tree-grid';
     let element;
 
     before(() => {

--- a/packages/integration-tests/src/components/slots/test-slotchange-event/slotchange-event.spec.js
+++ b/packages/integration-tests/src/components/slots/test-slotchange-event/slotchange-event.spec.js
@@ -6,7 +6,7 @@
  */
 const assert = require('assert');
 
-const URL = 'http://localhost:4567/slotchange-event';
+const URL = '/slotchange-event';
 
 describe('slotchange', () => {
     before(() => {

--- a/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Component with a wired method', () => {
-    const URL = 'http://localhost:4567/wired-method-suite';
+    const URL = '/wired-method-suite';
 
     before(() => {
         browser.url(URL);

--- a/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 
 describe('Component with a wired property', () => {
-    const URL = 'http://localhost:4567/wired-prop-suite';
+    const URL = '/wired-prop-suite';
 
     before(() => {
         browser.url(URL);


### PR DESCRIPTION
## Details

* Remove the hardcoded host and port from all the integration tests
* Accept port override via the `PORT` environment variable

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅


GUS work item: W-7095651
