### PR TITLE
fix(wire): remove WireContextEvent (camelcase)

### DIFF
--- a/packages/@lwc/wire-service/src/wiring.ts
+++ b/packages/@lwc/wire-service/src/wiring.ts
@@ -253,7 +253,7 @@ export class WireEventTarget {
             });
             this._cmp.dispatchEvent(internalDomEvent);
             return false; // canceling signal since we don't want this to propagate
-        } else if (evt.type === 'WireContextEvent' || evt.type === 'wirecontextevent') {
+        } else if (evt.type === 'wirecontextevent') {
             // TODO [#1357]: remove this branch
             return this._cmp.dispatchEvent(evt);
         } else {


### PR DESCRIPTION
## Details

Followup to #1679  to remove legacy `WireContextEvent`. Use `wirecontextevent` instead.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

Single consumer of `WireContextEvent` has been updated to use `wirecontextevent` so no impact expected.
