### PR TITLE
fix(wire): add lowercase wirecontextevent

### DIFF
--- a/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/wiring.spec.ts
@@ -487,6 +487,23 @@ describe('WireEventTarget', () => {
             );
             wireEventTarget.dispatchEvent(new LinkContextEvent('foo', callback));
         });
+        it('invokes dispatch method on element when wirecontextevent received', () => {
+            expect.assertions(1);
+            const event = { type: 'wirecontextevent' };
+            const mockCmp = {
+                dispatchEvent(evt) {
+                    expect(evt.type).toBe('wirecontextevent');
+                },
+            };
+            const wireEventTarget = new target.WireEventTarget(
+                mockCmp as any,
+                {} as ElementDef,
+                {} as target.Context,
+                { method: 1 } as WireDef,
+                'test'
+            );
+            wireEventTarget.dispatchEvent(event as Event);
+        });
         it('throws on non-ValueChangedEvent', () => {
             const test = {};
             test.toString = () => 'test';

--- a/packages/@lwc/wire-service/src/wiring.ts
+++ b/packages/@lwc/wire-service/src/wiring.ts
@@ -253,7 +253,7 @@ export class WireEventTarget {
             });
             this._cmp.dispatchEvent(internalDomEvent);
             return false; // canceling signal since we don't want this to propagate
-        } else if (evt.type === 'WireContextEvent') {
+        } else if (evt.type === 'WireContextEvent' || evt.type === 'wirecontextevent') {
             // TODO [#1357]: remove this branch
             return this._cmp.dispatchEvent(evt);
         } else {


### PR DESCRIPTION
## Details

Accept `wirecontextevent` to avoid [engine warnings about event names](https://github.com/salesforce/lwc/blob/master/packages/@lwc/engine/src/framework/restrictions.ts#L420-L427). 

`WireContextEvent` can be removed after all consumers are updated to `wirecontextevent`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
