### PR TITLE
refactor(engine): Remove unused comment api

### DIFF
--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -57,14 +57,6 @@ export interface VCustomElement extends VElement {
     clonedElement?: undefined;
 }
 
-export interface VComment extends VNode {
-    sel: string;
-    children: undefined;
-    elm: Comment | undefined;
-    text: string;
-    key: undefined;
-}
-
 export interface VText extends VNode {
     sel: undefined;
     children: undefined;

--- a/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
@@ -158,22 +158,6 @@ describe('api', () => {
         });
     });
 
-    describe('#p()', () => {
-        it('should produce a comment', () => {
-            function html($api) {
-                return [$api.h('span', { key: 0 }, [api.p('miami')])];
-            }
-            class Foo extends LightningElement {
-                render() {
-                    return registerTemplate(html);
-                }
-            }
-            const elm = createElement('x-foo', { is: Foo });
-            document.body.appendChild(elm);
-            expect(elm.shadowRoot.querySelector('span').innerHTML).toEqual('<!--miami-->');
-        });
-    });
-
     describe('#k()', () => {
         it('should combine keys', () => {
             let k1, k2;

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -39,7 +39,6 @@ import {
     VNodeData,
     VNodes,
     VElement,
-    VComment,
     VText,
     Hooks,
     Key,
@@ -88,7 +87,6 @@ export interface RenderAPI {
     i(items: any[], factory: () => VNode | VNode): VNodes;
     f(items: any[]): any[];
     t(text: string): VText;
-    p(text: string): VComment;
     d(value: any): VNode | null;
     b(fn: EventListener): EventListener;
     fb(fn: (...args: any[]) => any): (...args: any[]) => any;
@@ -113,20 +111,6 @@ const TextHook: Hooks = {
     update: updateNodeHook,
     insert: insertNodeHook,
     move: insertNodeHook, // same as insert for text nodes
-    remove: removeNodeHook,
-};
-
-const CommentHook: Hooks = {
-    create: (vnode: VComment) => {
-        vnode.elm = document.createComment(vnode.text);
-        linkNodeToShadow(vnode);
-        if (process.env.NODE_ENV !== 'production') {
-            markNodeFromVNode(vnode.elm);
-        }
-    },
-    update: updateNodeHook,
-    insert: insertNodeHook,
-    move: insertNodeHook, // same as insert for comment nodes
     remove: removeNodeHook,
 };
 

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -531,24 +531,6 @@ export function t(text: string): VText {
     };
 }
 
-// comment node
-export function p(text: string): VComment {
-    const data = EmptyObject;
-    const sel = '!';
-    let children, key, elm;
-    return {
-        sel,
-        data,
-        children,
-        text,
-        elm,
-        key,
-
-        hook: CommentHook,
-        owner: getVMBeingRendered()!,
-    };
-}
-
 // [d]ynamic value to produce a text vnode
 export function d(value: any): VNode | null {
     if (value == null) {


### PR DESCRIPTION
## Details

This PR removes the `p` render API and related code since the compiler doesn't produce VNodes for comment. This render API might be added back once we settle on a solution (#927) to add support for comment nodes.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631