### PR TITLE
fix(engine): infinite loop in getErrorBoundaryVM

### DIFF
--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -520,7 +520,7 @@ function getErrorBoundaryVM(vm: VM): VM | undefined {
             return currentVm;
         }
 
-        currentVm = vm.owner;
+        currentVm = currentVm.owner;
     }
 }
 

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -93,6 +93,19 @@ describe('error boundary', () => {
         });
     });
 
+    it('should render alternative view if nested child throws in render()', () => {
+        elm.toggleFlag('boundary-child-throw');
+        return waitForNestedRehydration().then(() => {
+            const innerShadowRoot = shadowRoot.querySelector('x-nested-boundary-child-throw')
+                .shadowRoot;
+            const altenativeView = innerShadowRoot.querySelector('.boundary-alt-view');
+            expect(altenativeView.textContent).toEqual('alternative view');
+
+            // ensure offender has been unmounted
+            expect(innerShadowRoot.querySelector('x-nested-grand-child-throw')).toBe(null);
+        });
+    });
+
     it('should render alternative view if child throws during self rehydration cycle', () => {
         elm.toggleFlag('boundary-child-self-rehydrate-throw');
         return Promise.resolve().then(() => {

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -28,7 +28,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child throws in renderedCallback()', () => {
-        elm.toggleFlag('boundary-child-rendered-throw');
+        elm.toggleFlag('boundaryChildRenderedThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-child-rendered-throw')
                 .shadowRoot;
@@ -41,7 +41,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child throws in render()', () => {
-        elm.toggleFlag('boundary-child-render-throw');
+        elm.toggleFlag('boundaryChildRenderThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-child-render-throw')
                 .shadowRoot;
@@ -54,7 +54,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child throws in constructor()', () => {
-        elm.toggleFlag('boundary-child-constructor-throw');
+        elm.toggleFlag('boundaryChildConstructorThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-child-constructor-throw')
                 .shadowRoot;
@@ -68,7 +68,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child throws in connectedCallback()', () => {
-        elm.toggleFlag('boundary-child-connected-throw');
+        elm.toggleFlag('boundaryChildConnectedThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-child-connected-throw')
                 .shadowRoot;
@@ -81,7 +81,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child slot throws in render()', () => {
-        elm.toggleFlag('boundary-child-slot-throw');
+        elm.toggleFlag('boundaryChildSlotThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-child-slot-throw')
                 .shadowRoot;
@@ -94,7 +94,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if nested child throws in render()', () => {
-        elm.toggleFlag('boundary-child-throw');
+        elm.toggleFlag('boundaryChildThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-nested-boundary-child-throw')
                 .shadowRoot;
@@ -107,7 +107,7 @@ describe('error boundary', () => {
     });
 
     it('should render alternative view if child throws during self rehydration cycle', () => {
-        elm.toggleFlag('boundary-child-self-rehydrate-throw');
+        elm.toggleFlag('boundaryChildSelfRehydrateThrow');
         return Promise.resolve().then(() => {
             const innerShadowRoot = shadowRoot.querySelector(
                 'x-boundary-child-self-rehydrate-throw'
@@ -126,7 +126,7 @@ describe('error boundary', () => {
 
     // #1169 parent's errorCallback never invoked
     xit('should render parent boundary`s alternative view when child boundary fails to render its alternative view', () => {
-        elm.toggleFlag('nested-boundary-child-alt-view-throw');
+        elm.toggleFlag('nestedBoundaryChildAltViewThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector(
                 'x-nested-boundary-child-alt-view-throw'
@@ -140,7 +140,7 @@ describe('error boundary', () => {
     });
 
     it('should fail to unmount alternatvie offender when root element is not a boundary', () => {
-        elm.toggleFlag('boundary-alternative-view-throw');
+        elm.toggleFlag('boundaryAlternativeViewThrow');
         return waitForNestedRehydration().then(() => {
             const innerShadowRoot = shadowRoot.querySelector('x-boundary-alternative-view-throw')
                 .shadowRoot;

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.html
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.html
@@ -15,6 +15,9 @@
     <x-boundary-child-slot-throw if:true={getBoundaryChildSlotThrow}></x-boundary-child-slot-throw>
 
     <br>
+    <x-nested-boundary-child-throw if:true={getBoundaryChildThrow}></x-nested-boundary-child-throw>
+
+    <br>
     <x-boundary-child-self-rehydrate-throw if:true={getBoundaryChildSelfRehydrateThrow}></x-boundary-child-self-rehydrate-throw>
 
     <br>

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.html
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.html
@@ -1,28 +1,28 @@
 
 <template>
-    <x-boundary-child-constructor-throw if:true={getBoundaryChildConstructorThrow}></x-boundary-child-constructor-throw>
+    <x-boundary-child-constructor-throw if:true={state.boundaryChildConstructorThrow}></x-boundary-child-constructor-throw>
 
     <br>
-    <x-boundary-child-render-throw if:true={getBoundaryChildRenderThrow}></x-boundary-child-render-throw>
+    <x-boundary-child-render-throw if:true={state.boundaryChildRenderThrow}></x-boundary-child-render-throw>
 
     <br>
-    <x-boundary-child-rendered-throw if:true={getBoundaryChildRenderedThrow}></x-boundary-child-rendered-throw>
+    <x-boundary-child-rendered-throw if:true={state.boundaryChildRenderedThrow}></x-boundary-child-rendered-throw>
 
     <br>
-    <x-boundary-child-connected-throw if:true={getBoundaryChildConnectedThrow}></x-boundary-child-connected-throw>
+    <x-boundary-child-connected-throw if:true={state.boundaryChildConnectedThrow}></x-boundary-child-connected-throw>
 
     <br>
-    <x-boundary-child-slot-throw if:true={getBoundaryChildSlotThrow}></x-boundary-child-slot-throw>
+    <x-boundary-child-slot-throw if:true={state.boundaryChildSlotThrow}></x-boundary-child-slot-throw>
 
     <br>
-    <x-nested-boundary-child-throw if:true={getBoundaryChildThrow}></x-nested-boundary-child-throw>
+    <x-nested-boundary-child-throw if:true={state.boundaryChildThrow}></x-nested-boundary-child-throw>
 
     <br>
-    <x-boundary-child-self-rehydrate-throw if:true={getBoundaryChildSelfRehydrateThrow}></x-boundary-child-self-rehydrate-throw>
+    <x-boundary-child-self-rehydrate-throw if:true={state.boundaryChildSelfRehydrateThrow}></x-boundary-child-self-rehydrate-throw>
 
     <br>
-    <x-nested-boundary-child-alt-view-throw if:true={getNestedBoundaryChildAltViewThrow}></x-nested-boundary-child-alt-view-throw>
+    <x-nested-boundary-child-alt-view-throw if:true={state.nestedBoundaryChildAltViewThrow}></x-nested-boundary-child-alt-view-throw>
 
     <br>
-    <x-boundary-alternative-view-throw if:true={getBoundaryAltViewThrow}></x-boundary-alternative-view-throw>
+    <x-boundary-alternative-view-throw if:true={state.boundaryAlternativeViewThrow}></x-boundary-alternative-view-throw>
 </template>

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
@@ -11,6 +11,7 @@ export default class RootParent extends LightningElement {
         boundaryChildThrow: false,
         boundaryChildSelfRehydrateThrow: false,
         boundaryAlternativeViewThrow: false,
+        nestedBoundaryChildAltViewThrow: false,
     };
 
     @api

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
@@ -8,6 +8,7 @@ export default class RootParent extends LightningElement {
         'boundary-child-connected-throw': false,
         'boundary-child-attr-changed-throw': false,
         'boundary-child-slot-throw': false,
+        'boundary-child-throw': false,
         'boundary-child-self-rehydrate-throw': false,
         'boundary-alternative-view-throw': false,
     };
@@ -39,6 +40,10 @@ export default class RootParent extends LightningElement {
 
     get getBoundaryChildSlotThrow() {
         return this.state['boundary-child-slot-throw'];
+    }
+
+    get getBoundaryChildThrow() {
+        return this.state['boundary-child-throw'];
     }
 
     get getBoundaryChildSelfRehydrateThrow() {

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/errorBoundary/errorBoundary.js
@@ -2,59 +2,19 @@ import { LightningElement, track, api } from 'lwc';
 
 export default class RootParent extends LightningElement {
     @track state = {
-        'boundary-child-constructor-throw': false,
-        'boundary-child-render-throw': false,
-        'boundary-child-rendered-throw': false,
-        'boundary-child-connected-throw': false,
-        'boundary-child-attr-changed-throw': false,
-        'boundary-child-slot-throw': false,
-        'boundary-child-throw': false,
-        'boundary-child-self-rehydrate-throw': false,
-        'boundary-alternative-view-throw': false,
+        boundaryChildConstructorThrow: false,
+        boundaryChildRenderThrow: false,
+        boundaryChildRenderedThrow: false,
+        boundaryChildConnectedThrow: false,
+        boundaryChildAttrChangedThrow: false,
+        boundaryChildSlotThrow: false,
+        boundaryChildThrow: false,
+        boundaryChildSelfRehydrateThrow: false,
+        boundaryAlternativeViewThrow: false,
     };
 
     @api
     toggleFlag(flag) {
         this.state[flag] = true;
-    }
-
-    get getBoundaryChildConstructorThrow() {
-        return this.state['boundary-child-constructor-throw'];
-    }
-
-    get getBoundaryChildRenderThrow() {
-        return this.state['boundary-child-render-throw'];
-    }
-
-    get getBoundaryChildRenderedThrow() {
-        return this.state['boundary-child-rendered-throw'];
-    }
-
-    get getBoundaryChildConnectedThrow() {
-        return this.state['boundary-child-connected-throw'];
-    }
-
-    get getBoundaryChildAttrChangedThrow() {
-        return this.state['boundary-child-attr-changed-throw'];
-    }
-
-    get getBoundaryChildSlotThrow() {
-        return this.state['boundary-child-slot-throw'];
-    }
-
-    get getBoundaryChildThrow() {
-        return this.state['boundary-child-throw'];
-    }
-
-    get getBoundaryChildSelfRehydrateThrow() {
-        return this.state['boundary-child-self-rehydrate-throw'];
-    }
-
-    get getBoundaryAltViewThrow() {
-        return this.state['boundary-alternative-view-throw'];
-    }
-
-    get getNestedBoundaryChildAltViewThrow() {
-        return this.state['nested-boundary-child-alt-view-throw'];
     }
 }

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedBoundaryChildThrow/nestedBoundaryChildThrow.html
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedBoundaryChildThrow/nestedBoundaryChildThrow.html
@@ -1,0 +1,9 @@
+<template>
+    NestedBoundaryHost: {state.title}
+    <template if:true={state.error}>
+        <div class='boundary-alt-view'>alternative view</div>
+    </template>
+    <template if:false={state.error}>
+        <x-nested-grand-child-throw></x-nested-grand-child-throw>
+    </template>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedBoundaryChildThrow/nestedBoundaryChildThrow.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedBoundaryChildThrow/nestedBoundaryChildThrow.js
@@ -1,0 +1,9 @@
+import { LightningElement, track } from 'lwc';
+
+export default class NestedBoundaryHost extends LightningElement {
+    @track state = { error: false };
+
+    errorCallback(error) {
+        this.state.error = error;
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedChildThrow/nestedChildThrow.html
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedChildThrow/nestedChildThrow.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child-render-throw></x-child-render-throw>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedChildThrow/nestedChildThrow.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedChildThrow/nestedChildThrow.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class NestedChildThrow extends LightningElement {}

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedGrandChildThrow/nestedGrandChildThrow.html
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedGrandChildThrow/nestedGrandChildThrow.html
@@ -1,0 +1,3 @@
+<template>
+    <x-nested-child-throw></x-nested-child-throw>
+</template>

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedGrandChildThrow/nestedGrandChildThrow.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/x/nestedGrandChildThrow/nestedGrandChildThrow.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class NestedGrandChildThrow extends LightningElement {}


### PR DESCRIPTION
## Details

This PR fixes the infinite loop that happens in `getErrorBoundaryVM` when a deeply nested component errors out.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅
