### PR TITLE
refactor(engine): lookup error boundaries using vm.owner

### DIFF
--- a/packages/@lwc/engine/src/env/dom.ts
+++ b/packages/@lwc/engine/src/env/dom.ts
@@ -6,11 +6,6 @@
  */
 import { getOwnPropertyDescriptor } from '@lwc/shared';
 
-const ShadowRootHostGetter: (this: ShadowRoot) => Element | null = getOwnPropertyDescriptor(
-    ShadowRoot.prototype,
-    'host'
-)!.get!;
-
 const ShadowRootInnerHTMLSetter: (this: ShadowRoot, s: string) => void = getOwnPropertyDescriptor(
     ShadowRoot.prototype,
     'innerHTML'
@@ -19,4 +14,4 @@ const ShadowRootInnerHTMLSetter: (this: ShadowRoot, s: string) => void = getOwnP
 const dispatchEvent =
     'EventTarget' in window ? EventTarget.prototype.dispatchEvent : Node.prototype.dispatchEvent; // IE11
 
-export { dispatchEvent, ShadowRootHostGetter, ShadowRootInnerHTMLSetter };
+export { dispatchEvent, ShadowRootInnerHTMLSetter };

--- a/packages/@lwc/engine/src/env/node.ts
+++ b/packages/@lwc/engine/src/env/node.ts
@@ -4,28 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { getOwnPropertyDescriptor, hasOwnProperty } from '@lwc/shared';
 
 const { appendChild, insertBefore, removeChild, replaceChild } = Node.prototype;
-
-const parentNodeGetter: (this: Node) => Element | null = getOwnPropertyDescriptor(
-    Node.prototype,
-    'parentNode'
-)!.get!;
-
-const parentElementGetter: (this: Node) => Element | null = hasOwnProperty.call(
-    Node.prototype,
-    'parentElement'
-)
-    ? getOwnPropertyDescriptor(Node.prototype, 'parentElement')!.get!
-    : getOwnPropertyDescriptor(HTMLElement.prototype, 'parentElement')!.get!; // IE11
 
 export {
     // Node.prototype
     appendChild,
     insertBefore,
-    parentElementGetter,
-    parentNodeGetter,
     removeChild,
     replaceChild,
 };

--- a/packages/@lwc/engine/src/framework/invoker.ts
+++ b/packages/@lwc/engine/src/framework/invoker.ts
@@ -8,10 +8,11 @@ import { assert, isFunction, isUndefined } from '@lwc/shared';
 import { currentContext, establishContext } from './context';
 
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
-import { getErrorComponentStack, VM, UninitializedVM, runWithBoundaryProtection } from './vm';
+import { VM, UninitializedVM, runWithBoundaryProtection } from './vm';
 import { ComponentConstructor, ComponentInterface } from './component';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { startMeasure, endMeasure } from './performance-timing';
+import { getErrorComponentStack } from '../shared/format';
 
 export let isInvokingRender: boolean = false;
 
@@ -80,7 +81,7 @@ export function invokeComponentConstructor(vm: UninitializedVM, Ctor: ComponentC
         }
         vmBeingConstructed = vmBeingConstructedInception;
         if (!isUndefined(error)) {
-            error.wcStack = getErrorComponentStack(vm.elm);
+            error.wcStack = getErrorComponentStack(vm);
             // re-throwing the original error annotated after restoring the context
             throw error; // eslint-disable-line no-unsafe-finally
         }

--- a/packages/@lwc/engine/src/shared/format.ts
+++ b/packages/@lwc/engine/src/shared/format.ts
@@ -6,7 +6,7 @@
  */
 import { isNull, ArrayJoin, ArrayPush, StringToLowerCase } from '@lwc/shared';
 
-import { VM, UninitializedVM } from '../framework/vm';
+import { UninitializedVM } from '../framework/vm';
 
 export function getComponentTag(vm: UninitializedVM): string {
     // Element.prototype.tagName getter might be poisoned. We need to use a try/catch to protect the
@@ -18,7 +18,7 @@ export function getComponentTag(vm: UninitializedVM): string {
     }
 }
 
-export function getComponentStack(vm: VM): string {
+export function getComponentStack(vm: UninitializedVM): string {
     const stack: string[] = [];
     let prefix = '';
 
@@ -30,4 +30,16 @@ export function getComponentStack(vm: VM): string {
     }
 
     return ArrayJoin.call(stack, '\n');
+}
+
+export function getErrorComponentStack(vm: UninitializedVM): string {
+    const wcStack: string[] = [];
+
+    let currentVm: UninitializedVM | null = vm;
+    while (!isNull(currentVm)) {
+        ArrayPush.call(wcStack, getComponentTag(currentVm));
+        currentVm = currentVm.owner;
+    }
+
+    return wcStack.reverse().join('\n\t');
 }

--- a/packages/@lwc/engine/src/shared/format.ts
+++ b/packages/@lwc/engine/src/shared/format.ts
@@ -18,6 +18,7 @@ export function getComponentTag(vm: UninitializedVM): string {
     }
 }
 
+// TODO [#1695]: Unify getComponentStack and getErrorComponentStack
 export function getComponentStack(vm: UninitializedVM): string {
     const stack: string[] = [];
     let prefix = '';


### PR DESCRIPTION
## Details

This PR changes the way error boundaries get resolved by internally LWC. Currently, the engine climbs the DOM tree (using `Node.prototype.parentNode` and `ShadowRoot.prototype.host`) to find a component boundary which creates a tight coupling between the DOM and the engine. With this PR, error boundaries will be resolved by climbing the `owner` property attached to the `VM`.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

This PR changes the current error boundary lookup behavior. When climbing the component using `vm.owner` the error propagation would stop at the component tree root. In the current implementation, the error would stop at the document root. This means that even if 2 component trees are disconnected and if one is nested into another the outer component tree would be able to catch the error.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS Work Item

W-7141806
