### PR TITLE
refactor(features): feature flag support for synthetic-shadow

### DIFF
--- a/packages/@lwc/features/src/global-this.ts
+++ b/packages/@lwc/features/src/global-this.ts
@@ -4,21 +4,44 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+
+// Cached reference to globalThis
+let _globalThis: any;
+
+if (typeof globalThis === 'object') {
+    _globalThis = globalThis;
+}
+
 export function getGlobalThis() {
-    if (typeof globalThis !== 'undefined') {
-        return globalThis;
+    if (typeof _globalThis === 'object') {
+        return _globalThis;
     }
-    // eslint-disable-next-line no-extend-native
-    Object.defineProperty(Object.prototype, '__magic__', {
-        get: function() {
-            return this;
-        },
-        configurable: true,
-    });
-    // @ts-ignore
-    // eslint-disable-next-line no-undef
-    const g = __magic__;
-    // @ts-ignore
-    delete Object.prototype.__magic__;
-    return g;
+
+    try {
+        // eslint-disable-next-line no-extend-native
+        Object.defineProperty(Object.prototype, '__magic__', {
+            get: function() {
+                return this;
+            },
+            configurable: true,
+        });
+
+        // @ts-ignore
+        // __magic__ is undefined in Safari 10 and IE10 and older.
+        // eslint-disable-next-line no-undef
+        _globalThis = __magic__;
+
+        // @ts-ignore
+        delete Object.prototype.__magic__;
+    } catch (ex) {
+        // In IE8, Object.defineProperty only works on DOM objects.
+    } finally {
+        // If the magic above fails for some reason we assume that we are in a
+        // legacy browser. Assume `window` exists in this case.
+        if (typeof _globalThis === 'undefined') {
+            _globalThis = window;
+        }
+    }
+
+    return _globalThis;
 }

--- a/packages/@lwc/features/src/global-this.ts
+++ b/packages/@lwc/features/src/global-this.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export function getGlobalThis() {
+    if (typeof globalThis !== 'undefined') {
+        return globalThis;
+    }
+    // eslint-disable-next-line no-extend-native
+    Object.defineProperty(Object.prototype, '__magic__', {
+        get: function() {
+            return this;
+        },
+        configurable: true,
+    });
+    // @ts-ignore
+    // eslint-disable-next-line no-undef
+    const g = __magic__;
+    // @ts-ignore
+    delete Object.prototype.__magic__;
+    return g;
+}

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -21,12 +21,12 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
     const isBoolean = isTrue(value) || isFalse(value);
     if (!isBoolean) {
         const message = `Failed to set the value "${value}" for the runtime feature flag "${name}". Runtime feature flags can only be set to a boolean value.`;
-        if (process.env.NODE_ENV === 'production') {
+        if (process.env.NODE_ENV !== 'production') {
+            throw new TypeError(message);
+        } else {
             // eslint-disable-next-line no-console
             console.error(message);
             return;
-        } else {
-            throw new TypeError(message);
         }
     }
     if (isUndefined(features[name])) {
@@ -36,7 +36,10 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
         );
         return;
     }
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'production') {
+        // Allow the same flag to be set more than once outside of production to enable testing
+        runtimeFlags[name] = value;
+    } else {
         // Disallow the same flag to be set more than once in production
         const runtimeValue = runtimeFlags[name];
         if (!isUndefined(runtimeValue)) {
@@ -47,9 +50,6 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
             return;
         }
         Object.defineProperty(runtimeFlags, name, { value });
-    } else {
-        // Allow the same flag to be set more than once outside of production to enable testing
-        runtimeFlags[name] = value;
     }
 }
 

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -6,29 +6,50 @@
  */
 import features, { FeatureFlagLookup, FeatureFlagValue } from './flags';
 import { create, isFalse, isTrue, isUndefined } from '@lwc/shared';
+import { getGlobalThis } from './global-this';
 
-const runtimeFlags: FeatureFlagLookup = create(null);
+const _globalThis: any = getGlobalThis();
+if (!_globalThis.lwcRuntimeFlags) {
+    Object.defineProperty(_globalThis, 'lwcRuntimeFlags', { value: create(null) });
+}
+
+const runtimeFlags: FeatureFlagLookup = _globalThis.lwcRuntimeFlags;
 
 // This function is not supported for use within components and is meant for
 // configuring runtime feature flags during app initialization.
 function setFeatureFlag(name: string, value: FeatureFlagValue) {
     const isBoolean = isTrue(value) || isFalse(value);
     if (!isBoolean) {
-        const message = `Invalid ${typeof value} value specified for the "${name}" flag. Runtime feature flags can only be set to a boolean value.`;
+        const message = `Failed to set the value "${value}" for the runtime feature flag "${name}". Runtime feature flags can only be set to a boolean value.`;
         if (process.env.NODE_ENV === 'production') {
             // eslint-disable-next-line no-console
             console.error(message);
+            return;
         } else {
             throw new TypeError(message);
         }
     }
-    if (!isUndefined(features[name])) {
-        runtimeFlags[name] = value;
-    } else {
+    if (isUndefined(features[name])) {
         // eslint-disable-next-line no-console
         console.warn(
-            `LWC feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
+            `Failed to set the value "${value}" for the runtime feature flag "${name}" because it is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
         );
+        return;
+    }
+    if (process.env.NODE_ENV === 'production') {
+        // Disallow the same flag to be set more than once in production
+        const runtimeValue = runtimeFlags[name];
+        if (!isUndefined(runtimeValue)) {
+            // eslint-disable-next-line no-console
+            console.error(
+                `Failed to set the value "${value}" for the runtime feature flag "${name}". "${name}" has already been set with the value "${runtimeValue}".`
+            );
+            return;
+        }
+        Object.defineProperty(runtimeFlags, name, { value });
+    } else {
+        // Allow the same flag to be set more than once outside of production to enable testing
+        runtimeFlags[name] = value;
     }
 }
 
@@ -36,11 +57,6 @@ function setFeatureFlag(name: string, value: FeatureFlagValue) {
 // check to make sure it is not invoked in production.
 function setFeatureFlagForTest(name: string, value: FeatureFlagValue) {
     if (process.env.NODE_ENV !== 'production') {
-        if (isUndefined(features[name])) {
-            throw new Error(
-                `Feature flag "${name}" is undefined. Possible reasons are that 1) it was misspelled or 2) it was removed from the @lwc/features package.`
-            );
-        }
         return setFeatureFlag(name, value);
     }
 }


### PR DESCRIPTION
## Summary

Packages like `@lwc/synthetic-shadow` produce build targets that don't export any bindings so it is impossible to set feature flag values for them today. This PR proposes a way for apps to set those flags through other packages that do export `setFeatureFlag`.

### Unresolved issues

- No first class multi-engine support. This approach would require engine-specific flags to uniquely configure multiple engines existing in the same runtime.
- Susceptible to poisoning if `globalThis.lwcRuntimeFlags` is defined before `@lwc/features` has a chance to do so.
- Food for thought from @caridy: Do we need to protect the storage? Is that something that should be taken care of by Locker?

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7094575
