### PR TITLE
feat(features): computed feature flags are not supported

### DIFF
--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -239,5 +239,21 @@ pluginTester({
                 }
             `,
         },
+        'should not transform member expressions that are computed': {
+            code: `
+                import featureFlags from '@lwc/features';
+
+                if (featureFlags['ENABLE_FEATURE_TRUE']) {
+                    console.log("featureFlags['ENABLE_FEATURE_TRUE']");
+                }
+            `,
+            output: `
+                import featureFlags, { runtimeFlags } from '@lwc/features';
+
+                if (featureFlags['ENABLE_FEATURE_TRUE']) {
+                    console.log("featureFlags['ENABLE_FEATURE_TRUE']");
+                }
+            `,
+        },
     },
 });

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -69,7 +69,7 @@ module.exports = function({ types: t }) {
                     testPath = testPath.get('argument');
                 }
 
-                if (!testPath.isMemberExpression()) {
+                if (!testPath.isMemberExpression({ computed: false })) {
                     return;
                 }
 


### PR DESCRIPTION
## Details

This transform is actually applied on [runtime.ts](https://github.com/salesforce/lwc/blob/master/packages/@lwc/features/src/runtime.ts) because it gets bundled with `engine` and `synthetic-shadow` and it was throwing due to an if-test against `runtimeFlags[name]` which was part of the process of setting flags during runtime.

This validation prevents evaluation of computed expressions.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item

W-7094575