### PR TITLE
chore: remove usage of white/black as good/bad

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
@@ -69,7 +69,7 @@ describe('Element import', () => {
     );
 
     pluginTest(
-        'throws non-whitelisted lwc api is imported',
+        'throws when a non-supported lwc api is imported',
         `
         import { registerTemplate } from "lwc";
         import tmpl from './localTemplate.html';
@@ -89,7 +89,7 @@ describe('Element import', () => {
     );
 
     pluginTest(
-        'allows importing whitelisted apis from "lwc"',
+        'allows importing supported apis from "lwc"',
         `
         import {
             api,

--- a/packages/@lwc/babel-plugin-component/src/component.js
+++ b/packages/@lwc/babel-plugin-component/src/component.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const { generateError, getEngineImportSpecifiers } = require('./utils');
-const { LWC_PACKAGE_EXPORTS, LWC_API_WHITELIST } = require('./constants');
+const { LWC_PACKAGE_EXPORTS, LWC_SUPPORTED_APIS } = require('./constants');
 const { LWCClassErrors } = require('@lwc/errors');
 
 module.exports = function() {
@@ -15,7 +15,7 @@ module.exports = function() {
 
             // validate internal api imports
             engineImportSpecifiers.forEach(({ name }) => {
-                if (!LWC_API_WHITELIST.has(name)) {
+                if (!LWC_SUPPORTED_APIS.has(name)) {
                     throw generateError(path, {
                         errorInfo: LWCClassErrors.INVALID_IMPORT_PROHIBITED_API,
                         messageArgs: [name],

--- a/packages/@lwc/babel-plugin-component/src/constants.js
+++ b/packages/@lwc/babel-plugin-component/src/constants.js
@@ -34,7 +34,7 @@ const LWC_PACKAGE_EXPORTS = {
     WIRE_DECORATOR: 'wire',
 };
 
-const LWC_API_WHITELIST = new Set([
+const LWC_SUPPORTED_APIS = new Set([
     'buildCustomElementConstructor',
     'createElement',
     'getComponentDef',
@@ -75,7 +75,7 @@ module.exports = {
     LWC_DECORATORS,
     LWC_PACKAGE_ALIAS,
     LWC_PACKAGE_EXPORTS,
-    LWC_API_WHITELIST,
+    LWC_SUPPORTED_APIS,
     LWC_COMPONENT_PROPERTIES,
     DECORATOR_TYPES,
 };

--- a/packages/@lwc/engine/scripts/jest/legacy-test-exceptions.js
+++ b/packages/@lwc/engine/scripts/jest/legacy-test-exceptions.js
@@ -12,7 +12,7 @@
  *
  * BY ADDING A NEW ENTRY IN THIS LIST, YOU WILL BRING SHAME ON YOURSELF OVER MULTIPLE GENERATIONS!!
  */
-const CONSOLE_WHITELIST = [
+const LEGACY_TEST_EXCEPTIONS = [
     '#shadowRootQuerySelector should not throw error if querySelector does not match any elements',
     '#shadowRootQuerySelector should not throw error if querySelectorAll does not match any elements',
     '#shadowRootQuerySelector should return null if querySelector does not match any elements',
@@ -27,14 +27,14 @@ const CONSOLE_WHITELIST = [
     'html-element global HTML Properties should log error message when attribute is set via elm.setAttribute if reflective property is defined',
 ];
 
-for (let i = 0; i < CONSOLE_WHITELIST.length; i++) {
-    for (let j = i + 1; j < CONSOLE_WHITELIST.length; j++) {
-        if (CONSOLE_WHITELIST[i] === CONSOLE_WHITELIST[j]) {
-            throw new Error(`Duplicate test name in whitelist "${CONSOLE_WHITELIST[i]}"`);
+for (let i = 0; i < LEGACY_TEST_EXCEPTIONS.length; i++) {
+    for (let j = i + 1; j < LEGACY_TEST_EXCEPTIONS.length; j++) {
+        if (LEGACY_TEST_EXCEPTIONS[i] === LEGACY_TEST_EXCEPTIONS[j]) {
+            throw new Error(`Duplicate test name "${LEGACY_TEST_EXCEPTIONS[i]}"`);
         }
     }
 }
 
 module.exports = {
-    CONSOLE_WHITELIST,
+    LEGACY_TEST_EXCEPTIONS,
 };

--- a/packages/@lwc/engine/scripts/jest/setup-test.js
+++ b/packages/@lwc/engine/scripts/jest/setup-test.js
@@ -9,7 +9,7 @@
 
 const chalk = require('chalk');
 
-const { CONSOLE_WHITELIST } = require('./test-whitelist');
+const { LEGACY_TEST_EXCEPTIONS } = require('./legacy-test-exceptions');
 const { toLogError } = require('./matchers/log-error');
 
 // Extract original methods from console
@@ -32,14 +32,14 @@ beforeEach(() => {
 afterEach(() => {
     const { fullName } = currentSpec;
 
-    const isWhitelistedTest = CONSOLE_WHITELIST.includes(fullName);
+    const isLegacyTest = LEGACY_TEST_EXCEPTIONS.includes(fullName);
     const didTestLogged = console.error.mock.calls.length > 0;
 
     try {
-        if (isWhitelistedTest) {
+        if (isLegacyTest) {
             if (!didTestLogged) {
                 const boldedName = chalk.green.bold(fullName);
-                const boldedFile = chalk.green.bold('test-whitelist.js');
+                const boldedFile = chalk.green.bold('legacy-test-exceptions.js');
                 const message = [
                     `This test used to log an error but no longer does.`,
                     `Please remove "${boldedName}" from "${boldedFile}"`,

--- a/packages/@lwc/engine/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/engine/scripts/rollup/rollup.config.js
@@ -39,8 +39,6 @@ function rollupFeaturesPlugin() {
     };
 }
 
-const TS_WHITELIST = ['**/*.ts', '/**/node_modules/**/*.js', '*.ts', '/**/*.js'];
-
 function rollupConfig({ format = 'es' } = {}) {
     return {
         input: entry,
@@ -57,7 +55,7 @@ function rollupConfig({ format = 'es' } = {}) {
             rollupTypescriptPlugin({
                 target: 'es2017',
                 typescript,
-                include: TS_WHITELIST,
+                include: ['**/*.ts', '/**/node_modules/**/*.js', '*.ts', '/**/*.js'],
             }),
             rollupFeaturesPlugin(),
         ],

--- a/packages/@lwc/engine/src/framework/modules/props.ts
+++ b/packages/@lwc/engine/src/framework/modules/props.ts
@@ -9,8 +9,8 @@ import { VNode } from '../../3rdparty/snabbdom/types';
 import { getAttrNameFromPropName } from '../attributes';
 
 function isLiveBindingProp(sel: string, key: string): boolean {
-    // For special whitelisted properties, we check against the actual property value on the DOM element instead of
-    // relying on tracked property values.
+    // For properties with live bindings, we read values from the DOM element
+    // instead of relying on internally tracked values.
     return sel === 'input' && (key === 'value' || key === 'checked');
 }
 

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -193,7 +193,7 @@ function getShadowRootRestrictionsDescriptors(
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    // blacklisting properties in dev mode only to avoid people doing the wrong
+    // Disallowing properties in dev mode only to avoid people doing the wrong
     // thing when using the real shadow root, because if that's the case,
     // the component will not work when running with synthetic shadow.
     const originalQuerySelector = sr.querySelector;
@@ -277,14 +277,14 @@ function getShadowRootRestrictionsDescriptors(
             },
         }),
     });
-    const BlackListedShadowRootMethods = {
+    const BlockedShadowRootMethods = {
         cloneNode: 0,
         getElementById: 0,
         getSelection: 0,
         elementsFromPoint: 0,
         dispatchEvent: 0,
     };
-    forEach.call(getOwnPropertyNames(BlackListedShadowRootMethods), (methodName: string) => {
+    forEach.call(getOwnPropertyNames(BlockedShadowRootMethods), (methodName: string) => {
         const descriptor = generateAccessorDescriptor({
             get() {
                 throw new Error(`Disallowed method "${methodName}" in ShadowRoot.`);

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -9,7 +9,7 @@ import { create, isFalse, isTrue, isUndefined } from '@lwc/shared';
 
 const runtimeFlags: FeatureFlagLookup = create(null);
 
-// This function is not whitelisted for use within components and is meant for
+// This function is not supported for use within components and is meant for
 // configuring runtime feature flags during app initialization.
 function setFeatureFlag(name: string, value: FeatureFlagValue) {
     const isBoolean = isTrue(value) || isFalse(value);
@@ -32,8 +32,8 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
     }
 }
 
-// This function is added to the LWC API whitelist (for testing purposes) so we
-// add a check to make sure it is not invoked in production.
+// This function is exposed to components to facilitate testing so we add a
+// check to make sure it is not invoked in production.
 function setFeatureFlagForTest(name: string, value: FeatureFlagValue) {
     if (process.env.NODE_ENV !== 'production') {
         if (isUndefined(features[name])) {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -68,7 +68,7 @@ const TEMPLATE_FUNCTION = template(
     { sourceType: 'module' }
 );
 
-const BLACKLIST_LWC_DIRECTIVES = new Set(['dynamic']);
+const DISALLOWED_LWC_DIRECTIVES = new Set(['dynamic']);
 
 function generateContext(element: IRElement, data: t.ObjectProperty[], codeGen: CodeGen) {
     const { lwc, locator } = element;
@@ -77,7 +77,7 @@ function generateContext(element: IRElement, data: t.ObjectProperty[], codeGen: 
     // LWC
     if (lwc) {
         const lwcObject: t.ObjectProperty[] = Object.keys(lwc)
-            .filter(key => !BLACKLIST_LWC_DIRECTIVES.has(key))
+            .filter(key => !DISALLOWED_LWC_DIRECTIVES.has(key))
             .map(key => {
                 return t.objectProperty(t.identifier(key), t.stringLiteral(lwc[key]));
             });

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -22,7 +22,7 @@ import {
     ATTR_NAME,
     DATA_RE,
     SVG_NAMESPACE_URI,
-    SVG_TAG_WHITELIST,
+    SUPPORTED_SVG_TAGS,
     ARIA_RE,
     GLOBAL_ATTRIBUTE_SET,
     ATTRS_PROPS_TRANFORMS,
@@ -70,17 +70,17 @@ export function isIdReferencingAttribute(attrName: string): boolean {
     return ID_REFERENCING_ATTRIBUTES_SET.has(attrName);
 }
 
-// Whitelists http://www.w3.org/1999/xhtml namespace idref elements for which we
+// http://www.w3.org/1999/xhtml namespace idref elements for which we
 // allow id references.
 export function isAllowedFragOnlyUrlsXHTML(
     tagName: string,
     attrName: string,
     namespaceURI: string
 ): boolean {
-    const whitelistedTags = [HTML_TAG.A, HTML_TAG.AREA];
+    const allowed = [HTML_TAG.A, HTML_TAG.AREA];
     return (
         attrName === ATTR_NAME.HREF &&
-        whitelistedTags.includes(tagName) &&
+        allowed.includes(tagName) &&
         namespaceURI === HTML_NAMESPACE_URI
     );
 }
@@ -263,7 +263,7 @@ export function isValidHTMLAttribute(tagName: string, attrName: string): boolean
     if (
         GLOBAL_ATTRIBUTE_SET.has(attrName) ||
         isAriaOrDataOrFmkAttribute(attrName) ||
-        SVG_TAG_WHITELIST.has(tagName) ||
+        SUPPORTED_SVG_TAGS.has(tagName) ||
         DASHED_TAGNAME_ELEMENT_SET.has(tagName) ||
         isTemplateDirective(attrName) ||
         !KNOWN_HTML_ELEMENTS.has(tagName)
@@ -284,7 +284,7 @@ function isTemplateDirective(attrName: string): boolean {
 function shouldCamelCaseAttribute(element: IRElement, attrName: string) {
     const { tag } = element;
     const isDataAttributeOrFmk = isDataAttribute(attrName) || isFmkAttribute(attrName);
-    const isSvgTag = SVG_TAG_WHITELIST.has(tag);
+    const isSvgTag = SUPPORTED_SVG_TAGS.has(tag);
     return !isSvgTag && !isDataAttributeOrFmk;
 }
 

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -118,7 +118,14 @@ export const SUPPORTED_SVG_TAGS = new Set([
     'use',
 ]);
 
-export const MATHML_TAG_BLACKLIST = new Set(['script', 'link', 'base', 'object', 'embed', 'meta']);
+export const DISALLOWED_MATHML_TAGS = new Set([
+    'script',
+    'link',
+    'base',
+    'object',
+    'embed',
+    'meta',
+]);
 
 export const GLOBAL_ATTRIBUTE_SET = new Set([
     'role',
@@ -226,7 +233,7 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     'aria-valuetext': 'ariaValueText',
 };
 
-export const HTML_TAG_BLACKLIST = new Set(['base', 'link', 'meta', 'script', 'title']);
+export const DISALLOWED_HTML_TAGS = new Set(['base', 'link', 'meta', 'script', 'title']);
 
 export const HTML_ATTRIBUTES_REVERSE_LOOKUP: {
     [attr: string]: string[];

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -46,7 +46,7 @@ const ATTRIBUTE_NAME_CHAR = [
 export const ARIA_RE = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
 export const DATA_RE = new RegExp('^(data)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
 
-export const SVG_TAG_WHITELIST = new Set([
+export const SUPPORTED_SVG_TAGS = new Set([
     'svg',
     'a',
     'altGlyph',

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -72,7 +72,7 @@ import {
     HTML_TAG_BLACKLIST,
     ITERATOR_RE,
     DASHED_TAGNAME_ELEMENT_SET,
-    SVG_TAG_WHITELIST,
+    SUPPORTED_SVG_TAGS,
     SVG_NAMESPACE_URI,
     HTML_NAMESPACE_URI,
     MATHML_TAG_BLACKLIST,
@@ -868,7 +868,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                 return warnOnElement(ParserDiagnostics.FORBIDDEN_TAG_ON_TEMPLATE, node, [tag]);
             }
 
-            const isNotAllowedSvgTag = !SVG_TAG_WHITELIST.has(tag);
+            const isNotAllowedSvgTag = !SUPPORTED_SVG_TAGS.has(tag);
             if (namespace === SVG_NAMESPACE_URI && isNotAllowedSvgTag) {
                 return warnOnElement(ParserDiagnostics.FORBIDDEN_SVG_NAMESPACE_IN_TEMPLATE, node, [
                     tag,
@@ -887,7 +887,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             const isKnownTag =
                 isCustomElement(element) ||
                 KNOWN_HTML_ELEMENTS.has(tag) ||
-                SVG_TAG_WHITELIST.has(tag) ||
+                SUPPORTED_SVG_TAGS.has(tag) ||
                 DASHED_TAGNAME_ELEMENT_SET.has(tag);
 
             if (!isKnownTag) {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -69,13 +69,13 @@ import {
     VALID_IF_MODIFIER,
     EVENT_HANDLER_RE,
     EVENT_HANDLER_NAME_RE,
-    HTML_TAG_BLACKLIST,
+    DISALLOWED_HTML_TAGS,
     ITERATOR_RE,
     DASHED_TAGNAME_ELEMENT_SET,
     SUPPORTED_SVG_TAGS,
     SVG_NAMESPACE_URI,
     HTML_NAMESPACE_URI,
-    MATHML_TAG_BLACKLIST,
+    DISALLOWED_MATHML_TAGS,
     MATHML_NAMESPACE_URI,
     KNOWN_HTML_ELEMENTS,
     LWC_DIRECTIVES,
@@ -863,7 +863,7 @@ export default function parse(source: string, state: State): TemplateParseResult
         } else {
             const namespace = node.namespaceURI;
 
-            const isNotAllowedHtmlTag = HTML_TAG_BLACKLIST.has(tag);
+            const isNotAllowedHtmlTag = DISALLOWED_HTML_TAGS.has(tag);
             if (namespace === HTML_NAMESPACE_URI && isNotAllowedHtmlTag) {
                 return warnOnElement(ParserDiagnostics.FORBIDDEN_TAG_ON_TEMPLATE, node, [tag]);
             }
@@ -875,7 +875,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                 ]);
             }
 
-            const isNotAllowedMathMlTag = MATHML_TAG_BLACKLIST.has(tag);
+            const isNotAllowedMathMlTag = DISALLOWED_MATHML_TAGS.has(tag);
             if (namespace === MATHML_NAMESPACE_URI && isNotAllowedMathMlTag) {
                 return warnOnElement(
                     ParserDiagnostics.FORBIDDEN_MATHML_NAMESPACE_IN_TEMPLATE,

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -145,7 +145,7 @@ function check() {
     if (invalidFiles.length > 0) {
         console.log(`Salesforce copyright header check failed for the following files:
   ${invalidFiles.join('\n  ')}
-Please include the header or blacklist the files in \`scripts/checkCopyrightHeaders.js\``);
+Please include the header or add an exception for the file in \`scripts/checkCopyrightHeaders.js\``);
         process.exit(1);
     }
 }


### PR DESCRIPTION
Implements the WHATWG style guide for documentation:

Don't use "white" as meaning good and "black" as meaning bad; more concretely, "safelist" and "blocklist" are established precedent.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`