### PR TITLE
fix(synthetic): Node patches for contains and parentElement

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -514,16 +514,16 @@ export const getInternalChildNodes: (node: Node) => NodeListOf<ChildNode> =
 // IE11 extra patches for wrong prototypes
 if (hasOwnProperty.call(HTMLElement.prototype, 'contains')) {
     defineProperty(
-        HTMLElement.prototype,
+        Node.prototype,
         'contains',
-        getOwnPropertyDescriptor(Node.prototype, 'contains')!
+        getOwnPropertyDescriptor(HTMLElement.prototype, 'contains')!
     );
 }
 
 if (hasOwnProperty.call(HTMLElement.prototype, 'parentElement')) {
     defineProperty(
-        HTMLElement.prototype,
+        Node.prototype,
         'parentElement',
-        getOwnPropertyDescriptor(Node.prototype, 'parentElement')!
+        getOwnPropertyDescriptor(HTMLElement.prototype, 'parentElement')!
     );
 }


### PR DESCRIPTION
## Details

IE11 has `contains` and `parentElement` descriptors on HTMLElement

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7109631