### PR TITLE
chore: update release script to reflect correct footer in dist files

### DIFF
--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -40,12 +40,12 @@ CMD_PUBLISH_PACKAGES="lerna publish ${PACKAGE_VERSION} ${TAG} --yes --force-publ
 echo $CMD_UPDATE_VERSION;
 $CMD_UPDATE_VERSION;
 
+# Build to regenerate distribution files with new package version, commit the version changes
 echo "Building artifacts for v${PACKAGE_VERSION} and creating release commit"
 yarn build;
 git add CHANGELOG.md lerna.json packages/*;
 git commit -m "release: v${PACKAGE_VERSION}";
 
-# Publish the packages to npm. Note that lerna cleans the working tree after this as of 3.0.4, so we need to reapply version
-# https://github.com/lerna/lerna/blob/3cbeeabcb443d9415bb86c4539652b85cd7b4025/commands/publish/index.js#L354-L363
+# Publish the packages to npm.
 echo $CMD_PUBLISH_PACKAGES;
 $CMD_PUBLISH_PACKAGES;

--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -21,7 +21,7 @@ if [ -z "${TAG_NAME}" ]; then
         exit 1;
 fi
 
-TAG="--npm-tag $TAG_NAME"
+TAG="--dist-tag $TAG_NAME"
 
 # Get the current version
 version=`lerna ls --json --scope @lwc/engine`
@@ -33,19 +33,19 @@ fi
 
 # Command to push the packages
 CMD_UPDATE_VERSION="lerna version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push"
-CMD_PUBLISH_PACKAGES="lerna publish ${PACKAGE_VERSION} ${TAG} --yes --exact --force-publish --no-git-tag-version --no-push --no-verify-access --no-verify-registry"
+CMD_PUBLISH_PACKAGES="lerna publish ${PACKAGE_VERSION} ${TAG} --yes --force-publish --no-git-tag-version --no-push --no-verify-access"
 
 # Update package version and build. This ensure the dist files are generated with the version that will be released.
 # The publish step will only publish, it does not build and generate the files with the provided version.
 echo $CMD_UPDATE_VERSION;
 $CMD_UPDATE_VERSION;
+
+echo "Building artifacts for v${PACKAGE_VERSION} and creating release commit"
 yarn build;
+git add CHANGELOG.md lerna.json packages/*;
+git commit -m "release: v${PACKAGE_VERSION}";
 
 # Publish the packages to npm. Note that lerna cleans the working tree after this as of 3.0.4, so we need to reapply version
 # https://github.com/lerna/lerna/blob/3cbeeabcb443d9415bb86c4539652b85cd7b4025/commands/publish/index.js#L354-L363
 echo $CMD_PUBLISH_PACKAGES;
 $CMD_PUBLISH_PACKAGES;
-
-# Update package version again for later commit during the "commit release" stage
-echo $CMD_UPDATE_VERSION;
-$CMD_UPDATE_VERSION;

--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -35,6 +35,12 @@ fi
 CMD_UPDATE_VERSION="lerna version ${PACKAGE_VERSION} --yes --exact --force-publish --no-git-tag-version --no-push"
 CMD_PUBLISH_PACKAGES="lerna publish ${PACKAGE_VERSION} ${TAG} --yes --exact --force-publish --no-git-tag-version --no-push --no-verify-access --no-verify-registry"
 
+# Update package version and build. This ensure the dist files are generated with the version that will be released.
+# The publish step will only publish, it does not build and generate the files with the provided version.
+echo $CMD_UPDATE_VERSION;
+$CMD_UPDATE_VERSION;
+yarn build;
+
 # Publish the packages to npm. Note that lerna cleans the working tree after this as of 3.0.4, so we need to reapply version
 # https://github.com/lerna/lerna/blob/3cbeeabcb443d9415bb86c4539652b85cd7b4025/commands/publish/index.js#L354-L363
 echo $CMD_PUBLISH_PACKAGES;

--- a/scripts/release_npm.sh
+++ b/scripts/release_npm.sh
@@ -43,7 +43,7 @@ $CMD_UPDATE_VERSION;
 # Build to regenerate distribution files with new package version, commit the version changes
 echo "Building artifacts for v${PACKAGE_VERSION} and creating release commit"
 yarn build;
-git add CHANGELOG.md lerna.json packages/*;
+git add lerna.json packages/*;
 git commit -m "release: v${PACKAGE_VERSION}";
 
 # Publish the packages to npm.


### PR DESCRIPTION
## Details
The version footer in the dist file had the previous release number instead of the current version being released. Setting the version and executing build ensures the footer has the right information.
Fixes https://github.com/salesforce/lwc/issues/1727
## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added?  ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7109631
