### PR TITLE
fix(synthetic-shadow): pass arguments through to original focus() method

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -116,7 +116,9 @@ function blurPatched(this: HTMLElement) {
 function focusPatched(this: HTMLElement) {
     disableKeyboardFocusNavigationRoutines();
     // TODO [#1327]: Shadow DOM semantics for focus method
-    focus.call(this);
+    // Typescript does not like it when you treat the `arguments` object as an array
+    // @ts-ignore type-mismatch
+    focus.apply(this, arguments);
     enableKeyboardFocusNavigationRoutines();
 }
 
@@ -152,7 +154,9 @@ defineProperties(HTMLElement.prototype, {
     },
     focus: {
         value(this: HTMLElement) {
-            focusPatched.call(this);
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            focusPatched.apply(this, arguments);
         },
         enumerable: true,
         writable: true,


### PR DESCRIPTION
## Details

The focus method supports an options object so we need to pass arguments through.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631