### PR TITLE
refactor(engine): remove unused $fromTemplate$ marker

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -64,7 +64,6 @@ import {
     markAsDynamicChildren,
 } from './hooks';
 import { Services, invokeServiceHook } from './services';
-import { markNodeFromVNode } from './restrictions';
 import { isComponentConstructor } from './def';
 
 export interface ElementCompilerData extends VNodeData {
@@ -104,9 +103,6 @@ const TextHook: Hooks = {
     create: (vnode: VNode) => {
         vnode.elm = document.createTextNode(vnode.text!);
         linkNodeToShadow(vnode);
-        if (process.env.NODE_ENV !== 'production') {
-            markNodeFromVNode(vnode.elm);
-        }
     },
     update: updateNodeHook,
     insert: insertNodeHook,
@@ -133,9 +129,6 @@ const ElementHook: Hooks = {
             vnode.elm = clonedElement;
         }
         linkNodeToShadow(vnode);
-        if (process.env.NODE_ENV !== 'production') {
-            markNodeFromVNode(vnode.elm);
-        }
         fallbackElmHook(vnode);
         createElmHook(vnode);
     },
@@ -161,9 +154,6 @@ const CustomElementHook: Hooks = {
         const { sel } = vnode;
         vnode.elm = document.createElement(sel);
         linkNodeToShadow(vnode);
-        if (process.env.NODE_ENV !== 'production') {
-            markNodeFromVNode(vnode.elm);
-        }
         createViewModelHook(vnode);
         allocateChildrenHook(vnode);
         createCustomElmHook(vnode);

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -499,14 +499,6 @@ interface RestrictionsOptions {
     isPortal?: boolean;
 }
 
-export function markNodeFromVNode(node: Node) {
-    if (process.env.NODE_ENV === 'production') {
-        // this method should never leak to prod
-        throw new ReferenceError();
-    }
-    (node as any).$fromTemplate$ = true;
-}
-
 export function patchElementWithRestrictions(elm: Element, options: RestrictionsOptions) {
     defineProperties(elm, getElementRestrictionsDescriptors(elm, options));
 }


### PR DESCRIPTION
## Details

The `$fromTemplate$` marker is an old artifact that hasn't been removed with the ab20a06 attribute restriction relaxation.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631
