### PR TITLE
feat(synthetic-shadow): preserve native behavior of attachShadow

### DIFF
--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -288,7 +288,7 @@ function BaseLightningElementConstructor(this: LightningElement) {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,
     };
-    assign(shadowRootOptions, { '$$lwc-synthetic-shadow$$': true });
+    assign(shadowRootOptions, { '$$lwc-synthetic-mode$$': true });
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM
     setHiddenField(component, ViewModelReflection, vm);

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -15,7 +15,6 @@
 import {
     ArrayReduce,
     assert,
-    assign,
     create,
     defineProperties,
     fields,
@@ -36,7 +35,7 @@ import {
     getComponentAsString,
     getTemplateReactiveObserver,
 } from './component';
-import { ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
+import { ViewModelReflection, EmptyObject } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
 import { getComponentVM, VM } from './vm';
 import { valueObserved, valueMutated } from '../libs/mutation-tracker';
@@ -284,13 +283,11 @@ function BaseLightningElementConstructor(this: LightningElement) {
         vm.getHook = getHook;
     }
     // attaching the shadowRoot
-    const shadowRootOptions: ShadowRootInit = {
+    const shadowRootOptions = {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,
+        '$$lwc-synthetic-mode$$': true,
     };
-    if (useSyntheticShadow) {
-        assign(shadowRootOptions, { '$$lwc-synthetic-mode$$': true });
-    }
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM
     setHiddenField(component, ViewModelReflection, vm);

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -36,7 +36,7 @@ import {
     getComponentAsString,
     getTemplateReactiveObserver,
 } from './component';
-import { ViewModelReflection, EmptyObject } from './utils';
+import { ViewModelReflection, EmptyObject, useSyntheticShadow } from './utils';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
 import { getComponentVM, VM } from './vm';
 import { valueObserved, valueMutated } from '../libs/mutation-tracker';
@@ -288,7 +288,9 @@ function BaseLightningElementConstructor(this: LightningElement) {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,
     };
-    assign(shadowRootOptions, { '$$lwc-synthetic-mode$$': true });
+    if (useSyntheticShadow) {
+        assign(shadowRootOptions, { '$$lwc-synthetic-mode$$': true });
+    }
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM
     setHiddenField(component, ViewModelReflection, vm);

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -15,6 +15,7 @@
 import {
     ArrayReduce,
     assert,
+    assign,
     create,
     defineProperties,
     fields,
@@ -287,6 +288,7 @@ function BaseLightningElementConstructor(this: LightningElement) {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,
     };
+    assign(shadowRootOptions, { '$$lwc-synthetic-shadow$$': true });
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM
     setHiddenField(component, ViewModelReflection, vm);

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
-import { SyntheticShadowRoot } from './../../faux-shadow/shadow-root';
+import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 
 export function pathComposer(startNode: EventTarget, composed: boolean): EventTarget[] {
     const composedPath: (Element | Document | Window)[] = [];

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
+import { SyntheticShadowRoot } from './../../faux-shadow/shadow-root';
 
 export function pathComposer(startNode: EventTarget, composed: boolean): EventTarget[] {
     const composedPath: (Element | Document | Window)[] = [];
@@ -33,7 +34,7 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
         }
         if (!isNull(assignedSlot)) {
             current = assignedSlot;
-        } else if (current instanceof ShadowRoot && (composed || current !== startRoot)) {
+        } else if (current instanceof SyntheticShadowRoot && (composed || current !== startRoot)) {
             current = (current as ShadowRoot).host;
         } else {
             current = (current as Element).parentNode;

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,7 +17,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
-import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 
 export function pathComposer(startNode: EventTarget, composed: boolean): EventTarget[] {
     const composedPath: (Element | Document | Window)[] = [];
@@ -34,7 +33,7 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
         }
         if (!isNull(assignedSlot)) {
             current = assignedSlot;
-        } else if (current instanceof SyntheticShadowRoot && (composed || current !== startRoot)) {
+        } else if (current instanceof ShadowRoot && (composed || current !== startRoot)) {
             current = (current as ShadowRoot).host;
         } else {
             current = (current as Element).parentNode;

--- a/packages/@lwc/synthetic-shadow/src/env/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/element.ts
@@ -76,29 +76,37 @@ const childrenGetter: (this: ParentNode) => HTMLCollectionOf<Element> = hasOwnPr
 // for all other browsers access the method from the parent Element interface
 const { getElementsByClassName } = HTMLElement.prototype;
 
+const shadowRootGetter: (this: Element) => ShadowRoot | null = hasOwnProperty.call(
+    Element.prototype,
+    'shadowRoot'
+)
+    ? getOwnPropertyDescriptor(Element.prototype, 'shadowRoot')!.get!
+    : () => null;
+
 export {
     addEventListener,
     attachShadow,
-    removeEventListener,
-    hasAttribute,
-    getAttribute,
-    setAttribute,
-    removeAttribute,
-    querySelectorAll,
-    getBoundingClientRect,
-    getElementsByTagName,
-    getElementsByClassName,
-    getElementsByTagNameNS,
-    tagNameGetter,
-    tabIndexGetter,
-    tabIndexSetter,
-    innerHTMLGetter,
-    innerHTMLSetter,
-    outerHTMLGetter,
-    outerHTMLSetter,
-    matches,
     childrenGetter,
     childElementCountGetter,
     firstElementChildGetter,
+    getAttribute,
+    getBoundingClientRect,
+    getElementsByClassName,
+    getElementsByTagName,
+    getElementsByTagNameNS,
+    hasAttribute,
+    innerHTMLGetter,
+    innerHTMLSetter,
     lastElementChildGetter,
+    matches,
+    outerHTMLGetter,
+    outerHTMLSetter,
+    querySelectorAll,
+    removeAttribute,
+    removeEventListener,
+    setAttribute,
+    shadowRootGetter,
+    tagNameGetter,
+    tabIndexGetter,
+    tabIndexSetter,
 };

--- a/packages/@lwc/synthetic-shadow/src/env/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/element.ts
@@ -8,7 +8,6 @@ import { hasOwnProperty, getOwnPropertyDescriptor } from '@lwc/shared';
 
 const {
     addEventListener,
-    attachShadow,
     getAttribute,
     getBoundingClientRect,
     getElementsByTagName,
@@ -20,6 +19,16 @@ const {
     setAttribute,
 } = Element.prototype;
 
+const attachShadow: (init: ShadowRootInit) => ShadowRoot = hasOwnProperty.call(
+    Element.prototype,
+    'attachShadow'
+)
+    ? Element.prototype.attachShadow
+    : () => {
+          throw new TypeError(
+              'attachShadow() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill and use Lightning Web Components'
+          );
+      };
 const childElementCountGetter: (this: ParentNode) => number = getOwnPropertyDescriptor(
     Element.prototype,
     'childElementCount'

--- a/packages/@lwc/synthetic-shadow/src/env/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/element.ts
@@ -7,17 +7,18 @@
 import { hasOwnProperty, getOwnPropertyDescriptor } from '@lwc/shared';
 
 const {
-    hasAttribute,
+    addEventListener,
+    attachShadow,
     getAttribute,
-    setAttribute,
-    removeAttribute,
-    querySelectorAll,
     getBoundingClientRect,
     getElementsByTagName,
     getElementsByTagNameNS,
+    hasAttribute,
+    querySelectorAll,
+    removeAttribute,
+    removeEventListener,
+    setAttribute,
 } = Element.prototype;
-
-const { addEventListener, removeEventListener } = Element.prototype;
 
 const childElementCountGetter: (this: ParentNode) => number = getOwnPropertyDescriptor(
     Element.prototype,
@@ -77,6 +78,7 @@ const { getElementsByClassName } = HTMLElement.prototype;
 
 export {
     addEventListener,
+    attachShadow,
     removeEventListener,
     hasAttribute,
     getAttribute,

--- a/packages/@lwc/synthetic-shadow/src/env/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/slot.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+const { assignedNodes, assignedElements } = HTMLSlotElement.prototype;
+
+export { assignedNodes, assignedElements };

--- a/packages/@lwc/synthetic-shadow/src/env/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/slot.ts
@@ -9,5 +9,16 @@ let assignedNodes, assignedElements;
 if (typeof HTMLSlotElement !== 'undefined') {
     assignedNodes = HTMLSlotElement.prototype.assignedNodes;
     assignedElements = HTMLSlotElement.prototype.assignedElements;
+} else {
+    assignedNodes = () => {
+        throw new TypeError(
+            "assignedNodes() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template"
+        );
+    };
+    assignedElements = () => {
+        throw new TypeError(
+            "assignedElements() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template"
+        );
+    };
 }
 export { assignedNodes, assignedElements };

--- a/packages/@lwc/synthetic-shadow/src/env/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/slot.ts
@@ -5,6 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-const { assignedNodes, assignedElements } = HTMLSlotElement.prototype;
-
+let assignedNodes, assignedElements;
+if (typeof HTMLSlotElement !== 'undefined') {
+    assignedNodes = HTMLSlotElement.prototype.assignedNodes;
+    assignedElements = HTMLSlotElement.prototype.assignedElements;
+}
 export { assignedNodes, assignedElements };

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -78,7 +78,7 @@ function outerHTMLGetterPatched(this: Element) {
 
 function attachShadowPatched(this: Element, options: ShadowRootInit): ShadowRoot {
     // To retain native behavior of the API, provide synthetic shadowRoot only when specified
-    if (isTrue(options['$$lwc-synthetic-mode$$']) || isUndefined(originalAttachShadow)) {
+    if (isTrue(options['$$lwc-synthetic-mode$$'])) {
         return attachShadow(this, options);
     } else {
         return originalAttachShadow.call(this, options);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -17,12 +17,7 @@ import {
     isUndefined,
 } from '@lwc/shared';
 import featureFlags from '@lwc/features';
-import {
-    attachShadow,
-    getShadowRoot,
-    SyntheticShadowRootInterface,
-    isHostElement,
-} from './shadow-root';
+import { attachShadow, getShadowRoot, isHostElement } from './shadow-root';
 import {
     getNodeOwner,
     getAllMatches,
@@ -34,12 +29,13 @@ import {
 import {
     attachShadow as originalAttachShadow,
     childrenGetter,
-    outerHTMLSetter,
     childElementCountGetter,
     firstElementChildGetter,
-    lastElementChildGetter,
     innerHTMLGetter,
+    lastElementChildGetter,
+    outerHTMLSetter,
     outerHTMLGetter,
+    shadowRootGetter as originalShadowRootGetter,
 } from '../env/element';
 import { createStaticNodeList } from '../shared/static-node-list';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
@@ -89,14 +85,14 @@ function attachShadowPatched(this: Element, options: ShadowRootInit): ShadowRoot
     }
 }
 
-function shadowRootGetterPatched(this: Element): SyntheticShadowRootInterface | null {
+function shadowRootGetterPatched(this: Element): ShadowRoot | null {
     if (isHostElement(this)) {
         const shadow = getShadowRoot(this);
         if (shadow.mode === 'open') {
             return shadow;
         }
     }
-    return null;
+    return originalShadowRootGetter.call(this);
 }
 
 function childrenGetterPatched(this: Element): HTMLCollectionOf<Element> {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -13,6 +13,7 @@ import {
     getOwnPropertyDescriptor,
     hasOwnProperty,
     isNull,
+    isTrue,
     isUndefined,
 } from '@lwc/shared';
 import featureFlags from '@lwc/features';
@@ -83,7 +84,8 @@ function attachShadowPatched(
     this: Element,
     options: ShadowRootInit
 ): SyntheticShadowRootInterface | ShadowRoot {
-    if (options['$$lwc-synthetic-shadow$$']) {
+    // To retain native behavior of the API, provide synthetic shadowRoot only when specified
+    if (isTrue(options['$$lwc-synthetic-mode$$'])) {
         return attachShadow(this, options);
     } else {
         return originalAttachShadow.call(this, options);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -80,10 +80,7 @@ function outerHTMLGetterPatched(this: Element) {
     return getOuterHTML(this);
 }
 
-function attachShadowPatched(
-    this: Element,
-    options: ShadowRootInit
-): SyntheticShadowRootInterface | ShadowRoot {
+function attachShadowPatched(this: Element, options: ShadowRootInit): ShadowRoot {
     // To retain native behavior of the API, provide synthetic shadowRoot only when specified
     if (isTrue(options['$$lwc-synthetic-mode$$'])) {
         return attachShadow(this, options);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -78,7 +78,7 @@ function outerHTMLGetterPatched(this: Element) {
 
 function attachShadowPatched(this: Element, options: ShadowRootInit): ShadowRoot {
     // To retain native behavior of the API, provide synthetic shadowRoot only when specified
-    if (isTrue(options['$$lwc-synthetic-mode$$'])) {
+    if (isTrue(options['$$lwc-synthetic-mode$$']) || isUndefined(originalAttachShadow)) {
         return attachShadow(this, options);
     } else {
         return originalAttachShadow.call(this, options);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -31,6 +31,7 @@ import {
     getFirstSlottedMatch,
 } from './traverse';
 import {
+    attachShadow as originalAttachShadow,
     childrenGetter,
     outerHTMLSetter,
     childElementCountGetter,
@@ -78,8 +79,15 @@ function outerHTMLGetterPatched(this: Element) {
     return getOuterHTML(this);
 }
 
-function attachShadowPatched(this: Element, options: ShadowRootInit): SyntheticShadowRootInterface {
-    return attachShadow(this, options);
+function attachShadowPatched(
+    this: Element,
+    options: ShadowRootInit
+): SyntheticShadowRootInterface | ShadowRoot {
+    if (options['$$lwc-synthetic-shadow$$']) {
+        return attachShadow(this, options);
+    } else {
+        return originalAttachShadow.call(this, options);
+    }
 }
 
 function shadowRootGetterPatched(this: Element): SyntheticShadowRootInterface | null {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -6,19 +6,24 @@
  */
 import {
     assert,
+    defineProperties,
+    ArrayFilter,
     ArrayIndexOf,
     ArrayPush,
+    ArrayReduce,
+    ArraySlice,
     fields,
     forEach,
-    isUndefined,
-    isTrue,
-    ArrayFilter,
     isNull,
-    ArrayReduce,
-    defineProperties,
+    isTrue,
+    isUndefined,
 } from '@lwc/shared';
 import { getAttribute, setAttribute } from '../env/element';
 import { dispatchEvent } from '../env/dom';
+import {
+    assignedNodes as originalAssignedNodes,
+    assignedElements as originalAssignedElements,
+} from '../env/slot';
 import { MutationObserverObserve, MutationObserver } from '../env/mutation-observer';
 import {
     isSlotElement,
@@ -124,11 +129,26 @@ defineProperties(HTMLSlotElement.prototype, {
     },
     assignedElements: {
         value(this: HTMLSlotElement, options?: AssignedNodesOptions): Element[] {
-            const flatten = !isUndefined(options) && isTrue(options.flatten);
-            const nodes = flatten
-                ? getFilteredSlotFlattenNodes(this)
-                : getFilteredSlotAssignedNodes(this);
-            return ArrayFilter.call(nodes, node => node instanceof Element);
+            if (isNodeShadowed(this)) {
+                const flatten = !isUndefined(options) && isTrue(options.flatten);
+                const nodes = flatten
+                    ? getFilteredSlotFlattenNodes(this)
+                    : getFilteredSlotAssignedNodes(this);
+                return ArrayFilter.call(nodes, node => node instanceof Element);
+            } else {
+                if (!isUndefined(originalAssignedElements)) {
+                    return originalAssignedElements.apply(this, ArraySlice.call(arguments) as [
+                        AssignedNodesOptions
+                    ]);
+                } else {
+                    if (process.env.NODE_ENV !== 'production') {
+                        throw new TypeError(
+                            '<slot> elements can only be used in a component template.'
+                        );
+                    }
+                    return [];
+                }
+            }
         },
         writable: true,
         enumerable: true,
@@ -136,8 +156,25 @@ defineProperties(HTMLSlotElement.prototype, {
     },
     assignedNodes: {
         value(this: HTMLSlotElement, options?: AssignedNodesOptions): Node[] {
-            const flatten = !isUndefined(options) && isTrue(options.flatten);
-            return flatten ? getFilteredSlotFlattenNodes(this) : getFilteredSlotAssignedNodes(this);
+            if (isNodeShadowed(this)) {
+                const flatten = !isUndefined(options) && isTrue(options.flatten);
+                return flatten
+                    ? getFilteredSlotFlattenNodes(this)
+                    : getFilteredSlotAssignedNodes(this);
+            } else {
+                if (!isUndefined(originalAssignedNodes)) {
+                    return originalAssignedNodes.apply(this, ArraySlice.call(arguments) as [
+                        AssignedNodesOptions
+                    ]);
+                } else {
+                    if (process.env.NODE_ENV !== 'production') {
+                        throw new TypeError(
+                            '<slot> elements can only be used in a component template.'
+                        );
+                    }
+                    return [];
+                }
+            }
         },
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -136,18 +136,9 @@ defineProperties(HTMLSlotElement.prototype, {
                     : getFilteredSlotAssignedNodes(this);
                 return ArrayFilter.call(nodes, node => node instanceof Element);
             } else {
-                if (!isUndefined(originalAssignedElements)) {
-                    return originalAssignedElements.apply(this, ArraySlice.call(arguments) as [
-                        AssignedNodesOptions
-                    ]);
-                } else {
-                    if (process.env.NODE_ENV !== 'production') {
-                        throw new TypeError(
-                            '<slot> elements can only be used in a component template.'
-                        );
-                    }
-                    return [];
-                }
+                return originalAssignedElements.apply(this, ArraySlice.call(arguments) as [
+                    AssignedNodesOptions
+                ]);
             }
         },
         writable: true,
@@ -162,18 +153,9 @@ defineProperties(HTMLSlotElement.prototype, {
                     ? getFilteredSlotFlattenNodes(this)
                     : getFilteredSlotAssignedNodes(this);
             } else {
-                if (!isUndefined(originalAssignedNodes)) {
-                    return originalAssignedNodes.apply(this, ArraySlice.call(arguments) as [
-                        AssignedNodesOptions
-                    ]);
-                } else {
-                    if (process.env.NODE_ENV !== 'production') {
-                        throw new TypeError(
-                            '<slot> elements can only be used in a component template.'
-                        );
-                    }
-                    return [];
-                }
+                return originalAssignedNodes.apply(this, ArraySlice.call(arguments) as [
+                    AssignedNodesOptions
+                ]);
             }
         },
         writable: true,

--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -8,6 +8,7 @@
 // Collecting env references before patching anything
 import './env/node';
 import './env/element';
+import './env/slot';
 import './env/dom';
 import './env/document';
 import './env/window';

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -1,266 +1,269 @@
 import NativeShadowParent from './x/NativeParent/NativeParent';
 import NativeShadowChild from './x/NativeChild/NativeChild';
 
-describe('Event target retains native behavior in native shadow dom tree', () => {
-    let parent;
-    let child;
-    let eventTargetAtBody;
-    let container;
-    const listener = evt => {
-        eventTargetAtBody = evt.target;
-    };
-    beforeEach(() => {
-        parent = NativeShadowParent();
-        document.body.appendChild(parent);
-        child = NativeShadowChild();
-        container = parent.shadowRoot.querySelector('div');
-        container.appendChild(child);
-        document.body.addEventListener('test', listener);
-    });
-    afterEach(() => {
-        document.body.removeEventListener('test', listener);
-        eventTargetAtBody = undefined;
-    });
-
-    describe('composed:false', () => {
-        it('event dispatched at root custom element', () => {
-            let targetAtSource;
-            parent.addEventListener('test', evt => {
-                targetAtSource = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true });
-            parent.dispatchEvent(event);
-            expect(targetAtSource).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
+// Should not be expecting native shadow behavior to work in compat mode
+if (process.env.COMPAT !== true) {
+    describe('Event target retains native behavior in native shadow dom tree', () => {
+        let parent;
+        let child;
+        let eventTargetAtBody;
+        let container;
+        const listener = evt => {
+            eventTargetAtBody = evt.target;
+        };
+        beforeEach(() => {
+            parent = NativeShadowParent();
+            document.body.appendChild(parent);
+            child = NativeShadowChild();
+            container = parent.shadowRoot.querySelector('div');
+            container.appendChild(child);
+            document.body.addEventListener('test', listener);
+        });
+        afterEach(() => {
+            document.body.removeEventListener('test', listener);
+            eventTargetAtBody = undefined;
         });
 
-        it('event dispatched inside root custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
+        describe('composed:false', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
 
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
             });
-            const event = new CustomEvent('test', { bubbles: true });
-            const innerElm = parent.shadowRoot.querySelector('x-native-child');
-            innerElm.dispatchEvent(event);
 
-            // bubbling event in shadow tree
-            expect(targetAtContainer).toBe(innerElm);
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
 
-            // Non-composed event should stop at shadow boundary
-            expect(targetAtParent).toBeUndefined();
-            expect(eventTargetAtBody).toBeUndefined();
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtContainer).toBeUndefined();
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
         });
 
-        it('event dispatched inside nested custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
+        describe('composed:true', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
 
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true });
-            const nestedElm = child.shadowRoot.querySelector('h2');
-            nestedElm.dispatchEvent(event);
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
 
-            // Non-composed event should stop at shadow boundary
-            expect(targetAtContainer).toBeUndefined();
-            expect(targetAtParent).toBeUndefined();
-            expect(eventTargetAtBody).toBeUndefined();
-        });
-    });
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
 
-    describe('composed:true', () => {
-        it('event dispatched at root custom element', () => {
-            let targetAtSource;
-            parent.addEventListener('test', evt => {
-                targetAtSource = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            parent.dispatchEvent(event);
-            expect(targetAtSource).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
-        });
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
 
-        it('event dispatched inside root custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
+                // composed event should bubble up to document
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
 
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // composed event should bubble up to document
+                expect(targetAtContainer).toBe(child);
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const innerElm = parent.shadowRoot.querySelector('x-native-child');
-            innerElm.dispatchEvent(event);
-
-            // bubbling event in shadow tree
-            expect(targetAtContainer).toBe(innerElm);
-
-            // composed event should bubble up to document
-            expect(targetAtParent).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
-        });
-
-        it('event dispatched inside nested custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
-            });
-
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const nestedElm = child.shadowRoot.querySelector('h2');
-            nestedElm.dispatchEvent(event);
-
-            // composed event should bubble up to document
-            expect(targetAtContainer).toBe(child);
-            expect(targetAtParent).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
-        });
-    });
-});
-
-describe('Event target retains native behavior in mixed shadow dom tree(synthetic-shadow outside & native inside)', () => {
-    let parent;
-    let child;
-    let eventTargetAtBody;
-    let container;
-    const listener = evt => {
-        eventTargetAtBody = evt.target;
-    };
-    beforeEach(() => {
-        parent = NativeShadowParent();
-        document.body.appendChild(parent);
-        child = NativeShadowChild();
-        container = parent.shadowRoot.querySelector('div');
-        container.appendChild(child);
-        document.body.addEventListener('test', listener);
-    });
-    afterEach(() => {
-        document.body.removeEventListener('test', listener);
-        eventTargetAtBody = undefined;
-    });
-
-    describe('composed:false', () => {
-        it('event dispatched at root custom element', () => {
-            let targetAtSource;
-            parent.addEventListener('test', evt => {
-                targetAtSource = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true });
-            parent.dispatchEvent(event);
-            expect(targetAtSource).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
-        });
-
-        it('event dispatched inside root custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
-            });
-
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true });
-            const innerElm = parent.shadowRoot.querySelector('x-native-child');
-            innerElm.dispatchEvent(event);
-
-            // bubbling event in shadow tree
-            expect(targetAtContainer).toBe(innerElm);
-
-            // Non-composed event should stop at shadow boundary
-            expect(targetAtParent).toBeUndefined();
-            expect(eventTargetAtBody).toBeUndefined();
-        });
-
-        it('event dispatched inside nested custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
-            });
-
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true });
-            const nestedElm = child.shadowRoot.querySelector('h2');
-            nestedElm.dispatchEvent(event);
-
-            // Non-composed event should stop at shadow boundary
-            expect(targetAtContainer).toBeUndefined();
-            expect(targetAtParent).toBeUndefined();
-            expect(eventTargetAtBody).toBeUndefined();
         });
     });
 
-    describe('composed:true', () => {
-        it('event dispatched at root custom element', () => {
-            let targetAtSource;
-            parent.addEventListener('test', evt => {
-                targetAtSource = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            parent.dispatchEvent(event);
-            expect(targetAtSource).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
+    describe('Event target retains native behavior in mixed shadow dom tree(synthetic-shadow outside & native inside)', () => {
+        let parent;
+        let child;
+        let eventTargetAtBody;
+        let container;
+        const listener = evt => {
+            eventTargetAtBody = evt.target;
+        };
+        beforeEach(() => {
+            parent = NativeShadowParent();
+            document.body.appendChild(parent);
+            child = NativeShadowChild();
+            container = parent.shadowRoot.querySelector('div');
+            container.appendChild(child);
+            document.body.addEventListener('test', listener);
+        });
+        afterEach(() => {
+            document.body.removeEventListener('test', listener);
+            eventTargetAtBody = undefined;
         });
 
-        it('event dispatched inside root custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
+        describe('composed:false', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
 
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
             });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const innerElm = parent.shadowRoot.querySelector('x-native-child');
-            innerElm.dispatchEvent(event);
 
-            // bubbling event in shadow tree
-            expect(targetAtContainer).toBe(innerElm);
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
 
-            // composed event should bubble up to document
-            expect(targetAtParent).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtContainer).toBeUndefined();
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
         });
 
-        it('event dispatched inside nested custom element', () => {
-            let targetAtParent;
-            parent.addEventListener('test', evt => {
-                targetAtParent = evt.target;
+        describe('composed:true', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
             });
 
-            let targetAtContainer;
-            container.addEventListener('test', evt => {
-                targetAtContainer = evt.target;
-            });
-            const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const nestedElm = child.shadowRoot.querySelector('h2');
-            nestedElm.dispatchEvent(event);
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
 
-            // composed event should bubble up to document
-            expect(targetAtContainer).toBe(child);
-            expect(targetAtParent).toBe(parent);
-            expect(eventTargetAtBody).toBe(parent);
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // composed event should bubble up to document
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
+
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // composed event should bubble up to document
+                expect(targetAtContainer).toBe(child);
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
         });
     });
-});
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -1,5 +1,5 @@
 import NativeShadowParent from './x/NativeParent/NativeParent';
-import NativeShadowChild from './x/NativeChild/nativeChild';
+import NativeShadowChild from './x/NativeChild/NativeChild';
 
 describe('Event target retains native behavior in native shadow dom tree', () => {
     let parent;

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -1,0 +1,134 @@
+import NativeShadowParent from './x/NativeParent/NativeParent';
+import NativeShadowChild from './x/NativeChild/nativeChild';
+
+describe('Event target retains native behavior in native shadow dom tree', () => {
+    let parent;
+    let child;
+    let eventTargetAtBody;
+    let container;
+    const listener = evt => {
+        eventTargetAtBody = evt.target;
+    };
+    beforeEach(() => {
+        parent = NativeShadowParent();
+        document.body.appendChild(parent);
+        child = NativeShadowChild();
+        container = parent.shadowRoot.querySelector('div');
+        container.appendChild(child);
+        document.body.addEventListener('test', listener);
+    });
+    afterEach(() => {
+        document.body.removeEventListener(listener);
+        eventTargetAtBody = undefined;
+    });
+
+    describe('composed:false', () => {
+        it('event dispatched at root custom element', () => {
+            let targetAtSource;
+            parent.addEventListener('test', evt => {
+                targetAtSource = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            parent.dispatchEvent(event);
+            expect(targetAtSource).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside root custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            const innerElm = parent.shadowRoot.querySelector('x-native-child');
+            innerElm.dispatchEvent(event);
+
+            // bubbling event in shadow tree
+            expect(targetAtContainer).toBe(innerElm);
+
+            // Non-composed event should stop at shadow boundary
+            expect(targetAtParent).toBeUndefined();
+            expect(eventTargetAtBody).toBeUndefined();
+        });
+
+        it('event dispatched inside nested custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            const nestedElm = child.shadowRoot.querySelector('h2');
+            nestedElm.dispatchEvent(event);
+
+            // Non-composed event should stop at shadow boundary
+            expect(targetAtContainer).toBeUndefined();
+            expect(targetAtParent).toBeUndefined();
+            expect(eventTargetAtBody).toBeUndefined();
+        });
+    });
+
+    describe('composed:true', () => {
+        it('event dispatched at root custom element', () => {
+            let targetAtSource;
+            parent.addEventListener('test', evt => {
+                targetAtSource = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            parent.dispatchEvent(event);
+            expect(targetAtSource).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside root custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const innerElm = parent.shadowRoot.querySelector('x-native-child');
+            innerElm.dispatchEvent(event);
+
+            // bubbling event in shadow tree
+            expect(targetAtContainer).toBe(innerElm);
+
+            // composed event should bubble up to document
+            expect(targetAtParent).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside nested custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const nestedElm = child.shadowRoot.querySelector('h2');
+            nestedElm.dispatchEvent(event);
+
+            // composed event should bubble up to document
+            expect(targetAtContainer).toBe(child);
+            expect(targetAtParent).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+    });
+});

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -132,3 +132,135 @@ describe('Event target retains native behavior in native shadow dom tree', () =>
         });
     });
 });
+
+describe('Event target retains native behavior in mixed shadow dom tree(synthetic-shadow outside & native inside)', () => {
+    let parent;
+    let child;
+    let eventTargetAtBody;
+    let container;
+    const listener = evt => {
+        eventTargetAtBody = evt.target;
+    };
+    beforeEach(() => {
+        parent = NativeShadowParent();
+        document.body.appendChild(parent);
+        child = NativeShadowChild();
+        container = parent.shadowRoot.querySelector('div');
+        container.appendChild(child);
+        document.body.addEventListener('test', listener);
+    });
+    afterEach(() => {
+        document.body.removeEventListener('test', listener);
+        eventTargetAtBody = undefined;
+    });
+
+    describe('composed:false', () => {
+        it('event dispatched at root custom element', () => {
+            let targetAtSource;
+            parent.addEventListener('test', evt => {
+                targetAtSource = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            parent.dispatchEvent(event);
+            expect(targetAtSource).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside root custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            const innerElm = parent.shadowRoot.querySelector('x-native-child');
+            innerElm.dispatchEvent(event);
+
+            // bubbling event in shadow tree
+            expect(targetAtContainer).toBe(innerElm);
+
+            // Non-composed event should stop at shadow boundary
+            expect(targetAtParent).toBeUndefined();
+            expect(eventTargetAtBody).toBeUndefined();
+        });
+
+        it('event dispatched inside nested custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true });
+            const nestedElm = child.shadowRoot.querySelector('h2');
+            nestedElm.dispatchEvent(event);
+
+            // Non-composed event should stop at shadow boundary
+            expect(targetAtContainer).toBeUndefined();
+            expect(targetAtParent).toBeUndefined();
+            expect(eventTargetAtBody).toBeUndefined();
+        });
+    });
+
+    describe('composed:true', () => {
+        it('event dispatched at root custom element', () => {
+            let targetAtSource;
+            parent.addEventListener('test', evt => {
+                targetAtSource = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            parent.dispatchEvent(event);
+            expect(targetAtSource).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside root custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const innerElm = parent.shadowRoot.querySelector('x-native-child');
+            innerElm.dispatchEvent(event);
+
+            // bubbling event in shadow tree
+            expect(targetAtContainer).toBe(innerElm);
+
+            // composed event should bubble up to document
+            expect(targetAtParent).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+
+        it('event dispatched inside nested custom element', () => {
+            let targetAtParent;
+            parent.addEventListener('test', evt => {
+                targetAtParent = evt.target;
+            });
+
+            let targetAtContainer;
+            container.addEventListener('test', evt => {
+                targetAtContainer = evt.target;
+            });
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const nestedElm = child.shadowRoot.querySelector('h2');
+            nestedElm.dispatchEvent(event);
+
+            // composed event should bubble up to document
+            expect(targetAtContainer).toBe(child);
+            expect(targetAtParent).toBe(parent);
+            expect(eventTargetAtBody).toBe(parent);
+        });
+    });
+});

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -18,7 +18,7 @@ describe('Event target retains native behavior in native shadow dom tree', () =>
         document.body.addEventListener('test', listener);
     });
     afterEach(() => {
-        document.body.removeEventListener(listener);
+        document.body.removeEventListener('test', listener);
         eventTargetAtBody = undefined;
     });
 

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
@@ -1,0 +1,8 @@
+export default function() {
+    const child = document.createElement('x-native-child');
+    const sr = child.attachShadow({ mode: 'open' });
+    const h2 = document.createElement('h2');
+    h2.innerHTML = 'Child running in native shadow(open) mode';
+    sr.appendChild(h2);
+    return child;
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
@@ -1,0 +1,10 @@
+export default function() {
+    const parent = document.createElement('x-native-parent');
+    const sr = parent.attachShadow({ mode: 'open' });
+    const h1 = document.createElement('h1');
+    h1.innerHTML = 'Parent running in native shadow(open) mode';
+    sr.appendChild(h1);
+    const container = document.createElement('div');
+    sr.appendChild(container);
+    return parent;
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.html
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class MyComponent extends LightningElement {}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -1,0 +1,51 @@
+import { createElement } from 'lwc';
+import LWCParent from 'x/lwcParent';
+import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
+
+function testAssignedElements(testDescription, container) {
+    describe(testDescription, () => {
+        let nativeSlottedBasic;
+        beforeEach(done => {
+            nativeSlottedBasic = NativeSlottedBasic();
+            container.appendChild(nativeSlottedBasic);
+            // Allow for portal elements to be adopted
+            return Promise.resolve().then(() => {
+                done();
+            });
+        });
+        it('assignedElements of default slot content', () => {
+            const defaultSlot = nativeSlottedBasic.shadowRoot.querySelector('slot');
+            const assignedElements = defaultSlot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('default');
+        });
+
+        it('assignedElements of named slot', () => {
+            const namedSlot = nativeSlottedBasic.shadowRoot.querySelector("slot[name='slot1']");
+            const assignedElements = namedSlot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('slot1');
+        });
+    });
+}
+
+// Chrome is the only browser implementing HTMLSlotElement.assignedElement natively.
+// Webkit - https://bugs.webkit.org/show_bug.cgi?id=180908
+// Gecko - https://bugzilla.mozilla.org/show_bug.cgi?id=1425685
+const SUPPORT_ASSIGNED_ELEMENTS =
+    !process.env.NATIVE_SHADOW || 'assignedElements' in document.createElement('slot');
+
+// Should not be expecting native shadow behavior to work in compat mode
+if (SUPPORT_ASSIGNED_ELEMENTS && process.env.COMPAT !== true) {
+    testAssignedElements(
+        'assignedElements() retains native behavior in native shadow dom tree',
+        document.body
+    );
+    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+    document.body.appendChild(lwcParent);
+    const domManual = lwcParent.shadowRoot.querySelector('div');
+    testAssignedElements(
+        'assignedElements() retains behavior in native shadow tree nested in lwc parent',
+        domManual
+    );
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
@@ -1,0 +1,45 @@
+import { createElement } from 'lwc';
+import LWCParent from 'x/lwcParent';
+import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
+
+function testAssignedNodes(testDescription, container) {
+    describe(testDescription, () => {
+        let nativeSlottedBasic;
+        beforeEach(done => {
+            nativeSlottedBasic = NativeSlottedBasic();
+            container.appendChild(nativeSlottedBasic);
+            // Allow for portal elements to be adopted
+            return Promise.resolve().then(() => {
+                done();
+            });
+        });
+        it('assignedNodes of default slot content', () => {
+            const defaultSlot = nativeSlottedBasic.shadowRoot.querySelector('slot');
+            const assignedNodes = defaultSlot.assignedNodes();
+            expect(assignedNodes.length).toBe(2);
+            expect(assignedNodes[0].getAttribute('data-slot-id')).toBe('default');
+        });
+
+        it('assignedNodes of named slot', () => {
+            const namedSlot = nativeSlottedBasic.shadowRoot.querySelector("slot[name='slot1']");
+            const assignedNodes = namedSlot.assignedNodes();
+            expect(assignedNodes.length).toBe(1);
+            expect(assignedNodes[0].getAttribute('data-slot-id')).toBe('slot1');
+        });
+    });
+}
+
+// Should not be expecting native shadow behavior to work in compat mode
+if (process.env.COMPAT !== true) {
+    testAssignedNodes(
+        'assignedNodes() retains native behavior in native shadow dom tree',
+        document.body
+    );
+    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+    document.body.appendChild(lwcParent);
+    const domManual = lwcParent.shadowRoot.querySelector('div');
+    testAssignedNodes(
+        'assignedNodes() retains behavior in native shadow tree nested in lwc parent',
+        domManual
+    );
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
@@ -1,0 +1,8 @@
+export default function() {
+    const xSlotted = document.createElement('x-slotted');
+    xSlotted.innerHTML =
+        "<div slot='slot1' data-slot-id='slot1'>Named slot content</div><div data-slot-id='default'><p>Default slot content</p></div>Text Node";
+    const shadowRoot = xSlotted.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = "<slot>Default content</slot><slot name='slot1'></slot>";
+    return xSlotted;
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.html
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}


### PR DESCRIPTION
## Details
Following APIs will be updated as described:
* Element.prototype.attachShadow patch will preserve native behavior by default. When invoked with a specific flag it will return a SyntheticShadowRoot
* Element.prototype.shadowRoot will return the SyntheticShadowRoot if the element is a lwc host, return a native ShadowRoot if the element is a native custom element and null in other cases.
* Event.prototype.target will retain its native behavior if the original target is a from a native shadow tree

Work to be done:
* When an event is fired in a DOM tree which has mixed shadow mode(native/synthetic-shadow), should Event.prototype.composePath() show account for both native and synthetic shadow or should it be biased towards the current target?
* HTMLSlotElement.prototype.assignedNodes should be aware of native slot elements.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS item
W-7102521