### PR TITLE
refactor(engine): Enforce strict typescript check 

### DIFF
--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -35,8 +35,7 @@ export interface VNode {
     parentElm?: Element;
     text: string | undefined;
     key: Key | undefined;
-
-    hook: Hooks;
+    hook: Hooks<any>;
     owner: VM;
 }
 
@@ -79,21 +78,15 @@ export interface VNodeData {
     ns?: string; // for SVGs
 }
 
-export type CreateHook = (vNode: VNode) => void;
-export type InsertHook = (vNode: VNode, parentNode: Node, referenceNode: Node | null) => void;
-export type MoveHook = (vNode: VNode, parentNode: Node, referenceNode: Node | null) => void;
-export type UpdateHook = (oldVNode: VNode, vNode: VNode) => void;
-export type RemoveHook = (vNode: VNode, parentNode: Node) => void;
-
-export interface Hooks {
-    create: CreateHook;
-    insert: InsertHook;
-    move: MoveHook;
-    update: UpdateHook;
-    remove: RemoveHook;
+export interface Hooks<N extends VNode> {
+    create: (vNode: N) => void;
+    insert: (vNode: N, parentNode: Node, referenceNode: Node | null) => void;
+    move: (vNode: N, parentNode: Node, referenceNode: Node | null) => void;
+    update: (oldVNode: N, vNode: N) => void;
+    remove: (vNode: N, parentNode: Node) => void;
 }
 
-export interface Module {
-    create?: CreateHook;
-    update?: UpdateHook;
+export interface Module<N extends VNode> {
+    create?: (vNode: N) => void;
+    update?: (oldVNode: N, vNode: N) => void;
 }

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -99,8 +99,8 @@ const CHAR_G = 103;
 const NamespaceAttributeForSVG = 'http://www.w3.org/2000/svg';
 const SymbolIterator = Symbol.iterator;
 
-const TextHook: Hooks = {
-    create: (vnode: VNode) => {
+const TextHook: Hooks<VText> = {
+    create: vnode => {
         vnode.elm = document.createTextNode(vnode.text!);
         linkNodeToShadow(vnode);
     },
@@ -115,8 +115,8 @@ const TextHook: Hooks = {
 // to rehydrate when dirty, because sometimes the element is not inserted just yet,
 // which breaks some invariants. For that reason, we have the following for any
 // Custom Element that is inserted via a template.
-const ElementHook: Hooks = {
-    create: (vnode: VElement) => {
+const ElementHook: Hooks<VElement> = {
+    create: vnode => {
         const { data, sel, clonedElement } = vnode;
         const { ns } = data;
         // TODO [#1364]: supporting the ability to inject a cloned StyleElement via a vnode this is
@@ -132,25 +132,25 @@ const ElementHook: Hooks = {
         fallbackElmHook(vnode);
         createElmHook(vnode);
     },
-    update: (oldVnode: VElement, vnode: VElement) => {
+    update: (oldVnode, vnode) => {
         updateElmHook(oldVnode, vnode);
         updateChildrenHook(oldVnode, vnode);
     },
-    insert: (vnode: VElement, parentNode: Node, referenceNode: Node | null) => {
+    insert: (vnode, parentNode, referenceNode) => {
         insertNodeHook(vnode, parentNode, referenceNode);
         createChildrenHook(vnode);
     },
-    move: (vnode: VElement, parentNode: Node, referenceNode: Node | null) => {
+    move: (vnode, parentNode, referenceNode) => {
         insertNodeHook(vnode, parentNode, referenceNode);
     },
-    remove: (vnode: VElement, parentNode: Node) => {
+    remove: (vnode, parentNode) => {
         removeNodeHook(vnode, parentNode);
         removeElmHook(vnode);
     },
 };
 
-const CustomElementHook: Hooks = {
-    create: (vnode: VCustomElement) => {
+const CustomElementHook: Hooks<VCustomElement> = {
+    create: vnode => {
         const { sel } = vnode;
         vnode.elm = document.createElement(sel);
         linkNodeToShadow(vnode);
@@ -158,7 +158,7 @@ const CustomElementHook: Hooks = {
         allocateChildrenHook(vnode);
         createCustomElmHook(vnode);
     },
-    update: (oldVnode: VCustomElement, vnode: VCustomElement) => {
+    update: (oldVnode, vnode) => {
         updateCustomElmHook(oldVnode, vnode);
         // in fallback mode, the allocation will always set children to
         // empty and delegate the real allocation to the slot elements
@@ -169,7 +169,7 @@ const CustomElementHook: Hooks = {
         // this will update the shadowRoot
         rerenderCustomElmHook(vnode);
     },
-    insert: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
+    insert: (vnode, parentNode, referenceNode) => {
         insertNodeHook(vnode, parentNode, referenceNode);
         const vm = getAssociatedVM(vnode.elm!);
         if (process.env.NODE_ENV !== 'production') {
@@ -179,10 +179,10 @@ const CustomElementHook: Hooks = {
         createChildrenHook(vnode);
         insertCustomElmHook(vnode);
     },
-    move: (vnode: VCustomElement, parentNode: Node, referenceNode: Node | null) => {
+    move: (vnode, parentNode, referenceNode) => {
         insertNodeHook(vnode, parentNode, referenceNode);
     },
-    remove: (vnode: VCustomElement, parentNode: Node) => {
+    remove: (vnode, parentNode) => {
         removeNodeHook(vnode, parentNode);
         removeCustomElmHook(vnode);
     },

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -416,13 +416,13 @@ export function i(
 
     if (process.env.NODE_ENV !== 'production') {
         assert.isFalse(
-            isUndefined(iterable[SymbolIterator]),
+            isUndefined((iterable as any)[SymbolIterator]),
             `Invalid template iteration for value \`${toString(
                 iterable
             )}\` in ${vmBeingRendered}. It must be an array-like object and not \`null\` nor \`undefined\`.`
         );
     }
-    const iterator = iterable[SymbolIterator]();
+    const iterator = (iterable as any)[SymbolIterator]();
 
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(

--- a/packages/@lwc/engine/src/framework/attributes.ts
+++ b/packages/@lwc/engine/src/framework/attributes.ts
@@ -46,7 +46,7 @@ const HTMLPropertyNamesWithLowercasedReflectiveAttributes = [
     'useMap',
 ];
 
-function offsetPropertyErrorMessage(name) {
+function offsetPropertyErrorMessage(name: string): string {
     return `Using the \`${name}\` property is an anti-pattern because it rounds the value to an integer. Instead, use the \`getBoundingClientRect\` method to obtain fractional values for the size of an element and its position relative to the viewport.`;
 }
 

--- a/packages/@lwc/engine/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine/src/framework/base-bridge-element.ts
@@ -60,7 +60,7 @@ function createMethodCaller(methodName: string): (...args: any[]) => any {
     return function(this: HTMLElement): any {
         const vm = getAssociatedVM(this);
         const { callHook, component } = vm;
-        const fn = component[methodName];
+        const fn = (component as any)[methodName];
         return callHook(vm.component, fn, ArraySlice.call(arguments));
     };
 }

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -525,20 +525,17 @@ BaseLightningElementConstructor.prototype = {
     },
 };
 
-// Typescript is inferring the wrong function type for this particular
-// overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-// @ts-ignore type-mismatch
-const baseDescriptors: PropertyDescriptorMap = ArrayReduce.call(
+const baseDescriptors = ArrayReduce.call(
     getOwnPropertyNames(HTMLElementOriginalDescriptors),
-    (descriptors: PropertyDescriptorMap, propName: string) => {
-        descriptors[propName] = createBridgeToElementDescriptor(
+    (descriptors, propName) => {
+        (descriptors as PropertyDescriptorMap)[propName] = createBridgeToElementDescriptor(
             propName,
             HTMLElementOriginalDescriptors[propName]
         );
         return descriptors;
     },
     create(null)
-);
+) as PropertyDescriptorMap;
 
 defineProperties(BaseLightningElementConstructor.prototype, baseDescriptors);
 

--- a/packages/@lwc/engine/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine/src/framework/decorators/api.ts
@@ -10,7 +10,7 @@ import { logError } from '../../shared/logger';
 import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { valueObserved, valueMutated, ReactiveObserver } from '../../libs/mutation-tracker';
 import { ComponentInterface, ComponentConstructor } from '../component';
-import { getAssociatedVM, rerenderVM } from '../vm';
+import { getAssociatedVM, rerenderVM, VM } from '../vm';
 import { getDecoratorsRegisteredMeta } from './register';
 import { addCallbackToNextTick } from '../utils';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
@@ -115,7 +115,7 @@ function createPublicPropertyDescriptor(
 class AccessorReactiveObserver extends ReactiveObserver {
     private value: any;
     private debouncing: boolean = false;
-    constructor(vm, set) {
+    constructor(vm: VM, set: (v: any) => void) {
         super(() => {
             if (isFalse(this.debouncing)) {
                 this.debouncing = true;

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -151,13 +151,16 @@ function getPublicMethodsHash(
         return EmptyObject;
     }
     return publicMethods.reduce((methodsHash: MethodDef, methodName: string): MethodDef => {
+        const method = (target.prototype as any)[methodName];
+
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(
-                isFunction(target.prototype[methodName]),
-                `Component "${target.name}" should have a method \`${methodName}\` instead of ${target.prototype[methodName]}.`
+                isFunction(method),
+                `Component "${target.name}" should have a method \`${methodName}\` instead of ${method}.`
             );
         }
-        methodsHash[methodName] = target.prototype[methodName];
+
+        methodsHash[methodName] = method;
         return methodsHash;
     }, create(null));
 }

--- a/packages/@lwc/engine/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine/src/framework/decorators/track.ts
@@ -9,7 +9,7 @@ import { valueObserved, valueMutated } from '../../libs/mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
-import { ComponentConstructor, ComponentInterface } from '../component';
+import { ComponentInterface } from '../component';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
 /**
@@ -18,11 +18,10 @@ import { isUpdatingTemplate, getVMBeingRendered } from '../template';
  * decorator.
  */
 export default function track(
-    target: ComponentConstructor,
+    target: any,
     prop: PropertyKey,
-    descriptor: PropertyDescriptor | undefined
-): PropertyDescriptor;
-export default function track(target: any, prop?, descriptor?): any {
+    descriptor?: PropertyDescriptor
+): any {
     if (arguments.length === 1) {
         return reactiveMembrane.getProxy(target);
     }

--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -285,14 +285,11 @@ export function setElementProto(elm: Element, def: ComponentDef) {
     setPrototypeOf(elm, def.bridge.prototype);
 }
 
-// Typescript is inferring the wrong function type for this particular
-// overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-// @ts-ignore type-mismatch
-const HTML_PROPS: PropsDef = ArrayReduce.call(
+const HTML_PROPS = ArrayReduce.call(
     getOwnPropertyNames(HTMLElementOriginalDescriptors),
-    (props: PropsDef, propName: string): PropsDef => {
+    (props, propName) => {
         const attrName = getAttrNameFromPropName(propName);
-        props[propName] = {
+        (props as PropsDef)[propName] = {
             config: 3,
             type: 'any',
             attr: attrName,
@@ -300,4 +297,4 @@ const HTML_PROPS: PropsDef = ArrayReduce.call(
         return props;
     },
     create(null)
-);
+) as PropsDef;

--- a/packages/@lwc/engine/src/framework/modules/props.ts
+++ b/packages/@lwc/engine/src/framework/modules/props.ts
@@ -52,9 +52,10 @@ function update(oldVnode: VNode, vnode: VNode) {
         // if it is the first time this element is patched, or the current value is different to the previous value...
         if (
             isFirstPatch ||
-            cur !== (isLiveBindingProp(sel as string, key) ? elm[key] : (oldProps as any)[key])
+            cur !==
+                (isLiveBindingProp(sel as string, key) ? (elm as any)[key] : (oldProps as any)[key])
         ) {
-            elm[key] = cur;
+            (elm as any)[key] = cur;
         }
     }
 }

--- a/packages/@lwc/engine/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine/src/framework/modules/static-style-attr.ts
@@ -22,7 +22,7 @@ function createStyleAttribute(vnode: VNode) {
     const { style } = elm as HTMLElement;
 
     for (const name in styleMap) {
-        style[name] = styleMap[name];
+        (style as any)[name] = styleMap[name];
     }
 }
 

--- a/packages/@lwc/engine/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine/src/framework/observed-fields.ts
@@ -12,8 +12,8 @@ import { valueMutated, valueObserved } from '../libs/mutation-tracker';
 export function createObservedFieldsDescriptorMap(fields: PropertyKey[]): PropertyDescriptorMap {
     return ArrayReduce.call(
         fields,
-        (acc: PropertyDescriptorMap, field) => {
-            acc[field] = createObservedFieldPropertyDescriptor(field);
+        (acc, field) => {
+            (acc as PropertyDescriptorMap)[field] = createObservedFieldPropertyDescriptor(field);
 
             return acc;
         },

--- a/packages/@lwc/engine/src/framework/restrictions.ts
+++ b/packages/@lwc/engine/src/framework/restrictions.ts
@@ -408,7 +408,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(
     const originalDispatchEvent = proto.dispatchEvent;
     const originalIsConnectedGetter = getOwnPropertyDescriptor(proto, 'isConnected')!.get!;
 
-    const descriptors = {
+    const descriptors: PropertyDescriptorMap = {
         dispatchEvent: generateDataDescriptor({
             value(this: LightningElement, event: Event): boolean {
                 const vm = getAssociatedVM(this);

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -97,7 +97,13 @@ export function applyStyleAttributes(vm: VM, hostAttribute: string, shadowAttrib
     context.shadowAttribute = shadowAttribute;
 }
 
-function collectStylesheets(stylesheets, hostSelector, shadowSelector, isNative, aggregatorFn) {
+function collectStylesheets(
+    stylesheets: StylesheetFactory[],
+    hostSelector: string,
+    shadowSelector: string,
+    isNative: boolean,
+    aggregatorFn: (content: string) => void
+): void {
     forEach.call(stylesheets, sheet => {
         if (isArray(sheet)) {
             collectStylesheets(sheet, hostSelector, shadowSelector, isNative, aggregatorFn);

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -131,11 +131,11 @@ function callHook(
 }
 
 function setHook(cmp: ComponentInterface, prop: PropertyKey, newValue: any) {
-    cmp[prop] = newValue;
+    (cmp as any)[prop] = newValue;
 }
 
 function getHook(cmp: ComponentInterface, prop: PropertyKey): any {
-    return cmp[prop];
+    return (cmp as any)[prop];
 }
 
 export function rerenderVM(vm: VM) {

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -57,7 +57,7 @@ export function buildCustomElementConstructor(
             const vm = getAssociatedVM(this);
             removeRootVM(vm);
         }
-        attributeChangedCallback(attrName, oldValue, newValue) {
+        attributeChangedCallback(attrName: string, oldValue: string, newValue: string) {
             if (oldValue === newValue) {
                 // ignoring similar values for better perf
                 return;
@@ -77,7 +77,7 @@ export function buildCustomElementConstructor(
             }
             // reflect attribute change to the corresponding props when changed
             // from outside.
-            this[propName] = newValue;
+            (this as any)[propName] = newValue;
         }
         // collecting all attribute names from all public props to apply
         // the reflection from attributes to props via attributeChangedCallback.

--- a/packages/@lwc/engine/tsconfig.json
+++ b/packages/@lwc/engine/tsconfig.json
@@ -3,8 +3,6 @@
 
     "compilerOptions": {
         "noImplicitAny": false,
-        "strictFunctionTypes": false,
-        "strictPropertyInitialization": false,
         "outDir": "types",
 
         "lib": ["dom", "es2015", "es2016", "es2017", "es2018"]

--- a/packages/@lwc/engine/tsconfig.json
+++ b/packages/@lwc/engine/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "noImplicitAny": false,
         "outDir": "types",
-
         "lib": ["dom", "es2015", "es2016", "es2017", "es2018"]
     },
 


### PR DESCRIPTION
## Details

Enable strict typescript check for the `@lwc/engine` package. Removed the following tsconfig overrides: `noImplicitAny`, `strictFunctionTypes` and `strictPropertyInitialization`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631