### PR TITLE
fix: relaxing attribute value errors

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -514,7 +514,7 @@ describe('expression', () => {
         const { root } = parseTemplate(
             `<template><select title=&#x007B;x&#x007D;></select></template>`
         );
-        expect(root.children[0].attrs.title.value).toBe('{x}');
+        expect(root.children[0].attrs.title).toMatchObject({ value: TEMPLATE_IDENTIFIER });
     });
 
     it('potential expression error', () => {

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -481,7 +481,7 @@ describe('expression', () => {
         expect(root.children[0].attrs.title).toMatchObject({ value: testAttr });
     });
 
-    it('quoted expression warpped in square brackets should not produce error', () => {
+    it('quoted expression of curly brackets inside square brackets should not produce error', () => {
         const testAttr = '[{myValue}]';
         const { root } = parseTemplate(`<template><input title="${testAttr}"/></template>`);
         expect(root.children[0].attrs.title).toMatchObject({ value: testAttr });

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -177,7 +177,7 @@ export function normalizeAttributeValue(
 
     // <input value="myValue"/>
     // -> Valid string literal.
-    return { value, escapedExpression: isUnicodeExpression(rawValue, isQuoted) };
+    return { value, escapedExpression: isUnicodeExpression(rawValue) };
 }
 
 export function attributeName(attr: parse5.AST.Default.Attribute): string {

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -20,7 +20,7 @@ import { isBoundToIterator } from '../shared/ir';
 export const EXPRESSION_SYMBOL_START = '{';
 export const EXPRESSION_SYMBOL_END = '}';
 
-const VALID_EXPRESSION_RE = /^{.+}$/;
+const VALID_EXPRESSION_RE = /^\s*{.+}$/;
 const POTENTIAL_EXPRESSION_RE = /^.?{.+}.*$/;
 
 const ITERATOR_NEXT_KEY = 'next';
@@ -31,6 +31,11 @@ export function isExpression(source: string): boolean {
 
 export function isPotentialExpression(source: string): boolean {
     return !!source.match(POTENTIAL_EXPRESSION_RE);
+}
+
+export function isUnicodeExpression(source: string, isQuoted: boolean): boolean {
+    source = isQuoted ? source.slice(1, -1) : source || '';
+    return source.startsWith('&#x007B;') && source.endsWith('&#x007D;');
 }
 
 // FIXME: Avoid throwing errors and return it properly

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -33,9 +33,8 @@ export function isPotentialExpression(source: string): boolean {
     return !!source.match(POTENTIAL_EXPRESSION_RE);
 }
 
-export function isUnicodeExpression(source: string, isQuoted: boolean): boolean {
-    source = isQuoted ? source.slice(1, -1) : source || '';
-    return source.startsWith('&#x007B;') && source.endsWith('&#x007D;');
+export function isUnicodeExpression(source: string): boolean {
+    return !!source && source.startsWith('"&#x007B;') && source.endsWith('&#x007D;"');
 }
 
 // FIXME: Avoid throwing errors and return it properly


### PR DESCRIPTION
## Details

In order to help developer mistakes and to disambiguate attribute values from expression we used to fail for any attribute value that contains `{`, `}`. This . causes some issues with values such as `h{ello}` or `[{x: 1}]` or any json-like string.

This PR simplifies so we only throw for specific bracket occurrence. To summarize:

```html
<input title="{xyz}"/><!-- this will still fail -->
```

```html
<!-- these will no longer fail -->
<input title="[{x: 1}]"/>
<input title="h{ello}"/>
```


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`