### PR TITLE
fix(engine): fix non-string template interpolation

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -532,14 +532,14 @@ export function f(items: any[]): any[] {
 }
 
 // [t]ext node
-export function t(text: string): VText {
+export function t(value: unknown): VText {
     const data = EmptyObject;
     let sel, children, key, elm;
     return {
         sel,
         data,
         children,
-        text,
+        text: String(value),
         elm,
         key,
 

--- a/packages/integration-karma/test/template/text/index.spec.js
+++ b/packages/integration-karma/test/template/text/index.spec.js
@@ -1,0 +1,17 @@
+import { createElement } from 'lwc';
+
+import ObjectReference from 'x/objectReference';
+
+describe('Object reference', () => {
+    it('should re-render the object if the object is mutated (#1680)', () => {
+        const elm = createElement('x-object-reference', { is: ObjectReference });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.querySelector('.object-reference').textContent).toBe('');
+
+        elm.push('updated');
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.object-reference').textContent).toBe('updated');
+        });
+    });
+});

--- a/packages/integration-karma/test/template/text/x/objectReference/objectReference.html
+++ b/packages/integration-karma/test/template/text/x/objectReference/objectReference.html
@@ -1,0 +1,3 @@
+<template>
+    <div class="object-reference">{arr}</div>
+</template>

--- a/packages/integration-karma/test/template/text/x/objectReference/objectReference.js
+++ b/packages/integration-karma/test/template/text/x/objectReference/objectReference.js
@@ -1,0 +1,10 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class NonString extends LightningElement {
+    @track arr = [];
+
+    @api
+    push(value) {
+        this.arr.push(value);
+    }
+}


### PR DESCRIPTION
## Details

Currently, the engine checks if [the old VNode text field is different than the new VNode text field](https://github.com/salesforce/lwc/blob/a4e8e5b988b924f9509562b9278433bbd7d68760/packages/@lwc/engine/src/framework/hooks.ts#L49) before updating the Node text value. 

This approach works well if the text field is a primitive value but not with non-primitive values like arrays for example. In the case of arrays, if a new item is added, the text value will not be updated because the object equality holds. This issue can be fixed by converting to string the value passed to the `api.t(value)`.

Fixes #1680

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

##  GUS Work Item

W-7133214
