### PR TITLE
build: Add linting for Jest and Jasmine

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -97,11 +97,12 @@
         {
             "files": [
                 "**/__tests__/**",
-                "**/__mocks__/**"
+                "**/__mocks__/**",
+                "**/integration-karma/**"
             ],
 
             "env": {
-                "jest": true
+                "jest": true,
             },
 
             "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,9 @@
     },
 
     "plugins": [
+        "jest",
+        "lwc-internal",
         "@typescript-eslint",
-        "lwc-internal"
     ],
     "extends": [
         "eslint:recommended",
@@ -101,6 +102,12 @@
 
             "env": {
                 "jest": true
+            },
+
+            "rules": {
+                "jest/no-focused-tests": "error",
+                "jest/valid-expect": "error",
+                "jest/valid-expect-in-promise": "error",
             }
         },
         {

--- a/.eslintrc
+++ b/.eslintrc
@@ -89,25 +89,7 @@
         "template-curly-spacing": "error",
         "yoda": "error",
 
-        "lwc-internal/no-invalid-todo": "error",
-
-        // Want to enable if there is consent
-        "no-shadow": "off", // 20 violations https://eslint.org/docs/rules/no-shadow	
-        "no-use-before-define": ["off", { "functions": true, "classes": true, "variables": false }], // 215 violations https://eslint.org/docs/rules/no-use-before-define
-        "prefer-arrow-callback": ["off", {
-            "allowNamedFunctions": false,
-            "allowUnboundThis": true
-          }], // 268 violations https://eslint.org/docs/rules/prefer-arrow-callback
-        "prefer-template": "off", // 52 violations, https://eslint.org/docs/rules/prefer-template template literals not supported in all browsers
-        "guard-for-in": "off", // 12 violations https://eslint.org/docs/rules/guard-for-in
-        "no-else-return": ["off", { "allowElseIf": false }], // 46 violations https://eslint.org/docs/rules/no-else-return
-        "no-implicit-coercion": ["off", {
-            "boolean": true,
-            "number": true,
-            "string": true,
-            "allow": []
-          }], // 28 violations https://eslint.org/docs/rules/no-implicit-coercion
-        "no-loop-func": "off" // 1 violation https://eslint.org/docs/rules/no-loop-func
+        "lwc-internal/no-invalid-todo": "error"
     },
 
     "overrides": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "concurrently": "^5.1.0",
     "es5-proxy-compat": "^0.22.0",
     "eslint": "^6.8.0",
+    "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-lwc-internal": "link:./scripts/eslint-plugin",
     "execa": "^4.0.0",
     "glob": "^7.1.6",

--- a/packages/@lwc/babel-plugin-component/src/__tests__/utils/test-transform.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/utils/test-transform.js
@@ -72,9 +72,11 @@ function pluginTest(plugin, pluginOpts, opts = {}) {
 
     const pluginTester = (name, actual, expected) =>
         test(name, () => transformTest(actual, expected));
-    pluginTester.only = (name, actual, expected) =>
-        test.only(name, () => transformTest(actual, expected));
     pluginTester.skip = name => test.skip(name);
+    pluginTester.only = (name, actual, expected) => {
+        // eslint-disable-next-line jest/no-focused-tests
+        test.only(name, () => transformTest(actual, expected));
+    };
 
     return pluginTester;
 }

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform.spec.ts
@@ -25,7 +25,7 @@ testValidateOptions('transformSync', transformSync);
 
 describe('transform', () => {
     it('returns a promise resolving to an object with code', () => {
-        expect(
+        return expect(
             transform(`console.log('Hello')`, 'foo.js', { name: 'foo', namespace: 'x' })
         ).resolves.toMatchObject({
             code: expect.any(String),

--- a/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
@@ -58,11 +58,11 @@ describe('api', () => {
         it('should throw for anything other than vnode and null', () => {
             expect(() => {
                 api.h('p', { key: 0 }, ['text']);
-            });
+            }).toThrow();
 
             expect(() => {
                 api.h('p', {}, [undefined]);
-            });
+            }).toThrow();
         });
     });
 

--- a/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/error-boundary.spec.ts
@@ -815,7 +815,7 @@ describe('error boundary component', () => {
 
                     const elm = createElement('inner-error-boundary', { is: InnerErrorBoundary });
                     document.body.appendChild(elm);
-                    Promise.resolve().then(() => {
+                    return Promise.resolve().then(() => {
                         // waiting for the alternative view to kick in
                         const p = elm.shadowRoot
                             .querySelector('post-error-child-content')

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-/* tslint:disable:max-line-length */
-
 import { mergeConfig } from '../config';
 import State from '../state';
 import parse from '../parser';

--- a/packages/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/integration-karma/test/api/createElement/index.spec.js
@@ -91,7 +91,7 @@ if (process.env.NATIVE_SHADOW) {
         // retrieve it by accessing the template property from the class.
         const shadowRoot = elm.getShadowRoot();
 
-        expect(shadowRoot).toBeInstanceof(ShadowRoot);
+        expect(shadowRoot).toBeInstanceOf(ShadowRoot);
         expect(shadowRoot.mode).toBe('closed');
     });
 }

--- a/packages/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/integration-karma/test/api/createElement/index.spec.js
@@ -70,7 +70,7 @@ if (process.env.NATIVE_SHADOW) {
             is: Test,
         });
 
-        expect(elm.shadowRoot instanceof ShadowRoot);
+        expect(elm.shadowRoot).toBeInstanceOf(ShadowRoot);
         expect(elm.shadowRoot.constructor.name).toBe('ShadowRoot');
     });
 
@@ -91,7 +91,7 @@ if (process.env.NATIVE_SHADOW) {
         // retrieve it by accessing the template property from the class.
         const shadowRoot = elm.getShadowRoot();
 
-        expect(shadowRoot instanceof ShadowRoot);
+        expect(shadowRoot).toBeInstanceof(ShadowRoot);
         expect(shadowRoot.mode).toBe('closed');
     });
 }

--- a/packages/integration-karma/test/component/LightningElement.classList/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.classList/index.spec.js
@@ -16,7 +16,7 @@ it('should return an instance of DOMTokenList', () => {
     const elm = createElement('x-test', { is: XTest });
     document.body.appendChild(elm);
 
-    expect(elm.getClassList() instanceof DOMTokenList);
+    expect(elm.getClassList()).toBeInstanceOf(DOMTokenList);
 });
 
 it('should return of classed applied from the outside', () => {

--- a/packages/integration-karma/test/component/LightningElement.shadowRoot/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.shadowRoot/index.spec.js
@@ -13,5 +13,5 @@ it('should be able to access the shadowRoot property from outside the component'
     document.body.appendChild(el);
 
     expect(el.shadowRoot).not.toBe(null);
-    expect(el.shadowRoot instanceof ShadowRoot);
+    expect(el.shadowRoot).toBeInstanceOf(ShadowRoot);
 });

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
@@ -11,70 +11,59 @@ function waitForSlotChange() {
 let parent;
 let child;
 
-beforeEach(() => {
+beforeEach(async () => {
     parent = createElement('x-parent', { is: Parent });
     document.body.appendChild(parent);
     child = parent.shadowRoot.querySelector('x-child');
+
+    await waitForSlotChange();
 });
 
 it('should fire slotchange on initial render', () => {
-    return waitForSlotChange().then(() => {
-        expect(child.getSlotChangeCount()).toBe(1);
-    });
+    expect(child.getSlotChangeCount()).toBe(1);
 });
 
 it('should fire non-composed slotchange', () => {
-    return waitForSlotChange().then(() => {
-        expect(parent.getSlotChangeCount()).toBe(0);
-    });
+    expect(parent.getSlotChangeCount()).toBe(0);
 });
 
 it('should fire slotchange on add', () => {
-    const firedFirstSlotchange = waitForSlotChange();
-    const addNewElementToSlot = firedFirstSlotchange.then(() => {
-        child.setSlotChangeCount(0);
-        parent.add();
-    });
-    const firedSecondSlotchange = addNewElementToSlot.then(waitForSlotChange);
-    return firedSecondSlotchange.then(() => {
+    child.setSlotChangeCount(0);
+    parent.add();
+
+    return waitForSlotChange().then(() => {
         expect(child.getSlotChangeCount()).toBe(1);
     });
 });
 
 it('should fire slotchange on remove', () => {
-    const firedFirstSlotChange = waitForSlotChange();
-    const removeElementsFromSlot = firedFirstSlotChange.then(() => {
-        child.setSlotChangeCount(0);
-        parent.clear();
-    });
-    const firedSecondSlotchange = removeElementsFromSlot.then(waitForSlotChange);
-    return firedSecondSlotchange.then(() => {
+    child.setSlotChangeCount(0);
+    parent.clear();
+
+    return waitForSlotChange().then(() => {
         expect(child.getSlotChangeCount()).toBe(1);
     });
 });
 
 it('should fire slotchange on replace', () => {
-    const firedFirstSlotChange = waitForSlotChange();
-    const replaceElementInSlot = firedFirstSlotChange.then(() => {
-        child.setSlotChangeCount(0);
-        parent.replace();
-    });
-    const firedSecondSlotchange = replaceElementInSlot.then(waitForSlotChange);
-    return firedSecondSlotchange.then(() => {
+    child.setSlotChangeCount(0);
+    parent.replace();
+
+    return waitForSlotChange().then(() => {
         expect(child.getSlotChangeCount()).toBe(1);
     });
 });
 
 it('should fire slotchange when listener added programmatically', () => {
     let count = 0;
-    const firedFirstSlotChange = waitForSlotChange();
-    const addNewElementToSlot = firedFirstSlotChange.then(() => {
-        child.shadowRoot.querySelector('slot').addEventListener('slotchange', () => {
-            count += 1;
-        });
-        parent.add();
+
+    child.shadowRoot.querySelector('slot').addEventListener('slotchange', () => {
+        count += 1;
     });
-    return addNewElementToSlot.then(waitForSlotChange).then(() => {
+
+    parent.add();
+
+    return waitForSlotChange().then(() => {
         expect(count).toBe(1);
     });
 });

--- a/packages/integration-karma/test/template/directive-for-each/arrayMutation.spec.js
+++ b/packages/integration-karma/test/template/directive-for-each/arrayMutation.spec.js
@@ -16,7 +16,7 @@ describe('Testing array primitives', () => {
     function testReactivity(testCase, expectedItems, fn) {
         it(`check ${testCase} reactivity`, function() {
             fn(elm);
-            Promise.resolve().then(function() {
+            return Promise.resolve().then(function() {
                 var list = Array.prototype.slice.call(elm.shadowRoot.querySelectorAll('li'));
 
                 var textList = list.map(function(li) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,6 +2726,15 @@
     "@typescript-eslint/typescript-estree" "2.22.0"
     eslint-scope "^5.0.0"
 
+"@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz#5d2261c8038ec1698ca4435a8da479c661dc9242"
+  integrity sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.23.0"
+    eslint-scope "^5.0.0"
+
 "@typescript-eslint/parser@^2.22.0":
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.22.0.tgz#8eeb6cb6de873f655e64153397d4790898e149d0"
@@ -2740,6 +2749,19 @@
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz#a16ed45876abf743e1f5857e2f4a1c3199fd219e"
   integrity sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz#d355960fab96bd550855488dcc34b9a4acac8d36"
+  integrity sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -5411,6 +5433,13 @@ escodegen@^1.11.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-plugin-jest@^23.8.2:
+  version "23.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz#6f28b41c67ef635f803ebd9e168f6b73858eb8d4"
+  integrity sha512-xwbnvOsotSV27MtAe7s8uGWOori0nUsrXh2f1EnpmXua8sDfY6VZhHAhHg2sqK7HBNycRQExF074XSZ7DvfoFg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
 
 "eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"


### PR DESCRIPTION
## Details

To prevent focussed tests in the future to [sneak](https://github.com/salesforce/lwc/pull/1602#discussion_r390950818) into the codebase and to avoid other tests gotchas, this PR introduces the following jest rules:
- [`jest/no-focused-tests`](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-focused-tests.md)
- [`jest/valid-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect.md)
- [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md)

**Misc. changes:**
- Removed eslint rules from the `.eslintrc` that were never enabled. We can add them back later if we feel the need for it.
- Remove last reference to TSLint in the repo :tada: 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7109631
