### PR TITLE
refactor(wire-service): Enforce strict typescript check

### DIFF
--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -15,7 +15,6 @@ import { assert } from '@lwc/shared';
 import { CONTEXT_ID, CONTEXT_CONNECTED, CONTEXT_DISCONNECTED, CONTEXT_UPDATED } from './constants';
 import { ElementDef } from './engine';
 import {
-    NoArgumentListener,
     WireEventTargetListener,
     Context,
     WireContext,
@@ -45,7 +44,7 @@ const adapterFactories: Map<any, WireAdapterFactory> = new Map<any, WireAdapterF
  * Invokes the specified callbacks.
  * @param listeners functions to call
  */
-function invokeListener(listeners: NoArgumentListener[]): void {
+function invokeListener(listeners: WireEventTargetListener[]): void {
     for (let i = 0, len = listeners.length; i < len; ++i) {
         listeners[i].call(undefined);
     }
@@ -131,7 +130,7 @@ const wireService: Service = {
     },
 
     connected: (cmp, data, def, context) => {
-        let listeners: NoArgumentListener[];
+        let listeners: WireEventTargetListener[];
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(
                 !def.wire || context[CONTEXT_ID],
@@ -145,7 +144,7 @@ const wireService: Service = {
     },
 
     disconnected: (cmp, data, def, context) => {
-        let listeners: NoArgumentListener[];
+        let listeners: WireEventTargetListener[];
         if (process.env.NODE_ENV !== 'production') {
             assert.isTrue(
                 !def.wire || context[CONTEXT_ID],

--- a/packages/@lwc/wire-service/src/property-trap.ts
+++ b/packages/@lwc/wire-service/src/property-trap.ts
@@ -93,7 +93,7 @@ export function getReactiveParameterValue(
     cmp: EventTarget,
     reactiveParameter: ReactiveParameter
 ): any {
-    let value: any = cmp[reactiveParameter.head];
+    let value = (cmp as any)[reactiveParameter.head];
     if (!reactiveParameter.tail) {
         return value;
     }
@@ -161,7 +161,7 @@ export function findDescriptor(
  * @param callback A function to invoke when the prop's value changes
  * @return A property descriptor
  */
-function getOverrideDescriptor(cmp: Object, prop: string, callback: () => void) {
+function getOverrideDescriptor(cmp: EventTarget, prop: string, callback: () => void) {
     const descriptor = findDescriptor(cmp, prop);
     let enumerable;
     let get;
@@ -169,19 +169,19 @@ function getOverrideDescriptor(cmp: Object, prop: string, callback: () => void) 
     // This does not cover the override of existing descriptors at the instance level
     // and that's ok because eventually we will not need to do any of these :)
     if (descriptor === null || (descriptor.get === undefined && descriptor.set === undefined)) {
-        let value = cmp[prop];
+        let value = (cmp as any)[prop];
         enumerable = true;
         get = function() {
             return value;
         };
-        set = function(newValue) {
+        set = function(newValue: any) {
             value = newValue;
             callback();
         };
     } else {
         const { set: originalSet, get: originalGet } = descriptor;
         enumerable = descriptor.enumerable;
-        set = function(newValue) {
+        set = function(newValue: any) {
             if (originalSet) {
                 originalSet.call(cmp, newValue);
             }

--- a/packages/@lwc/wire-service/src/wiring.ts
+++ b/packages/@lwc/wire-service/src/wiring.ts
@@ -20,10 +20,8 @@ import { ValueChangedEvent } from './value-changed-event';
 import { LinkContextEvent } from './link-context-event';
 
 export type NoArgumentListener = () => void;
-export interface ConfigListenerArgument {
-    [key: string]: any;
-}
-export type ConfigListener = (ConfigListenerArgument) => void;
+
+export type ConfigListener = (config: any) => void;
 
 // a reactive parameter (WireDef.params.key) may be a dot-notation string to traverse into another @wire's target
 export interface ReactiveParameter {
@@ -101,7 +99,7 @@ function buildReactiveParameter(reference: string): ReactiveParameter {
     };
 }
 
-export class WireEventTarget {
+export class WireEventTarget implements EventTarget {
     _cmp: EventTarget;
     _def: ElementDef;
     _context: Context;
@@ -254,9 +252,9 @@ export class WireEventTarget {
         if (evt instanceof ValueChangedEvent) {
             const value = evt.value;
             if (this._wireDef.method) {
-                this._cmp[this._wireTarget](value);
+                (this._cmp as any)[this._wireTarget](value);
             } else {
-                this._cmp[this._wireTarget] = value;
+                (this._cmp as any)[this._wireTarget] = value;
             }
             return false; // canceling signal since we don't want this to propagate
         } else if (evt instanceof LinkContextEvent) {

--- a/packages/@lwc/wire-service/tsconfig.json
+++ b/packages/@lwc/wire-service/tsconfig.json
@@ -2,8 +2,6 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "noImplicitAny": false,
-
         "outDir": "types",
 
         "baseUrl": ".",


### PR DESCRIPTION
## Details

Enable strict typescript check for the `@lwc/wire-service` package. Removed the following tsconfig overrides: `noImplicitAny`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631
