### PR TITLE
refactor(template-compiler): Enforce strict typescript check

### DIFF
--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -53,7 +53,7 @@ export function isSlot(element: IRElement) {
 }
 
 export function containsDynamicChildren(element: IRElement) {
-    return element.children.some(isDynamic);
+    return element.children.some(child => isElement(child) && isDynamic(child));
 }
 
 export function isDynamic(element: IRElement): boolean {

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -89,7 +89,7 @@ export function destructuringAssignmentFromObject(
 
 export function memorizeHandler(
     codeGen: CodeGen,
-    element,
+    element: IRElement,
     componentHandler: t.Expression,
     handler: t.Expression
 ): t.Expression {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -79,7 +79,7 @@ function generateContext(element: IRElement, data: t.ObjectProperty[], codeGen: 
         const lwcObject: t.ObjectProperty[] = Object.keys(lwc)
             .filter(key => !DISALLOWED_LWC_DIRECTIVES.has(key))
             .map(key => {
-                return t.objectProperty(t.identifier(key), t.stringLiteral(lwc[key]));
+                return t.objectProperty(t.identifier(key), t.stringLiteral((lwc as any)[key]));
             });
 
         const lwcObj = t.objectProperty(t.identifier('lwc'), t.objectExpression(lwcObject));

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -349,8 +349,8 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
             const { expression: testExpression } = bindExpression(element.if!, element);
 
             return t.arrayExpression(
-                fragmentNodes.elements.map((child: t.Expression) =>
-                    applyInlineIf(element, child, testExpression)
+                fragmentNodes.elements.map(child =>
+                    child !== null ? applyInlineIf(element, child as any, testExpression) : null
                 )
             );
         } else {

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -11,15 +11,15 @@ import { CompilerDiagnostic, generateCompilerDiagnostic, ParserDiagnostics } fro
 
 import { VOID_ELEMENT_SET } from './constants';
 
-export type VisitorFn = (element: parse5.AST.Node) => void;
-
-export interface NodeVisitor {
-    enter?: VisitorFn;
-    exit?: VisitorFn;
+interface NodeVisitor<N extends parse5.AST.Default.Node> {
+    enter?: (node: N) => void;
+    exit?: (node: N) => void;
 }
 
-export interface Visitor {
-    [type: string]: NodeVisitor;
+interface Visitor {
+    Comment?: NodeVisitor<parse5.AST.Default.CommentNode>;
+    Text?: NodeVisitor<parse5.AST.Default.TextNode>;
+    Element?: NodeVisitor<parse5.AST.Default.Element>;
 }
 
 export const treeAdapter = parse5.treeAdapters.default;
@@ -91,7 +91,7 @@ export function parseHTML(source: string) {
 }
 
 export function traverseHTML(node: parse5.AST.Default.Node, visitor: Visitor): void {
-    let nodeVisitor: NodeVisitor;
+    let nodeVisitor: NodeVisitor<any> | undefined;
     switch (node.nodeName) {
         case '#comment':
             nodeVisitor = visitor.Comment;

--- a/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
+++ b/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
@@ -419,24 +419,25 @@ const HTML_ELEMENT_ATTRIBUTE_MAP = {
     ],
 };
 
-export const HTML_ATTRIBUTE_ELEMENT_MAP: { [attr: string]: string[] } = Object.entries(
-    HTML_ELEMENT_ATTRIBUTE_MAP
-).reduce((accumulator, entry) => {
-    const element = entry[0];
-    const attributes = entry[1];
+export const HTML_ATTRIBUTE_ELEMENT_MAP = Object.entries(HTML_ELEMENT_ATTRIBUTE_MAP).reduce(
+    (accumulator, entry) => {
+        const element = entry[0];
+        const attributes = entry[1];
 
-    if (element !== '*') {
-        attributes.forEach(attribute => {
-            if (!hasOwnProperty.call(accumulator, attribute)) {
-                accumulator[attribute] = [];
-            }
+        if (element !== '*') {
+            attributes.forEach(attribute => {
+                if (!hasOwnProperty.call(accumulator, attribute)) {
+                    accumulator[attribute] = [];
+                }
 
-            accumulator[attribute].push(element);
-        });
-    }
+                accumulator[attribute].push(element);
+            });
+        }
 
-    return accumulator;
-}, {});
+        return accumulator;
+    },
+    {} as Record<string, string[]>
+);
 
 Object.values(HTML_ELEMENT_ATTRIBUTE_MAP['*']).forEach(
     globalAttribute => (HTML_ATTRIBUTE_ELEMENT_MAP[globalAttribute] = [])

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -14,15 +14,14 @@ import {
     HTMLText,
 } from './types';
 
-export type VisitorFn = (element: IRNode) => void;
-
-export interface NodeVisitor {
-    enter?: VisitorFn;
-    exit?: VisitorFn;
+export interface NodeVisitor<T extends IRNode> {
+    enter?: (element: T) => void;
+    exit?: (element: T) => void;
 }
 
 export interface Visitor {
-    [type: string]: NodeVisitor;
+    text?: NodeVisitor<IRText>;
+    element?: NodeVisitor<IRElement>;
 }
 
 export function createElement(tag: string, original: HTMLElement): IRElement {
@@ -53,8 +52,7 @@ export function isCustomElement(node: IRNode): boolean {
 }
 
 export function traverse(node: IRNode, visitor: Visitor): void {
-    const nodeVisitor = visitor[node.type] || {};
-    const { enter, exit } = nodeVisitor;
+    const { enter, exit }: NodeVisitor<any> = visitor[node.type] || {};
 
     if (enter) {
         enter(node);

--- a/packages/@lwc/template-compiler/src/shared/naming.ts
+++ b/packages/@lwc/template-compiler/src/shared/naming.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export function kebabcaseToCamelcase(name) {
+export function kebabcaseToCamelcase(name: string): string {
     const newName: string[] = [];
     let nsFound = false;
     let upper = false;

--- a/packages/@lwc/template-compiler/src/shared/stack.ts
+++ b/packages/@lwc/template-compiler/src/shared/stack.ts
@@ -4,35 +4,38 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-class Node<T> {
-    public previous: Node<T>;
-    public data: T;
 
-    constructor(data: T, previous: Node<T>) {
-        this.previous = previous;
-        this.data = data;
-    }
+interface Node<T> {
+    previous: Node<T> | null;
+    data: T;
 }
 
-// tslint:disable-next-line:max-classes-per-file
-export default class Stack<TData> {
-    private topNode: Node<TData>;
+export default class Stack<T> {
+    private topNode: Node<T> | null = null;
 
-    public push(value: TData): void {
-        // create a new Node and add it to the top
-        const node = new Node<TData>(value, this.topNode);
-        this.topNode = node;
+    private getTopNode(): Node<T> {
+        if (!this.topNode) {
+            throw new Error('Stack is empty');
+        }
+
+        return this.topNode;
     }
 
-    public pop(): TData {
-        // remove the top node from the stack.
-        // the node at the top now is the one before it
-        const poppedNode = this.topNode;
-        this.topNode = poppedNode.previous;
-        return poppedNode.data;
+    push(value: T): void {
+        this.topNode = {
+            previous: this.topNode,
+            data: value,
+        };
     }
 
-    public peek(): TData {
-        return this.topNode.data;
+    pop(): T {
+        const { data, previous } = this.getTopNode();
+
+        this.topNode = previous;
+        return data;
+    }
+
+    peek(): T {
+        return this.getTopNode().data;
     }
 }

--- a/packages/@lwc/template-compiler/tsconfig.json
+++ b/packages/@lwc/template-compiler/tsconfig.json
@@ -3,7 +3,6 @@
 
     "compilerOptions": {
         "noImplicitAny": false,
-        "strictFunctionTypes": false,
 
         "outDir": "dist/commonjs",
         "declarationDir": "dist/types"

--- a/packages/@lwc/template-compiler/tsconfig.json
+++ b/packages/@lwc/template-compiler/tsconfig.json
@@ -4,7 +4,6 @@
     "compilerOptions": {
         "noImplicitAny": false,
         "strictFunctionTypes": false,
-        "strictPropertyInitialization": false,
 
         "outDir": "dist/commonjs",
         "declarationDir": "dist/types"

--- a/packages/@lwc/template-compiler/tsconfig.json
+++ b/packages/@lwc/template-compiler/tsconfig.json
@@ -2,8 +2,6 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "noImplicitAny": false,
-
         "outDir": "dist/commonjs",
         "declarationDir": "dist/types"
     },


### PR DESCRIPTION
## Details

Enable strict typescript check for the `@lwc/template-compiler` package. Removed the following tsconfig overrides: `noImplicitAny`, `strictFunctionTypes` and `strictPropertyInitialization`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631
