### PR TITLE
build: make our pseudo-private packages actually-private

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -16,7 +16,6 @@
     "dependencies": {
         "@babel/helper-module-imports": "7.0.0",
         "@babel/plugin-proposal-class-properties": "7.1.0",
-        "@lwc/errors": "1.3.1",
         "line-column": "^1.0.2"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -17,8 +17,6 @@
         "@babel/core": "7.1.0",
         "@babel/plugin-proposal-object-rest-spread": "7.0.0",
         "@lwc/babel-plugin-component": "1.3.1",
-        "@lwc/errors": "1.3.1",
-        "@lwc/shared": "1.3.1",
         "@lwc/style-compiler": "1.3.1",
         "@lwc/template-compiler": "1.3.1",
         "@rollup/plugin-replace": "^2.3.1",

--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -19,8 +19,6 @@
         "observable-membrane": "0.26.1"
     },
     "devDependencies": {
-        "@lwc/features": "1.3.1",
-        "@lwc/shared": "1.3.1",
         "@lwc/template-compiler": "1.3.1"
     },
     "lwc": {

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@lwc/errors",
+    "private": true,
     "version": "1.3.1",
     "description": "LWC Error Utilities",
     "main": "dist/commonjs/index.js",

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@lwc/features",
+    "private": true,
     "version": "1.3.1",
     "description": "LWC Features Flags",
     "main": "dist/flags.cjs.js",

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -15,9 +15,6 @@
         "dist/",
         "types/"
     ],
-    "devDependencies": {
-        "@lwc/shared": "1.3.1"
-    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@lwc/shared",
+    "private": true,
     "version": "1.3.1",
     "description": "Utilities and methods that are shared across packages",
     "main": "dist/index.cjs.js",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -22,9 +22,5 @@
     },
     "publishConfig": {
         "access": "public"
-    },
-    "devDependencies": {
-        "@lwc/features": "1.3.1",
-        "@lwc/shared": "1.3.1"
     }
 }

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -22,8 +22,6 @@
         "@babel/template": "~7.1.2",
         "@babel/traverse": "~7.1.5",
         "@babel/types": "~7.1.5",
-        "@lwc/errors": "1.3.1",
-        "@lwc/shared": "1.3.1",
         "esutils": "^2.0.3",
         "he": "^1.1.1",
         "parse5-with-errors": "4.0.3-beta1"

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -21,8 +21,7 @@
     "devDependencies": {
         "@lwc/compiler": "1.3.1",
         "@lwc/engine": "1.3.1",
-        "@lwc/rollup-plugin": "1.3.1",
-        "@lwc/shared": "1.3.1"
+        "@lwc/rollup-plugin": "1.3.1"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -18,7 +18,6 @@
     "dependencies": {
         "@lwc/compiler": "1.3.1",
         "@lwc/engine": "1.3.1",
-        "@lwc/features": "1.3.1",
         "@lwc/synthetic-shadow": "1.3.1",
         "@lwc/wire-service": "1.3.1"
     }


### PR DESCRIPTION
## Details

Fixes #1736 

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

These packages had warnings in their README. They should not have been used by external projects.

## GUS work item
W-7259323