### PR TITLE
refactor(engine): Decouple createElement from engine internals

### DIFF
--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -25,13 +25,7 @@ import {
 import { logError } from '../shared/logger';
 import { invokeEventListener, invokeComponentCallback } from './invoker';
 import { getVMBeingRendered } from './template';
-import {
-    EmptyArray,
-    resolveCircularModuleDependency,
-    isCircularModuleDependency,
-    EmptyObject,
-    useSyntheticShadow,
-} from './utils';
+import { EmptyArray, EmptyObject, useSyntheticShadow } from './utils';
 import { getAssociatedVM, runConnectedCallback, SlotSet, VM, VMState } from './vm';
 import { ComponentConstructor } from './component';
 import {
@@ -330,9 +324,6 @@ export function c(
     data: CustomElementCompilerData,
     children: VNodes = EmptyArray
 ): VCustomElement {
-    if (isCircularModuleDependency(Ctor)) {
-        Ctor = resolveCircularModuleDependency(Ctor);
-    }
     const vmBeingRendered = getVMBeingRendered()!;
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `c() 1st argument sel must be a string.`);

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
-import { EmptyArray, EmptyObject, useSyntheticShadow } from './utils';
+import { EmptyArray, useSyntheticShadow } from './utils';
 import {
     rerenderVM,
     createVM,
@@ -26,12 +26,7 @@ import modStaticClassName from './modules/static-class-attr';
 import modStaticStyle from './modules/static-style-attr';
 import modContext from './modules/context';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
-import {
-    patchCustomElementWithRestrictions,
-    patchElementWithRestrictions,
-    unlockDomMutation,
-    lockDomMutation,
-} from './restrictions';
+import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentDef, setElementProto } from './def';
 
 const noop = () => void 0;
@@ -197,9 +192,6 @@ export function createViewModelHook(vnode: VCustomElement) {
             isArray(vnode.children),
             `Invalid vnode for a custom element, it must have children defined.`
         );
-    }
-    if (process.env.NODE_ENV !== 'production') {
-        patchCustomElementWithRestrictions(elm, EmptyObject);
     }
 }
 

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -78,7 +78,7 @@ function portalRestrictionErrorMessage(name: string, type: string) {
 
 function getNodeRestrictionsDescriptors(
     node: Node,
-    options: RestrictionsOptions
+    options: RestrictionsOptions = {}
 ): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
@@ -301,15 +301,12 @@ function getShadowRootRestrictionsDescriptors(
 // Custom Elements Restrictions:
 // -----------------------------
 
-function getCustomElementRestrictionsDescriptors(
-    elm: HTMLElement,
-    options: RestrictionsOptions
-): PropertyDescriptorMap {
+function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    const descriptors: PropertyDescriptorMap = getNodeRestrictionsDescriptors(elm, options);
+    const descriptors = getNodeRestrictionsDescriptors(elm);
 
     const originalAddEventListener = elm.addEventListener;
     const originalInnerHTMLDescriptor = getPropertyDescriptor(elm, 'innerHTML')!;
@@ -509,8 +506,8 @@ export function patchShadowRootWithRestrictions(sr: ShadowRoot, options: Restric
     defineProperties(sr, getShadowRootRestrictionsDescriptors(sr, options));
 }
 
-export function patchCustomElementWithRestrictions(elm: HTMLElement, options: RestrictionsOptions) {
-    const restrictionsDescriptors = getCustomElementRestrictionsDescriptors(elm, options);
+export function patchCustomElementWithRestrictions(elm: HTMLElement) {
+    const restrictionsDescriptors = getCustomElementRestrictionsDescriptors(elm);
     const elmProto = getPrototypeOf(elm);
     setPrototypeOf(elm, create(elmProto, restrictionsDescriptors));
 }

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -186,10 +186,7 @@ function getElementRestrictionsDescriptors(
     return descriptors;
 }
 
-function getShadowRootRestrictionsDescriptors(
-    sr: ShadowRoot,
-    options: RestrictionsOptions
-): PropertyDescriptorMap {
+function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
         throw new ReferenceError();
@@ -200,7 +197,7 @@ function getShadowRootRestrictionsDescriptors(
     const originalQuerySelector = sr.querySelector;
     const originalQuerySelectorAll = sr.querySelectorAll;
     const originalAddEventListener = sr.addEventListener;
-    const descriptors: PropertyDescriptorMap = getNodeRestrictionsDescriptors(sr, options);
+    const descriptors = getNodeRestrictionsDescriptors(sr);
     const originalInnerHTMLDescriptor = getPropertyDescriptor(sr, 'innerHTML')!;
     const originalTextContentDescriptor = getPropertyDescriptor(sr, 'textContent')!;
     assign(descriptors, {
@@ -502,8 +499,8 @@ export function patchElementWithRestrictions(elm: Element, options: Restrictions
 
 // This routine will prevent access to certain properties on a shadow root instance to guarantee
 // that all components will work fine in IE11 and other browsers without shadow dom support.
-export function patchShadowRootWithRestrictions(sr: ShadowRoot, options: RestrictionsOptions) {
-    defineProperties(sr, getShadowRootRestrictionsDescriptors(sr, options));
+export function patchShadowRootWithRestrictions(sr: ShadowRoot) {
+    defineProperties(sr, getShadowRootRestrictionsDescriptors(sr));
 }
 
 export function patchCustomElementWithRestrictions(elm: HTMLElement) {

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -25,7 +25,6 @@ import {
     getAssociatedVMIfPresent,
 } from './vm';
 import { ComponentConstructor } from './component';
-import { isCircularModuleDependency, resolveCircularModuleDependency } from './utils';
 import { getComponentDef, setElementProto } from './def';
 import { appendChild, insertBefore, replaceChild, removeChild } from '../env/node';
 
@@ -98,15 +97,15 @@ export function createElement(
         );
     }
 
-    let Ctor = options.is;
+    const Ctor = options.is;
     if (!isFunction(Ctor)) {
         throw new TypeError(
             `"createElement" function expects a "is" option with a valid component constructor.`
         );
     }
 
-    // Create element with correct tagName
     const element = document.createElement(sel);
+
     if (!isUndefined(getAssociatedVMIfPresent(element))) {
         // There is a possibility that a custom element is registered under tagName,
         // in which case, the initialization is already carry on, and there is nothing else
@@ -114,14 +113,10 @@ export function createElement(
         return element;
     }
 
-    if (isCircularModuleDependency(Ctor)) {
-        Ctor = resolveCircularModuleDependency(Ctor);
-    }
-
     const def = getComponentDef(Ctor);
     setElementProto(element, def);
 
-    createVM(element, Ctor, {
+    createVM(element, def.ctor, {
         mode: options.mode !== 'closed' ? 'open' : 'closed',
         isRoot: true,
         owner: null,

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -22,13 +22,11 @@ import {
     removeRootVM,
     appendRootVM,
     getAssociatedVM,
-    VMState,
     getAssociatedVMIfPresent,
 } from './vm';
 import { ComponentConstructor } from './component';
 import { isCircularModuleDependency, resolveCircularModuleDependency } from './utils';
 import { getComponentDef, setElementProto } from './def';
-import { GlobalMeasurementPhase, startGlobalMeasure, endGlobalMeasure } from './performance-timing';
 import { appendChild, insertBefore, replaceChild, removeChild } from '../env/node';
 
 type NodeSlot = () => {};
@@ -131,13 +129,7 @@ export function createElement(
 
     setHiddenField(element, ConnectingSlot, () => {
         const vm = getAssociatedVM(element);
-        startGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
-        if (vm.state === VMState.connected) {
-            // usually means moving the element from one place to another, which is observable via life-cycle hooks
-            removeRootVM(vm);
-        }
         appendRootVM(vm);
-        endGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
     });
 
     setHiddenField(element, DisconnectingSlot, () => {

--- a/packages/@lwc/engine/src/framework/utils.ts
+++ b/packages/@lwc/engine/src/framework/utils.ts
@@ -43,31 +43,4 @@ export function addCallbackToNextTick(callback: Callback) {
     ArrayPush.call(nextTickCallbackQueue, callback);
 }
 
-interface CircularModuleDependency {
-    <T>(): T;
-    readonly __circular__?: any;
-}
-
-export function isCircularModuleDependency(value: any): value is CircularModuleDependency {
-    return hasOwnProperty.call(value, '__circular__');
-}
-
-/**
- * When LWC is used in the context of an Aura application, the compiler produces AMD
- * modules, that doesn't resolve properly circular dependencies between modules. In order
- * to circumvent this issue, the module loader returns a factory with a symbol attached
- * to it.
- *
- * This method returns the resolved value if it received a factory as argument. Otherwise
- * it returns the original value.
- */
-export function resolveCircularModuleDependency(fn: CircularModuleDependency): any {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isFunction(fn)) {
-            throw new TypeError(`Circular module dependency must be a function.`);
-        }
-    }
-    return fn();
-}
-
 export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -144,8 +144,17 @@ export function rerenderVM(vm: VM) {
 }
 
 export function appendRootVM(vm: VM) {
+    startGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
+
+    // usually means moving the element from one place to another, which is observable via life-cycle hooks
+    if (vm.state === VMState.connected) {
+        removeRootVM(vm);
+    }
+
     runConnectedCallback(vm);
     rehydrate(vm);
+
+    endGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
 }
 
 export function appendVM(vm: VM) {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -204,7 +204,7 @@ export interface CreateVMInit {
     owner: VM | null;
 }
 
-export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: CreateVMInit) {
+export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: CreateVMInit): VM {
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
             elm instanceof HTMLElement,
@@ -261,6 +261,8 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
     if (process.env.NODE_ENV !== 'production') {
         patchCustomElementWithRestrictions(elm);
     }
+
+    return initializedVm;
 }
 
 function assertIsVM(obj: any): asserts obj is VM {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -50,6 +50,7 @@ import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdo
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from '../libs/mutation-tracker';
 import { LightningElement } from './base-lightning-element';
+import { patchCustomElementWithRestrictions } from './restrictions';
 import { getErrorComponentStack } from '../shared/format';
 
 export interface SlotSet {
@@ -247,6 +248,10 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
     // link component to the wire service
     const initializedVm = uninitializedVm as VM;
     linkComponent(initializedVm);
+
+    if (process.env.NODE_ENV !== 'production') {
+        patchCustomElementWithRestrictions(elm);
+    }
 }
 
 function assertIsVM(obj: any): asserts obj is VM {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -50,7 +50,6 @@ import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdo
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from '../libs/mutation-tracker';
 import { LightningElement } from './base-lightning-element';
-import { patchCustomElementWithRestrictions } from './restrictions';
 import { getErrorComponentStack } from '../shared/format';
 
 export interface SlotSet {
@@ -257,10 +256,6 @@ export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: 
     // link component to the wire service
     const initializedVm = uninitializedVm as VM;
     linkComponent(initializedVm);
-
-    if (process.env.NODE_ENV !== 'production') {
-        patchCustomElementWithRestrictions(elm);
-    }
 
     return initializedVm;
 }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -115,7 +115,7 @@ export interface VM extends UninitializedVM {
     oar: Record<PropertyKey, ReactiveObserver>;
 }
 
-type VMAssociable = ShadowRoot | LightningElement | ComponentInterface;
+type VMAssociable = Node | LightningElement | ComponentInterface;
 
 let idx: number = 0;
 
@@ -142,18 +142,26 @@ export function rerenderVM(vm: VM) {
     rehydrate(vm);
 }
 
-export function appendRootVM(vm: VM) {
+export function connectRootElement(elm: HTMLElement) {
+    const vm = getAssociatedVM(elm);
+
     startGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
 
-    // usually means moving the element from one place to another, which is observable via life-cycle hooks
+    // Usually means moving the element from one place to another, which is observable via
+    // life-cycle hooks.
     if (vm.state === VMState.connected) {
-        removeRootVM(vm);
+        disconnectedRootElement(elm);
     }
 
     runConnectedCallback(vm);
     rehydrate(vm);
 
     endGlobalMeasure(GlobalMeasurementPhase.HYDRATE, vm);
+}
+
+export function disconnectedRootElement(elm: HTMLElement) {
+    const vm = getAssociatedVM(elm);
+    resetComponentStateWhenRemoved(vm);
 }
 
 export function appendVM(vm: VM) {
@@ -191,19 +199,15 @@ export function removeVM(vm: VM) {
     resetComponentStateWhenRemoved(vm);
 }
 
-// this method is triggered by the removal of a root element from the DOM.
-export function removeRootVM(vm: VM) {
-    resetComponentStateWhenRemoved(vm);
-}
-
-export interface CreateVMInit {
-    mode: 'open' | 'closed';
-    // custom settings for now
-    isRoot?: boolean;
-    owner: VM | null;
-}
-
-export function createVM(elm: HTMLElement, Ctor: ComponentConstructor, options: CreateVMInit): VM {
+export function createVM(
+    elm: HTMLElement,
+    Ctor: ComponentConstructor,
+    options: {
+        mode: 'open' | 'closed';
+        isRoot?: boolean;
+        owner: VM | null;
+    }
+): VM {
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
             elm instanceof HTMLElement,

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -7,11 +7,9 @@
 import { ArrayMap, getOwnPropertyNames, isNull, isObject, isUndefined } from '@lwc/shared';
 import { ComponentConstructor } from './component';
 import { createVM, appendRootVM, removeRootVM, getAssociatedVM, CreateVMInit } from './vm';
-import { EmptyObject } from './utils';
 import { getComponentDef } from './def';
 import { getPropNameFromAttrName, isAttributeLocked } from './attributes';
 import { HTMLElementConstructor } from './base-bridge-element';
-import { patchCustomElementWithRestrictions } from './restrictions';
 
 /**
  * This function builds a Web Component class from a LWC constructor
@@ -45,9 +43,6 @@ export function buildCustomElementConstructor(
         constructor() {
             super();
             createVM(this, Ctor, normalizedOptions);
-            if (process.env.NODE_ENV !== 'production') {
-                patchCustomElementWithRestrictions(this, EmptyObject);
-            }
         }
         connectedCallback() {
             const vm = getAssociatedVM(this);

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -32,7 +32,7 @@ export function buildCustomElementConstructor(
 ): HTMLElementConstructor {
     const { props, bridge: BaseElement } = getComponentDef(Ctor);
     const mode =
-        !isUndefined(options) && !isUndefined(options.mode) && options.mode !== 'closed'
+        isUndefined(options) || isUndefined(options.mode) || options.mode !== 'closed'
             ? 'open'
             : 'closed';
 

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -4,45 +4,46 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayMap, getOwnPropertyNames, isNull, isObject, isUndefined } from '@lwc/shared';
+import { ArrayMap, getOwnPropertyNames, isUndefined } from '@lwc/shared';
 import { ComponentConstructor } from './component';
-import { createVM, appendRootVM, removeRootVM, getAssociatedVM, CreateVMInit } from './vm';
+import { createVM, appendRootVM, removeRootVM, getAssociatedVM } from './vm';
 import { getComponentDef } from './def';
 import { getPropNameFromAttrName, isAttributeLocked } from './attributes';
 import { HTMLElementConstructor } from './base-bridge-element';
 
 /**
- * This function builds a Web Component class from a LWC constructor
- * so it can be registered as a new element via customElements.define()
- * at any given time. E.g.:
+ * EXPERIMENTAL: This function builds a Web Component class from a LWC constructor so it can be
+ * registered as a new element via customElements.define() at any given time.
  *
- *      import { buildCustomElementConstructor } from 'lwc';
- *      import Foo from 'ns/foo';
- *      const WC = buildCustomElementConstructor(Foo);
- *      customElements.define('x-foo', WC);
- *      const elm = document.createElement('x-foo');
- *
+ * @example
+ * ```
+ * import { buildCustomElementConstructor } from 'lwc';
+ * import Foo from 'ns/foo';
+ * const WC = buildCustomElementConstructor(Foo);
+ * customElements.define('x-foo', WC);
+ * const elm = document.createElement('x-foo');
+ * ```
  */
 export function buildCustomElementConstructor(
     Ctor: ComponentConstructor,
-    options?: ShadowRootInit
+    options?: {
+        mode?: 'open' | 'closed';
+    }
 ): HTMLElementConstructor {
     const { props, bridge: BaseElement } = getComponentDef(Ctor);
-    const normalizedOptions: CreateVMInit = {
-        mode: 'open',
-        isRoot: true,
-        owner: null,
-    };
-    if (isObject(options) && !isNull(options)) {
-        const { mode } = options;
-        if (mode === 'closed') {
-            normalizedOptions.mode = mode;
-        }
-    }
+    const mode =
+        !isUndefined(options) && !isUndefined(options.mode) && options.mode !== 'closed'
+            ? 'open'
+            : 'closed';
+
     return class extends BaseElement {
         constructor() {
             super();
-            createVM(this, Ctor, normalizedOptions);
+            createVM(this, Ctor, {
+                mode,
+                isRoot: true,
+                owner: null,
+            });
         }
         connectedCallback() {
             const vm = getAssociatedVM(this);

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -5,8 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { ArrayMap, getOwnPropertyNames, isUndefined } from '@lwc/shared';
+
 import { ComponentConstructor } from './component';
-import { createVM, appendRootVM, removeRootVM, getAssociatedVM } from './vm';
+import { createVM, connectRootElement, disconnectedRootElement } from './vm';
 import { getComponentDef } from './def';
 import { getPropNameFromAttrName, isAttributeLocked } from './attributes';
 import { HTMLElementConstructor } from './base-bridge-element';
@@ -46,12 +47,10 @@ export function buildCustomElementConstructor(
             });
         }
         connectedCallback() {
-            const vm = getAssociatedVM(this);
-            appendRootVM(vm);
+            connectRootElement(this);
         }
         disconnectedCallback() {
-            const vm = getAssociatedVM(this);
-            removeRootVM(vm);
+            disconnectedRootElement(this);
         }
         attributeChangedCallback(attrName: string, oldValue: string, newValue: string) {
             if (oldValue === newValue) {

--- a/packages/@lwc/engine/src/shared/circular-module-dependencies.ts
+++ b/packages/@lwc/engine/src/shared/circular-module-dependencies.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { isFunction, hasOwnProperty } from '@lwc/shared';
+
+/**
+ * When LWC is used in the context of an Aura application, the compiler produces AMD modules, that
+ * doesn't resolve properly circular dependencies between modules. In order to circumvent this
+ * issue, the module loader returns a factory with a symbol attached to it.
+ */
+
+interface CircularModuleDependency<M extends Object> {
+    (): M;
+    __circular__: boolean;
+}
+
+export function resolveCircularModuleDependency<M = any>(fn: CircularModuleDependency<M>): M {
+    return fn();
+}
+
+export function isCircularModuleDependency(obj: unknown): obj is CircularModuleDependency<any> {
+    return isFunction(obj) && hasOwnProperty.call(obj, '__circular__');
+}


### PR DESCRIPTION
## Details

This PR decouples the `createElement` method from the engine internals in preparation from the server-side rendering code split. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
<!--Work ID in text, no links -->
