### PR TITLE
chore: remove git add from lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,13 +76,8 @@
     }
   },
   "lint-staged": {
-    "**/*.{js,ts}": [
-      "eslint"
-    ],
-    "{packages,scripts}/**/*.{js,ts,json,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "**/*.{js,ts}": "eslint",
+    "{packages,scripts}/**/*.{js,ts,json,md}": "prettier --write"
   },
   "workspaces": [
     "packages/@lwc/*",


### PR DESCRIPTION
## Details

With the [v10.0 release](https://github.com/okonet/lint-staged/releases/tag/v10.0.0), `lint-staged` automatically add to the staging area all the modification made to the staged files. We can remove the `git add` step to get rid of the warning message.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item

W-7109631
