### PR TITLE
feat(synthetic-shadow): preserve native behavior of attachShadow (#1693)

### DIFF
--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -273,9 +273,10 @@ function BaseLightningElementConstructor(this: LightningElement) {
         vm.getHook = getHook;
     }
     // attaching the shadowRoot
-    const shadowRootOptions: ShadowRootInit = {
+    const shadowRootOptions = {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,
+        '$$lwc-synthetic-mode$$': true,
     };
     const cmpRoot = elm.attachShadow(shadowRootOptions);
     // linking elm, shadow root and component with the VM

--- a/packages/@lwc/synthetic-shadow/src/env/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/element.ts
@@ -7,18 +7,28 @@
 import { hasOwnProperty, getOwnPropertyDescriptor } from '@lwc/shared';
 
 const {
-    hasAttribute,
+    addEventListener,
     getAttribute,
-    setAttribute,
-    removeAttribute,
-    querySelectorAll,
     getBoundingClientRect,
     getElementsByTagName,
     getElementsByTagNameNS,
+    hasAttribute,
+    querySelectorAll,
+    removeAttribute,
+    removeEventListener,
+    setAttribute,
 } = Element.prototype;
 
-const { addEventListener, removeEventListener } = Element.prototype;
-
+const attachShadow: (init: ShadowRootInit) => ShadowRoot = hasOwnProperty.call(
+    Element.prototype,
+    'attachShadow'
+)
+    ? Element.prototype.attachShadow
+    : () => {
+          throw new TypeError(
+              'attachShadow() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill and use Lightning Web Components'
+          );
+      };
 const childElementCountGetter: (this: ParentNode) => number = getOwnPropertyDescriptor(
     Element.prototype,
     'childElementCount'
@@ -75,28 +85,37 @@ const childrenGetter: (this: ParentNode) => HTMLCollectionOf<Element> = hasOwnPr
 // for all other browsers access the method from the parent Element interface
 const { getElementsByClassName } = HTMLElement.prototype;
 
+const shadowRootGetter: (this: Element) => ShadowRoot | null = hasOwnProperty.call(
+    Element.prototype,
+    'shadowRoot'
+)
+    ? getOwnPropertyDescriptor(Element.prototype, 'shadowRoot')!.get!
+    : () => null;
+
 export {
     addEventListener,
-    removeEventListener,
-    hasAttribute,
-    getAttribute,
-    setAttribute,
-    removeAttribute,
-    querySelectorAll,
-    getBoundingClientRect,
-    getElementsByTagName,
-    getElementsByClassName,
-    getElementsByTagNameNS,
-    tagNameGetter,
-    tabIndexGetter,
-    tabIndexSetter,
-    innerHTMLGetter,
-    innerHTMLSetter,
-    outerHTMLGetter,
-    outerHTMLSetter,
-    matches,
+    attachShadow,
     childrenGetter,
     childElementCountGetter,
     firstElementChildGetter,
+    getAttribute,
+    getBoundingClientRect,
+    getElementsByClassName,
+    getElementsByTagName,
+    getElementsByTagNameNS,
+    hasAttribute,
+    innerHTMLGetter,
+    innerHTMLSetter,
     lastElementChildGetter,
+    matches,
+    outerHTMLGetter,
+    outerHTMLSetter,
+    querySelectorAll,
+    removeAttribute,
+    removeEventListener,
+    setAttribute,
+    shadowRootGetter,
+    tagNameGetter,
+    tabIndexGetter,
+    tabIndexSetter,
 };

--- a/packages/@lwc/synthetic-shadow/src/env/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/slot.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+let assignedNodes: (options?: AssignedNodesOptions) => Node[],
+    assignedElements: (options?: AssignedNodesOptions) => Element[];
+if (typeof HTMLSlotElement !== 'undefined') {
+    assignedNodes = HTMLSlotElement.prototype.assignedNodes;
+    assignedElements = HTMLSlotElement.prototype.assignedElements;
+} else {
+    assignedNodes = () => {
+        throw new TypeError(
+            "assignedNodes() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template"
+        );
+    };
+    assignedElements = () => {
+        throw new TypeError(
+            "assignedElements() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template"
+        );
+    };
+}
+export { assignedNodes, assignedElements };

--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -8,6 +8,7 @@
 // Collecting env references before patching anything
 import './env/node';
 import './env/element';
+import './env/slot';
 import './env/dom';
 import './env/document';
 import './env/window';

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -1,0 +1,284 @@
+import { createElement } from 'lwc';
+import LWCParent from 'x/lwcParent';
+import NativeShadowParent from './x/NativeParent/NativeParent';
+import NativeShadowChild from './x/NativeChild/NativeChild';
+
+// Should not be expecting native shadow behavior to work in compat mode
+if (process.env.COMPAT !== true) {
+    describe('Event target retains native behavior in native shadow dom tree', () => {
+        let parent;
+        let child;
+        let eventTargetAtBody;
+        let container;
+        const listener = evt => {
+            eventTargetAtBody = evt.target;
+        };
+        beforeEach(() => {
+            parent = NativeShadowParent();
+            document.body.appendChild(parent);
+            child = NativeShadowChild();
+            container = parent.shadowRoot.querySelector('div');
+            container.appendChild(child);
+            document.body.addEventListener('test', listener);
+        });
+        afterEach(() => {
+            document.body.removeEventListener('test', listener);
+            eventTargetAtBody = undefined;
+        });
+
+        describe('composed:false', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
+
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
+
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtContainer).toBeUndefined();
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
+        });
+
+        describe('composed:true', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
+
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // composed event should bubble up to document
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
+
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // composed event should bubble up to document
+                expect(targetAtContainer).toBe(child);
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(parent);
+            });
+        });
+    });
+
+    describe('Event target retains native behavior in mixed shadow dom tree(synthetic-shadow outside & native inside)', () => {
+        let parent;
+        let child;
+        let eventTargetAtBody;
+        let container;
+        let lwcParent;
+        const listener = evt => {
+            eventTargetAtBody = evt.target;
+        };
+        beforeEach(done => {
+            parent = NativeShadowParent();
+            child = NativeShadowChild();
+            container = parent.shadowRoot.querySelector('div');
+            container.appendChild(child);
+            document.body.addEventListener('test', listener);
+
+            // LWC tree
+            lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+            document.body.appendChild(lwcParent);
+            const domManual = lwcParent.shadowRoot.querySelector('div');
+            domManual.appendChild(parent);
+            // Allow for portal elements to be adopted
+            return Promise.resolve().then(() => {
+                done();
+            });
+        });
+        afterEach(() => {
+            document.body.removeEventListener('test', listener);
+            eventTargetAtBody = undefined;
+        });
+
+        describe('composed:false', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+
+                // Non-composed event should stop at shadow boundary
+                // TODO [#1700]: Listener should not be invoked
+                expect(eventTargetAtBody).toBeFalsy();
+            });
+
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
+
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // Non-composed event should stop at shadow boundary
+                expect(targetAtContainer).toBeUndefined();
+                expect(targetAtParent).toBeUndefined();
+                expect(eventTargetAtBody).toBeUndefined();
+            });
+        });
+
+        describe('composed:true', () => {
+            it('event dispatched at root custom element', () => {
+                let targetAtSource;
+                parent.addEventListener('test', evt => {
+                    targetAtSource = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                parent.dispatchEvent(event);
+                expect(targetAtSource).toBe(parent);
+                expect(eventTargetAtBody).toBe(lwcParent);
+            });
+
+            it('event dispatched inside root custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const innerElm = parent.shadowRoot.querySelector('x-native-child');
+                innerElm.dispatchEvent(event);
+
+                // bubbling event in shadow tree
+                expect(targetAtContainer).toBe(innerElm);
+
+                // composed event should bubble up to document
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(lwcParent);
+            });
+
+            it('event dispatched inside nested custom element', () => {
+                let targetAtParent;
+                parent.addEventListener('test', evt => {
+                    targetAtParent = evt.target;
+                });
+
+                let targetAtContainer;
+                container.addEventListener('test', evt => {
+                    targetAtContainer = evt.target;
+                });
+                const event = new CustomEvent('test', { bubbles: true, composed: true });
+                const nestedElm = child.shadowRoot.querySelector('h2');
+                nestedElm.dispatchEvent(event);
+
+                // composed event should bubble up to document
+                expect(targetAtContainer).toBe(child);
+                expect(targetAtParent).toBe(parent);
+                expect(eventTargetAtBody).toBe(lwcParent);
+            });
+        });
+    });
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
@@ -1,0 +1,8 @@
+export default function() {
+    const child = document.createElement('x-native-child');
+    const sr = child.attachShadow({ mode: 'open' });
+    const h2 = document.createElement('h2');
+    h2.innerHTML = 'Child running in native shadow(open) mode';
+    sr.appendChild(h2);
+    return child;
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
@@ -1,0 +1,10 @@
+export default function() {
+    const parent = document.createElement('x-native-parent');
+    const sr = parent.attachShadow({ mode: 'open' });
+    const h1 = document.createElement('h1');
+    h1.innerHTML = 'Parent running in native shadow(open) mode';
+    sr.appendChild(h1);
+    const container = document.createElement('div');
+    sr.appendChild(container);
+    return parent;
+}

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.html
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/lwcParent/lwcParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class MyComponent extends LightningElement {}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -1,0 +1,51 @@
+import { createElement } from 'lwc';
+import LWCParent from 'x/lwcParent';
+import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
+
+function testAssignedElements(testDescription, container) {
+    describe(testDescription, () => {
+        let nativeSlottedBasic;
+        beforeEach(done => {
+            nativeSlottedBasic = NativeSlottedBasic();
+            container.appendChild(nativeSlottedBasic);
+            // Allow for portal elements to be adopted
+            return Promise.resolve().then(() => {
+                done();
+            });
+        });
+        it('assignedElements of default slot content', () => {
+            const defaultSlot = nativeSlottedBasic.shadowRoot.querySelector('slot');
+            const assignedElements = defaultSlot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('default');
+        });
+
+        it('assignedElements of named slot', () => {
+            const namedSlot = nativeSlottedBasic.shadowRoot.querySelector("slot[name='slot1']");
+            const assignedElements = namedSlot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('slot1');
+        });
+    });
+}
+
+// Chrome is the only browser implementing HTMLSlotElement.assignedElement natively.
+// Webkit - https://bugs.webkit.org/show_bug.cgi?id=180908
+// Gecko - https://bugzilla.mozilla.org/show_bug.cgi?id=1425685
+const SUPPORT_ASSIGNED_ELEMENTS =
+    !process.env.NATIVE_SHADOW || 'assignedElements' in document.createElement('slot');
+
+// Should not be expecting native shadow behavior to work in compat mode
+if (SUPPORT_ASSIGNED_ELEMENTS && process.env.COMPAT !== true) {
+    testAssignedElements(
+        'assignedElements() retains native behavior in native shadow dom tree',
+        document.body
+    );
+    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+    document.body.appendChild(lwcParent);
+    const domManual = lwcParent.shadowRoot.querySelector('div');
+    testAssignedElements(
+        'assignedElements() retains behavior in native shadow tree nested in lwc parent',
+        domManual
+    );
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
@@ -1,0 +1,45 @@
+import { createElement } from 'lwc';
+import LWCParent from 'x/lwcParent';
+import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
+
+function testAssignedNodes(testDescription, container) {
+    describe(testDescription, () => {
+        let nativeSlottedBasic;
+        beforeEach(done => {
+            nativeSlottedBasic = NativeSlottedBasic();
+            container.appendChild(nativeSlottedBasic);
+            // Allow for portal elements to be adopted
+            return Promise.resolve().then(() => {
+                done();
+            });
+        });
+        it('assignedNodes of default slot content', () => {
+            const defaultSlot = nativeSlottedBasic.shadowRoot.querySelector('slot');
+            const assignedNodes = defaultSlot.assignedNodes();
+            expect(assignedNodes.length).toBe(2);
+            expect(assignedNodes[0].getAttribute('data-slot-id')).toBe('default');
+        });
+
+        it('assignedNodes of named slot', () => {
+            const namedSlot = nativeSlottedBasic.shadowRoot.querySelector("slot[name='slot1']");
+            const assignedNodes = namedSlot.assignedNodes();
+            expect(assignedNodes.length).toBe(1);
+            expect(assignedNodes[0].getAttribute('data-slot-id')).toBe('slot1');
+        });
+    });
+}
+
+// Should not be expecting native shadow behavior to work in compat mode
+if (process.env.COMPAT !== true) {
+    testAssignedNodes(
+        'assignedNodes() retains native behavior in native shadow dom tree',
+        document.body
+    );
+    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+    document.body.appendChild(lwcParent);
+    const domManual = lwcParent.shadowRoot.querySelector('div');
+    testAssignedNodes(
+        'assignedNodes() retains behavior in native shadow tree nested in lwc parent',
+        domManual
+    );
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
@@ -1,0 +1,8 @@
+export default function() {
+    const xSlotted = document.createElement('x-slotted');
+    xSlotted.innerHTML =
+        "<div slot='slot1' data-slot-id='slot1'>Named slot content</div><div data-slot-id='default'><p>Default slot content</p></div>Text Node";
+    const shadowRoot = xSlotted.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = "<slot>Default content</slot><slot name='slot1'></slot>";
+    return xSlotted;
+}

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.html
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/lwcParent/lwcParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}


### PR DESCRIPTION
## Details
_Porting https://github.com/salesforce/lwc/pull/1693 to master_
Following APIs will be updated as described:
* Element.prototype.attachShadow patch will preserve native behavior by default. When invoked with a specific flag it will return a SyntheticShadowRoot
* Element.prototype.shadowRoot will return the SyntheticShadowRoot if the element is a lwc host, return a native ShadowRoot if the element is a native custom element and null in other cases.
* Event.prototype.target will retain its native behavior if the original target is a from a native shadow tree
* HTMLSlotElement.prototype.assignedNodes & assignedElements will check if the current context is a synthetic shadowed node, if the test is negative, native behavior will be preserved

Work to be done:
* When an event is fired in a DOM tree which has mixed shadow mode(native/synthetic-shadow), should Event.prototype.composePath() show account for both native and synthetic shadow or should it be biased towards the current target?


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS item
W-7172128