### PR TITLE
fix(synthetic-shadow): make Event constructor handle composed

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-composed/detect.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-composed/detect.ts
@@ -5,5 +5,5 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export default function detect(): boolean {
-    return Object.getOwnPropertyDescriptor(Event.prototype, 'composed') === undefined;
+    return (new Event('test', { composed: true })).composed !== true;
 }

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-composed/detect.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-composed/detect.ts
@@ -5,5 +5,5 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export default function detect(): boolean {
-    return (new Event('test', { composed: true })).composed !== true;
+    return new Event('test', { composed: true }).composed !== true;
 }

--- a/packages/integration-karma/test/polyfills/event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/event-composed/index.spec.js
@@ -13,6 +13,7 @@ it('should respect when the event composed flag is set during construction', () 
 
 it('should set composed to true for click events dispatched by the user agent', done => {
     const elm = document.createElement('div');
+    document.body.appendChild(elm);
 
     elm.addEventListener('click', evt => {
         expect(evt.composed).toBe(true);

--- a/packages/integration-karma/test/polyfills/event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/event-composed/index.spec.js
@@ -1,14 +1,23 @@
-// TODO [#938]: Standard event composed flag should not be set if the event is created manually.
-xit('should not set composed to true if the event is not trusted', () => {
+it('should not set composed to true if the event is not set during construction', () => {
     const clickEvent = new Event('click');
     expect(clickEvent.composed).toBe(false);
 });
 
-// TODO [#938]: Standard event composed flag should not be set if the event is created manually.
-xit('should respect when the event composed flag is set during construction', () => {
+it('should respect when the event composed flag is set during construction', () => {
     const composedClickEvent = new Event('click', { composed: true });
     expect(composedClickEvent.composed).toBe(true);
 
     const notComposedClickEvent = new Event('click', { composed: false });
     expect(notComposedClickEvent.composed).toBe(false);
+});
+
+it('should set composed to true for click events dispatched by the user agent', done => {
+    const elm = document.createElement('div');
+
+    elm.addEventListener('click', evt => {
+        expect(evt.composed).toBe(true);
+        done();
+    });
+
+    elm.click();
 });


### PR DESCRIPTION
## Details

This PR adds support for `composed` to the `Event` constructor.

Fixes #938.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item

W-5983676
