### PR TITLE
build: update to prettier@2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
     "printWidth": 100,
-    "tabWidth": 4,
     "singleQuote": true,
-    "trailingComma": "es5"
+    "tabWidth": 4
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lerna": "^3.20.2",
     "lint-staged": "^10.1.3",
     "mime-types": "^2.1.26",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "rollup": "^1.32.1",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-compat": "^0.22.0",

--- a/packages/@lwc/babel-plugin-component/src/__tests__/utils/test-transform.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/utils/test-transform.js
@@ -20,7 +20,7 @@ function transform(plugin, pluginOpts = {}, opts = {}) {
         opts
     );
 
-    return function(source) {
+    return function (source) {
         return babel.transform(prettify(source), testConfig);
     };
 }
@@ -30,15 +30,15 @@ function prettify(str) {
         .toString()
         .replace(/^\s+|\s+$/, '')
         .split('\n')
-        .map(line => line.trim())
-        .filter(line => line.length)
+        .map((line) => line.trim())
+        .filter((line) => line.length)
         .join('\n');
 }
 
 function pluginTest(plugin, pluginOpts, opts = {}) {
     const testTransform = transform(plugin, pluginOpts, opts);
 
-    const transformTest = function(actual, expected) {
+    const transformTest = function (actual, expected) {
         if (expected.error) {
             let transformError;
 
@@ -72,7 +72,7 @@ function pluginTest(plugin, pluginOpts, opts = {}) {
 
     const pluginTester = (name, actual, expected) =>
         test(name, () => transformTest(actual, expected));
-    pluginTester.skip = name => test.skip(name);
+    pluginTester.skip = (name) => test.skip(name);
     pluginTester.only = (name, actual, expected) => {
         // eslint-disable-next-line jest/no-focused-tests
         test.only(name, () => transformTest(actual, expected));

--- a/packages/@lwc/babel-plugin-component/src/component.js
+++ b/packages/@lwc/babel-plugin-component/src/component.js
@@ -8,7 +8,7 @@ const { generateError, getEngineImportSpecifiers } = require('./utils');
 const { LWC_PACKAGE_EXPORTS, LWC_SUPPORTED_APIS } = require('./constants');
 const { LWCClassErrors } = require('@lwc/errors');
 
-module.exports = function() {
+module.exports = function () {
     return {
         Program(path, state) {
             const engineImportSpecifiers = getEngineImportSpecifiers(path);

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/transform.js
@@ -34,7 +34,7 @@ function getSiblingGetSetPair(propertyPath, propertyName, type) {
     const siblingType = type === 'getter' ? 'set' : 'get';
     const klassBody = propertyPath.parentPath.get('body');
     const siblingNode = klassBody.find(
-        classMethodPath =>
+        (classMethodPath) =>
             classMethodPath !== propertyPath &&
             classMethodPath.isClassMethod({ kind: siblingType }) &&
             classMethodPath.node.key.name === propertyName

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/validate.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/validate.js
@@ -17,7 +17,7 @@ const { generateError } = require('../../utils');
 
 function validateConflict(path, decorators) {
     const isPublicFieldTracked = decorators.some(
-        decorator =>
+        (decorator) =>
             decorator.name === TRACK_DECORATOR &&
             decorator.path.parentPath.node === path.parentPath.node
     );
@@ -84,7 +84,7 @@ function validateSingleApiDecoratorOnSetterGetterPair(decorators) {
     // keep track of visited class methods
     const visitedMethods = new Set();
 
-    decorators.forEach(decorator => {
+    decorators.forEach((decorator) => {
         const { path, type } = decorator;
 
         // since we are validating get/set we only look at @api methods

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.js
@@ -21,7 +21,7 @@ const { DecoratorErrors } = require('@lwc/errors');
 const DECORATOR_TRANSFORMS = [api, wire, track];
 
 function isLwcDecoratorName(name) {
-    return DECORATOR_TRANSFORMS.some(transform => transform.name === name);
+    return DECORATOR_TRANSFORMS.some((transform) => transform.name === name);
 }
 
 /** Returns a list of all the references to an identifier */
@@ -52,7 +52,7 @@ function getLwcDecorators(importSpecifiers) {
         .reduce((acc, { name, path }) => {
             // Get a list of all the  local references
             const local = path.get('imported');
-            const references = getReferences(local).map(reference => ({
+            const references = getReferences(local).map((reference) => ({
                 name,
                 reference,
             }));
@@ -94,7 +94,7 @@ function getLwcDecorators(importSpecifiers) {
 /** Group decorator per class */
 function groupDecorator(decorators) {
     return decorators.reduce((acc, decorator) => {
-        const classPath = decorator.path.findParent(node => node.isClass());
+        const classPath = decorator.path.findParent((node) => node.isClass());
 
         if (acc.has(classPath)) {
             acc.set(classPath, [...acc.get(classPath), decorator]);
@@ -180,7 +180,7 @@ function decorators({ types: t }) {
         },
 
         Decorator(path) {
-            const AVAILABLE_DECORATORS = DECORATOR_TRANSFORMS.map(transform => transform.name);
+            const AVAILABLE_DECORATORS = DECORATOR_TRANSFORMS.map((transform) => transform.name);
 
             throw generateError(path.parentPath, {
                 errorInfo: DecoratorErrors.INVALID_DECORATOR,

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -21,15 +21,15 @@ function isObservedProperty(configProperty) {
 function getWiredStatic(wireConfig) {
     return wireConfig
         .get('properties')
-        .filter(property => !isObservedProperty(property))
-        .map(path => path.node);
+        .filter((property) => !isObservedProperty(property))
+        .map((path) => path.node);
 }
 
 function getWiredParams(t, wireConfig) {
     return wireConfig
         .get('properties')
-        .filter(property => isObservedProperty(property))
-        .map(path => {
+        .filter((property) => isObservedProperty(property))
+        .map((path) => {
             // Need to clone deep the observed property to remove the param prefix
             const clonedProperty = t.cloneDeep(path.node);
             clonedProperty.value.value = clonedProperty.value.value.slice(1);
@@ -42,7 +42,7 @@ function getGeneratedConfig(t, wiredValue) {
     let counter = 0;
     const configBlockBody = [];
     const configProps = [];
-    const generateParameterConfigValue = memberExprPaths => {
+    const generateParameterConfigValue = (memberExprPaths) => {
         // Note: When memberExprPaths ($foo.bar) has an invalid identifier (eg: foo..bar, foo.bar[3])
         //       it should (ideally) resolve in a compilation error during validation phase.
         //       This is not possible due that platform components may have a param definition which is invalid
@@ -50,7 +50,7 @@ function getGeneratedConfig(t, wiredValue) {
         //       In such cases where the param does not have proper notation, the config generated will use the bracket
         //       notation to match the current behavior (that most likely end up resolving that param as undefined).
         const isInvalidMemberExpr = memberExprPaths.some(
-            maybeIdentifier =>
+            (maybeIdentifier) =>
                 !(t.isValidES3Identifier(maybeIdentifier) && maybeIdentifier.length > 0)
         );
         const memberExprPropertyGen = !isInvalidMemberExpr ? t.identifier : t.StringLiteral;
@@ -119,7 +119,7 @@ function getGeneratedConfig(t, wiredValue) {
     }
 
     if (wiredValue.params) {
-        wiredValue.params.forEach(param => {
+        wiredValue.params.forEach((param) => {
             const memberExprPaths = param.value.value.split('.');
             const paramConfigValue = generateParameterConfigValue(memberExprPaths);
 
@@ -144,7 +144,7 @@ function getGeneratedConfig(t, wiredValue) {
 
 function buildWireConfigValue(t, wiredValues) {
     return t.objectExpression(
-        wiredValues.map(wiredValue => {
+        wiredValues.map((wiredValue) => {
             const wireConfig = [];
             if (wiredValue.adapter) {
                 wireConfig.push(
@@ -190,7 +190,7 @@ const SUPPORTED_VALUE_TO_TYPE_MAP = {
     BooleanLiteral: 'boolean',
 };
 
-const scopedReferenceLookup = scope => name => {
+const scopedReferenceLookup = (scope) => (name) => {
     const binding = scope.getBinding(name);
 
     let type;

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.js
@@ -69,7 +69,7 @@ function validateWireParameters(path) {
 }
 
 function validateUsageWithOtherDecorators(path, decorators) {
-    decorators.forEach(decorator => {
+    decorators.forEach((decorator) => {
         if (
             path !== decorator.path &&
             decorator.name === WIRE_DECORATOR &&

--- a/packages/@lwc/babel-plugin-component/src/dynamic-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/dynamic-imports.js
@@ -24,7 +24,7 @@ function validateImport(sourcePath) {
  * Expected API for this plugin:
  * { dynamicImports: { loader: string, strictSpecifier: boolean } }
  */
-module.exports = function() {
+module.exports = function () {
     function getLoaderRef(path, loaderName, state) {
         if (!state.loaderRef) {
             state.loaderRef = moduleImports.addNamed(path, 'load', loaderName);

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -53,14 +53,14 @@ module.exports = function postProcess({ types: t }) {
         const nonDecoratedFields = body
             .get('body')
             .filter(
-                path =>
+                (path) =>
                     t.isClassProperty(path.node) &&
                     !isLWCNode(path.node) &&
                     !path.node.static &&
                     t.isIdentifier(path.node.key) &&
                     !(decoratedIdentifiers.indexOf(path.node.key.name) >= 0)
             )
-            .map(path => path.node.key.name);
+            .map((path) => path.node.key.name);
 
         return nonDecoratedFields.length
             ? t.objectProperty(t.identifier('fields'), t.valueToNode(nonDecoratedFields))

--- a/packages/@lwc/babel-plugin-component/src/utils.js
+++ b/packages/@lwc/babel-plugin-component/src/utils.js
@@ -40,9 +40,9 @@ function staticClassProperty(types, name, expression) {
 }
 
 function getEngineImportsStatements(path) {
-    const programPath = path.isProgram() ? path : path.findParent(node => node.isProgram());
+    const programPath = path.isProgram() ? path : path.findParent((node) => node.isProgram());
 
-    return programPath.get('body').filter(node => {
+    return programPath.get('body').filter((node) => {
         const source = node.get('source');
         return node.isImportDeclaration() && source.isStringLiteral({ value: LWC_PACKAGE_ALIAS });
     });

--- a/packages/@lwc/compiler/src/__tests__/utils.ts
+++ b/packages/@lwc/compiler/src/__tests__/utils.ts
@@ -22,7 +22,7 @@ export function pretify(str: string): string {
         .toString()
         .replace(/^\s+|\s+$/, '')
         .split('\n')
-        .map(line => line.trim())
-        .filter(line => line.length)
+        .map((line) => line.trim())
+        .filter((line) => line.length)
         .join('\n');
 }

--- a/packages/@lwc/compiler/src/compiler/__tests__/modes.spec.ts
+++ b/packages/@lwc/compiler/src/compiler/__tests__/modes.spec.ts
@@ -25,7 +25,7 @@ function getConfig(env = {}) {
     };
 }
 
-describe('environment replacement', function() {
+describe('environment replacement', function () {
     it('should not replace environment variable if unset', async () => {
         const {
             result: { code },

--- a/packages/@lwc/compiler/src/compiler/__tests__/result.spec.ts
+++ b/packages/@lwc/compiler/src/compiler/__tests__/result.spec.ts
@@ -236,7 +236,7 @@ export default class Test extends LightningElement {
             },
         });
 
-        await SourceMapConsumer.with(result!.map, null, sourceMapConsumer => {
+        await SourceMapConsumer.with(result!.map, null, (sourceMapConsumer) => {
             const mainDefMappedToOutputPosition = sourceMapConsumer.generatedPositionFor({
                 source: 'utils/util.js',
                 line: 1,

--- a/packages/@lwc/compiler/src/compiler/compiler.ts
+++ b/packages/@lwc/compiler/src/compiler/compiler.ts
@@ -53,7 +53,7 @@ export async function compile(options: CompileOptions): Promise<CompilerOutput> 
 }
 
 function hasError(diagnostics: CompilerDiagnostic[]) {
-    return diagnostics.some(d => {
+    return diagnostics.some((d) => {
         return d.level === DiagnosticLevel.Error || d.level === DiagnosticLevel.Fatal;
     });
 }

--- a/packages/@lwc/compiler/src/rollup-plugins/__tests__/compat.spec.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/__tests__/compat.spec.ts
@@ -30,7 +30,7 @@ describe('rollup plugin lwc-compat', () => {
 
         expect(result.map).not.toBeNull();
 
-        await SourceMapConsumer.with(result!.map, null, sourceMapConsumer => {
+        await SourceMapConsumer.with(result!.map, null, (sourceMapConsumer) => {
             const varMappedToConstPosition = sourceMapConsumer.originalPositionFor({
                 line: 2,
                 column: 0,

--- a/packages/@lwc/compiler/src/rollup-plugins/__tests__/minify.spec.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/__tests__/minify.spec.ts
@@ -27,7 +27,7 @@ describe('rollup plugin lwc-minify', () => {
 
         expect(result.map).not.toBeNull();
 
-        await SourceMapConsumer.with(result!.map, null, sourceMapConsumer => {
+        await SourceMapConsumer.with(result!.map, null, (sourceMapConsumer) => {
             const commentInOutputPosition = sourceMapConsumer.generatedPositionFor({
                 line: 2,
                 column: 0,

--- a/packages/@lwc/compiler/src/rollup-plugins/compat.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/compat.ts
@@ -10,7 +10,7 @@ import * as babel from '@babel/core';
 import { BABEL_CONFIG_BASE } from '../babel-plugins';
 import { NormalizedOutputConfig } from '../options';
 
-export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
+export default function ({ sourcemap }: NormalizedOutputConfig): Plugin {
     // Inlining the `babel-preset-compat` module require to only pay the parsing and evaluation cost for needed modules
     const presetCompat = require('babel-preset-compat');
 

--- a/packages/@lwc/compiler/src/rollup-plugins/env-replacement.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/env-replacement.ts
@@ -9,7 +9,7 @@ import rollupPluginReplace from '@rollup/plugin-replace';
 
 import { NormalizedCompileOptions } from '../options';
 
-export default function({ options }: { options: NormalizedCompileOptions }): Plugin {
+export default function ({ options }: { options: NormalizedCompileOptions }): Plugin {
     const { env } = options.outputConfig;
 
     const patterns: { [pattern: string]: string } = {};

--- a/packages/@lwc/compiler/src/rollup-plugins/minify.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/minify.ts
@@ -11,7 +11,7 @@ import { NormalizedOutputConfig } from '../options';
 /**
  * Rollup plugin applying minification to the generated bundle.
  */
-export default function({ sourcemap }: NormalizedOutputConfig): Plugin {
+export default function ({ sourcemap }: NormalizedOutputConfig): Plugin {
     // Inlining the `terser` module require to only pay the parsing and evaluation cost for needed
     // modules
     const { minify } = require('terser');

--- a/packages/@lwc/compiler/src/rollup-plugins/module-resolver.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/module-resolver.ts
@@ -47,7 +47,8 @@ function isFirstCharacterUppercased(importee: string) {
 
 function inferExtension(fileName: string, files: BundleFiles) {
     if (!path.extname(fileName)) {
-        const ext = VALID_EXTENSIONS.find(ext => hasOwnProperty.call(files, fileName + ext)) || '';
+        const ext =
+            VALID_EXTENSIONS.find((ext) => hasOwnProperty.call(files, fileName + ext)) || '';
         return fileName + ext;
     }
     return fileName;
@@ -131,7 +132,7 @@ function getCaseIgnoredFilenameMatch(files: { [key: string]: string }, nameToMat
     );
 }
 
-export default function({ options }: { options: NormalizedCompileOptions }): Plugin {
+export default function ({ options }: { options: NormalizedCompileOptions }): Plugin {
     return {
         name: 'lwc-module-resolver',
 

--- a/packages/@lwc/compiler/src/rollup-plugins/transform.ts
+++ b/packages/@lwc/compiler/src/rollup-plugins/transform.ts
@@ -10,7 +10,7 @@ import { transformFile } from '../transformers/transformer';
 
 import { NormalizedCompileOptions } from '../options';
 
-export default function({ options }: { options: NormalizedCompileOptions }): Plugin {
+export default function ({ options }: { options: NormalizedCompileOptions }): Plugin {
     return {
         name: 'lwc-file-transform',
         transform(src: string, id: string) {

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -42,7 +42,7 @@ export default function templateTransform(
         throw normalizeToCompilerError(TransformerErrors.HTML_TRANSFORMER_ERROR, e, { filename });
     }
 
-    const fatalError = result.warnings.find(warning => warning.level === DiagnosticLevel.Error);
+    const fatalError = result.warnings.find((warning) => warning.level === DiagnosticLevel.Error);
     if (fatalError) {
         throw CompilerError.from(fatalError, { filename });
     }

--- a/packages/@lwc/engine/scripts/jest/matchers/log-error.js
+++ b/packages/@lwc/engine/scripts/jest/matchers/log-error.js
@@ -39,7 +39,7 @@ function createMatcher(methodName) {
             if (this.isNot) {
                 if (receivedMessages.length > 0) {
                     const formattedMessages = receivedMessages
-                        .map(message => this.utils.printReceived(message))
+                        .map((message) => this.utils.printReceived(message))
                         .join('\n\n');
 
                     return {
@@ -80,7 +80,7 @@ function createMatcher(methodName) {
                     }
                 } else {
                     const formattedMessages = receivedMessages
-                        .map(message => this.utils.printReceived(message))
+                        .map((message) => this.utils.printReceived(message))
                         .join('\n\n');
 
                     return {

--- a/packages/@lwc/engine/src/__tests__/dom.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/dom.spec.ts
@@ -9,37 +9,37 @@ import { createElement, LightningElement, registerDecorators } from '../';
 
 describe('dom', () => {
     describe('composed polyfill', () => {
-        it('should get native events as composed true', function() {
+        it('should get native events as composed true', function () {
             expect.assertions(1);
             const elm = document.createElement('div');
             document.body.appendChild(elm);
-            elm.addEventListener('click', function(e) {
+            elm.addEventListener('click', function (e) {
                 expect(e.composed).toBe(true);
             });
             elm.click();
         });
 
-        it('should get custom events as composed false', function() {
+        it('should get custom events as composed false', function () {
             expect.assertions(1);
             const elm = document.createElement('div');
             document.body.appendChild(elm);
-            elm.addEventListener('bar', function(e) {
+            elm.addEventListener('bar', function (e) {
                 expect(e.composed).toBe(false);
             });
             elm.dispatchEvent(new CustomEvent('bar', {}));
         });
 
-        it('should allow customization of composed init in custom events', function() {
+        it('should allow customization of composed init in custom events', function () {
             expect.assertions(1);
             const elm = document.createElement('div');
             document.body.appendChild(elm);
-            elm.addEventListener('foo', function(e) {
+            elm.addEventListener('foo', function (e) {
                 expect(e.composed).toBe(true);
             });
             elm.dispatchEvent(new CustomEvent('foo', { composed: true }));
         });
 
-        it('should handle event.target on events dispatched on custom elements', function() {
+        it('should handle event.target on events dispatched on custom elements', function () {
             expect.assertions(1);
             class MyComponent extends LightningElement {
                 trigger() {

--- a/packages/@lwc/engine/src/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/__tests__/events.spec.ts
@@ -58,7 +58,7 @@ describe('events', () => {
 
             class MyComponent extends LightningElement {
                 renderedCallback() {
-                    this.template.addEventListener('click', event => {
+                    this.template.addEventListener('click', (event) => {
                         event.stopPropagation();
                     });
                 }
@@ -179,7 +179,7 @@ describe('events', () => {
             elm.setAttribute('data-target', 'x-root');
             const divWithClickHandler = document.createElement('div');
             let target;
-            divWithClickHandler.addEventListener('click', function(event) {
+            divWithClickHandler.addEventListener('click', function (event) {
                 target = event.target;
             });
             divWithClickHandler.appendChild(elm);
@@ -204,7 +204,7 @@ describe('events', () => {
             `);
 
             let target;
-            document.addEventListener('click', function(event) {
+            document.addEventListener('click', function (event) {
                 target = event.target;
             });
             const elm = createElement('x-root', { is: Root });
@@ -297,7 +297,7 @@ describe('events', () => {
 
             class Root extends LightningElement {
                 renderedCallback() {
-                    this.template.addEventListener('click', event => {
+                    this.template.addEventListener('click', (event) => {
                         target = event.target;
                     });
                     this.template.querySelector('.container').innerHTML = `<span><a></a></span>`;
@@ -331,7 +331,7 @@ describe('events', () => {
                 }
                 renderedCallback() {
                     let domEvent;
-                    this.addEventListener('change', e => {
+                    this.addEventListener('change', (e) => {
                         domEvent = e;
                         expect(e.target).toBe(this.template.host);
                     });
@@ -515,7 +515,7 @@ describe('events', () => {
             let target;
             class Root extends LightningElement {
                 connectedCallback() {
-                    this.template.addEventListener('bubblesnotcomposed', evt => {
+                    this.template.addEventListener('bubblesnotcomposed', (evt) => {
                         listenerCalled = true;
                         target = evt.target;
                     });
@@ -556,7 +556,7 @@ describe('events', () => {
         it('Issue#941: an object type EventListener works on standard html nodes outside custom element', () => {
             let target;
             const eventListener = {
-                handleEvent: function(evt) {
+                handleEvent: function (evt) {
                     expect(this).toBe(eventListener);
                     target = evt.target;
                 },
@@ -583,7 +583,7 @@ describe('events', () => {
                 renderedCallback() {
                     const button = this.template.querySelector('button');
                     const eventListener = {
-                        handleEvent: function(evt) {
+                        handleEvent: function (evt) {
                             expect(this).toBe(eventListener);
                             expect(evt.target).toBe(button);
                         },

--- a/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/api.spec.ts
@@ -16,7 +16,7 @@ describe('api', () => {
         class Foo extends LightningElement {}
 
         it('should call the Ctor factory for circular dependencies', () => {
-            const factory = function() {
+            const factory = function () {
                 class Foo extends LightningElement {
                     xyz() {
                         return 1;
@@ -42,7 +42,7 @@ describe('api', () => {
             }).toThrowError(/className/);
         });
 
-        it('should throw an error when createElement is called without Ctor', function() {
+        it('should throw an error when createElement is called without Ctor', function () {
             expect(() => {
                 createElement('x-foo');
             }).toThrow();
@@ -98,32 +98,32 @@ describe('api', () => {
             expect(vnodes).toEqual([false, false, true]);
         });
 
-        it('should handle arrays', function() {
+        it('should handle arrays', function () {
             const o = [1, 2];
-            const vnodes = api.i(o, item => item + 'a');
+            const vnodes = api.i(o, (item) => item + 'a');
             expect(vnodes).toEqual(['1a', '2a']);
         });
 
-        it('should handle Sets', function() {
+        it('should handle Sets', function () {
             const o = new Set();
             o.add(1);
             o.add(2);
-            const vnodes = api.i(o, item => item + 'a');
+            const vnodes = api.i(o, (item) => item + 'a');
             expect(vnodes).toEqual(['1a', '2a']);
         });
 
-        it('should handle Map', function() {
+        it('should handle Map', function () {
             const o = new Map();
             o.set('foo', 1);
             o.set('bar', 2);
-            const vnodes = api.i(o, item => item + 'a');
+            const vnodes = api.i(o, (item) => item + 'a');
             expect(vnodes).toEqual(['foo,1a', 'bar,2a']);
         });
 
-        it('should handle proxies objects', function() {
+        it('should handle proxies objects', function () {
             const array = [1, 2];
             const o = new Proxy(array, {});
-            const vnodes = api.i(o, item => item + 'a');
+            const vnodes = api.i(o, (item) => item + 'a');
             expect(vnodes).toEqual(['1a', '2a']);
         });
 

--- a/packages/@lwc/engine/src/framework/__tests__/diff.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/diff.spec.ts
@@ -108,7 +108,7 @@ class Store {
     }
 
     delete(id) {
-        const idx = this.data.findIndex(d => d.id == id);
+        const idx = this.data.findIndex((d) => d.id == id);
         this.data.splice(idx, 1);
     }
 
@@ -144,7 +144,7 @@ class Store {
             const d4 = this.data[4];
             const d9 = this.data[9];
 
-            const newData = this.data.map(function(data, i) {
+            const newData = this.data.map(function (data, i) {
                 if (i === 4) {
                     return d9;
                 } else if (i === 9) {

--- a/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/events.spec.ts
@@ -56,7 +56,7 @@ describe('Composed events', () => {
 });
 
 describe('Events on Custom Elements', () => {
-    it('attaches click event handler to custom element from within (wc-compat)', function() {
+    it('attaches click event handler to custom element from within (wc-compat)', function () {
         let cmp;
         const result = [];
         function clicked(ev) {
@@ -85,7 +85,7 @@ describe('Events on Custom Elements', () => {
         expect(result).toHaveLength(1);
     });
 
-    it('should dispatch internal listeners first', function() {
+    it('should dispatch internal listeners first', function () {
         let cmp;
         const result = [];
         function clicked1() {
@@ -118,7 +118,7 @@ describe('Events on Custom Elements', () => {
         expect(result).toEqual([1, 2]);
     });
 
-    it('should preserve behavior of stopimmidiatepropagation() for internal listeners', function() {
+    it('should preserve behavior of stopimmidiatepropagation() for internal listeners', function () {
         let cmp;
         const result = [];
         function clicked1(ev) {
@@ -152,7 +152,7 @@ describe('Events on Custom Elements', () => {
         expect(result).toEqual([1]);
     });
 
-    it('should preserve behavior of stopimmidiatepropagation() for external listeners', function() {
+    it('should preserve behavior of stopimmidiatepropagation() for external listeners', function () {
         let cmp;
         const result = [];
         function clicked1(ev) {
@@ -186,7 +186,7 @@ describe('Events on Custom Elements', () => {
         expect(result).toEqual([1]);
     });
 
-    it('attaches custom event handler to custom element from within (wc-compat)', function() {
+    it('attaches custom event handler to custom element from within (wc-compat)', function () {
         let cmp;
         const result = [];
         function tested(ev) {
@@ -215,7 +215,7 @@ describe('Events on Custom Elements', () => {
         expect(result).toHaveLength(1);
     });
 
-    it('should expose template as context to the event handler when defined from within (wc-compat)', function() {
+    it('should expose template as context to the event handler when defined from within (wc-compat)', function () {
         let cmp;
         const result = [];
         function clicked() {
@@ -321,7 +321,7 @@ describe('Events on Custom Elements', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    it('should add event listeners in constructor when created via createElement', function() {
+    it('should add event listeners in constructor when created via createElement', function () {
         let count = 0;
 
         const html = compileTemplate(`
@@ -332,7 +332,7 @@ describe('Events on Custom Elements', () => {
         class MyComponent extends LightningElement {
             constructor() {
                 super();
-                this.template.addEventListener('c-event', function() {
+                this.template.addEventListener('c-event', function () {
                     count += 1;
                 });
             }
@@ -354,7 +354,7 @@ describe('Events on Custom Elements', () => {
         expect(count).toBe(1);
     });
 
-    it('should add event listeners in connectedCallback when created via createElement', function() {
+    it('should add event listeners in connectedCallback when created via createElement', function () {
         let count = 0;
 
         const html = compileTemplate(`
@@ -364,7 +364,7 @@ describe('Events on Custom Elements', () => {
         `);
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.template.addEventListener('c-event', function() {
+                this.template.addEventListener('c-event', function () {
                     count += 1;
                 });
             }
@@ -386,7 +386,7 @@ describe('Events on Custom Elements', () => {
         expect(count).toBe(1);
     });
 
-    it('should add event listeners in connectedCallback when created via render', function() {
+    it('should add event listeners in connectedCallback when created via render', function () {
         let count = 0;
 
         const childTmpl = compileTemplate(`
@@ -396,7 +396,7 @@ describe('Events on Custom Elements', () => {
         `);
         class MyChild extends LightningElement {
             connectedCallback() {
-                this.template.addEventListener('c-event', function() {
+                this.template.addEventListener('c-event', function () {
                     count += 1;
                 });
             }
@@ -441,7 +441,7 @@ describe('Events on Custom Elements', () => {
         expect(count).toBe(1);
     });
 
-    it('should add event listeners in constructor when created via render', function() {
+    it('should add event listeners in constructor when created via render', function () {
         let count = 0;
 
         const childTmpl = compileTemplate(`
@@ -452,7 +452,7 @@ describe('Events on Custom Elements', () => {
         class MyChild extends LightningElement {
             constructor() {
                 super();
-                this.template.addEventListener('c-event', function() {
+                this.template.addEventListener('c-event', function () {
                     count += 1;
                 });
             }
@@ -541,7 +541,7 @@ describe('Events on Custom Elements', () => {
 
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.addEventListener('click', function() {
+                this.addEventListener('click', function () {
                     expect(this).toBe(undefined);
                 });
             }
@@ -595,7 +595,7 @@ describe('Events on Custom Elements', () => {
         `);
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.addEventListener('click', function() {
+                this.addEventListener('click', function () {
                     expect(this).toBe(undefined);
                 });
             }
@@ -628,7 +628,7 @@ describe('Events on Custom Elements', () => {
         `);
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.addEventListener('click', function(evt) {
+                this.addEventListener('click', function (evt) {
                     expect(evt.target).toBe(elm);
                 });
             }
@@ -653,7 +653,7 @@ describe('Events on Custom Elements', () => {
         `);
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.addEventListener('click', function(evt) {
+                this.addEventListener('click', function (evt) {
                     expect(evt.target).toBe(elm);
                 });
             }
@@ -691,7 +691,7 @@ describe('Events on Custom Elements', () => {
                     div.dispatchEvent(new CustomEvent('foo', { bubbles: true, composed: true }));
                 });
 
-                this.template.addEventListener('foo', evt => {
+                this.template.addEventListener('foo', (evt) => {
                     expect(evt.target).toBe(this.template.querySelector('div'));
                 });
             }
@@ -766,7 +766,7 @@ describe('Component events', () => {
                 this.addEventListener('click', () => {
                     this.dispatchEvent(new CustomEvent('foo'));
                 });
-                this.addEventListener('foo', evt => {
+                this.addEventListener('foo', (evt) => {
                     expect(evt.target).toBe(elm);
                 });
             }
@@ -795,7 +795,7 @@ describe('Component events', () => {
         // expect().toThrowError() is not enough in the case where an Error is thrown during event
         // dispatching. In the case of event, the only way to catch the error to add an event listener
         // at the page level.
-        const errorHandler = jest.fn(evt => evt.preventDefault());
+        const errorHandler = jest.fn((evt) => evt.preventDefault());
         window.addEventListener('error', errorHandler);
 
         const buttonEl = element.shadowRoot.querySelector('button');
@@ -821,7 +821,7 @@ describe('Shadow Root events', () => {
         `);
         class MyComponent extends LightningElement {
             connectedCallback() {
-                this.template.addEventListener('click', evt => {
+                this.template.addEventListener('click', (evt) => {
                     expect(evt.target).toBe(this.template.querySelector('div'));
                 });
             }
@@ -854,7 +854,7 @@ describe('Shadow Root events', () => {
         class MyComponent extends LightningElement {
             connectedCallback() {
                 const template = this.template;
-                this.template.addEventListener('click', function() {
+                this.template.addEventListener('click', function () {
                     expect(this).toBe(template);
                 });
             }
@@ -984,7 +984,7 @@ describe('Shadow Root events', () => {
         );
         class Child extends LightningElement {
             connectedCallback() {
-                this.template.addEventListener('click', evt => {
+                this.template.addEventListener('click', (evt) => {
                     expect(evt.target.tagName).toBe('X-GRAND-CHILD');
                     expect(evt.currentTarget).toBe(this.template);
                 });
@@ -1014,10 +1014,7 @@ describe('Shadow Root events', () => {
         const elm = createElement('x-root', { is: Root });
         document.body.appendChild(elm);
 
-        elm.shadowRoot
-            .querySelector('x-child')
-            .shadowRoot.querySelector('x-grand-child')
-            .click();
+        elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('x-grand-child').click();
     });
 
     it('should have correct target when native event gets dispatched from within shadow root event handler', () => {

--- a/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/patch.spec.ts
@@ -263,7 +263,7 @@ describe('patch', () => {
             });
         });
 
-        it('should rehydrate when state is updated in renderedCallback', function() {
+        it('should rehydrate when state is updated in renderedCallback', function () {
             const html = compileTemplate(`
                 <template>
                     <span>{state.foo}</span>

--- a/packages/@lwc/engine/src/framework/__tests__/services.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/services.spec.ts
@@ -9,14 +9,14 @@ import { createElement, LightningElement } from '../main';
 import { compileTemplate } from 'test-utils';
 
 function resetServices() {
-    Object.keys(target.Services).forEach(name => {
+    Object.keys(target.Services).forEach((name) => {
         delete target.Services[name];
     });
 }
 
 describe('services', () => {
     describe('register()', () => {
-        beforeEach(function() {
+        beforeEach(function () {
             resetServices();
         });
 

--- a/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
+++ b/packages/@lwc/engine/src/framework/__tests__/watcher.spec.ts
@@ -59,7 +59,7 @@ describe('watcher', () => {
             document.body.appendChild(elm);
             elm.updateRound();
 
-            return Promise.resolve().then(_ => {
+            return Promise.resolve().then((_) => {
                 // parent slotted into child, not need to rerender child
                 expect(counter).toBe(1);
             });

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -90,7 +90,7 @@ const NamespaceAttributeForSVG = 'http://www.w3.org/2000/svg';
 const SymbolIterator = Symbol.iterator;
 
 const TextHook: Hooks<VText> = {
-    create: vnode => {
+    create: (vnode) => {
         vnode.elm = document.createTextNode(vnode.text!);
         linkNodeToShadow(vnode);
     },
@@ -106,7 +106,7 @@ const TextHook: Hooks<VText> = {
 // which breaks some invariants. For that reason, we have the following for any
 // Custom Element that is inserted via a template.
 const ElementHook: Hooks<VElement> = {
-    create: vnode => {
+    create: (vnode) => {
         const { data, sel, clonedElement } = vnode;
         const { ns } = data;
         // TODO [#1364]: supporting the ability to inject a cloned StyleElement via a vnode this is
@@ -140,7 +140,7 @@ const ElementHook: Hooks<VElement> = {
 };
 
 const CustomElementHook: Hooks<VCustomElement> = {
-    create: vnode => {
+    create: (vnode) => {
         const { sel } = vnode;
         vnode.elm = document.createElement(sel);
         linkNodeToShadow(vnode);
@@ -523,7 +523,7 @@ export function b(fn: EventListener): EventListener {
         throw new Error();
     }
     const vm: VM = vmBeingRendered;
-    return function(event: Event) {
+    return function (event: Event) {
         invokeEventListener(vm, fn, vm.component, event);
     };
 }

--- a/packages/@lwc/engine/src/framework/attributes.ts
+++ b/packages/@lwc/engine/src/framework/attributes.ts
@@ -162,13 +162,13 @@ forEach.call(ElementPrototypeAriaPropertyNames, (propName: string) => {
     PropNameToAttrNameMap[propName] = attrName;
 });
 
-forEach.call(defaultDefHTMLPropertyNames, propName => {
+forEach.call(defaultDefHTMLPropertyNames, (propName) => {
     const attrName = StringToLowerCase.call(propName);
     AttrNameToPropNameMap[attrName] = propName;
     PropNameToAttrNameMap[propName] = attrName;
 });
 
-forEach.call(HTMLPropertyNamesWithLowercasedReflectiveAttributes, propName => {
+forEach.call(HTMLPropertyNamesWithLowercasedReflectiveAttributes, (propName) => {
     const attrName = StringToLowerCase.call(propName);
     AttrNameToPropNameMap[attrName] = propName;
     PropNameToAttrNameMap[propName] = attrName;
@@ -182,7 +182,7 @@ const CAMEL_REGEX = /-([a-z])/g;
  */
 export function getPropNameFromAttrName(attrName: string): string {
     if (isUndefined(AttrNameToPropNameMap[attrName])) {
-        AttrNameToPropNameMap[attrName] = StringReplace.call(attrName, CAMEL_REGEX, g =>
+        AttrNameToPropNameMap[attrName] = StringReplace.call(attrName, CAMEL_REGEX, (g) =>
             g[1].toUpperCase()
         );
     }
@@ -200,7 +200,7 @@ export function getAttrNameFromPropName(propName: string): string {
         PropNameToAttrNameMap[propName] = StringReplace.call(
             propName,
             CAPS_REGEX,
-            match => '-' + match.toLowerCase()
+            (match) => '-' + match.toLowerCase()
         );
     }
     return PropNameToAttrNameMap[propName];

--- a/packages/@lwc/engine/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine/src/framework/base-bridge-element.ts
@@ -34,7 +34,7 @@ const cachedSetterByKey: Record<string, (this: HTMLElement, newValue: any) => an
 function createGetter(key: string) {
     let fn = cachedGetterByKey[key];
     if (isUndefined(fn)) {
-        fn = cachedGetterByKey[key] = function(this: HTMLElement): any {
+        fn = cachedGetterByKey[key] = function (this: HTMLElement): any {
             const vm = getAssociatedVM(this);
             const { getHook } = vm;
             return getHook(vm.component, key);
@@ -46,7 +46,7 @@ function createGetter(key: string) {
 function createSetter(key: string) {
     let fn = cachedSetterByKey[key];
     if (isUndefined(fn)) {
-        fn = cachedSetterByKey[key] = function(this: HTMLElement, newValue: any): any {
+        fn = cachedSetterByKey[key] = function (this: HTMLElement, newValue: any): any {
             const vm = getAssociatedVM(this);
             const { setHook } = vm;
             newValue = reactiveMembrane.getReadOnlyProxy(newValue);
@@ -57,7 +57,7 @@ function createSetter(key: string) {
 }
 
 function createMethodCaller(methodName: string): (...args: any[]) => any {
-    return function(this: HTMLElement): any {
+    return function (this: HTMLElement): any {
         const vm = getAssociatedVM(this);
         const { callHook, component } = vm;
         const fn = (component as any)[methodName];
@@ -88,7 +88,7 @@ export function HTMLBridgeElementFactory(
     if (isFunction(SuperClass)) {
         HTMLBridgeElement = class extends SuperClass {};
     } else {
-        HTMLBridgeElement = function() {
+        HTMLBridgeElement = function () {
             // Bridge classes are not supposed to be instantiated directly in
             // browsers that do not support web components.
             throw new TypeError('Illegal constructor');

--- a/packages/@lwc/engine/src/framework/component.ts
+++ b/packages/@lwc/engine/src/framework/component.ts
@@ -122,7 +122,7 @@ export function getWrappedComponentsListener(vm: VM, listener: EventListener): E
     }
     let wrappedListener = cmpEventListenerMap.get(listener);
     if (isUndefined(wrappedListener)) {
-        wrappedListener = function(event: Event) {
+        wrappedListener = function (event: Event) {
             invokeEventListener(vm, listener, undefined, event);
         };
         cmpEventListenerMap.set(listener, wrappedListener);

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -203,7 +203,7 @@ export function registerDecorators(
         }
     }
     if (!isUndefined(publicMethods)) {
-        forEach.call(publicMethods, methodName => {
+        forEach.call(publicMethods, (methodName) => {
             descriptor = getOwnPropertyDescriptor(proto, methodName);
             if (process.env.NODE_ENV !== 'production') {
                 validateMethodDecoratedWithApi(Ctor, methodName, descriptor);

--- a/packages/@lwc/engine/src/framework/html-properties.ts
+++ b/packages/@lwc/engine/src/framework/html-properties.ts
@@ -24,7 +24,7 @@ forEach.call(ElementPrototypeAriaPropertyNames, (propName: string) => {
         HTMLElementOriginalDescriptors[propName] = descriptor;
     }
 });
-forEach.call(defaultDefHTMLPropertyNames, propName => {
+forEach.call(defaultDefHTMLPropertyNames, (propName) => {
     // Note: intentionally using our in-house getPropertyDescriptor instead of getOwnPropertyDescriptor here because
     // in IE11, id property is on Element.prototype instead of HTMLElement, and we suspect that more will fall into
     // this category, so, better to be sure.

--- a/packages/@lwc/engine/src/framework/membrane.ts
+++ b/packages/@lwc/engine/src/framework/membrane.ts
@@ -22,7 +22,7 @@ export const reactiveMembrane = new ObservableMembrane({
  * works for observable membrane objects. This API is subject to
  * change or being removed.
  */
-export const unwrap = function(value: any): any {
+export const unwrap = function (value: any): any {
     const unwrapped = reactiveMembrane.unwrapProxy(value);
     if (unwrapped !== value) {
         // if value is a proxy, unwrap to access original value and apply distortion

--- a/packages/@lwc/engine/src/framework/performance-timing.ts
+++ b/packages/@lwc/engine/src/framework/performance-timing.ts
@@ -61,13 +61,13 @@ function noop() {
 
 export const startMeasure = !isUserTimingSupported
     ? noop
-    : function(phase: MeasurementPhase, vm: UninitializedVM) {
+    : function (phase: MeasurementPhase, vm: UninitializedVM) {
           const markName = getMarkName(phase, vm);
           start(markName);
       };
 export const endMeasure = !isUserTimingSupported
     ? noop
-    : function(phase: MeasurementPhase, vm: UninitializedVM) {
+    : function (phase: MeasurementPhase, vm: UninitializedVM) {
           const markName = getMarkName(phase, vm);
           const measureName = getMeasureName(phase, vm);
           end(measureName, markName);
@@ -75,13 +75,13 @@ export const endMeasure = !isUserTimingSupported
 
 export const startGlobalMeasure = !isUserTimingSupported
     ? noop
-    : function(phase: GlobalMeasurementPhase, vm?: UninitializedVM) {
+    : function (phase: GlobalMeasurementPhase, vm?: UninitializedVM) {
           const markName = isUndefined(vm) ? phase : getMarkName(phase, vm);
           start(markName);
       };
 export const endGlobalMeasure = !isUserTimingSupported
     ? noop
-    : function(phase: GlobalMeasurementPhase, vm?: UninitializedVM) {
+    : function (phase: GlobalMeasurementPhase, vm?: UninitializedVM) {
           const markName = isUndefined(vm) ? phase : getMarkName(phase, vm);
           end(phase, markName);
       };

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -104,7 +104,7 @@ function collectStylesheets(
     isNative: boolean,
     aggregatorFn: (content: string) => void
 ): void {
-    forEach.call(stylesheets, sheet => {
+    forEach.call(stylesheets, (sheet) => {
         if (isArray(sheet)) {
             collectStylesheets(sheet, hostSelector, shadowSelector, isNative, aggregatorFn);
         } else {
@@ -126,7 +126,7 @@ export function evaluateCSS(
         const hostSelector = `[${hostAttribute}]`;
         const shadowSelector = `[${shadowAttribute}]`;
 
-        collectStylesheets(stylesheets, hostSelector, shadowSelector, false, textContent => {
+        collectStylesheets(stylesheets, hostSelector, shadowSelector, false, (textContent) => {
             insertGlobalStyle(textContent);
         });
 
@@ -136,7 +136,7 @@ export function evaluateCSS(
         // empty shadow selector since it is not really needed.
 
         let buffer = '';
-        collectStylesheets(stylesheets, emptyString, emptyString, true, textContent => {
+        collectStylesheets(stylesheets, emptyString, emptyString, true, (textContent) => {
             buffer += textContent;
         });
 

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -43,7 +43,7 @@ expect.extend({
 });
 
 function traverseErrorInfo(object, fn: (errorInfo: LWCErrorInfo, path: string) => void, path) {
-    Object.keys(object).forEach(key => {
+    Object.keys(object).forEach((key) => {
         const property = object[key];
         if (property && hasOwnProperty.call(property, 'code')) {
             fn(property as LWCErrorInfo, `${path}.${key}`);

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -25,7 +25,7 @@ function isBindingReference(path, scope) {
     return !!(binding && binding.referencePaths.includes(path));
 }
 
-module.exports = function({ types: t }) {
+module.exports = function ({ types: t }) {
     return {
         name: 'babel-plugin-lwc-features',
         visitor: {
@@ -35,7 +35,7 @@ module.exports = function({ types: t }) {
                     const specifiers = path.node.specifiers;
 
                     // Check if we've already imported runtime flags
-                    const didImportRuntimeFlags = specifiers.some(specifier => {
+                    const didImportRuntimeFlags = specifiers.some((specifier) => {
                         return specifier.local && specifier.local.name === RUNTIME_FLAGS_IDENTIFIER;
                     });
                     if (didImportRuntimeFlags && !this.opts.prod) {

--- a/packages/@lwc/features/src/global-this.ts
+++ b/packages/@lwc/features/src/global-this.ts
@@ -20,7 +20,7 @@ export function getGlobalThis() {
     try {
         // eslint-disable-next-line no-extend-native
         Object.defineProperty(Object.prototype, '__magic__', {
-            get: function() {
+            get: function () {
                 return this;
             },
             configurable: true,

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -69,7 +69,7 @@ export function getModuleEntry(
 export function normalizeConfig(config: Partial<ModuleResolverConfig>): ModuleResolverConfig {
     const rootDir = config.rootDir ? path.resolve(config.rootDir) : process.cwd();
     const modules = config.modules || [];
-    const normalizedModules = modules.map(m =>
+    const normalizedModules = modules.map((m) =>
         isDirModuleRecord(m) ? { ...m, dir: path.resolve(rootDir, m.dir) } : m
     );
 
@@ -94,7 +94,7 @@ export function mergeModules(
     const modules = userModules.slice();
 
     // Visit the user modules to created an index with the name as keys
-    userModules.forEach(m => {
+    userModules.forEach((m) => {
         if (isAliasModuleRecord(m)) {
             visitedAlias.add(m.name);
         } else if (isDirModuleRecord(m)) {
@@ -104,7 +104,7 @@ export function mergeModules(
         }
     });
 
-    configModules.forEach(m => {
+    configModules.forEach((m) => {
         if (
             (isAliasModuleRecord(m) && !visitedAlias.has(m.name)) ||
             (isDirModuleRecord(m) && !visitedDirs.has(normalizeDirName(m.dir))) ||
@@ -168,7 +168,7 @@ export function validateNpmAlias(
     map: { [key: string]: string },
     opts: InnerResolverOptions
 ) {
-    Object.keys(map).forEach(specifier => {
+    Object.keys(map).forEach((specifier) => {
         if (!exposed.includes(specifier)) {
             throw new LwcConfigError(
                 `Unable to apply mapping: The specifier "${specifier}" is not exposed by the npm module`,

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -95,7 +95,7 @@ describe('typescript relative import', () => {
     it(`should throw when .ts imports .js file`, () => {
         const entry = path.join(tsImportsJsDir, 'main.ts');
         expect.assertions(1);
-        return doRollup(entry, { compat: false }).catch(error => {
+        return doRollup(entry, { compat: false }).catch((error) => {
             expect(error).toEqual(new Error('Importing a .js file into a .ts is not supported'));
         });
     });
@@ -105,7 +105,7 @@ describe('javascript relative import', () => {
     it(`should throw when .js imports .ts file`, () => {
         const entry = path.join(jsImportsTsDir, 'main.js');
         expect.assertions(1);
-        return doRollup(entry, { compat: false }).catch(error => {
+        return doRollup(entry, { compat: false }).catch((error) => {
             expect(error).toEqual(new Error('Importing a .ts file into a .js is not supported'));
         });
     });
@@ -127,7 +127,7 @@ const globalModules = { lwc: 'LWC', myCssResolver: 'resolveCss' };
 async function doRollup(input, { compat } = {}, rollupCompileOptions) {
     const bundle = await rollup.rollup({
         input,
-        external: id => id in globalModules,
+        external: (id) => id in globalModules,
         plugins: [
             rollupCompile(rollupCompileOptions),
             compat && rollupCompat({ polyfills: false }),

--- a/packages/@lwc/style-compiler/src/css-import/transform.ts
+++ b/packages/@lwc/style-compiler/src/css-import/transform.ts
@@ -10,7 +10,7 @@ import valueParser from 'postcss-value-parser';
 import { importMessage } from '../utils/message';
 
 export default function process(root: Root, result: Result) {
-    root.walkAtRules('import', node => {
+    root.walkAtRules('import', (node) => {
         // Ensure @import are at the top of the file
         let prev = node.prev();
         while (prev) {

--- a/packages/@lwc/style-compiler/src/custom-properties/transform.ts
+++ b/packages/@lwc/style-compiler/src/custom-properties/transform.ts
@@ -9,7 +9,7 @@ import parseValue from 'postcss-value-parser';
 import { varFunctionMessage } from '../utils/message';
 
 export default function process(root: Root, result: Result) {
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
         const valueRoot = parseValue(decl.value);
         let varFound = false;
         valueRoot.walk(({ type, value }) => {

--- a/packages/@lwc/style-compiler/src/custom-properties/validate.ts
+++ b/packages/@lwc/style-compiler/src/custom-properties/validate.ts
@@ -9,7 +9,7 @@ import { Root } from 'postcss';
 const CUSTOM_PROPERTY_IDENTIFIER = '--';
 
 export default function validate(root: Root): void {
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
         const { prop } = decl;
 
         if (prop.startsWith(CUSTOM_PROPERTY_IDENTIFIER)) {

--- a/packages/@lwc/style-compiler/src/dir-pseudo-class/transform.ts
+++ b/packages/@lwc/style-compiler/src/dir-pseudo-class/transform.ts
@@ -12,10 +12,10 @@ function isValidDirValue(value: string): boolean {
     return value === 'ltr' || value === 'rtl';
 }
 
-export default function(root: Root) {
-    root.nodes.forEach(node => {
+export default function (root: Root) {
+    root.nodes.forEach((node) => {
         const selector = node as Selector;
-        selector.nodes.forEach(node => {
+        selector.nodes.forEach((node) => {
             if (!isDirPseudoClass(node)) {
                 return;
             }

--- a/packages/@lwc/style-compiler/src/no-id-selectors/validate.ts
+++ b/packages/@lwc/style-compiler/src/no-id-selectors/validate.ts
@@ -6,8 +6,8 @@
  */
 import { Root } from 'postcss-selector-parser';
 
-export default function(root: Root) {
-    root.walkIds(node => {
+export default function (root: Root) {
+    root.walkIds((node) => {
         const message = `Invalid usage of id selector '#${node.value}'. Try using a class selector or some other selector.`;
         throw root.error(message, {
             index: node.sourceIndex,

--- a/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
+++ b/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
@@ -33,7 +33,7 @@ function shouldTransformSelector(rule: Rule) {
 }
 
 function selectorProcessorFactory(config: PluginConfig, transformConfig: SelectorScopingConfig) {
-    return postCssSelector(root => {
+    return postCssSelector((root) => {
         validateIdSelectors(root);
 
         transformSelectorScoping(root, transformConfig);
@@ -61,7 +61,7 @@ export default postcss.plugin<PluginConfig>('postcss-plugin-lwc', (config = {}) 
 
         transformCustomProperties(root, result);
 
-        root.walkRules(rule => {
+        root.walkRules((rule) => {
             if (!shouldTransformSelector(rule)) {
                 return;
             }

--- a/packages/@lwc/style-compiler/src/postcss-minify-plugins.ts
+++ b/packages/@lwc/style-compiler/src/postcss-minify-plugins.ts
@@ -22,7 +22,7 @@ const CSS_NANO_PRESET_OPTIONS = {
  * We may switch back to cssnano if/when they decide to go back to a synchronous API:
  * https://github.com/cssnano/cssnano/issues/68
  */
-export default function() {
+export default function () {
     const { plugins } = cssnanoPreset(CSS_NANO_PRESET_OPTIONS);
 
     return plugins

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -41,7 +41,7 @@ function scopeSelector(selector: Selector) {
 
     // Split the selector per compound selector. Compound selectors are interleaved with combinator nodes.
     // https://drafts.csswg.org/selectors-4/#typedef-complex-selector
-    selector.each(node => {
+    selector.each((node) => {
         if (isCombinator(node)) {
             compoundSelectors.push([]);
         } else {
@@ -112,13 +112,13 @@ function transformHost(selector: Selector) {
 
         // Generate a unique contextualized version of the selector for each selector pass as argument
         // to the :host
-        const contextualSelectors = hostNode.nodes.map(contextSelectors => {
+        const contextualSelectors = hostNode.nodes.map((contextSelectors) => {
             const clonedSelector = selector.clone({}) as Selector;
             const clonedHostNode = clonedSelector.at(hostIndex) as Tag;
 
             // Add to the compound selector previously containing the :host pseudo class
             // the contextual selectors.
-            (contextSelectors as Selector).each(node => {
+            (contextSelectors as Selector).each((node) => {
                 trimNodeWhitespaces(node);
                 clonedSelector.insertAfter(clonedHostNode, node);
             });
@@ -134,12 +134,12 @@ function transformHost(selector: Selector) {
 export default function transformSelector(root: Root, transformConfig: SelectorScopingConfig) {
     validateSelectors(root);
 
-    root.each(selector => {
+    root.each((selector) => {
         scopeSelector(selector as Selector);
     });
 
     if (transformConfig.transformHost) {
-        root.each(selector => {
+        root.each((selector) => {
             transformHost(selector as Selector);
         });
     }

--- a/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
@@ -11,7 +11,7 @@ const UNSUPPORTED_SELECTORS = new Set(['::slotted', ':root', ':host-context']);
 const TEMPLATE_DIRECTIVES = [/^key$/, /^lwc:*/, /^if:*/, /^for:*/, /^iterator:*/];
 
 function validateSelectors(root: Root) {
-    root.walk(node => {
+    root.walk((node) => {
         const { value, sourceIndex } = node;
 
         if (value) {
@@ -35,9 +35,9 @@ function validateSelectors(root: Root) {
 }
 
 function validateAttribute(root: Root) {
-    root.walkAttributes(node => {
+    root.walkAttributes((node) => {
         const { attribute: attributeName, sourceIndex } = node as Attribute;
-        const isTemplateDirective = TEMPLATE_DIRECTIVES.some(directive => {
+        const isTemplateDirective = TEMPLATE_DIRECTIVES.some((directive) => {
             return directive.test(attributeName);
         });
 

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -36,7 +36,7 @@ export default function serialize(result: postcss.LazyResult, config: Config): s
     );
     const minify = Boolean(config.outputConfig && config.outputConfig.minify);
     const useVarResolver = messages.some(isVarFunctionMessage);
-    const importedStylesheets = messages.filter(isImportMessage).map(message => message.id);
+    const importedStylesheets = messages.filter(isImportMessage).map((message) => message.id);
 
     let buffer = '';
 
@@ -83,7 +83,7 @@ function reduceTokens(tokens: Token[]): Token[] {
                 return [...acc, token];
             }
         }, [])
-        .filter(t => t.value !== '');
+        .filter((t) => t.value !== '');
 }
 
 function normalizeString(str: string) {

--- a/packages/@lwc/style-compiler/src/utils/selector-parser.ts
+++ b/packages/@lwc/style-compiler/src/utils/selector-parser.ts
@@ -21,7 +21,7 @@ export function replaceNodeWith(oldNode: Node, ...newNodes: Node[]): void {
             throw new Error(`Impossible to replace root node.`);
         }
 
-        newNodes.forEach(node => {
+        newNodes.forEach((node) => {
             parent.insertBefore(oldNode, node);
         });
 

--- a/packages/@lwc/synthetic-shadow/src/env/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/node.ts
@@ -77,7 +77,7 @@ const childNodesGetter: (this: Node) => NodeListOf<Node & Element> = hasOwnPrope
 
 const isConnected = hasOwnProperty.call(Node.prototype, 'isConnected')
     ? getOwnPropertyDescriptor(Node.prototype, 'isConnected')!.get!
-    : function(this: Node): boolean {
+    : function (this: Node): boolean {
           const doc = ownerDocumentGetter.call(this);
           // IE11
           return (

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -267,7 +267,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         const ownerKey = getNodeOwnerKey(this);
         if (!isUndefined(ownerKey)) {
             // `this` is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
-            const elm = ArrayFind.call(nodeList, elm => getNodeNearestOwnerKey(elm) === ownerKey);
+            const elm = ArrayFind.call(nodeList, (elm) => getNodeNearestOwnerKey(elm) === ownerKey);
             return isUndefined(elm) ? null : elm;
         } else {
             if (!featureFlags.ENABLE_NODE_LIST_PATCH) {
@@ -280,7 +280,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
             const contextNearestOwnerKey = getNodeNearestOwnerKey(this);
             const elm = ArrayFind.call(
                 nodeList,
-                elm => getNodeNearestOwnerKey(elm) === contextNearestOwnerKey
+                (elm) => getNodeNearestOwnerKey(elm) === contextNearestOwnerKey
             );
             return isUndefined(elm) ? null : elm;
         }
@@ -296,7 +296,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
         const elm = ArrayFind.call(
             nodeList,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(this)
         );
         return isUndefined(elm) ? null : elm;
     }
@@ -327,14 +327,14 @@ function getFilteredArrayOfNodes<T extends Node>(
             // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
             filtered = ArrayFilter.call(
                 unfilteredNodes,
-                elm => getNodeNearestOwnerKey(elm) === ownerKey
+                (elm) => getNodeNearestOwnerKey(elm) === ownerKey
             );
         } else if (shadowDomSemantic === ShadowDomSemantic.Enabled) {
             // context is inside a shadow, we dont know which one.
             const contextNearestOwnerKey = getNodeNearestOwnerKey(context);
             filtered = ArrayFilter.call(
                 unfilteredNodes,
-                elm => getNodeNearestOwnerKey(elm) === contextNearestOwnerKey
+                (elm) => getNodeNearestOwnerKey(elm) === contextNearestOwnerKey
             );
         } else {
             // context is manually inserted without lwc:dom-manual and ShadowDomSemantics is off, return everything
@@ -346,7 +346,7 @@ function getFilteredArrayOfNodes<T extends Node>(
             filtered = ArrayFilter.call(
                 unfilteredNodes,
                 // TODO [#1222]: remove global bypass
-                elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
+                (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
             );
         } else {
             // `context` is outside the lwc boundary and patch is not enabled.

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -183,7 +183,7 @@ function getWrappedShadowRootListener(
     }
     let shadowRootWrappedListener = shadowRootEventListenerMap.get(listener);
     if (isUndefined(shadowRootWrappedListener)) {
-        shadowRootWrappedListener = function(event: Event) {
+        shadowRootWrappedListener = function (event: Event) {
             // * if the event is dispatched directly on the host, it is not observable from root
             // * if the event is dispatched in an element that does not belongs to the shadow and it is not composed,
             //   it is not observable from the root
@@ -223,7 +223,7 @@ function getWrappedCustomElementListener(elm: Element, listener: EventListener):
     }
     let customElementWrappedListener = customElementEventListenerMap.get(listener);
     if (isUndefined(customElementWrappedListener)) {
-        customElementWrappedListener = function(event: Event) {
+        customElementWrappedListener = function (event: Event) {
             if (isValidEventForCustomElement(event)) {
                 // all handlers on the custom element should be called with undefined 'this'
                 listener.call(elm, event);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -65,7 +65,7 @@ const FocusableSelector = `
 const formElementTagNames = new Set(['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA']);
 
 function filterSequentiallyFocusableElements(elements: Element[]): Element[] {
-    return elements.filter(element => {
+    return elements.filter((element) => {
         if (hasAttribute.call(element, 'tabindex')) {
             // Even though LWC only supports tabindex values of 0 or -1,
             // passing through elements with tabindex="0" is a tighter criteria

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -40,7 +40,7 @@ export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
             // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
             filtered = ArrayFilter.call(
                 unfilteredNodes,
-                elm => getNodeNearestOwnerKey(elm) === ownerKey
+                (elm) => getNodeNearestOwnerKey(elm) === ownerKey
             );
         }
     } else if (context instanceof HTMLBodyElement) {
@@ -48,7 +48,7 @@ export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
         filtered = ArrayFilter.call(
             unfilteredNodes,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context)
         );
     } else {
         // `context` is outside the lwc boundary, return unfiltered list.

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -262,7 +262,7 @@ const getDocumentOrRootNode: (this: Node, options?: GetRootNodeOptions) => Node 
     nativeGetRootNode
 )
     ? nativeGetRootNode
-    : function(this: Node): Node {
+    : function (this: Node): Node {
           let node = this;
           let nodeParent: Node | null;
           while (!isNull((nodeParent = parentNodeGetter.call(node)))) {
@@ -497,7 +497,7 @@ export function isExternalChildNodeAccessorFlagOn(): boolean {
 }
 export const getInternalChildNodes: (node: Node) => NodeListOf<ChildNode> =
     process.env.NODE_ENV !== 'production' && isFalse(hasNativeSymbolsSupport)
-        ? function(node) {
+        ? function (node) {
               internalChildNodeAccessorFlag = true;
               let childNodes;
               let error = null;
@@ -515,7 +515,7 @@ export const getInternalChildNodes: (node: Node) => NodeListOf<ChildNode> =
               }
               return childNodes as NodeListOf<ChildNode>;
           }
-        : function(node) {
+        : function (node) {
               return node.childNodes;
           };
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -18,7 +18,7 @@ import { setShadowToken, getShadowToken } from './shadow-token';
 const DomManualPrivateKey = '$$DomManualKey$$';
 
 // Resolver function used when a node is removed from within a portal
-const DocumentResolverFn = function() {} as ShadowRootResolver;
+const DocumentResolverFn = function () {} as ShadowRootResolver;
 
 // We can use a single observer without having to worry about leaking because
 // "Registered observers in a node’s registered observer list have a weak
@@ -57,8 +57,8 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
 }
 
 function initPortalObserver() {
-    return new MutationObserver(mutations => {
-        forEach.call(mutations, mutation => {
+    return new MutationObserver((mutations) => {
+        forEach.call(mutations, (mutation) => {
             /**
              * This routine will process all nodes added or removed from elm (which is marked as a portal)
              * When adding a node to the portal element, we should add the ownership.

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -49,9 +49,9 @@ const observerConfig: MutationObserverInit = { childList: true };
 const SlotChangeKey = createHiddenField<boolean>('slotchange', 'synthetic-shadow');
 
 function initSlotObserver() {
-    return new MutationObserver(mutations => {
+    return new MutationObserver((mutations) => {
         const slots: Node[] = [];
-        forEach.call(mutations, mutation => {
+        forEach.call(mutations, (mutation) => {
             if (process.env.NODE_ENV !== 'production') {
                 assert.invariant(
                     mutation.type === 'childList',
@@ -133,7 +133,7 @@ defineProperties(HTMLSlotElement.prototype, {
                 const nodes = flatten
                     ? getFilteredSlotFlattenNodes(this)
                     : getFilteredSlotAssignedNodes(this);
-                return ArrayFilter.call(nodes, node => node instanceof Element);
+                return ArrayFilter.call(nodes, (node) => node instanceof Element);
             } else {
                 return originalAssignedElements.apply(
                     this,

--- a/packages/@lwc/synthetic-shadow/src/polyfills/HTMLSlotElement/detect.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/HTMLSlotElement/detect.ts
@@ -5,6 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-export default function() {
+export default function () {
     return typeof HTMLSlotElement === 'undefined';
 }

--- a/packages/@lwc/synthetic-shadow/src/polyfills/HTMLSlotElement/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/HTMLSlotElement/polyfill.ts
@@ -26,7 +26,7 @@ export default function apply() {
     // need to patch Document.prototype.createElement to remap `slot`
     // elements to the right prototype
     defineProperty(Document.prototype, 'createElement', {
-        value: function<K extends keyof HTMLElementTagNameMap>(
+        value: function <K extends keyof HTMLElementTagNameMap>(
             this: Document,
             tagName: K,
             _options?: ElementCreationOptions

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -101,7 +101,7 @@ defineProperty(Document.prototype, 'querySelector', {
         const filtered = ArrayFind.call(
             elements,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return !isUndefined(filtered) ? filtered : null;
     },
@@ -118,7 +118,7 @@ defineProperty(Document.prototype, 'querySelectorAll', {
         const filtered = ArrayFilter.call(
             elements,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticNodeList(filtered);
     },
@@ -135,7 +135,7 @@ defineProperty(Document.prototype, 'getElementsByClassName', {
         const filtered = ArrayFilter.call(
             elements,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
     },
@@ -152,7 +152,7 @@ defineProperty(Document.prototype, 'getElementsByTagName', {
         const filtered = ArrayFilter.call(
             elements,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
     },
@@ -172,7 +172,7 @@ defineProperty(Document.prototype, 'getElementsByTagNameNS', {
         const filtered = ArrayFilter.call(
             elements,
             // TODO [#1222]: remove global bypass
-            elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+            (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
         );
         return createStaticHTMLCollection(filtered);
     },
@@ -195,7 +195,7 @@ defineProperty(
             const filtered = ArrayFilter.call(
                 elements,
                 // TODO [#1222]: remove global bypass
-                elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
+                (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm)
             );
             return createStaticNodeList(filtered);
         },

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
@@ -41,7 +41,7 @@ function getEventListenerWrapper(
     }
 
     const isHandlerFunction = isFunction(listener);
-    const wrapperFn = ((listener as EventListenerWrapper).$$lwcEventWrapper$$ = function(
+    const wrapperFn = ((listener as EventListenerWrapper).$$lwcEventWrapper$$ = function (
         this: EventTarget,
         e: Event
     ) {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/patch.ts
@@ -14,7 +14,7 @@ export default function apply() {
         'contentWindow'
     ) as PropertyDescriptor;
     const { get: originalGetter } = desc;
-    desc.get = function(this: HTMLIFrameElement): WindowProxy | null {
+    desc.get = function (this: HTMLIFrameElement): WindowProxy | null {
         const original = (originalGetter as any).call(this);
         // If the original iframe element is not a keyed node, then do not wrap it
         if (isNull(original) || isUndefined(getNodeOwnerKey(this))) {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -219,7 +219,7 @@ function patchedDisconnect(this: MutationObserver): void {
     // Clear the node to observer reference which is a strong references
     const observedNodes = observerToNodesMap.get(this);
     if (!isUndefined(observedNodes)) {
-        forEach.call(observedNodes, observedNode => {
+        forEach.call(observedNodes, (observedNode) => {
             const observers = observedNode[observerLookupField];
             if (!isUndefined(observers)) {
                 const index = ArrayIndexOf.call(observers, this);

--- a/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
@@ -10,7 +10,7 @@ function mockRenderApi() {
     let id = 0;
     const calls = [];
 
-    const mock = name => (...args) => {
+    const mock = (name) => (...args) => {
         id++;
 
         calls.push([`${name}#${id}`, args]);

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -74,7 +74,7 @@ export default class CodeGen {
             const parsed = babylon.parse(src, { sourceType: 'module' });
             const inlineStylesAst = parsed.program.body;
 
-            inlineStylesAst.forEach(node => {
+            inlineStylesAst.forEach((node) => {
                 if (t.isImportDeclaration(node)) {
                     importDeclarations.push(node);
                 } else if (t.isExportDefaultDeclaration(node)) {

--- a/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
@@ -26,7 +26,7 @@ function moduleNameToLookup(name: string): t.VariableDeclaration {
 }
 
 export function format(templateFn: t.FunctionDeclaration, state: State): t.Program {
-    const lookups = state.dependencies.map(cmpClassName => moduleNameToLookup(cmpClassName));
+    const lookups = state.dependencies.map((cmpClassName) => moduleNameToLookup(cmpClassName));
     const metadata = generateTemplateMetadata(state);
 
     return t.program([

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -29,7 +29,7 @@ function moduleNameToImport(name: string): t.ImportDeclaration {
 }
 
 function generateSecureImports(additionalImports: string[]): t.ImportDeclaration {
-    const imports = additionalImports.map(additionalImport => {
+    const imports = additionalImports.map((additionalImport) => {
         return t.importSpecifier(t.identifier(additionalImport), t.identifier(additionalImport));
     });
 
@@ -50,7 +50,7 @@ function generateInlineStylesImports(state: State) {
 }
 
 export function format(templateFn: t.FunctionDeclaration, state: State): t.Program {
-    const imports = state.dependencies.map(cmpClassName => moduleNameToImport(cmpClassName));
+    const imports = state.dependencies.map((cmpClassName) => moduleNameToImport(cmpClassName));
 
     const metadata = generateTemplateMetadata(state);
 

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -34,7 +34,7 @@ export function objectToAST(
     valueMapper: (key: string) => t.Expression
 ): t.ObjectExpression {
     return t.objectExpression(
-        Object.keys(obj).map(key => t.objectProperty(t.stringLiteral(key), valueMapper(key)))
+        Object.keys(obj).map((key) => t.objectProperty(t.stringLiteral(key), valueMapper(key)))
     );
 }
 
@@ -53,7 +53,7 @@ export function isSlot(element: IRElement) {
 }
 
 export function containsDynamicChildren(element: IRElement) {
-    return element.children.some(child => isElement(child) && isDynamic(child));
+    return element.children.some((child) => isElement(child) && isDynamic(child));
 }
 
 export function isDynamic(element: IRElement): boolean {
@@ -68,7 +68,7 @@ export function isDynamic(element: IRElement): boolean {
  */
 export function shouldFlatten(element: IRElement): boolean {
     return element.children.some(
-        child =>
+        (child) =>
             isElement(child) &&
             (isDynamic(child) ||
                 !!child.forEach ||
@@ -123,7 +123,7 @@ export function generateTemplateMetadata(state: State): t.Statement[] {
             t.identifier('slots')
         );
 
-        const slotsArray = t.arrayExpression(state.slots.map(slot => t.stringLiteral(slot)));
+        const slotsArray = t.arrayExpression(state.slots.map((slot) => t.stringLiteral(slot)));
 
         const slotsMetadata = t.assignmentExpression('=', slotsProperty, slotsArray);
         metadataExpressions.push(t.expressionStatement(slotsMetadata));

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -77,8 +77,8 @@ function generateContext(element: IRElement, data: t.ObjectProperty[]) {
     // LWC
     if (lwc) {
         const lwcObject: t.ObjectProperty[] = Object.keys(lwc)
-            .filter(key => !DISALLOWED_LWC_DIRECTIVES.has(key))
-            .map(key => {
+            .filter((key) => !DISALLOWED_LWC_DIRECTIVES.has(key))
+            .map((key) => {
                 return t.objectProperty(t.identifier(key), t.stringLiteral((lwc as any)[key]));
             });
 
@@ -281,7 +281,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
             last: t.identifier(`${iteratorName}Last`),
         };
 
-        const functionParams = Object.keys(argNames).map(key => argNames[key]);
+        const functionParams = Object.keys(argNames).map((key) => argNames[key]);
         const iterationFunction = t.functionExpression(
             undefined,
             functionParams,
@@ -326,7 +326,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
             const { expression: testExpression } = bindExpression(element.if!, element);
 
             return t.arrayExpression(
-                fragmentNodes.elements.map(child =>
+                fragmentNodes.elements.map((child) =>
                     child !== null ? applyInlineIf(element, child as any, testExpression) : null
                 )
             );
@@ -347,7 +347,9 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
         // [api_scoped_id()] => `${api_scoped_id()}`
         // [api_scoped_id(), api_scoped_id()] => `${api_scoped_id()} ${api_scoped_id()}`
         const spacesBetweenIdRefs = ' '.repeat(expressions.length - 1).split('');
-        const quasis = ['', ...spacesBetweenIdRefs, ''].map(str => t.templateElement({ raw: str }));
+        const quasis = ['', ...spacesBetweenIdRefs, ''].map((str) =>
+            t.templateElement({ raw: str })
+        );
         return t.templateLiteral(quasis, expressions);
     }
 
@@ -438,7 +440,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
 
         // Style attribute defined via object
         if (styleMap) {
-            const styleObj = objectToAST(styleMap, key =>
+            const styleObj = objectToAST(styleMap, (key) =>
                 typeof styleMap[key] === 'number'
                     ? t.numericLiteral(styleMap[key] as number)
                     : t.stringLiteral(styleMap[key] as string)
@@ -455,7 +457,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
 
         // Attributes
         if (attrs) {
-            const attrsObj = objectToAST(attrs, key => {
+            const attrsObj = objectToAST(attrs, (key) => {
                 return computeAttrValue(attrs[key], element, templateContainsId);
             });
             data.push(t.objectProperty(t.identifier('attrs'), attrsObj));
@@ -463,7 +465,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
 
         // Properties
         if (props) {
-            const propsObj = objectToAST(props, key => {
+            const propsObj = objectToAST(props, (key) => {
                 return computeAttrValue(props[key], element, templateContainsId);
             });
             data.push(t.objectProperty(t.identifier('props'), propsObj));
@@ -492,7 +494,7 @@ function transform(root: IRNode, codeGen: CodeGen): t.Expression {
 
         // Event handler
         if (on) {
-            const onObj = objectToAST(on, key => {
+            const onObj = objectToAST(on, (key) => {
                 const { expression: componentHandler } = bindExpression(on[key], element);
                 let handler: t.Expression = codeGen.genBind(componentHandler);
 
@@ -519,7 +521,7 @@ function generateTemplateFunction(templateRoot: IRElement, state: State): t.Func
 
     const apis = destructuringAssignmentFromObject(
         t.identifier(TEMPLATE_PARAMS.API),
-        Object.keys(codeGen.usedApis).map(name =>
+        Object.keys(codeGen.usedApis).map((name) =>
             t.objectProperty(t.identifier(name), codeGen.usedApis[name], false, true)
         )
     );
@@ -528,7 +530,7 @@ function generateTemplateFunction(templateRoot: IRElement, state: State): t.Func
     if (Object.keys(codeGen.usedSlots).length) {
         slots = destructuringAssignmentFromObject(
             t.identifier(TEMPLATE_PARAMS.SLOT_SET),
-            Object.keys(codeGen.usedSlots).map(name =>
+            Object.keys(codeGen.usedSlots).map((name) =>
                 t.objectProperty(t.stringLiteral(name), codeGen.usedSlots[name], false, true)
             )
         );
@@ -538,7 +540,7 @@ function generateTemplateFunction(templateRoot: IRElement, state: State): t.Func
     if (codeGen.memorizedIds.length) {
         context = destructuringAssignmentFromObject(
             t.identifier(TEMPLATE_PARAMS.CONTEXT),
-            codeGen.memorizedIds.map(id => t.objectProperty(id, id, false, true))
+            codeGen.memorizedIds.map((id) => t.objectProperty(id, id, false, true))
         );
     }
 
@@ -560,7 +562,7 @@ function format({ config }: State) {
     }
 }
 
-export default function(templateRoot: IRElement, state: State): CompilationOutput {
+export default function (templateRoot: IRElement, state: State): CompilationOutput {
     const templateFunction = generateTemplateFunction(templateRoot, state);
     const formatter = format(state);
     const program = formatter(templateFunction, state);

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -43,7 +43,7 @@ export default function compile(source: string, config: Config): TemplateCompile
         warnings.push(...parsingResults.warnings);
 
         const hasParsingError = parsingResults.warnings.some(
-            warning => warning.level === DiagnosticLevel.Error
+            (warning) => warning.level === DiagnosticLevel.Error
         );
 
         if (!hasParsingError && parsingResults.root) {

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -182,7 +182,7 @@ export function getAttribute(
     el: IRElement,
     pattern: string | RegExp
 ): parse5.AST.Default.Attribute | undefined {
-    return el.attrsList.find(attr =>
+    return el.attrsList.find((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) === pattern
             : !!attributeName(attr).match(pattern)
@@ -190,7 +190,7 @@ export function getAttribute(
 }
 
 export function removeAttribute(el: IRElement, pattern: string | RegExp): void {
-    el.attrsList = el.attrsList.filter(attr =>
+    el.attrsList = el.attrsList.filter((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) !== pattern
             : !attributeName(attr).match(pattern)

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -248,7 +248,7 @@ export default function parse(source: string, state: State): TemplateParseResult
     ): parse5.AST.Default.Element | undefined {
         // Filter all the empty text nodes
         const validRoots = documentFragment.childNodes.filter(
-            child =>
+            (child) =>
                 treeAdapter.isElementNode(child) ||
                 (treeAdapter.isTextNode(child) &&
                     treeAdapter.getTextNodeContent(child).trim().length)
@@ -258,7 +258,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             warnOnElement(ParserDiagnostics.MULTIPLE_ROOTS_FOUND, documentFragment.childNodes[1]);
         }
 
-        const templateTag = documentFragment.childNodes.find(child =>
+        const templateTag = documentFragment.childNodes.find((child) =>
             treeAdapter.isElementNode(child)
         );
 
@@ -436,7 +436,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             hasOwnProperty.call(LWCDirectiveDomMode, lwcDomAttribute.value) === false
         ) {
             const possibleValues = Object.keys(LWCDirectiveDomMode)
-                .map(value => `"${value}"`)
+                .map((value) => `"${value}"`)
                 .join(', or ');
             return warnOnElement(ParserDiagnostics.LWC_DOM_INVALID_VALUE, element.__original, [
                 possibleValues,
@@ -689,7 +689,7 @@ export default function parse(source: string, state: State): TemplateParseResult
     function applyAttributes(element: IRElement) {
         const { tag, attrsList } = element;
 
-        attrsList.forEach(rawAttr => {
+        attrsList.forEach((rawAttr) => {
             const attr = getTemplateAttribute(element, attributeName(rawAttr));
             if (!attr) {
                 return;
@@ -838,7 +838,7 @@ export default function parse(source: string, state: State): TemplateParseResult
         const { tag, attrsList } = element;
         const node = element.__original as parse5.AST.Default.Element;
 
-        attrsList.forEach(attr => {
+        attrsList.forEach((attr) => {
             const attrName = attr.name;
 
             if (isProhibitedIsAttribute(attrName)) {

--- a/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
+++ b/packages/@lwc/template-compiler/src/parser/utils/html-element-attributes.ts
@@ -425,7 +425,7 @@ export const HTML_ATTRIBUTE_ELEMENT_MAP = Object.entries(HTML_ELEMENT_ATTRIBUTE_
         const attributes = entry[1];
 
         if (element !== '*') {
-            attributes.forEach(attribute => {
+            attributes.forEach((attribute) => {
                 if (!hasOwnProperty.call(accumulator, attribute)) {
                     accumulator[attribute] = [];
                 }
@@ -440,5 +440,5 @@ export const HTML_ATTRIBUTE_ELEMENT_MAP = Object.entries(HTML_ELEMENT_ATTRIBUTE_
 );
 
 Object.values(HTML_ELEMENT_ATTRIBUTE_MAP['*']).forEach(
-    globalAttribute => (HTML_ATTRIBUTE_ELEMENT_MAP[globalAttribute] = [])
+    (globalAttribute) => (HTML_ATTRIBUTE_ELEMENT_MAP[globalAttribute] = [])
 );

--- a/packages/@lwc/wire-service/README.md
+++ b/packages/@lwc/wire-service/README.md
@@ -108,9 +108,7 @@ import { register, ValueChangedEvent } from 'wire-service';
 
 // Imperative access.
 export function getTodo(config) {
-    return getObservable(config)
-        .map(makeReadOnlyMembrane)
-        .toPromise();
+    return getObservable(config).map(makeReadOnlyMembrane).toPromise();
 }
 
 // Declarative access: register a wire adapter factory for  @wire(getTodo).
@@ -119,7 +117,7 @@ register(getTodo, function getTodoWireAdapterFactory(eventTarget) {
     let config;
 
     // Invoked when config is updated.
-    eventTarget.addListener('config', newConfig => {
+    eventTarget.addListener('config', (newConfig) => {
         // Capture config for use during subscription.
         config = newConfig;
     });
@@ -130,11 +128,11 @@ register(getTodo, function getTodoWireAdapterFactory(eventTarget) {
         subscription = getObservable(config)
             .map(makeReadOnlyMembrane)
             .subscribe({
-                next: data =>
+                next: (data) =>
                     wiredEventTarget.dispatchEvent(
                         new ValueChangedEvent({ data, error: undefined })
                     ),
-                error: error =>
+                error: (error) =>
                     wiredEventTarget.dispatchEvent(
                         new ValueChangedEvent({ data: undefined, error })
                     ),

--- a/packages/@lwc/wire-service/src/__tests__/index.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/index.spec.ts
@@ -200,7 +200,7 @@ describe('WireEventTarget from register', () => {
     });
 
     describe('removeEventListener', () => {
-        ['connect', 'disconnect', 'config'].forEach(eventType => {
+        ['connect', 'disconnect', 'config'].forEach((eventType) => {
             it(`should remove listener from the queue for ${eventType} event`, () => {
                 const eventToAdapterMethod = {
                     connect: 'connect',

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -96,7 +96,7 @@ function isEmptyConfig(config: Record<string, any>): boolean {
 }
 
 function isValidConfig(config: Record<string, any>): boolean {
-    return Object.keys(config).some(key => !isUndefined(config[key]));
+    return Object.keys(config).some((key) => !isUndefined(config[key]));
 }
 
 export class WireAdapter {
@@ -203,17 +203,17 @@ export class WireAdapter {
         }
 
         this.currentConfig = config;
-        forEach.call(this.configuring, listener => {
+        forEach.call(this.configuring, (listener) => {
             listener.call(undefined, config);
         });
     }
 
     connect() {
-        forEach.call(this.connecting, listener => listener.call(undefined));
+        forEach.call(this.connecting, (listener) => listener.call(undefined));
     }
 
     disconnect() {
-        forEach.call(this.disconnecting, listener => listener.call(undefined));
+        forEach.call(this.disconnecting, (listener) => listener.call(undefined));
     }
 }
 

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-window.TestUtils = (function(lwc, jasmine, beforeAll) {
+window.TestUtils = (function (lwc, jasmine, beforeAll) {
     function pass() {
         return {
             pass: true,
@@ -33,26 +33,26 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         };
 
         window.console = {
-            log: function() {
+            log: function () {
                 calls.log.push(Array.prototype.slice.call(arguments));
             },
-            warn: function() {
+            warn: function () {
                 calls.warn.push(Array.prototype.slice.call(arguments));
             },
-            error: function() {
+            error: function () {
                 calls.error.push(Array.prototype.slice.call(arguments));
             },
-            group: function() {
+            group: function () {
                 calls.group.push(Array.prototype.slice.call(arguments));
             },
-            groupEnd: function() {
+            groupEnd: function () {
                 calls.groupEnd.push(Array.prototype.slice.call(arguments));
             },
         };
 
         return {
             calls: calls,
-            reset: function() {
+            reset: function () {
                 window.console = originalConsole;
             },
         };
@@ -76,7 +76,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
 
                     var callsArgs = spy.calls[internalMethodName || methodName];
                     var formattedCalls = callsArgs
-                        .map(function(arg) {
+                        .map(function (arg) {
                             return '"' + formatConsoleCall(arg) + '"';
                         })
                         .join(', ');
@@ -88,7 +88,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
                     }
                     return {
                         pass: false,
-                        message: function() {
+                        message: function () {
                             return 'Expect no message but received:\n' + formattedCalls;
                         },
                     };
@@ -123,7 +123,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
 
                     var callsArgs = spy.calls[internalMethodName || methodName];
                     var formattedCalls = callsArgs
-                        .map(function(callArgs) {
+                        .map(function (callArgs) {
                             return '"' + formatConsoleCall(callArgs) + '"';
                         })
                         .join(', ');
@@ -188,7 +188,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         toLogErrorDev: consoleDevMatcherFactory('error'),
         toThrowErrorDev: function toThrowErrorDev() {
             return {
-                compare: function(actual, expectedErrorCtor, expectedMessage) {
+                compare: function (actual, expectedErrorCtor, expectedMessage) {
                     function matchMessage(message) {
                         if (typeof expectedMessage === 'string') {
                             return message === expectedMessage;
@@ -267,7 +267,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
         },
     };
 
-    beforeAll(function() {
+    beforeAll(function () {
         jasmine.addMatchers(customMatchers);
     });
 
@@ -333,7 +333,7 @@ window.TestUtils = (function(lwc, jasmine, beforeAll) {
     // #986 - childNodes on the host element returns a fake shadow comment node on IE11 for debugging purposed. This method
     // filters this node.
     function getHostChildNodes(host) {
-        return Array.prototype.slice.call(host.childNodes).filter(function(n) {
+        return Array.prototype.slice.call(host.childNodes).filter(function (n) {
             return !(n.nodeType === Node.COMMENT_NODE && n.tagName.startsWith('#shadow-root'));
         });
     }

--- a/packages/integration-karma/scripts/karma-configs/base.js
+++ b/packages/integration-karma/scripts/karma-configs/base.js
@@ -76,7 +76,7 @@ function getFiles(lwcConfig) {
  * More details here:
  * https://karma-runner.github.io/3.0/config/configuration-file.html
  */
-module.exports = config => {
+module.exports = (config) => {
     const lwcConfig = getLwcConfig(config);
 
     config.set({

--- a/packages/integration-karma/scripts/karma-configs/local.js
+++ b/packages/integration-karma/scripts/karma-configs/local.js
@@ -9,7 +9,7 @@
 
 const loadBaseConfig = require('./base');
 
-module.exports = config => {
+module.exports = (config) => {
     loadBaseConfig(config);
 
     config.set({

--- a/packages/integration-karma/scripts/karma-configs/sauce.js
+++ b/packages/integration-karma/scripts/karma-configs/sauce.js
@@ -109,7 +109,7 @@ function getSauceConfig(config) {
 }
 
 function getMatchingBrowsers({ compat, nativeShadow }) {
-    return SAUCE_BROWSERS.filter(browser => {
+    return SAUCE_BROWSERS.filter((browser) => {
         return (
             browser.compat === compat &&
             (!nativeShadow || browser.nativeShadowCompatible === nativeShadow)
@@ -117,7 +117,7 @@ function getMatchingBrowsers({ compat, nativeShadow }) {
     });
 }
 
-module.exports = config => {
+module.exports = (config) => {
     localConfig(config);
 
     const sauceConfig = getSauceConfig(config);
@@ -130,7 +130,7 @@ module.exports = config => {
     config.set({
         sauceLabs: sauceConfig,
 
-        browsers: matchingBrowsers.map(browser => browser.label),
+        browsers: matchingBrowsers.map((browser) => browser.label),
         customLaunchers: matchingBrowsers.reduce((acc, browser) => {
             const { label, browserName, platform, version } = browser;
             return {

--- a/packages/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/integration-karma/scripts/karma-plugins/lwc.js
@@ -34,7 +34,9 @@ function createPreprocessor(config, emitter, logger) {
 
         // Wrap all the tests into a describe block with the file stricture name
         const ancestorDirectories = path.relative(basePath, suiteDir).split(path.sep);
-        const intro = ancestorDirectories.map(tag => `describe("${tag}", function () {`).join('\n');
+        const intro = ancestorDirectories
+            .map((tag) => `describe("${tag}", function () {`)
+            .join('\n');
         const outro = ancestorDirectories.map(() => `});`).join('\n');
 
         const plugins = [

--- a/packages/integration-karma/scripts/merge-coverage.js
+++ b/packages/integration-karma/scripts/merge-coverage.js
@@ -45,7 +45,7 @@ const reporter = istanbul.createReporter(config);
 reporter.addAll(['html', 'json', 'text']);
 reporter.write(coverageMap);
 
-istanbul.checkCoverage.run(config, err => {
+istanbul.checkCoverage.run(config, (err) => {
     if (err) {
         console.log(err);
         process.exit(1);

--- a/packages/integration-karma/test/api/buildCustomElementConstructor/index.spec.js
+++ b/packages/integration-karma/test/api/buildCustomElementConstructor/index.spec.js
@@ -99,7 +99,7 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
             elm.setAttribute('number', 10);
             document.body.appendChild(elm);
 
-            elm.runInComponentContext(cmp => {
+            elm.runInComponentContext((cmp) => {
                 cmp.setAttribute('title', 'foo');
                 cmp.setAttribute('number', 10);
             });

--- a/packages/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/integration-karma/test/api/createElement/index.spec.js
@@ -39,7 +39,7 @@ function testInvalidComponentConstructor(type, isValue) {
     });
 }
 
-testInvalidComponentConstructor('Function', function() {});
+testInvalidComponentConstructor('Function', function () {});
 testInvalidComponentConstructor('Class not extending LightningElement', class Component {});
 
 it('returns an HTMLElement', () => {

--- a/packages/integration-karma/test/api/getComponentDef/index.spec.js
+++ b/packages/integration-karma/test/api/getComponentDef/index.spec.js
@@ -15,21 +15,21 @@ function testInvalidComponentConstructor(name, ctor) {
     });
 }
 
-beforeAll(function() {
-    const getNormalizedFunctionAsString = fn => fn.toString().replace(/(\s|\n)/g, '');
+beforeAll(function () {
+    const getNormalizedFunctionAsString = (fn) => fn.toString().replace(/(\s|\n)/g, '');
 
     jasmine.addMatchers({
-        toEqualWireSettings: function() {
+        toEqualWireSettings: function () {
             return {
-                compare: function(actual, expected) {
-                    Object.keys(actual).forEach(currentKey => {
+                compare: function (actual, expected) {
+                    Object.keys(actual).forEach((currentKey) => {
                         const normalizedActual = Object.assign({}, actual[currentKey], {
                             config: getNormalizedFunctionAsString(actual[currentKey].config),
                         });
 
                         const normalizedExpected = Object.assign({}, expected[currentKey], {
                             config: getNormalizedFunctionAsString(
-                                expected[currentKey].config || function() {}
+                                expected[currentKey].config || function () {}
                             ),
                         });
 
@@ -49,7 +49,7 @@ testInvalidComponentConstructor('null', null);
 testInvalidComponentConstructor('undefined', undefined);
 testInvalidComponentConstructor('String', 'component');
 testInvalidComponentConstructor('Object', {});
-testInvalidComponentConstructor('Function', function() {});
+testInvalidComponentConstructor('Function', function () {});
 testInvalidComponentConstructor('Class not extending LightningElement', class Component {});
 
 const GLOBAL_HTML_ATTRIBUTES = [
@@ -200,7 +200,7 @@ describe('@api', () => {
 describe('circular dependencies', () => {
     // Emulates an AMD module with circular dependency.
     function circularDependency(klass) {
-        const ctor = function() {
+        const ctor = function () {
             return klass;
         };
         ctor.__circular__ = true;

--- a/packages/integration-karma/test/api/isComponentConstructor/index.spec.js
+++ b/packages/integration-karma/test/api/isComponentConstructor/index.spec.js
@@ -10,7 +10,7 @@ testInvalidComponentConstructor('null', null);
 testInvalidComponentConstructor('undefined', undefined);
 testInvalidComponentConstructor('String', 'component');
 testInvalidComponentConstructor('Object', {});
-testInvalidComponentConstructor('Function', function() {});
+testInvalidComponentConstructor('Function', function () {});
 testInvalidComponentConstructor('Class', class Foo {});
 
 it('should return true if when passing a class inheriting from LightningElement', () => {

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -54,7 +54,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     if (!process.env.NATIVE_SHADOW) {
         expect(isNodeFromTemplate(div)).toBe(false); // it is false sync because MO hasn't pick up the element yet
     }
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         setTimeout(resolve);
     }).then(() => {
         expect(isNodeFromTemplate(div)).toBe(true); // it is true async because MO has already pick up the element
@@ -72,7 +72,7 @@ if (!process.env.NATIVE_SHADOW) {
         const span = document.createElement('span');
         elm.shadowRoot.querySelector('h2').appendChild(span);
 
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             setTimeout(resolve);
         }).then(() => {
             expect(isNodeFromTemplate(span)).toBe(false);

--- a/packages/integration-karma/test/bundle/css_only/index.spec.js
+++ b/packages/integration-karma/test/bundle/css_only/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/cssContainer';
 
 describe('CSS only modules', () => {
-    it('CSS should be applied', function() {
+    it('CSS should be applied', function () {
         const elm = createElement('x-css-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/component/LightningElement.addEventListener/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.addEventListener/index.spec.js
@@ -7,7 +7,7 @@ it('should be able to attach an event listener on the host element', () => {
     let thisValue;
     let args;
 
-    const clickHandler = function(...handlerArgs) {
+    const clickHandler = function (...handlerArgs) {
         thisValue = this;
         args = handlerArgs;
     };

--- a/packages/integration-karma/test/component/LightningElement.connectedCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.connectedCallback/index.spec.js
@@ -10,7 +10,7 @@ function testConnectSlot(name, fn) {
         let thisValue;
 
         const elm = createElement('x-test', { is: Test });
-        elm.connect = function(context) {
+        elm.connect = function (context) {
             isConnected = true;
             thisValue = context;
         };
@@ -22,17 +22,17 @@ function testConnectSlot(name, fn) {
     });
 }
 
-testConnectSlot('Node.appendChild', elm => {
+testConnectSlot('Node.appendChild', (elm) => {
     document.body.appendChild(elm);
 });
 
-testConnectSlot('Node.insertBefore', elm => {
+testConnectSlot('Node.insertBefore', (elm) => {
     const child = document.createElement('div');
     document.body.appendChild(child);
     document.body.insertBefore(elm, child);
 });
 
-testConnectSlot('Node.replaceChild', elm => {
+testConnectSlot('Node.replaceChild', (elm) => {
     const child = document.createElement('div');
     document.body.appendChild(child);
     document.body.replaceChild(elm, child);
@@ -54,7 +54,7 @@ it('should associate the component stack when the invocation throws', () => {
 });
 
 describe('addEventListner in `connectedCallback`', () => {
-    it('clicking force button should update value', function() {
+    it('clicking force button should update value', function () {
         const elm = createElement('x-slotted-parent', { is: XSlottedParent });
         document.body.appendChild(elm);
         const child = elm.shadowRoot.querySelector('x-child');

--- a/packages/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
@@ -7,9 +7,9 @@ import DualTemplate from 'x/dualTemplate';
 import ExplicitRender from 'x/explicitRender';
 
 function testDisconnectSlot(name, fn) {
-    it(`should invoke the disconnectedCallback when root element is removed from the DOM via ${name}`, done => {
+    it(`should invoke the disconnectedCallback when root element is removed from the DOM via ${name}`, (done) => {
         const elm = createElement('x-test', { is: Test });
-        elm.disconnect = function(context) {
+        elm.disconnect = function (context) {
             expect(context instanceof Test).toBe(true);
             done();
         };
@@ -19,18 +19,18 @@ function testDisconnectSlot(name, fn) {
 }
 
 describe('disconnectedCallback should be invoked for Node APIs', () => {
-    testDisconnectSlot('Node.removeChild', elm => {
+    testDisconnectSlot('Node.removeChild', (elm) => {
         document.body.appendChild(elm);
         document.body.removeChild(elm);
     });
 
-    testDisconnectSlot('Node.replaceChild', elm => {
+    testDisconnectSlot('Node.replaceChild', (elm) => {
         const newChild = document.createElement('div');
         document.body.appendChild(elm);
         document.body.replaceChild(newChild, elm);
     });
 
-    testDisconnectSlot('Node.appendChild', elm => {
+    testDisconnectSlot('Node.appendChild', (elm) => {
         const sibling = document.createElement('div');
         document.body.appendChild(elm);
         document.body.appendChild(sibling);
@@ -38,7 +38,7 @@ describe('disconnectedCallback should be invoked for Node APIs', () => {
         sibling.appendChild(elm);
     });
 
-    testDisconnectSlot('Node.insertBefore', elm => {
+    testDisconnectSlot('Node.insertBefore', (elm) => {
         const container = document.createElement('div');
         document.body.appendChild(elm);
         document.body.appendChild(container);
@@ -51,18 +51,18 @@ describe('disconnectedCallback should be invoked for Node APIs', () => {
 });
 
 xdescribe('#1102 - disconnectedCallback should be invoked for ChildNode APIs', () => {
-    testDisconnectSlot('ChildNode.remove', elm => {
+    testDisconnectSlot('ChildNode.remove', (elm) => {
         document.body.appendChild(elm);
         elm.remove();
     });
 
-    testDisconnectSlot('ChildNode.replaceWith', elm => {
+    testDisconnectSlot('ChildNode.replaceWith', (elm) => {
         const newChild = document.createElement('div');
         document.body.appendChild(elm);
         elm.replaceWith(newChild);
     });
 
-    testDisconnectSlot('ChildNode.after', elm => {
+    testDisconnectSlot('ChildNode.after', (elm) => {
         const container = document.createElement('div');
         document.body.appendChild(elm);
         document.body.appendChild(container);
@@ -72,7 +72,7 @@ xdescribe('#1102 - disconnectedCallback should be invoked for ChildNode APIs', (
         p.after(elm);
     });
 
-    testDisconnectSlot('ChildNode.before', elm => {
+    testDisconnectSlot('ChildNode.before', (elm) => {
         const container = document.createElement('div');
         document.body.appendChild(elm);
         document.body.appendChild(container);

--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -10,7 +10,7 @@ function testDispatchEvent(type, name, dispatchedEvent) {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        elm.addEventListener(name, event => {
+        elm.addEventListener(name, (event) => {
             receivedEvent = event;
         });
         elm.dispatch(dispatchedEvent);
@@ -32,7 +32,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
     }).toThrowError();
 });
 
-it('should throw when event is dispatched during construction', function() {
+it('should throw when event is dispatched during construction', function () {
     class Test extends LightningElement {
         constructor() {
             super();

--- a/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -98,7 +98,7 @@ describe('error boundary', () => {
         });
     });
 
-    it('should render alternative view if child throws during self rehydration cycle', done => {
+    it('should render alternative view if child throws during self rehydration cycle', (done) => {
         const elm = createElement('x-boundary-child-self-rehydrate-throw', {
             is: XBoundaryChildSelfRehydrateThrow,
         });

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -80,13 +80,13 @@ if ('onunhandledrejection' in window) {
             // Cleanup listener after test
             window.removeEventListener('unhandledrejection', listener);
         });
-        it('should throw when render() switches a valid template with an undefined value', done => {
+        it('should throw when render() switches a valid template with an undefined value', (done) => {
             const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
             elm.template = template1;
             document.body.appendChild(elm);
 
             elm.template = undefined;
-            listener = event => {
+            listener = (event) => {
                 expect(event.reason).toMatch(
                     /Assert Violation: evaluateTemplate\(\) second argument must be an imported template instead of undefined/
                 );

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -48,7 +48,7 @@ describe('properties', () => {
         document.body.appendChild(elm);
 
         expect(() => {
-            elm.mutateCmp(cmp => {
+            elm.mutateCmp((cmp) => {
                 cmp.publicProp.x = 1;
             });
         }).toThrowError();

--- a/packages/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/track/index.spec.js
@@ -11,7 +11,7 @@ it('rerenders the component when a track property is updated - literal', () => {
 
     expect(elm.shadowRoot.querySelector('.prop').textContent).toBe('0');
 
-    elm.mutateCmp(cmp => (cmp.prop = 1));
+    elm.mutateCmp((cmp) => (cmp.prop = 1));
     return Promise.resolve().then(() => {
         expect(elm.shadowRoot.querySelector('.prop').textContent).toBe('1');
     });
@@ -23,7 +23,7 @@ it('rerenders the component when a track property is updated - object', () => {
 
     expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('0');
 
-    elm.mutateCmp(cmp => (cmp.obj.value = 1));
+    elm.mutateCmp((cmp) => (cmp.obj.value = 1));
     return Promise.resolve().then(() => {
         expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
     });
@@ -49,7 +49,7 @@ describe('object mutations', () => {
 
         expect(elm.shadowRoot.querySelector('.nested-obj').textContent).toBe('0');
 
-        elm.mutateCmp(cmp => (cmp.nestedObj.value.nestedValue = 1));
+        elm.mutateCmp((cmp) => (cmp.nestedObj.value.nestedValue = 1));
         return Promise.resolve().then(() => {
             expect(elm.shadowRoot.querySelector('.nested-obj').textContent).toBe('1');
         });
@@ -59,7 +59,7 @@ describe('object mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => {
+        elm.mutateCmp((cmp) => {
             delete cmp.obj.value;
         });
         return Promise.resolve().then(() => {
@@ -71,7 +71,7 @@ describe('object mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => {
+        elm.mutateCmp((cmp) => {
             Object.defineProperty(cmp.obj, 'value', {
                 value: 1,
             });
@@ -85,7 +85,7 @@ describe('object mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => {
+        elm.mutateCmp((cmp) => {
             cmp.obj = { value: 1 };
             Object.freeze(cmp.obj);
         });
@@ -106,7 +106,7 @@ describe('array mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => cmp.array.push(4));
+        elm.mutateCmp((cmp) => cmp.array.push(4));
         return Promise.resolve().then(() => {
             expect(elm.shadowRoot.querySelector('.array').textContent).toBe('1234');
         });
@@ -116,7 +116,7 @@ describe('array mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => cmp.array.pop());
+        elm.mutateCmp((cmp) => cmp.array.pop());
         return Promise.resolve().then(() => {
             expect(elm.shadowRoot.querySelector('.array').textContent).toBe('12');
         });
@@ -126,7 +126,7 @@ describe('array mutations', () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
-        elm.mutateCmp(cmp => cmp.array.unshift(4));
+        elm.mutateCmp((cmp) => cmp.array.unshift(4));
         return Promise.resolve().then(() => {
             expect(elm.shadowRoot.querySelector('.array').textContent).toBe('4123');
         });

--- a/packages/integration-karma/test/component/dynamic-imports/index.spec.js
+++ b/packages/integration-karma/test/component/dynamic-imports/index.spec.js
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 function waitForMacroTask(fn) {
     // waiting for the macro-task first, then micro-task
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         setTimeout(() => {
             resolve();
         });

--- a/packages/integration-karma/test/context/advanced-context.spec.js
+++ b/packages/integration-karma/test/context/advanced-context.spec.js
@@ -4,7 +4,7 @@ import Consumer from 'x/advancedConsumer';
 import { setValueForIdentity } from './x/advancedProvider/advancedProvider';
 
 describe('Advanced Custom Context Provider', () => {
-    it('should be install-able on any dom element', function() {
+    it('should be install-able on any dom element', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);
@@ -13,14 +13,14 @@ describe('Advanced Custom Context Provider', () => {
         expect(typeof elm.getIdentity()).toBe('function');
         expect(getValueForIdentity(elm.getIdentity())).toBe(undefined);
     });
-    it('should provide identity as null when missing provider', function() {
+    it('should provide identity as null when missing provider', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);
         div.appendChild(elm);
         expect(elm.getIdentity()).toBe(null);
     });
-    it('should allow setting value associated to identity', function() {
+    it('should allow setting value associated to identity', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);

--- a/packages/integration-karma/test/context/simple-context.spec.js
+++ b/packages/integration-karma/test/context/simple-context.spec.js
@@ -3,7 +3,7 @@ import { installCustomContext, setCustomContext } from 'x/simpleProvider';
 import Consumer from 'x/simpleConsumer';
 
 describe('Simple Custom Context Provider', () => {
-    it('should be install-able on any dom element', function() {
+    it('should be install-able on any dom element', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);
@@ -12,14 +12,14 @@ describe('Simple Custom Context Provider', () => {
         div.appendChild(elm);
         expect(elm.shadowRoot.textContent).toBe('ready');
     });
-    it('should provide "missing" as the default value when no provider is installed', function() {
+    it('should provide "missing" as the default value when no provider is installed', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);
         div.appendChild(elm);
         expect(elm.shadowRoot.textContent).toBe('missing');
     });
-    it('should provide "pending" when provide is installed by no value was provided', function() {
+    it('should provide "pending" when provide is installed by no value was provided', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });
         document.body.appendChild(div);
@@ -27,7 +27,7 @@ describe('Simple Custom Context Provider', () => {
         div.appendChild(elm);
         expect(elm.shadowRoot.textContent).toBe('pending');
     });
-    it('should use closest context when installed in a hierarchy of targets', function() {
+    it('should use closest context when installed in a hierarchy of targets', function () {
         const div = document.createElement('div');
         div.innerHTML = '<div class="parent-ctx"><div class="child-ctx"></div></div>';
         const elm = createElement('x-consumer', { is: Consumer });

--- a/packages/integration-karma/test/context/x/advancedProvider/advancedProvider.js
+++ b/packages/integration-karma/test/context/x/advancedProvider/advancedProvider.js
@@ -45,7 +45,7 @@ export class WireAdapter {
 function createNewConsumerMeta(consumer) {
     // identity must be an object that can't be proxified otherwise we
     // loose the identity when tracking the value.
-    const identity = Object.freeze(_ => {
+    const identity = Object.freeze((_) => {
         throw new Error(`Invalid Invocation`);
     });
     // default value is undefined

--- a/packages/integration-karma/test/context/x/simpleProvider/simpleProvider.js
+++ b/packages/integration-karma/test/context/x/simpleProvider/simpleProvider.js
@@ -94,5 +94,5 @@ export function setCustomContext(target, newValue) {
     const contextData = getContextData(target);
     // in this example, all consumers get the same context value
     contextData.value = newValue;
-    contextData.consumers.forEach(consumer => consumer.provide({ value: newValue }));
+    contextData.consumers.forEach((consumer) => consumer.provide({ value: newValue }));
 }

--- a/packages/integration-karma/test/events/click-event-composed/index.spec.js
+++ b/packages/integration-karma/test/events/click-event-composed/index.spec.js
@@ -8,7 +8,7 @@ it('should set the composed property to true when invoking click() on an element
     const elm = document.createElement('div');
     document.body.appendChild(elm);
 
-    elm.addEventListener('click', evt => {
+    elm.addEventListener('click', (evt) => {
         clickEvent = evt;
     });
 
@@ -23,7 +23,7 @@ it('should let the event bubble through the shadow root when invoking click() on
 
     const elm = createElement('x-test', { is: Test });
     document.body.appendChild(elm);
-    elm.addEventListener('click', evt => {
+    elm.addEventListener('click', (evt) => {
         clickEvent = evt;
     });
 

--- a/packages/integration-karma/test/events/nested-template-event-target/index.spec.js
+++ b/packages/integration-karma/test/events/nested-template-event-target/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event target in slot elements', () => {
-    it('should receive event with correct target', function() {
+    it('should receive event with correct target', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/non-composed-events-on-custom-element/index.spec.js
+++ b/packages/integration-karma/test/events/non-composed-events-on-custom-element/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Non-composed events', () => {
-    it('should dispatch Event on the custom element', function() {
+    it('should dispatch Event on the custom element', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
@@ -16,7 +16,7 @@ describe('Non-composed events', () => {
         });
     });
 
-    it('should dispatch CustomEvent on the custom element', function() {
+    it('should dispatch CustomEvent on the custom element', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/root-listener-event-target/index.spec.js
+++ b/packages/integration-karma/test/events/root-listener-event-target/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event target in slot elements', () => {
-    it('should receive event with correct event.target in a shadowRoot listener', function() {
+    it('should receive event with correct event.target in a shadowRoot listener', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/root-listener-event-target/x/container/container.js
+++ b/packages/integration-karma/test/events/root-listener-event-target/x/container/container.js
@@ -4,7 +4,7 @@ export default class Container extends LightningElement {
     @track eventTargetIsCorrect = false;
 
     connectedCallback() {
-        this.template.addEventListener('click', evt => {
+        this.template.addEventListener('click', (evt) => {
             this.eventTargetIsCorrect = evt.target.tagName === 'X-CHILD';
         });
     }

--- a/packages/integration-karma/test/events/slotted-event-target/index.spec.js
+++ b/packages/integration-karma/test/events/slotted-event-target/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event target in slot elements', () => {
-    it('should receive event with correct target in slotted custom element', function() {
+    it('should receive event with correct target in slotted custom element', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
@@ -19,7 +19,7 @@ describe('Event target in slot elements', () => {
         });
     });
 
-    it('should receive event with correct target for slotted native element', function() {
+    it('should receive event with correct target for slotted native element', function () {
         const elm = createElement('x-container', { is: Container });
         elm.isNativeElement = true;
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/events/window-event-listener/index.spec.js
+++ b/packages/integration-karma/test/events/window-event-listener/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event Target on window event listener', () => {
-    it('should return correct target', function() {
+    it('should return correct target', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/window-event-listener/x/container/container.js
+++ b/packages/integration-karma/test/events/window-event-listener/x/container/container.js
@@ -3,7 +3,7 @@ import { LightningElement, track } from 'lwc';
 export default class Container extends LightningElement {
     @track windowEventTargetTagName = '';
     connectedCallback() {
-        window.addEventListener('click', evt => {
+        window.addEventListener('click', (evt) => {
             this.windowEventTargetTagName = evt.target.tagName.toLowerCase();
         });
     }

--- a/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
+++ b/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
@@ -36,29 +36,29 @@ describe('HTMLIFrameElement.contentWindow patching', () => {
         });
     }
 
-    testContentWindowProperty('postMessage', contentWindow =>
+    testContentWindowProperty('postMessage', (contentWindow) =>
         contentWindow.postMessage('foo', '*')
     );
-    testContentWindowProperty('focus', contentWindow => contentWindow.focus());
-    testContentWindowProperty('blur', contentWindow => contentWindow.blur());
-    testContentWindowProperty('close', contentWindow => contentWindow.close());
-    testContentWindowProperty('closed', contentWindow => contentWindow.closed);
-    testContentWindowProperty('frames', contentWindow => contentWindow.frames);
-    testContentWindowProperty('length', contentWindow => contentWindow.length);
-    testContentWindowProperty('location', contentWindow => {
+    testContentWindowProperty('focus', (contentWindow) => contentWindow.focus());
+    testContentWindowProperty('blur', (contentWindow) => contentWindow.blur());
+    testContentWindowProperty('close', (contentWindow) => contentWindow.close());
+    testContentWindowProperty('closed', (contentWindow) => contentWindow.closed);
+    testContentWindowProperty('frames', (contentWindow) => contentWindow.frames);
+    testContentWindowProperty('length', (contentWindow) => contentWindow.length);
+    testContentWindowProperty('location', (contentWindow) => {
         contentWindow.location;
         contentWindow.location = 'http://example.com';
     });
-    testContentWindowProperty('opener', contentWindow => contentWindow.opener);
-    testContentWindowProperty('parent', contentWindow => contentWindow.parent);
-    testContentWindowProperty('self', contentWindow => contentWindow.self);
-    testContentWindowProperty('top', contentWindow => contentWindow.top);
-    testContentWindowProperty('window', contentWindow => contentWindow.window);
+    testContentWindowProperty('opener', (contentWindow) => contentWindow.opener);
+    testContentWindowProperty('parent', (contentWindow) => contentWindow.parent);
+    testContentWindowProperty('self', (contentWindow) => contentWindow.self);
+    testContentWindowProperty('top', (contentWindow) => contentWindow.top);
+    testContentWindowProperty('window', (contentWindow) => contentWindow.window);
 
-    testSameOriginContentWindowProperty('addEventListener', contentWindow =>
+    testSameOriginContentWindowProperty('addEventListener', (contentWindow) =>
         contentWindow.addEventListener('resize', () => {})
     );
-    testSameOriginContentWindowProperty('removeEventListener', contentWindow => {
+    testSameOriginContentWindowProperty('removeEventListener', (contentWindow) => {
         contentWindow.removeEventListener('resize', () => {});
     });
 });

--- a/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/Event.target.spec.js
@@ -10,7 +10,7 @@ if (process.env.COMPAT !== true) {
         let child;
         let eventTargetAtBody;
         let container;
-        const listener = evt => {
+        const listener = (evt) => {
             eventTargetAtBody = evt.target;
         };
         beforeEach(() => {
@@ -29,7 +29,7 @@ if (process.env.COMPAT !== true) {
         describe('composed:false', () => {
             it('event dispatched at root custom element', () => {
                 let targetAtSource;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtSource = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -40,12 +40,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside root custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -62,12 +62,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside nested custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -84,7 +84,7 @@ if (process.env.COMPAT !== true) {
         describe('composed:true', () => {
             it('event dispatched at root custom element', () => {
                 let targetAtSource;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtSource = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -95,12 +95,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside root custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -117,12 +117,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside nested custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -143,10 +143,10 @@ if (process.env.COMPAT !== true) {
         let eventTargetAtBody;
         let container;
         let lwcParent;
-        const listener = evt => {
+        const listener = (evt) => {
             eventTargetAtBody = evt.target;
         };
-        beforeEach(done => {
+        beforeEach((done) => {
             parent = NativeShadowParent();
             child = NativeShadowChild();
             container = parent.shadowRoot.querySelector('div');
@@ -171,7 +171,7 @@ if (process.env.COMPAT !== true) {
         describe('composed:false', () => {
             it('event dispatched at root custom element', () => {
                 let targetAtSource;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtSource = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -185,12 +185,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside root custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -207,12 +207,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside nested custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true });
@@ -229,7 +229,7 @@ if (process.env.COMPAT !== true) {
         describe('composed:true', () => {
             it('event dispatched at root custom element', () => {
                 let targetAtSource;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtSource = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -240,12 +240,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside root custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -262,12 +262,12 @@ if (process.env.COMPAT !== true) {
 
             it('event dispatched inside nested custom element', () => {
                 let targetAtParent;
-                parent.addEventListener('test', evt => {
+                parent.addEventListener('test', (evt) => {
                     targetAtParent = evt.target;
                 });
 
                 let targetAtContainer;
-                container.addEventListener('test', evt => {
+                container.addEventListener('test', (evt) => {
                     targetAtContainer = evt.target;
                 });
                 const event = new CustomEvent('test', { bubbles: true, composed: true });

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeChild/NativeChild.js
@@ -1,4 +1,4 @@
-export default function() {
+export default function () {
     const child = document.createElement('x-native-child');
     const sr = child.attachShadow({ mode: 'open' });
     const h2 = document.createElement('h2');

--- a/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
+++ b/packages/integration-karma/test/native-shadow/Event-properties/x/NativeParent/NativeParent.js
@@ -1,4 +1,4 @@
-export default function() {
+export default function () {
     const parent = document.createElement('x-native-parent');
     const sr = parent.attachShadow({ mode: 'open' });
     const h1 = document.createElement('h1');

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -5,7 +5,7 @@ import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 function testAssignedElements(testDescription, container) {
     describe(testDescription, () => {
         let nativeSlottedBasic;
-        beforeEach(done => {
+        beforeEach((done) => {
             nativeSlottedBasic = NativeSlottedBasic();
             container.appendChild(nativeSlottedBasic);
             // Allow for portal elements to be adopted

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
@@ -5,7 +5,7 @@ import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 function testAssignedNodes(testDescription, container) {
     describe(testDescription, () => {
         let nativeSlottedBasic;
-        beforeEach(done => {
+        beforeEach((done) => {
             nativeSlottedBasic = NativeSlottedBasic();
             container.appendChild(nativeSlottedBasic);
             // Allow for portal elements to be adopted

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/x/NativeBasic/NativeBasic.js
@@ -1,4 +1,4 @@
-export default function() {
+export default function () {
     const xSlotted = document.createElement('x-slotted');
     xSlotted.innerHTML =
         "<div slot='slot1' data-slot-id='slot1'>Named slot content</div><div data-slot-id='default'><p>Default slot content</p></div>Text Node";

--- a/packages/integration-karma/test/natives/array/array-splice-slice.spec.js
+++ b/packages/integration-karma/test/natives/array/array-splice-slice.spec.js
@@ -1,10 +1,10 @@
 describe('Testing array primitives', () => {
-    it('Array.slice without arguments returns shallow copy of all entries', function() {
+    it('Array.slice without arguments returns shallow copy of all entries', function () {
         const original = ['one', 'two', 'three', 'four', 'five'];
         expect(original.slice()).toEqual(['one', 'two', 'three', 'four', 'five']);
     });
 
-    it('Array.splice will remove specified item', function() {
+    it('Array.splice will remove specified item', function () {
         const original = ['one', 'two', 'three', 'four', 'five'];
         const splicedList = ['one', 'three', 'four', 'five'];
         original.splice(1, 1);

--- a/packages/integration-karma/test/natives/array/plain.array.spec.js
+++ b/packages/integration-karma/test/natives/array/plain.array.spec.js
@@ -1,10 +1,10 @@
 describe('Plain array methods', () => {
-    it('should get expected items correctly after push', function() {
+    it('should get expected items correctly after push', function () {
         const array = [1, 2];
         array.push(3, 4);
         expect(array).toEqual([1, 2, 3, 4]);
     });
-    it('should display concat items correctly', function() {
+    it('should display concat items correctly', function () {
         let array = [1, 2];
         array = array.concat([3, 4]);
         expect(array).toEqual([1, 2, 3, 4]);

--- a/packages/integration-karma/test/natives/array/push-concat-unshift.spec.js
+++ b/packages/integration-karma/test/natives/array/push-concat-unshift.spec.js
@@ -3,22 +3,22 @@ describe('Array prototype methods', () => {
     beforeEach(() => {
         items = ['first', 'second'];
     });
-    it('should display unshifted items correctly', function() {
+    it('should display unshifted items correctly', function () {
         items.unshift('unshifted');
         expect(items).toEqual(['unshifted', 'first', 'second']);
     });
 
-    it('should display pushed items correctly', function() {
+    it('should display pushed items correctly', function () {
         items.push('pushed');
         expect(items).toEqual(['first', 'second', 'pushed']);
     });
 
-    it('should display concat items correctly', function() {
+    it('should display concat items correctly', function () {
         items = items.concat(['concat 1', 'concat 2']);
         expect(items).toEqual(['first', 'second', 'concat 1', 'concat 2']);
     });
 
-    it('should display concat items correctly', function() {
+    it('should display concat items correctly', function () {
         items = ['concat 1', 'concat 2'].concat(items);
         expect(items).toEqual(['concat 1', 'concat 2', 'first', 'second']);
     });

--- a/packages/integration-karma/test/natives/json/json.stringify.spec.js
+++ b/packages/integration-karma/test/natives/json/json.stringify.spec.js
@@ -1,5 +1,5 @@
 describe('JSON.stringify on proxies', () => {
-    it('should return proper value for simple object', function() {
+    it('should return proper value for simple object', function () {
         const arr = new Proxy(
             {
                 x: 'x',
@@ -12,14 +12,14 @@ describe('JSON.stringify on proxies', () => {
         expect(actual).toBe('{"x":"x","y":"y"}');
     });
 
-    it('should return proper value for simple array', function() {
+    it('should return proper value for simple array', function () {
         const arr = new Proxy([1, 2], {});
 
         const actual = JSON.stringify(arr);
         expect(actual).toBe('[1,2]');
     });
 
-    it('should return proper value for complex object', function() {
+    it('should return proper value for complex object', function () {
         const obj = new Proxy(
             {
                 string: 'x',
@@ -39,7 +39,7 @@ describe('JSON.stringify on proxies', () => {
         );
     });
 
-    it('should return proper value for nested proxies', function() {
+    it('should return proper value for nested proxies', function () {
         const nested = new Proxy(
             {
                 x: new Proxy({ y: true }, {}),

--- a/packages/integration-karma/test/natives/object/object.assign.spec.js
+++ b/packages/integration-karma/test/natives/object/object.assign.spec.js
@@ -1,5 +1,5 @@
 describe('Object assign', () => {
-    it('should return copy of object on using object.assign', function() {
+    it('should return copy of object on using object.assign', function () {
         const assign = { inner: 'foo' };
         const obj = Object.assign({}, assign);
         expect(obj.inner).toBe('foo');

--- a/packages/integration-karma/test/natives/object/object.keys.spec.js
+++ b/packages/integration-karma/test/natives/object/object.keys.spec.js
@@ -1,5 +1,5 @@
 describe('Object keys', () => {
-    it('should have the right value', function() {
+    it('should have the right value', function () {
         const keys = Object.keys({
             bar: 'foo',
             foo: 'bar',

--- a/packages/integration-karma/test/natives/object/object.setPrototypeOf.spec.js
+++ b/packages/integration-karma/test/natives/object/object.setPrototypeOf.spec.js
@@ -1,12 +1,12 @@
 describe('Set Prototype Of', () => {
-    it('should have set prototype correctly', function() {
+    it('should have set prototype correctly', function () {
         const obj = {};
         Object.setPrototypeOf(obj, []);
         const actual = obj instanceof Array;
         expect(actual).toBe(true);
     });
 
-    it('should have set proxy prototype correctly', function() {
+    it('should have set proxy prototype correctly', function () {
         const proxy = new Proxy(
             {},
             {
@@ -20,7 +20,7 @@ describe('Set Prototype Of', () => {
         expect(actual).toBe(true);
     });
 
-    it('should have ignored proto argument in favor of trap', function() {
+    it('should have ignored proto argument in favor of trap', function () {
         const proxy = new Proxy(
             {},
             {
@@ -34,7 +34,7 @@ describe('Set Prototype Of', () => {
         expect(actual).toBe(false);
     });
 
-    it('should have ignored proto argument in favor of trap', function() {
+    it('should have ignored proto argument in favor of trap', function () {
         const obj = {};
         const proto = [];
         Object.setPrototypeOf(obj, proto);

--- a/packages/integration-karma/test/natives/weak-set/index.spec.js
+++ b/packages/integration-karma/test/natives/weak-set/index.spec.js
@@ -1,5 +1,5 @@
 describe('WeakSet insertion', () => {
-    it('should have the right value', function() {
+    it('should have the right value', function () {
         const set = new WeakSet();
         const proxy = new Proxy({}, {});
         expect(set.has(proxy)).toBe(false);

--- a/packages/integration-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/document-properties/index.spec.js
@@ -45,7 +45,7 @@ describe('dynamic nodes', () => {
         span.classList.add('manual-span');
         const div = elm.shadowRoot.querySelector('div');
         div.appendChild(span);
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             setTimeout(resolve);
         }).then(() => {
             expect(document.querySelector('span.manual-span')).toBe(null);
@@ -64,7 +64,7 @@ describe('dynamic nodes', () => {
             h2.classList.add('manual-h2');
             const div = elm.shadowRoot.querySelector('.in-the-shadow');
             div.appendChild(h2);
-            return new Promise(resolve => {
+            return new Promise((resolve) => {
                 setTimeout(resolve);
             }).then(() => {
                 expect(document.querySelector('h2.manual-h2')).toBe(h2);

--- a/packages/integration-karma/test/polyfills/event-composed/index.spec.js
+++ b/packages/integration-karma/test/polyfills/event-composed/index.spec.js
@@ -11,11 +11,11 @@ it('should respect when the event composed flag is set during construction', () 
     expect(notComposedClickEvent.composed).toBe(false);
 });
 
-it('should set composed to true for click events dispatched by the user agent', done => {
+it('should set composed to true for click events dispatched by the user agent', (done) => {
     const elm = document.createElement('div');
     document.body.appendChild(elm);
 
-    elm.addEventListener('click', evt => {
+    elm.addEventListener('click', (evt) => {
         expect(evt.composed).toBe(true);
         done();
     });

--- a/packages/integration-karma/test/polyfills/proxy-concat/index.spec.js
+++ b/packages/integration-karma/test/polyfills/proxy-concat/index.spec.js
@@ -74,7 +74,7 @@ it('should invoke get traps for length, 0 and 1', () => {
     // ensure consistent behavior regardless with we use the Native or the COMPAT version of Proxy.
     //    Native Proxy => ['length', '0', '1']
     //    Native Proxy => ['length', 0, 1]
-    const getKeys = getCalls.map(item => String(item[1]));
+    const getKeys = getCalls.map((item) => String(item[1]));
 
     // Instead of comparing all the items using .toEqual(), we look if specific elements are present in the accessed
     // keys. On older versions of Chrome and Firefox we are running a strange mode where the served code is COMPAT,

--- a/packages/integration-karma/test/reactivity/setters/x/child/child.js
+++ b/packages/integration-karma/test/reactivity/setters/x/child/child.js
@@ -10,7 +10,7 @@ export default class Test extends LightningElement {
     }
     set items(items) {
         this.originalItems = items;
-        this.normalizedItems = items.map(item => {
+        this.normalizedItems = items.map((item) => {
             const normalizedItem = {
                 key: `id-${item}`,
                 label: item,

--- a/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
+++ b/packages/integration-karma/test/rendering/disconnecting-root-vm/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import ParentCmp from 'x/parent';
 
 describe('disconnecting root vm', () => {
-    it('should not throw an error when disconnecting an already disconnected child vm', function(done) {
+    it('should not throw an error when disconnecting an already disconnected child vm', function (done) {
         const elm = createElement('x-parent', { is: ParentCmp });
         elm.labels = ['label 1', 'label 2'];
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/rendering/duplicate-text-rendering/index.spec.js
+++ b/packages/integration-karma/test/rendering/duplicate-text-rendering/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Dynamic text nodes rendering duplicate text', () => {
-    it('should not render duplicate text', function() {
+    it('should not render duplicate text', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -7,7 +7,7 @@ import Container from 'x/container';
 // In the synthetic shadow however, slot content will be not be present in the DOM when not rendered.
 
 describe('custom elements', () => {
-    it('should not be reused when slotted', function() {
+    it('should not be reused when slotted', function () {
         const elm = createElement('x-container', { is: Container });
         elm.isCustomElement = true;
         document.body.appendChild(elm);
@@ -38,7 +38,7 @@ describe('custom elements', () => {
 
 describe('elements', () => {
     if (!process.env.NATIVE_SHADOW) {
-        it('should not be reused when slotted', function() {
+        it('should not be reused when slotted', function () {
             const elm = createElement('x-container', { is: Container });
             elm.isElement = true;
             document.body.appendChild(elm);
@@ -63,7 +63,7 @@ describe('elements', () => {
         });
     }
 
-    it('should not add listener multiple times', function() {
+    it('should not add listener multiple times', function () {
         const elm = createElement('x-container', { is: Container });
         elm.isElement = true;
         document.body.appendChild(elm);
@@ -95,13 +95,13 @@ describe('elements', () => {
 });
 
 if (process.env.NATIVE_SHADOW) {
-    it('should render same styles for custom element instances', function() {
+    it('should render same styles for custom element instances', function () {
         const elm = createElement('x-container', { is: Container });
         elm.isStyleCheck = true;
         document.body.appendChild(elm);
 
         return Promise.resolve().then(() => {
-            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map(xSimple =>
+            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map((xSimple) =>
                 xSimple.shadowRoot.querySelector('style')
             );
 

--- a/packages/integration-karma/test/rendering/form-tag/index.spec.js
+++ b/packages/integration-karma/test/rendering/form-tag/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Form tag rendering', () => {
-    it('should have the right value', function() {
+    it('should have the right value', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/rendering/inheritance/index.spec.js
+++ b/packages/integration-karma/test/rendering/inheritance/index.spec.js
@@ -3,14 +3,14 @@ import Foo from 'x/foo';
 import Bar from 'x/bar';
 
 describe('template inheritance', () => {
-    it('should support implicit definition of new template', function() {
+    it('should support implicit definition of new template', function () {
         const elm = createElement('x-foo', { is: Foo });
         document.body.appendChild(elm);
 
         const text = elm.shadowRoot.textContent;
         expect(text).toBe('foo');
     });
-    it('should support implicit definition of no template', function() {
+    it('should support implicit definition of no template', function () {
         const elm = createElement('x-bar', { is: Bar });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/rendering/nested-state/index.spec.js
+++ b/packages/integration-karma/test/rendering/nested-state/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Nested state', () => {
-    it('Object keys should have the right value', function() {
+    it('Object keys should have the right value', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/rendering/nested-state/x/container/container.js
+++ b/packages/integration-karma/test/rendering/nested-state/x/container/container.js
@@ -5,7 +5,7 @@ function getType(recordId, recordUi) {
     const { apiName } = record;
     const recordTypeInfos = recordUi.objectInfos[apiName].recordTypeInfos;
     const keys = Object.keys(recordTypeInfos);
-    const masterRecordTypeId = keys.find(id => {
+    const masterRecordTypeId = keys.find((id) => {
         return recordTypeInfos[id].master;
     });
 

--- a/packages/integration-karma/test/rendering/null-logging/index.spec.js
+++ b/packages/integration-karma/test/rendering/null-logging/index.spec.js
@@ -5,7 +5,7 @@ import Container from 'x/container';
  * https://github.com/salesforce/lwc/issues/720
  */
 describe('Issue 720: Wrap all string literal variables with toString method', () => {
-    it('should not have have an error accessing state.foo', function() {
+    it('should not have have an error accessing state.foo', function () {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import XAsyncEventCurrentTarget from 'x/asyncEventCurrentTarget';
 
-it('Async event currentTarget should be null', function() {
+it('Async event currentTarget should be null', function () {
     const elm = createElement('x-async-event-current-target', { is: XAsyncEventCurrentTarget });
     document.body.appendChild(elm);
     const triggerElm = elm.shadowRoot.querySelector('div.triggerEventHandler');

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.defaultPrevented.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.defaultPrevented.spec.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import XDefaultPreventingParent from 'x/defaultPreventingParent';
 
-it('defaultPrevented should be true after preventDefault() is invoked', function() {
+it('defaultPrevented should be true after preventDefault() is invoked', function () {
     const elm = createElement('x-default-prevented-parent', { is: XDefaultPreventingParent });
     document.body.appendChild(elm);
     const child = elm.shadowRoot.querySelector('x-default-prevented-child');

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -4,7 +4,7 @@ import XEventHandlingParent from 'x/eventHandlingParent';
 import XDocumentEventListener from 'x/documentEventListener';
 import XParentWithDynamicChild from 'x/parentWithDynamicChild';
 
-it('Async event target should be root node', function() {
+it('Async event target should be root node', function () {
     const elm = createElement('x-async-event-target', { is: XAsyncEventTarget });
     document.body.appendChild(elm);
     const triggerElm = elm.shadowRoot.querySelector('x-child');
@@ -15,7 +15,7 @@ it('Async event target should be root node', function() {
     });
 });
 
-it('parent should receive composed event with correct target', function() {
+it('parent should receive composed event with correct target', function () {
     const elm = createElement('x-parent', { is: XEventHandlingParent });
     document.body.appendChild(elm);
     const child = elm.shadowRoot.querySelector('x-event-dispatching-child');
@@ -28,7 +28,7 @@ it('parent should receive composed event with correct target', function() {
 
 describe('event.target on document event listener', () => {
     let actual;
-    const listener = evt => {
+    const listener = (evt) => {
         actual = evt.target.tagName.toLowerCase();
     };
     beforeAll(() => {
@@ -37,7 +37,7 @@ describe('event.target on document event listener', () => {
     afterAll(() => {
         document.removeEventListener('click', listener);
     });
-    it('should return correct target', function() {
+    it('should return correct target', function () {
         const elm = createElement('x-document-event-listener', { is: XDocumentEventListener });
         document.body.appendChild(elm);
         elm.shadowRoot.querySelector('button').click();
@@ -61,8 +61,8 @@ describe('should not retarget event', () => {
             child = elm.shadowRoot.querySelector('x-child-with-out-lwc-dom-manual');
             originalTarget = child.shadowRoot.querySelector('span');
         });
-        it('when original target node is not keyed and event is accessed async (W-6586380)', done => {
-            elm.eventListener = evt => {
+        it('when original target node is not keyed and event is accessed async (W-6586380)', (done) => {
+            elm.eventListener = (evt) => {
                 expect(evt.currentTarget).toBe(elm.shadowRoot.querySelector('div'));
                 expect(evt.target).toBe(child);
                 setTimeout(() => {
@@ -78,7 +78,7 @@ describe('should not retarget event', () => {
         describe('received at a global listener', () => {
             let actualCurrentTarget;
             let actualTarget;
-            const globalListener = evt => {
+            const globalListener = (evt) => {
                 actualCurrentTarget = evt.currentTarget;
                 actualTarget = evt.target;
             };

--- a/packages/integration-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
@@ -64,7 +64,7 @@ describe('global HTML Properties', () => {
         { prop: 'title', value: 'title' },
     ];
 
-    cases.forEach(testCase => {
+    cases.forEach((testCase) => {
         const { prop, value } = testCase;
         describe(`#${prop}`, () => {
             if (prop !== 'hidden') {
@@ -141,15 +141,15 @@ describe('global HTML Properties', () => {
     });
 });
 
-describe('#tabIndex', function() {
-    it('should have a valid value during connectedCallback', function() {
+describe('#tabIndex', function () {
+    it('should have a valid value during connectedCallback', function () {
         const elm = createElement('x-foo', { is: TabIndexTester });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
         expect(elm.tabIndexInConnectedCallback).toBe(3);
     });
 
-    it('should have a valid value after initial render', function() {
+    it('should have a valid value after initial render', function () {
         const elm = createElement('x-foo', { is: TabIndexTester });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
@@ -157,7 +157,7 @@ describe('#tabIndex', function() {
         expect(elm.getTabIndex()).toBe(3);
     });
 
-    it('should set tabindex correctly', function() {
+    it('should set tabindex correctly', function () {
         const elm = createElement('x-foo', { is: TabIndexSetInConnectedCallback });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
@@ -166,7 +166,7 @@ describe('#tabIndex', function() {
         expect(elm.getTabIndex()).toBe(2);
     });
 
-    it('should not trigger render cycle', function() {
+    it('should not trigger render cycle', function () {
         const elm = createElement('x-foo', { is: TabIndexSetInConnectedCallback });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
@@ -175,7 +175,7 @@ describe('#tabIndex', function() {
         });
     });
 
-    it('should allow parent component to overwrite internally set tabIndex', function() {
+    it('should allow parent component to overwrite internally set tabIndex', function () {
         const elm = createElement('x-foo', { is: TabIndexSetInConnectedCallback });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
@@ -185,14 +185,14 @@ describe('#tabIndex', function() {
         expect(elm.getTabIndex()).toBe(4);
     });
 
-    it('should throw if setting tabIndex during render', function() {
+    it('should throw if setting tabIndex during render', function () {
         const elm = createElement('x-foo', { is: TabIndexSetInRender });
         expect(() => {
             document.body.appendChild(elm);
         }).toThrowErrorDev(Error, /render\(\) method has side effects on the state of/);
     });
 
-    it('should throw if setting tabIndex during construction', function() {
+    it('should throw if setting tabIndex during construction', function () {
         expect(() => {
             createElement('x-foo', { is: TabIndexSetInConstructor });
         }).toThrowErrorDev(Error, /The result must not have attributes./);

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -13,7 +13,7 @@ const observerConfig = { childList: true, subtree: true };
  **/
 
 function waitForMutationObservedToBeInvoked() {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         setTimeout(resolve);
     });
 }
@@ -31,12 +31,12 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             globalObserver.observe(container, observerConfig);
         });
 
-        it('global observer should be called 1 time, when the host element is attached to document', done => {
+        it('global observer should be called 1 time, when the host element is attached to document', (done) => {
             // Prepare body for new lwc element
             const host = createElement('x-parent', { is: XParent });
             const container = document.createElement('div');
             document.body.appendChild(container);
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(containerObserver);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(container);
@@ -90,14 +90,14 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
 
-        it('should invoke observer on parent when slotted content is altered', done => {
+        it('should invoke observer on parent when slotted content is altered', (done) => {
             const parent = createElement('x-slotted-child', { is: XSlottedChild });
             container.appendChild(parent);
             const slottedDiv = parent.shadowRoot.querySelector('div.manual');
 
             // observer on parent element's shadowRoot will be notified
             // because the slot content being mutated belongs to that shadow tree
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(parentSRObserver);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(slottedDiv);
@@ -125,14 +125,14 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
 
-        it('should invoke observer on slot content owner', done => {
+        it('should invoke observer on slot content owner', (done) => {
             const parent = createElement('x-nested-slot-container', { is: XNestedSlotContainer });
             container.appendChild(parent);
             const slottedDiv = parent.shadowRoot.querySelector('div.manual');
 
             // observer on parent element's shadowRoot will be notified
             // because the slot content being mutated belongs to that shadow tree
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(parentSRObserver);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(slottedDiv);
@@ -195,10 +195,10 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
         it('should invoke observer with correct MutationRecords when adding child nodes using appendChild', () => {
             const parent = createElement('x-parent', { is: XParent });
             container.appendChild(parent);
-            return new Promise(resolve => {
+            return new Promise((resolve) => {
                 let observer;
                 const parentDiv = parent.shadowRoot.querySelector('div');
-                const callback = function(actualMutationRecords, actualObserver) {
+                const callback = function (actualMutationRecords, actualObserver) {
                     expect(actualObserver).toBe(observer);
                     expect(actualMutationRecords.length).toBe(1);
                     expect(actualMutationRecords[0].target).toBe(parentDiv);
@@ -213,8 +213,8 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             }).then(() => {
                 const childElm = parent.shadowRoot.querySelector('x-child');
                 const childDiv = childElm.shadowRoot.querySelector('div');
-                const promise = new Promise(resolve => {
-                    const callback = function(actualMutationRecords) {
+                const promise = new Promise((resolve) => {
+                    const callback = function (actualMutationRecords) {
                         expect(actualMutationRecords.length).toBe(2);
                         expect(actualMutationRecords[0].target).toBe(childDiv);
                         expect(actualMutationRecords[0].addedNodes.length).toBe(1);
@@ -233,12 +233,12 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
 
-        it('should invoke observer with correct MutationRecords when adding child nodes using innerHTML', done => {
+        it('should invoke observer with correct MutationRecords when adding child nodes using innerHTML', (done) => {
             const parent = createElement('x-parent', { is: XParent });
             container.appendChild(parent);
             let observer;
             const parentDiv = parent.shadowRoot.querySelector('div');
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(observer);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(parentDiv);
@@ -253,13 +253,13 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             parentDiv.innerHTML = `<h3></h3><p></p>`;
         });
 
-        it('should invoke observer with correct MutationRecords when removing child nodes using innerHTML', done => {
+        it('should invoke observer with correct MutationRecords when removing child nodes using innerHTML', (done) => {
             const parent = createElement('x-parent', { is: XParent });
             container.appendChild(parent);
             const parentDiv = parent.shadowRoot.querySelector('div');
             parentDiv.innerHTML = `<h3></h3><p></p>`;
             let observer;
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(observer);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(parentDiv);
@@ -330,14 +330,17 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             container.appendChild(parent);
             let firstObserverCallback;
             let secondObserverCallback;
-            const promise1 = new Promise(resolve => {
+            const promise1 = new Promise((resolve) => {
                 firstObserverCallback = resolve;
             });
-            const promise2 = new Promise(resolve => {
+            const promise2 = new Promise((resolve) => {
                 secondObserverCallback = resolve;
             });
             const parentDiv = parent.shadowRoot.querySelector('div');
-            const observer1 = new MutationObserver(function(actualMutationRecords, actualObserver) {
+            const observer1 = new MutationObserver(function (
+                actualMutationRecords,
+                actualObserver
+            ) {
                 expect(actualObserver).toBe(observer1);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(parentDiv);
@@ -346,7 +349,10 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 firstObserverCallback();
             });
             observer1.observe(parent.shadowRoot, observerConfig);
-            const observer2 = new MutationObserver(function(actualMutationRecords, actualObserver) {
+            const observer2 = new MutationObserver(function (
+                actualMutationRecords,
+                actualObserver
+            ) {
                 expect(actualObserver).toBe(observer2);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(parentDiv);
@@ -362,11 +368,11 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             return Promise.all([promise1, promise2]);
         });
 
-        it('should retarget MutationRecord for mutations directly under shadowRoot - added nodes', done => {
+        it('should retarget MutationRecord for mutations directly under shadowRoot - added nodes', (done) => {
             const host = createElement('x-template-mutations', { is: XTemplateMutations });
             container.appendChild(host);
 
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(shadowRootObserver);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(host.shadowRoot);
@@ -393,11 +399,11 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
 
-        it('should retarget MutationRecord for mutations directly under shadowRoot - removed nodes', done => {
+        it('should retarget MutationRecord for mutations directly under shadowRoot - removed nodes', (done) => {
             const host = createElement('x-template-mutations', { is: XTemplateMutations });
             container.appendChild(host);
 
-            const callback = function(actualMutationRecords, actualObserver) {
+            const callback = function (actualMutationRecords, actualObserver) {
                 expect(actualObserver).toBe(shadowRootObserver);
                 expect(actualMutationRecords.length).toBe(1);
                 expect(actualMutationRecords[0].target).toBe(host.shadowRoot);

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -14,7 +14,7 @@ function dispatchEventWithLog(target, event) {
     for (var node = target; node; node = node.parentNode || node.host) {
         node.addEventListener(
             event.type,
-            function(event) {
+            function (event) {
                 log.push([this, event.target, event.composedPath()]);
             }.bind(node)
         );
@@ -67,7 +67,7 @@ describe('event propagation in simple shadow tree', () => {
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
         // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             setTimeout(resolve);
         }).then(() => {
             const logs = dispatchEventWithLog(
@@ -241,7 +241,7 @@ describe('event propagation in nested shadow tree', () => {
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
         // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             setTimeout(resolve);
         }).then(() => {
             const logs = dispatchEventWithLog(

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-scope.spec.js
@@ -17,7 +17,7 @@ function dispatchEventWithLog(target, event) {
     for (var node = target; node; node = node.parentNode || node.host) {
         node.addEventListener(
             event.type,
-            function(event) {
+            function (event) {
                 log.push([this, event.target, event.composedPath()]);
             }.bind(node)
         );

--- a/packages/integration-karma/test/template/attribute-id/aria.spec.js
+++ b/packages/integration-karma/test/template/attribute-id/aria.spec.js
@@ -32,7 +32,7 @@ function testAria(type, create) {
         });
 
         it('should transform only the aria attributes that can have idref values', () => {
-            elm.shadowRoot.querySelectorAll('li').forEach(li => {
+            elm.shadowRoot.querySelectorAll('li').forEach((li) => {
                 const ariaAttrName = li.className;
                 const id = elm.shadowRoot.querySelector('ul').getAttribute('id');
                 if (ID_REFERENCING_ARIA_ATTRS.has(ariaAttrName)) {

--- a/packages/integration-karma/test/template/directive-for-each/arrayMutation.spec.js
+++ b/packages/integration-karma/test/template/directive-for-each/arrayMutation.spec.js
@@ -8,18 +8,18 @@ describe('Testing array primitives', () => {
         document.body.appendChild(elm);
     });
 
-    it('check initial state', function() {
+    it('check initial state', function () {
         const actual = elm.shadowRoot.querySelectorAll('li').length;
         expect(actual).toBe(5);
     });
 
     function testReactivity(testCase, expectedItems, fn) {
-        it(`check ${testCase} reactivity`, function() {
+        it(`check ${testCase} reactivity`, function () {
             fn(elm);
-            return Promise.resolve().then(function() {
+            return Promise.resolve().then(function () {
                 var list = Array.prototype.slice.call(elm.shadowRoot.querySelectorAll('li'));
 
-                var textList = list.map(function(li) {
+                var textList = list.map(function (li) {
                     return li.textContent;
                 });
                 expect(textList).toEqual(expectedItems);
@@ -27,26 +27,26 @@ describe('Testing array primitives', () => {
         });
     }
 
-    testReactivity('slice', ['one', 'three', 'four', 'five'], elm => {
+    testReactivity('slice', ['one', 'three', 'four', 'five'], (elm) => {
         elm.spliceItems();
     });
-    testReactivity('unshift', ['unshifted', 'one', 'two', 'three', 'four', 'five'], elm => {
+    testReactivity('unshift', ['unshifted', 'one', 'two', 'three', 'four', 'five'], (elm) => {
         elm.unshiftItem();
     });
-    testReactivity('push', ['one', 'two', 'three', 'four', 'five', 'pushed'], elm => {
+    testReactivity('push', ['one', 'two', 'three', 'four', 'five', 'pushed'], (elm) => {
         elm.pushItem();
     });
     testReactivity(
         'concat native to proxy',
         ['one', 'two', 'three', 'four', 'five', 'concat 1', 'concat 2'],
-        elm => {
+        (elm) => {
             elm.concatNativeToProxy();
         }
     );
     testReactivity(
         'concat proxy to native',
         ['concat 1', 'concat 2', 'one', 'two', 'three', 'four', 'five'],
-        elm => {
+        (elm) => {
             elm.concatProxyToNative();
         }
     );

--- a/packages/integration-karma/test/template/directive-lwc-dom-manual/index.spec.js
+++ b/packages/integration-karma/test/template/directive-lwc-dom-manual/index.spec.js
@@ -8,7 +8,7 @@ function waitForStyleToBeApplied() {
     // Using a timeout instead of a Promise.resolve to wait for the MutationObserver to be triggered.
     // The Promise polyfill on COMPAT browsers is based on MutationObserver. There are some timing issues between
     // Promise.resolve and MutationObserver callback invocation.
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         setTimeout(resolve);
     });
 }
@@ -28,23 +28,23 @@ describe('dom mutation without the lwc:dom="manual" directive', () => {
         });
     }
 
-    testErrorOnDomMutation('appendChild', elm => {
+    testErrorOnDomMutation('appendChild', (elm) => {
         const child = document.createElement('div');
         elm.appendChild(child);
     });
 
-    testErrorOnDomMutation('insertBefore', elm => {
+    testErrorOnDomMutation('insertBefore', (elm) => {
         const child = document.createElement('div');
         const span = elm.firstElementChild;
         elm.insertBefore(child, span);
     });
 
-    testErrorOnDomMutation('removeChild', elm => {
+    testErrorOnDomMutation('removeChild', (elm) => {
         const span = elm.firstElementChild;
         elm.removeChild(span);
     });
 
-    testErrorOnDomMutation('replaceChild', elm => {
+    testErrorOnDomMutation('replaceChild', (elm) => {
         const child = document.createElement('div');
         const span = elm.firstElementChild;
         elm.replaceChild(child, span);
@@ -67,12 +67,12 @@ describe('dom mutation with the lwc:dom="manual" directive', () => {
         });
     }
 
-    testAllowDomMutationWithLwcDomDirective('appendChild', elm => {
+    testAllowDomMutationWithLwcDomDirective('appendChild', (elm) => {
         const child = document.createElement('div');
         elm.appendChild(child);
     });
 
-    testAllowDomMutationWithLwcDomDirective('innerHTML', elm => {
+    testAllowDomMutationWithLwcDomDirective('innerHTML', (elm) => {
         elm.innerHTML = `<div></div>`;
     });
 

--- a/packages/integration-karma/test/template/directive-on/index.spec.js
+++ b/packages/integration-karma/test/template/directive-on/index.spec.js
@@ -7,7 +7,7 @@ it('adds supports standard events', () => {
     let event;
 
     const elm = createElement('x-click', { is: Click });
-    elm.eventCallback = e => (event = e);
+    elm.eventCallback = (e) => (event = e);
     document.body.appendChild(elm);
 
     const target = elm.shadowRoot.querySelector('div');
@@ -21,7 +21,7 @@ it('adds supports custom events', () => {
     let event;
 
     const elm = createElement('x-test', { is: Test });
-    elm.eventCallback = e => (event = e);
+    elm.eventCallback = (e) => (event = e);
     document.body.appendChild(elm);
 
     const target = elm.shadowRoot.querySelector('div');

--- a/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -36,7 +36,7 @@ describe('legacy wire adapters (register call)', () => {
     });
 
     describe('with dynamic config', () => {
-        it('should not call config when all initially all props of config are undefined', done => {
+        it('should not call config when all initially all props of config are undefined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
 
             setTimeout(() => {
@@ -46,7 +46,7 @@ describe('legacy wire adapters (register call)', () => {
             }, 0);
         });
 
-        it('should call config when at least one prop in config is defined', done => {
+        it('should call config when at least one prop in config is defined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
 
             setTimeout(() => {
@@ -58,7 +58,7 @@ describe('legacy wire adapters (register call)', () => {
             }, 0);
         });
 
-        it('should call config when all props become undefined after initialization', done => {
+        it('should call config when all props become undefined after initialization', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
 
             setTimeout(() => {
@@ -77,7 +77,7 @@ describe('legacy wire adapters (register call)', () => {
             }, 0);
         });
 
-        it('should call config when initially all props of config are undefined and some change', done => {
+        it('should call config when initially all props of config are undefined and some change', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
 
             setTimeout(() => {

--- a/packages/integration-karma/test/wire/legacy-adapters/x/echoWireAdapter/echoWireAdapter.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/x/echoWireAdapter/echoWireAdapter.js
@@ -2,8 +2,8 @@ import { register, ValueChangedEvent } from 'wire-service';
 
 export function EchoWireAdapter() {}
 
-register(EchoWireAdapter, wireEventTarget => {
-    wireEventTarget.addEventListener('config', config => {
+register(EchoWireAdapter, (wireEventTarget) => {
+    wireEventTarget.addEventListener('config', (config) => {
         wireEventTarget.dispatchEvent(new ValueChangedEvent(config));
     });
 });

--- a/packages/integration-karma/test/wire/reactive-params.spec.js
+++ b/packages/integration-karma/test/wire/reactive-params.spec.js
@@ -3,9 +3,9 @@ import { createElement } from 'lwc';
 import CascadeWiredProps from 'x/cascadeWiredProps';
 
 describe('@wire reactive parameters', () => {
-    it('should provide complete configuration to dependent adapter', done => {
+    it('should provide complete configuration to dependent adapter', (done) => {
         const elm = createElement('x-cascade-wire', { is: CascadeWiredProps });
-        elm.addEventListener('dependantwirevalue', evt => {
+        elm.addEventListener('dependantwirevalue', (evt) => {
             const secondWireValue = evt.detail.providedValue;
 
             expect(secondWireValue.firstParam).toBe('first-param-value');

--- a/packages/integration-karma/test/wire/wirecontextevent-legacy/x/wireContextAdapter/wireContextAdapter.js
+++ b/packages/integration-karma/test/wire/wirecontextevent-legacy/x/wireContextAdapter/wireContextAdapter.js
@@ -2,14 +2,14 @@ import { register, ValueChangedEvent } from 'wire-service';
 
 export const wireContextAdapter = () => {};
 
-register(wireContextAdapter, wiredEventTarget => {
+register(wireContextAdapter, (wiredEventTarget) => {
     wiredEventTarget.addEventListener('connect', () => {
         const srEvent = new CustomEvent('wirecontextevent', {
             bubbles: true,
             cancelable: true,
             composed: true,
             detail: {
-                callback: contextValue => {
+                callback: (contextValue) => {
                     wiredEventTarget.dispatchEvent(new ValueChangedEvent(contextValue));
                 },
             },

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -12,7 +12,7 @@ const ComponentClass = AdapterConsumer;
 const AdapterId = EchoWireAdapter;
 
 function filterCalls(echoAdapterSpy, methodType) {
-    return echoAdapterSpy.filter(call => call.method === methodType);
+    return echoAdapterSpy.filter((call) => call.method === methodType);
 }
 
 describe('wiring', () => {
@@ -184,7 +184,7 @@ describe('wiring', () => {
                 });
         });
 
-        it('should trigger component rerender when field is updated', done => {
+        it('should trigger component rerender when field is updated', (done) => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
@@ -257,8 +257,8 @@ describe('wired methods', () => {
 
         // No need to wait for next tick, the wire only has static config.
         const calls = filterCalls(spy, 'update');
-        const getCallByName = name => {
-            return calls.filter(call => name === call.args[0].name)[0];
+        const getCallByName = (name) => {
+            return calls.filter((call) => name === call.args[0].name)[0];
         };
 
         expect(calls.length).toBe(3);

--- a/packages/integration-karma/test/wire/wiring/x/broadcastAdapter/broadcastAdapter.js
+++ b/packages/integration-karma/test/wire/wiring/x/broadcastAdapter/broadcastAdapter.js
@@ -8,7 +8,7 @@ export class BroadcastAdapter {
     }
 
     static broadcastData(data) {
-        instances.forEach(instance => {
+        instances.forEach((instance) => {
             instance.callback(data);
         });
     }

--- a/packages/integration-karma/test/wire/x/echoWireAdapter/echoWireAdapter.js
+++ b/packages/integration-karma/test/wire/x/echoWireAdapter/echoWireAdapter.js
@@ -2,8 +2,8 @@ import { register, ValueChangedEvent } from 'wire-service';
 
 export function EchoWireAdapter() {}
 
-register(EchoWireAdapter, wireEventTarget => {
-    wireEventTarget.addEventListener('config', config => {
+register(EchoWireAdapter, (wireEventTarget) => {
+    wireEventTarget.addEventListener('config', (config) => {
         wireEventTarget.dispatchEvent(new ValueChangedEvent(config));
     });
 });

--- a/packages/integration-tests/scripts/build.js
+++ b/packages/integration-tests/scripts/build.js
@@ -51,7 +51,7 @@ const testOutput = path.join(__dirname, '../', 'public');
 const testSharedOutput = path.join(testOutput, 'shared');
 const testEntries = functionalTests.reduce((seed, functionalFolder) => {
     const testsFolder = path.join(functionalTestDir, functionalFolder);
-    const tests = fs.readdirSync(testsFolder).map(test => {
+    const tests = fs.readdirSync(testsFolder).map((test) => {
         const testPath = path.join(testsFolder, test, `${test}${testSufix}`);
         return { path: testPath, namespace: functionalFolder, name: getTestName(testPath) };
     });
@@ -115,7 +115,7 @@ const globalModules = {
 
 function createRollupInputConfig() {
     return {
-        external: function(id) {
+        external: function (id) {
             return id in globalModules;
         },
         plugins: [
@@ -171,6 +171,6 @@ testEntries
             'utf8'
         );
     }, Promise.resolve())
-    .catch(err => {
+    .catch((err) => {
         console.log(err);
     });

--- a/packages/integration-tests/scripts/wdio.conf.js
+++ b/packages/integration-tests/scripts/wdio.conf.js
@@ -21,9 +21,9 @@ const suiteFolders = path.resolve(__dirname, '../', 'src/components');
         }>
     }
 */
-const suites = fs.readdirSync(suiteFolders).map(suiteName => {
+const suites = fs.readdirSync(suiteFolders).map((suiteName) => {
     const suitePath = path.resolve(suiteFolders, suiteName);
-    const specs = fs.readdirSync(suitePath).map(specFolderName => {
+    const specs = fs.readdirSync(suitePath).map((specFolderName) => {
         const testBasePath = path.basename(specFolderName).replace('test-', '');
         return {
             mount: `/${testBasePath}`,
@@ -61,7 +61,7 @@ exports.config = {
     staticServerPort: port,
     staticServerFolders: [
         { mount: '/', path: './public' },
-        ...suites.flatMap(suite => suite.specs),
+        ...suites.flatMap((suite) => suite.specs),
     ],
 
     framework: 'mocha',

--- a/packages/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/integration-tests/scripts/wdio.sauce.conf.js
@@ -101,7 +101,7 @@ function getCapabilities() {
     const userBrowsers = args.browsers;
 
     if (userBrowsers) {
-        filtered = filtered.filter(b => {
+        filtered = filtered.filter((b) => {
             return userBrowsers.includes(b.commonName);
         });
 
@@ -112,7 +112,7 @@ function getCapabilities() {
         }
     }
 
-    return filtered.map(capability => {
+    return filtered.map((capability) => {
         return {
             ...capability,
             tunnelIdentifier: tunnelId,

--- a/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused/delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused.spec.js
@@ -16,10 +16,10 @@ describe('Delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should focus the input when clicked', function() {
+    it('should focus the input when clicked', function () {
         browser.keys(['Tab']); // focus first anchor
         browser.keys(['Tab']); // focus second anchor
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector(
                     'integration-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused'
@@ -30,7 +30,7 @@ describe('Delegates focus', () => {
 
         input.click();
 
-        const active = browser.$(function() {
+        const active = browser.$(function () {
             return document
                 .querySelector(
                     'integration-delegate-focus-click-input-in-negative-tabindex-previous-sibling-focused'

--- a/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex/delegate-focus-click-input-in-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegate-focus-click-input-in-negative-tabindex/delegate-focus-click-input-in-negative-tabindex.spec.js
@@ -12,16 +12,16 @@ describe('Delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should focus the input when clicked', function() {
+    it('should focus the input when clicked', function () {
         browser.keys(['Tab']); // focus first anchor
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegate-focus-click-input-in-negative-tabindex')
                 .shadowRoot.querySelector('integration-child')
                 .shadowRoot.querySelector('input');
         });
         input.click(); // click into input
-        const active = browser.$(function() {
+        const active = browser.$(function () {
             return document
                 .querySelector('integration-delegate-focus-click-input-in-negative-tabindex')
                 .shadowRoot.querySelector('integration-child').shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-shadow-input-negative-tab-index/delegates-focus-click-shadow-input-negative-tab-index.spec.js
@@ -11,14 +11,14 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
-        const div = browser.$(function() {
+    it('should apply focus to input in shadow', function () {
+        const div = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-shadow-input-negative-tab-index')
                 .shadowRoot.querySelector('.selectable-div');
         });
         div.click();
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-shadow-input-negative-tab-index')
                 .shadowRoot.querySelector('integration-child')
@@ -29,7 +29,7 @@ describe('Tabbing into custom element with delegates focus', () => {
         // browser.click('.negative-tab-index-input');
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document
                         .querySelector(
                             'integration-delegates-focus-click-shadow-input-negative-tab-index'

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
@@ -14,7 +14,7 @@ describe('when the click target is natively non-focusable', () => {
     });
 
     it('should apply focus to natively focusable parent (button) when click target is custom element', () => {
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-target-natively-non-focusable')
                 .shadowRoot.querySelector('.head');
@@ -22,7 +22,7 @@ describe('when the click target is natively non-focusable', () => {
         input.click();
 
         // Click on the custom element wrapped by the button
-        const child = browser.$(function() {
+        const child = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-target-natively-non-focusable')
                 .shadowRoot.querySelector('integration-parent')
@@ -30,7 +30,7 @@ describe('when the click target is natively non-focusable', () => {
         });
         child.click();
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             return document
                 .activeElement.shadowRoot.activeElement.shadowRoot.activeElement.className;
         });
@@ -40,7 +40,7 @@ describe('when the click target is natively non-focusable', () => {
     });
 
     it('should apply focus to natively focusable parent (button) when click target is span element', () => {
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-target-natively-non-focusable')
                 .shadowRoot.querySelector('.head');
@@ -48,7 +48,7 @@ describe('when the click target is natively non-focusable', () => {
         input.click();
 
         // Click on the span wrapped by the button
-        const span = browser.$(function() {
+        const span = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-click-target-natively-non-focusable')
                 .shadowRoot.querySelector('integration-parent')
@@ -56,7 +56,7 @@ describe('when the click target is natively non-focusable', () => {
         });
         span.click();
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             return document
                 .activeElement.shadowRoot.activeElement.shadowRoot.activeElement.className;
         });

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-false-negative-tab-index/delegates-focus-false-negative-tab-index.spec.js
@@ -18,7 +18,7 @@ describe('Tabbing into custom element with delegates focus', () => {
 
         browser.waitUntil(
             () => {
-                const activeFromDocument = browser.$(function() {
+                const activeFromDocument = browser.$(function () {
                     return document.activeElement;
                 });
 
@@ -33,7 +33,7 @@ describe('Tabbing into custom element with delegates focus', () => {
 
         browser.waitUntil(
             () => {
-                const activeFromShadow = browser.$(function() {
+                const activeFromShadow = browser.$(function () {
                     return document.querySelector(
                         'integration-delegates-focus-false-negative-tab-index'
                     ).shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-false/delegates-focus-false.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-false/delegates-focus-false.spec.js
@@ -16,12 +16,12 @@ describe('Tabbing into custom element with delegates focus', () => {
     it('should not apply focus to input in shadow', () => {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
 
         assert.equal(activeFromDocument.getTagName(), 'integration-delegates-focus-false');
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-false'
             ).shadowRoot.activeElement;
@@ -29,7 +29,7 @@ describe('Tabbing into custom element with delegates focus', () => {
         assert.equal(activeFromShadow.getTagName(), 'integration-child');
         browser.keys(['Tab']);
         browser.keys(['Tab']);
-        const activeFromShadowAfter = browser.$(function() {
+        const activeFromShadowAfter = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-false')
                 .shadowRoot.querySelector('integration-child').shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-host-element/delegates-focus-focus-method-on-host-element.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-host-element/delegates-focus-focus-method-on-host-element.spec.js
@@ -13,25 +13,25 @@ describe('Invoking the focus method of a host element', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to the host element (tabindex -1)', function() {
+    it('should apply focus to the host element (tabindex -1)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-delegates-focus-focus-method-on-host-element')
                     .shadowRoot.querySelector('input');
             })
             .click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-host-element')
                 .shadowRoot.querySelector('integration-button.negative')
                 .focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-host-element'
             );
@@ -42,24 +42,24 @@ describe('Invoking the focus method of a host element', () => {
         assert.equal(className, 'negative');
     });
 
-    it('should apply focus to the host element (tabindex 0)', function() {
+    it('should apply focus to the host element (tabindex 0)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
-        browser.execute(function() {
+        browser.execute(function () {
             return document
                 .querySelector('integration-delegates-focus-focus-method-on-host-element')
                 .shadowRoot.querySelector('input')
                 .click();
         });
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-host-element')
                 .shadowRoot.querySelector('integration-button.zero')
                 .focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-host-element'
             );
@@ -70,24 +70,24 @@ describe('Invoking the focus method of a host element', () => {
         assert.equal(className, 'zero');
     });
 
-    it('should apply focus to the host element (no tabindex)', function() {
+    it('should apply focus to the host element (no tabindex)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
-        browser.execute(function() {
+        browser.execute(function () {
             return document
                 .querySelector('integration-delegates-focus-focus-method-on-host-element')
                 .shadowRoot.querySelector('input')
                 .click();
         });
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-host-element')
                 .shadowRoot.querySelector('integration-button.none')
                 .focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-host-element'
             );

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-internal-element/delegates-focus-focus-method-on-internal-element.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-focus-method-on-internal-element/delegates-focus-focus-method-on-internal-element.spec.js
@@ -13,10 +13,10 @@ describe('Invoking the focus method on an element inside a shadow tree', () => {
         browser.url(URL);
     });
 
-    it('should apply focus (tabindex -1)', function() {
+    it('should apply focus (tabindex -1)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
-        const input = browser.$(function() {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                 .shadowRoot.querySelector('.head');
@@ -24,14 +24,14 @@ describe('Invoking the focus method on an element inside a shadow tree', () => {
 
         input.click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                 .shadowRoot.querySelector('integration-button.negative')
                 .focus();
         });
 
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-internal-element'
             );
@@ -43,25 +43,25 @@ describe('Invoking the focus method on an element inside a shadow tree', () => {
         assert.equal(tagName, 'BUTTON');
     });
 
-    it('should apply focus (tabindex 0)', function() {
+    it('should apply focus (tabindex 0)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                     .shadowRoot.querySelector('.head');
             })
             .click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                 .shadowRoot.querySelector('integration-button.zero')
                 .focus();
         });
 
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-internal-element'
             );
@@ -73,25 +73,25 @@ describe('Invoking the focus method on an element inside a shadow tree', () => {
         assert.equal(tagName, 'BUTTON');
     });
 
-    it('should apply focus (no tabindex)', function() {
+    it('should apply focus (no tabindex)', function () {
         // Click the top input to give the focus event's relatedTarget a
         // non-null value so that we enter the code path that we want to test.
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                     .shadowRoot.querySelector('.head');
             })
             .click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-delegates-focus-focus-method-on-internal-element')
                 .shadowRoot.querySelector('integration-button.none')
                 .focus();
         });
 
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             var container = document.querySelector(
                 'integration-delegates-focus-focus-method-on-internal-element'
             );

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-next-sibling/delegates-focus-from-next-sibling.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-next-sibling/delegates-focus-from-next-sibling.spec.js
@@ -13,20 +13,20 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
+    it('should apply focus to input in shadow', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
         browser.keys(['Tab']);
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(
             activeFromDocument.getTagName(),
             'integration-delegates-focus-from-previous-sibling'
         );
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-from-previous-sibling'
             ).shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-previous-sibling/delegates-focus-from-previous-sibling.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-from-previous-sibling/delegates-focus-from-previous-sibling.spec.js
@@ -13,18 +13,18 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
+    it('should apply focus to input in shadow', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
 
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(
             activeFromDocument.getTagName(),
             'integration-delegates-focus-from-previous-sibling'
         );
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-from-previous-sibling'
             ).shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-negative-tabindex-focusin-handler/delegates-focus-negative-tabindex-focusin-handler.spec.js
@@ -12,8 +12,8 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
-        const input = browser.$(function() {
+    it('should apply focus to input in shadow', function () {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-negative-tabindex-focusin-handler')
                 .shadowRoot.querySelector('integration-child')
@@ -21,8 +21,8 @@ describe('Tabbing into custom element with delegates focus', () => {
         });
         input.click();
         browser.waitUntil(
-            function() {
-                const div = browser.$(function() {
+            function () {
+                const div = browser.$(function () {
                     return document
                         .querySelector(
                             'integration-delegates-focus-negative-tabindex-focusin-handler'

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-nested-focusable-custom-elements/delegates-focus-click-shadow-input-negative-tab-index.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-nested-focusable-custom-elements/delegates-focus-click-shadow-input-negative-tab-index.spec.js
@@ -13,15 +13,15 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
-        const span = browser.$(function() {
+    it('should apply focus to input in shadow', function () {
+        const span = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-nested-focusable-custom-elements')
                 .shadowRoot.querySelector('integration-parent')
                 .shadowRoot.querySelector('.focusable-span');
         });
         span.click();
-        const active = browser.$(function() {
+        const active = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-nested-focusable-custom-elements')
                 .shadowRoot.querySelector('integration-parent').shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-next-sibling-visibility-false/delegates-focus-next-sibling-visibility-false.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-next-sibling-visibility-false/delegates-focus-next-sibling-visibility-false.spec.js
@@ -13,10 +13,10 @@ describe('Tabbing into custom element proceeding an invisible button', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to the document body', function() {
+    it('should apply focus to the document body', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(activeFromDocument.getTagName(), 'body');

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-non-focusable-click-target/delegates-focus-non-focusable-click-target.spec.js
@@ -13,8 +13,8 @@ describe('focus delegation when clicking on form element label', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to element associated with label when relatedTarget is null', function() {
-        const label = browser.$(function() {
+    it('should apply focus to element associated with label when relatedTarget is null', function () {
+        const label = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-non-focusable-click-target')
                 .shadowRoot.querySelector('integration-input')
@@ -22,7 +22,7 @@ describe('focus delegation when clicking on form element label', () => {
         });
         label.click();
 
-        const inputClassName = browser.execute(function() {
+        const inputClassName = browser.execute(function () {
             const container = document.activeElement;
             const integrationInput = container.shadowRoot.activeElement;
             const inputClassName = integrationInput.shadowRoot.activeElement.className;
@@ -32,8 +32,8 @@ describe('focus delegation when clicking on form element label', () => {
         assert.strictEqual(inputClassName, 'internal');
     });
 
-    it('should apply focus to element associated with label when relatedTarget is non-null', function() {
-        const headInput = browser.$(function() {
+    it('should apply focus to element associated with label when relatedTarget is non-null', function () {
+        const headInput = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-non-focusable-click-target')
                 .shadowRoot.querySelector('.head');
@@ -41,7 +41,7 @@ describe('focus delegation when clicking on form element label', () => {
         // Focus on input so that relatedTarget will be non-null
         headInput.click();
 
-        const label = browser.$(function() {
+        const label = browser.$(function () {
             return document
                 .querySelector('integration-delegates-focus-non-focusable-click-target')
                 .shadowRoot.querySelector('integration-input')
@@ -49,7 +49,7 @@ describe('focus delegation when clicking on form element label', () => {
         });
         label.click();
 
-        const inputClassName = browser.execute(function() {
+        const inputClassName = browser.execute(function () {
             const container = document.activeElement;
             const integrationInput = container.shadowRoot.activeElement;
             const inputClassName = integrationInput.shadowRoot.activeElement.className;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-slot/delegates-focus-slot.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-slot/delegates-focus-slot.spec.js
@@ -13,13 +13,13 @@ describe('Tabbing into custom element with delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to input in shadow', function() {
+    it('should apply focus to input in shadow', function () {
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(activeFromDocument.getTagName(), 'integration-delegates-focus-slot');
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-slot'
             ).shadowRoot.activeElement;
@@ -27,9 +27,9 @@ describe('Tabbing into custom element with delegates focus', () => {
         assert.equal(activeFromShadow.getTagName(), 'input');
     });
 
-    it('should apply focus to body after exiting in shadow', function() {
+    it('should apply focus to body after exiting in shadow', function () {
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
 
@@ -37,7 +37,7 @@ describe('Tabbing into custom element with delegates focus', () => {
         const isTopElement = tabName === 'body' || tabName === 'html';
         assert.ok(isTopElement);
 
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-slot'
             ).shadowRoot.activeElement;
@@ -45,13 +45,13 @@ describe('Tabbing into custom element with delegates focus', () => {
         assert.equal(activeFromShadow.value, null);
     });
 
-    it('should apply focus to input in shadow when tabbing backwards', function() {
+    it('should apply focus to input in shadow when tabbing backwards', function () {
         browser.keys(['Shift', 'Tab', 'Shift']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(activeFromDocument.getTagName(), 'integration-delegates-focus-slot');
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector(
                 'integration-delegates-focus-slot'
             ).shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements/delegates-focus-tab-index-zero-no-focusable-elements-no-after-elements.spec.js
@@ -13,11 +13,11 @@ describe('Delegate focus with tabindex 0, no tabbable elements, and no tabbable 
         browser.url(URL);
     });
 
-    it('should correctly have no activeelement', function() {
+    it('should correctly have no activeelement', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
 
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             return document.activeElement.tagName;
         });
 

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero-no-focusable-elements/delegates-focus-tab-index-zero-no-focusable-elements.spec.js
@@ -11,13 +11,13 @@ describe('Delegate focus with tabindex 0 and no tabbable elements', () => {
         browser.url(URL);
     });
 
-    it('should correctly skip the custom element', function() {
+    it('should correctly skip the custom element', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement;
                 });
 
@@ -31,7 +31,7 @@ describe('Delegate focus with tabindex 0 and no tabbable elements', () => {
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement;
                 });
 

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-tab-index-zero/delegates-focus-tab-index-zero.spec.js
@@ -11,13 +11,13 @@ describe('Delegate focus with tabindex 0', () => {
         browser.url(URL);
     });
 
-    it('should correctly focus on the input, not custom element', function() {
+    it('should correctly focus on the input, not custom element', function () {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement.shadowRoot.activeElement;
                 });
 
@@ -28,12 +28,12 @@ describe('Delegate focus with tabindex 0', () => {
         );
     });
 
-    it('should correctly focus on the previous element when shift tabbing', function() {
+    it('should correctly focus on the previous element when shift tabbing', function () {
         browser.keys(['Tab']);
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement;
                 });
 
@@ -47,7 +47,7 @@ describe('Delegate focus with tabindex 0', () => {
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement.shadowRoot.activeElement;
                 });
 
@@ -61,7 +61,7 @@ describe('Delegate focus with tabindex 0', () => {
 
         browser.waitUntil(
             () => {
-                const active = browser.$(function() {
+                const active = browser.$(function () {
                     return document.activeElement.shadowRoot.activeElement;
                 });
                 return active.getText() === 'first button';

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus/delegates-focus.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus/delegates-focus.spec.js
@@ -15,12 +15,12 @@ describe('Tabbing into custom element with delegates focus', () => {
 
     it('should apply focus to input in shadow', () => {
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(activeFromDocument.getTagName(), 'integration-delegates-focus');
 
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector('integration-delegates-focus').shadowRoot.activeElement;
         });
         assert.equal(activeFromShadow.getTagName(), 'input');
@@ -28,27 +28,27 @@ describe('Tabbing into custom element with delegates focus', () => {
 
     it('should apply focus to body after exiting in shadow', () => {
         browser.keys(['Tab']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
 
         const tabName = activeFromDocument.getTagName();
         const isTopElement = tabName === 'body' || tabName === 'html';
         assert.ok(isTopElement);
-        const activeFromShadow = browser.execute(function() {
+        const activeFromShadow = browser.execute(function () {
             return document.querySelector('integration-delegates-focus').shadowRoot.activeElement;
         });
 
         assert.equal(activeFromShadow, null);
     });
 
-    it('should apply focus to input in shadow when tabbing backwards', function() {
+    it('should apply focus to input in shadow when tabbing backwards', function () {
         browser.keys(['Shift', 'Tab', 'Shift']);
-        const activeFromDocument = browser.$(function() {
+        const activeFromDocument = browser.$(function () {
             return document.activeElement;
         });
         assert.equal(activeFromDocument.getTagName(), 'integration-delegates-focus');
-        const activeFromShadow = browser.$(function() {
+        const activeFromShadow = browser.$(function () {
             return document.querySelector('integration-delegates-focus').shadowRoot.activeElement;
         });
         assert.equal(activeFromShadow.getTagName(), 'input');

--- a/packages/integration-tests/src/components/accessibility/test-related-target/related-target.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-related-target/related-target.spec.js
@@ -8,12 +8,12 @@ const assert = require('assert');
 const URL = '/related-target';
 
 function getRootEvents() {
-    return browser.execute(function() {
+    return browser.execute(function () {
         return document.querySelector('integration-related-target').getEvents();
     }).value;
 }
 function getRootInput() {
-    return browser.$(function() {
+    return browser.$(function () {
         return document
             .querySelector('integration-related-target')
             .shadowRoot.querySelector('input');
@@ -21,7 +21,7 @@ function getRootInput() {
 }
 
 function getChildEvents() {
-    return browser.execute(function() {
+    return browser.execute(function () {
         return document
             .querySelector('integration-related-target')
             .shadowRoot.querySelector('integration-parent')
@@ -30,7 +30,7 @@ function getChildEvents() {
     }).value;
 }
 function getChildInput() {
-    return browser.$(function() {
+    return browser.$(function () {
         return document
             .querySelector('integration-related-target')
             .shadowRoot.querySelector('integration-parent')
@@ -47,7 +47,7 @@ if (process.env.COMPAT === 'false') {
         });
 
         describe('when focus moves downwards in a shadow tree', () => {
-            it('should retarget for blur', function() {
+            it('should retarget for blur', function () {
                 getRootInput().click();
                 getChildInput().click();
 
@@ -56,7 +56,7 @@ if (process.env.COMPAT === 'false') {
                 assert.strictEqual(`${type},${relatedTarget}`, 'blur,INTEGRATION-PARENT');
             });
 
-            it('should not retarget for focus', function() {
+            it('should not retarget for focus', function () {
                 getRootInput().click();
                 getChildInput().click();
 
@@ -67,7 +67,7 @@ if (process.env.COMPAT === 'false') {
         });
 
         describe('when focus moves upwards in a shadow tree', () => {
-            it('should retarget for focus', function() {
+            it('should retarget for focus', function () {
                 getChildInput().click();
                 getRootInput().click();
 
@@ -76,7 +76,7 @@ if (process.env.COMPAT === 'false') {
                 assert.strictEqual(`${type},${relatedTarget}`, 'focus,INTEGRATION-PARENT');
             });
 
-            it('should not retarget for blur', function() {
+            it('should not retarget for blur', function () {
                 getChildInput().click();
                 getRootInput().click();
 
@@ -87,10 +87,10 @@ if (process.env.COMPAT === 'false') {
         });
 
         it('should be `undefined` if the event lacks a relatedTarget getter', () => {
-            const relatedTarget = browser.execute(function() {
+            const relatedTarget = browser.execute(function () {
                 var relatedTarget = null;
                 var container = document.querySelector('integration-related-target');
-                container.addEventListener('foo', function(event) {
+                container.addEventListener('foo', function (event) {
                     relatedTarget = event.relatedTarget;
                 });
                 container.dispatchEvent(new CustomEvent('foo'));

--- a/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-negative/tab-navigation-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-negative/tab-navigation-tabindex-negative.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when tabindex -1', () => {
         browser.url(URL);
     });
 
-    it('should skip shadow (forward)', function() {
-        const secondInput = browser.$(function() {
+    it('should skip shadow (forward)', function () {
+        const secondInput = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-negative')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation when tabindex -1', () => {
         secondInput.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -30,8 +30,8 @@ describe('Tab navigation when tabindex -1', () => {
         assert.equal(className, 'third-outside');
     });
 
-    it('should skip shadow (backward)', function() {
-        const thirdInput = browser.$(function() {
+    it('should skip shadow (backward)', function () {
+        const thirdInput = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-negative')
                 .shadowRoot.querySelector('.third-outside');
@@ -39,7 +39,7 @@ describe('Tab navigation when tabindex -1', () => {
         thirdInput.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;

--- a/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-zero/tab-navigation-tabindex-zero.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-tab-navigation-tabindex-zero/tab-navigation-tabindex-zero.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when tabindex 0', () => {
         browser.url(URL);
     });
 
-    it('should focus on custom element when tabbing forward from a sibling element', function() {
-        const secondOutside = browser.$(function() {
+    it('should focus on custom element when tabbing forward from a sibling element', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-zero')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,14 +21,14 @@ describe('Tab navigation when tabindex 0', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var tagName = browser.execute(function() {
+        var tagName = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             return child.tagName.toLowerCase();
         });
         assert.equal(tagName, 'integration-child');
 
-        var internal = browser.execute(function() {
+        var internal = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -37,8 +37,8 @@ describe('Tab navigation when tabindex 0', () => {
         assert.equal(internal, null);
     });
 
-    it('should focus on internal element when tabbing forward twice from a sibling element', function() {
-        const secondOutside = browser.$(function() {
+    it('should focus on internal element when tabbing forward twice from a sibling element', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-zero')
                 .shadowRoot.querySelector('.second-outside');
@@ -47,7 +47,7 @@ describe('Tab navigation when tabindex 0', () => {
         browser.keys(['Tab']);
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -56,8 +56,8 @@ describe('Tab navigation when tabindex 0', () => {
         assert.equal(className, 'first-inside');
     });
 
-    it('should focus on internal element when tabbing backwards from a sibling element', function() {
-        const thirdOutside = browser.$(function() {
+    it('should focus on internal element when tabbing backwards from a sibling element', function () {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-zero')
                 .shadowRoot.querySelector('.third-outside');
@@ -65,7 +65,7 @@ describe('Tab navigation when tabindex 0', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -74,8 +74,8 @@ describe('Tab navigation when tabindex 0', () => {
         assert.equal(className, 'third-inside');
     });
 
-    it('should focus on custom element when tabbing backwards out of the shadow', function() {
-        const firstInside = browser.$(function() {
+    it('should focus on custom element when tabbing backwards out of the shadow', function () {
+        const firstInside = browser.$(function () {
             return document
                 .querySelector('integration-tab-navigation-tabindex-zero')
                 .shadowRoot.querySelector('integration-child')
@@ -84,7 +84,7 @@ describe('Tab navigation when tabindex 0', () => {
         firstInside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var activeElement = document.activeElement;
             while (activeElement.shadowRoot && activeElement.shadowRoot.activeElement) {
                 activeElement = activeElement.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-backwards-compatible/backwards-compatible.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-backwards-compatible/backwards-compatible.spec.js
@@ -13,14 +13,14 @@ describe('when the component overrides the focus method', () => {
         browser.url(URL);
     });
 
-    it('should continue custom focus behavior', function() {
-        browser.execute(function() {
+    it('should continue custom focus behavior', function () {
+        browser.execute(function () {
             return document
                 .querySelector('integration-backwards-compatible')
                 .shadowRoot.querySelector('integration-child')
                 .focus();
         });
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var active = document.activeElement;
             while (active.shadowRoot) {
                 active = active.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-basic/basic.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-basic/basic.spec.js
@@ -13,12 +13,12 @@ describe('basic invocation', () => {
         browser.url(URL);
     });
 
-    it('should focus on the first programmatically focusable element', function() {
-        const button = browser.$(function() {
+    it('should focus on the first programmatically focusable element', function () {
+        const button = browser.$(function () {
             return document.querySelector('integration-basic').shadowRoot.querySelector('button');
         });
         button.click();
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             const container = document.activeElement;
             const child = container.shadowRoot.activeElement;
             return child.shadowRoot.activeElement.className;

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-nested/nested.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-nested/nested.spec.js
@@ -13,12 +13,12 @@ describe('when the only focusable element is in a nested shadow', () => {
         browser.url(URL);
     });
 
-    it('should apply focus in the nested shadow', function() {
-        const button = browser.$(function() {
+    it('should apply focus in the nested shadow', function () {
+        const button = browser.$(function () {
             return document.querySelector('integration-nested').shadowRoot.querySelector('button');
         });
         button.click();
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var active = document.activeElement;
             while (active.shadowRoot) {
                 active = active.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-noop-when-already-focused/noop-when-already-focused.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-noop-when-already-focused/noop-when-already-focused.spec.js
@@ -13,19 +13,19 @@ describe('when the shadow already contains the active element', () => {
         browser.url(URL);
     });
 
-    it('should not change the currently focused element', function() {
-        const input = browser.$(function() {
+    it('should not change the currently focused element', function () {
+        const input = browser.$(function () {
             var container = document.querySelector('integration-noop-when-already-focused');
             var child = container.shadowRoot.querySelector('integration-child');
             return child.shadowRoot.querySelector('input');
         });
         input.click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             document.querySelector('integration-noop-when-already-focused').focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var active = document.activeElement;
             while (active.shadowRoot) {
                 active = active.shadowRoot.activeElement;
@@ -35,12 +35,12 @@ describe('when the shadow already contains the active element', () => {
         assert.equal(className, 'child-input');
     });
 
-    it('should result in the same focused element when invoked twice', function() {
-        browser.execute(function() {
+    it('should result in the same focused element when invoked twice', function () {
+        browser.execute(function () {
             document.querySelector('integration-noop-when-already-focused').focus();
             document.querySelector('integration-noop-when-already-focused').focus();
         });
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var active = document.activeElement;
             while (active.shadowRoot) {
                 active = active.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-not-focusable/not-focusable.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-not-focusable/not-focusable.spec.js
@@ -13,21 +13,21 @@ describe('when there are no focusable elements in the shadow', () => {
         browser.url(URL);
     });
 
-    it('should not change the currently focused element', function() {
-        const first = browser.$(function() {
+    it('should not change the currently focused element', function () {
+        const first = browser.$(function () {
             return document
                 .querySelector('integration-not-focusable')
                 .shadowRoot.querySelector('.first');
         });
         first.click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             var container = document.querySelector('integration-not-focusable');
             var child = container.shadowRoot.querySelector('integration-child');
             child.focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             return document.activeElement.shadowRoot.activeElement.className;
         });
         assert.equal(className, 'first');

--- a/packages/integration-tests/src/components/delegates-focus-programmatic/test-slotted/slotted.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-programmatic/test-slotted/slotted.spec.js
@@ -13,20 +13,20 @@ describe('when the first focusable element is slotted', () => {
         browser.url(URL);
     });
 
-    it('should apply focus to slotted element', function() {
-        const first = browser.$(function() {
+    it('should apply focus to slotted element', function () {
+        const first = browser.$(function () {
             return document.querySelector('integration-slotted').shadowRoot.querySelector('.first');
         });
         first.click();
 
-        browser.execute(function() {
+        browser.execute(function () {
             return document
                 .querySelector('integration-slotted')
                 .shadowRoot.querySelector('integration-child')
                 .focus();
         });
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             var active = document.activeElement;
             while (active.shadowRoot) {
                 active = active.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-disabled-button-after-negative-tabindex/disabled-button-after-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-disabled-button-after-negative-tabindex/disabled-button-after-negative-tabindex.spec.js
@@ -12,9 +12,9 @@ describe('when disabled button comes after a component that is delegating focus 
         browser.url(URL);
     });
 
-    it('should transfer focus to the body', function() {
+    it('should transfer focus to the body', function () {
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-disabled-button-after-negative-tabindex')
                     .shadowRoot.querySelector('.first');
@@ -22,7 +22,7 @@ describe('when disabled button comes after a component that is delegating focus 
             .click();
         browser.keys(['Tab']); // tab into second input
         browser.keys(['Tab']); // tab over integration-child
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             return document.activeElement.tagName;
         });
         assert.equal(tagName, 'BODY');

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focus-event-while-navigating/focus-event-while-navigating.spec.js
@@ -16,13 +16,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe.skip('delegatesFocus: true, tabindex: -1', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should not invoke focus event listeners (forward)', () => {
-            const headInput = browser.$(function() {
+            const headInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-negative .head');
@@ -31,7 +31,7 @@ describe('Focus event while sequential focus navigation', () => {
 
             browser.keys(['Tab']);
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -52,7 +52,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should not invoke focus event listeners (backward)', () => {
-            const tailInput = browser.$(function() {
+            const tailInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-negative .tail');
@@ -61,7 +61,7 @@ describe('Focus event while sequential focus navigation', () => {
 
             browser.keys(['Shift', 'Tab', 'Shift']);
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -86,13 +86,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe.skip('delegatesFocus: true, tabindex: none', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should invoke focus event listeners (forward)', () => {
-            const headInput = browser.$(function() {
+            const headInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-none .head');
@@ -102,7 +102,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Tab']); // internal input
             browser.keys(['Tab']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -123,7 +123,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should invoke focus event listeners (backward)', () => {
-            const tailInput = browser.$(function() {
+            const tailInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-none .tail');
@@ -133,7 +133,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Shift', 'Tab', 'Shift']); // internal input
             browser.keys(['Shift', 'Tab', 'Shift']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -157,13 +157,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe('delegatesFocus: true, tabindex: 0', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should not invoke focus event listener on host and should invoke focus event listener in shadow (forward)', () => {
-            const headInput = browser.$(function() {
+            const headInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-zero .head');
@@ -173,7 +173,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Tab']); // internal input
             browser.keys(['Tab']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -194,7 +194,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should not invoke focus event listener on host and should invoke focus event listener in shadow (backward)', () => {
-            const tailInput = browser.$(function() {
+            const tailInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-zero .tail');
@@ -204,7 +204,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Shift', 'Tab', 'Shift']); // internal input
             browser.keys(['Shift', 'Tab', 'Shift']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -229,13 +229,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe.skip('delegatesFocus: false, tabindex: -1', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should not invoke focus event listeners (forward)', () => {
-            const headInput = browser.$(function() {
+            const headInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-false-tabindex-negative .head');
@@ -244,7 +244,7 @@ describe('Focus event while sequential focus navigation', () => {
 
             browser.keys(['Tab']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -265,7 +265,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should not invoke focus event listeners (backward)', () => {
-            const tailInput = browser.$(function() {
+            const tailInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-false-tabindex-negative .tail');
@@ -274,7 +274,7 @@ describe('Focus event while sequential focus navigation', () => {
 
             browser.keys(['Shift', 'Tab', 'Shift']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -298,13 +298,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe('delegatesFocus: false, tabindex: 0', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should invoke focus event listener on both host and in shadow (forward)', () => {
-            const headInput = browser.$(function() {
+            const headInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-false-tabindex-zero .head');
@@ -315,7 +315,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Tab']); // internal input
             browser.keys(['Tab']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -336,7 +336,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should invoke focus event listener on both host and in shadow (backward)', () => {
-            const tailInput = browser.$(function() {
+            const tailInput = browser.$(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-false-tabindex-zero .tail');
@@ -347,7 +347,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Shift', 'Tab', 'Shift']); // host
             browser.keys(['Shift', 'Tab', 'Shift']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -372,13 +372,13 @@ describe('Focus event while sequential focus navigation', () => {
     describe.skip('delegatesFocus: false, tabindex: none', () => {
         beforeEach(() => {
             // Reset counters
-            browser.execute(function() {
+            browser.execute(function () {
                 document.querySelector('integration-focus-event-while-navigating').reset();
             });
         });
 
         it('should invoke focus event listeners (forward)', () => {
-            const headInput = browser.execute(function() {
+            const headInput = browser.execute(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-none .head');
@@ -388,7 +388,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Tab']); // internal input
             browser.keys(['Tab']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),
@@ -409,7 +409,7 @@ describe('Focus event while sequential focus navigation', () => {
         });
 
         it('should invoke focus event listeners (backward)', () => {
-            const tailInput = browser.execute(function() {
+            const tailInput = browser.execute(function () {
                 return document
                     .querySelector('integration-focus-event-while-navigating')
                     .shadowRoot.querySelector('.delegates-true-tabindex-none .tail');
@@ -419,7 +419,7 @@ describe('Focus event while sequential focus navigation', () => {
             browser.keys(['Shift', 'Tab', 'Shift']); // internal input
             browser.keys(['Shift', 'Tab', 'Shift']); // external input
 
-            var count = browser.execute(function() {
+            var count = browser.execute(function () {
                 var container = document.querySelector('integration-focus-event-while-navigating');
                 return {
                     host: container.hostFocusCount(),

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-coverage/focusable-coverage.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-coverage/focusable-coverage.spec.js
@@ -43,10 +43,10 @@ describe('sequential focus navigation coverage', () => {
             // 'svgAnchorXlinkHref', // a[xlink:href] should only be focusable when inside <svg>
             'textarea',
             'videoControls',
-        ].forEach(type => {
+        ].forEach((type) => {
             it(type, () => {
                 // Click and focus on the first input
-                const start = browser.$(function() {
+                const start = browser.$(function () {
                     return document
                         .querySelector('integration-focusable-coverage')
                         .shadowRoot.querySelector('.start');
@@ -54,14 +54,14 @@ describe('sequential focus navigation coverage', () => {
                 start.click();
 
                 // Set the type
-                browser.execute(function(type) {
+                browser.execute(function (type) {
                     var container = document.querySelector('integration-focusable-coverage');
                     container.type = type;
                 }, type);
 
                 browser.keys(['Tab']);
 
-                const activeElementType = browser.execute(function() {
+                const activeElementType = browser.execute(function () {
                     const container = document.activeElement;
                     const child = container.shadowRoot.activeElement;
                     const elm = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-span-after-negative-tabindex/focusable-span-after-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-focusable-span-after-negative-tabindex/focusable-span-after-negative-tabindex.spec.js
@@ -12,9 +12,9 @@ describe('Delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should focus the input when clicked', function() {
+    it('should focus the input when clicked', function () {
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-focusable-span-after-negative-tabindex')
                     .shadowRoot.querySelector('.first');
@@ -23,7 +23,7 @@ describe('Delegates focus', () => {
 
         browser.keys(['Tab']); // tab over integration-child
 
-        const tagName = browser.execute(function() {
+        const tagName = browser.execute(function () {
             var container = document.activeElement;
             var activeElement = container.shadowRoot.activeElement;
             return activeElement.tagName;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-issue-1031/issue-1031.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-issue-1031/issue-1031.spec.js
@@ -12,14 +12,14 @@ describe('issue #1031', () => {
         browser.url(URL);
     });
 
-    it('should skip child shadow when tabbing after dynamically updating parent tabindex from 0 to -1', function() {
-        const initialize = browser.$(function() {
+    it('should skip child shadow when tabbing after dynamically updating parent tabindex from 0 to -1', function () {
+        const initialize = browser.$(function () {
             return document
                 .querySelector('integration-issue-1031')
                 .shadowRoot.querySelector('.initialize');
         });
         initialize.click(); // init tabindex to 0
-        const firstOutside = browser.$(function() {
+        const firstOutside = browser.$(function () {
             return document
                 .querySelector('integration-issue-1031')
                 .shadowRoot.querySelector('.first-outside');
@@ -28,7 +28,7 @@ describe('issue #1031', () => {
         browser.keys(['Tab']); // host element
         browser.keys(['Tab']); // second outside input
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -37,14 +37,14 @@ describe('issue #1031', () => {
         assert.equal(className, 'second-outside');
     });
 
-    it('should skip child shadow when shift-tabbing after dynamically updating parent tabindex from 0 to -1', function() {
-        const initialize = browser.$(function() {
+    it('should skip child shadow when shift-tabbing after dynamically updating parent tabindex from 0 to -1', function () {
+        const initialize = browser.$(function () {
             return document
                 .querySelector('integration-issue-1031')
                 .shadowRoot.querySelector('.initialize');
         });
         initialize.click(); // init tabindex to 0
-        const secondOutside = browser.$(function() {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-issue-1031')
                 .shadowRoot.querySelector('.second-outside');
@@ -53,7 +53,7 @@ describe('issue #1031', () => {
         browser.keys(['Shift', 'Tab', 'Shift']); // <integration-parent>
         browser.keys(['Shift', 'Tab', 'Shift']); // first outside input
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-manual-delegation/manual-delegation.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-manual-delegation/manual-delegation.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when component passes tabindex attribute to an internal
         browser.url(URL);
     });
 
-    it('should focus on internal element when tabbing forward from a sibling element', function() {
-        const secondOutside = browser.$(function() {
+    it('should focus on internal element when tabbing forward from a sibling element', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-manual-delegation')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation when component passes tabindex attribute to an internal
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -30,8 +30,8 @@ describe('Tab navigation when component passes tabindex attribute to an internal
         assert.equal(className, 'first-inside');
     });
 
-    it('should focus on internal element when tabbing backwards from a sibling element', function() {
-        const thirdOutside = browser.$(function() {
+    it('should focus on internal element when tabbing backwards from a sibling element', function () {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-manual-delegation')
                 .shadowRoot.querySelector('.third-outside');
@@ -39,7 +39,7 @@ describe('Tab navigation when component passes tabindex attribute to an internal
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-shift-tab-into-negative-tabindex/shift-tab-into-negative-tabindex.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-shift-tab-into-negative-tabindex/shift-tab-into-negative-tabindex.spec.js
@@ -12,9 +12,9 @@ describe('Delegates focus', () => {
         browser.url(URL);
     });
 
-    it('should focus the input when clicked', function() {
+    it('should focus the input when clicked', function () {
         browser
-            .$(function() {
+            .$(function () {
                 return document
                     .querySelector('integration-shift-tab-into-negative-tabindex')
                     .shadowRoot.querySelector('.bottom');
@@ -23,7 +23,7 @@ describe('Delegates focus', () => {
 
         browser.keys(['Shift', 'Tab', 'Shift']); // tab backwards over integration-child
 
-        const className = browser.execute(function() {
+        const className = browser.execute(function () {
             const container = document.activeElement;
             const activeElement = container.shadowRoot.activeElement;
             return activeElement.className;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-after-inside-click/tabindex-negative-after-inside-click.spec.js
@@ -12,15 +12,15 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         browser.url(URL);
     });
 
-    it('should continue skipping elements (forward)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue skipping elements (forward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('integration-child[data-id=click-target]')
                 .shadowRoot.querySelector('.second-inside');
         });
         secondInside.click();
-        const secondOutside = browser.$(function() {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('.second-outside');
@@ -28,7 +28,7 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -37,8 +37,8 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         assert.equal(className, 'third-outside');
     });
 
-    it('should continue skipping elements after navigating out (forward)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue skipping elements after navigating out (forward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('integration-child[data-id=click-target]')
@@ -48,7 +48,7 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         browser.keys(['Tab']); // third inside
         browser.keys(['Tab']); // third outside
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -57,15 +57,15 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         assert.equal(className, 'third-outside');
     });
 
-    it('should continue skipping elements (backward)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue skipping elements (backward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('integration-child[data-id=click-target]')
                 .shadowRoot.querySelector('.second-inside');
         });
         secondInside.click();
-        const thirdOutside = browser.$(function() {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('.third-outside');
@@ -73,7 +73,7 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -82,8 +82,8 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         assert.equal(className, 'second-outside');
     });
 
-    it('should continue skipping elements after navigating out (backwards)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue skipping elements after navigating out (backwards)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-after-inside-click')
                 .shadowRoot.querySelector('integration-child[data-id=click-target]')
@@ -93,7 +93,7 @@ describe('Tab navigation when tabindex -1 after inside click', () => {
         browser.keys(['Shift', 'Tab', 'Shift']); // first inside
         browser.keys(['Shift', 'Tab', 'Shift']); // second outside
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-internal/tabindex-negative-internal.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative-internal/tabindex-negative-internal.spec.js
@@ -12,8 +12,8 @@ describe('Internal tab navigation when tabindex -1', () => {
         browser.url(URL);
     });
 
-    it('should navigate (forward)', function() {
-        const secondInside = browser.$(function() {
+    it('should navigate (forward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-internal')
                 .shadowRoot.querySelector('integration-child')
@@ -22,7 +22,7 @@ describe('Internal tab navigation when tabindex -1', () => {
         secondInside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -32,8 +32,8 @@ describe('Internal tab navigation when tabindex -1', () => {
         assert.equal(className, 'third-inside');
     });
 
-    it('should navigate (backward)', function() {
-        const secondInside = browser.$(function() {
+    it('should navigate (backward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative-internal')
                 .shadowRoot.querySelector('integration-child')
@@ -42,7 +42,7 @@ describe('Internal tab navigation when tabindex -1', () => {
         secondInside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-negative/tabindex-negative.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when tabindex -1', () => {
         browser.url(URL);
     });
 
-    it('should skip shadow (forward)', function() {
-        const secondOutside = browser.$(function() {
+    it('should skip shadow (forward)', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation when tabindex -1', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -30,8 +30,8 @@ describe('Tab navigation when tabindex -1', () => {
         assert.equal(className, 'third-outside');
     });
 
-    it('should skip shadow (backward)', function() {
-        const thirdOutside = browser.$(function() {
+    it('should skip shadow (backward)', function () {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-negative')
                 .shadowRoot.querySelector('.third-outside');
@@ -39,7 +39,7 @@ describe('Tab navigation when tabindex -1', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-none/tabindex-none.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-none/tabindex-none.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation without tabindex', () => {
         browser.url(URL);
     });
 
-    it('should delegate focus (forward)', function() {
-        const secondOutside = browser.$(function() {
+    it('should delegate focus (forward)', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-none')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation without tabindex', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -31,8 +31,8 @@ describe('Tab navigation without tabindex', () => {
         assert.equal(className, 'first-inside');
     });
 
-    it('should delegate focus (backward)', function() {
-        const thirdOutside = browser.$(function() {
+    it('should delegate focus (backward)', function () {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-none')
                 .shadowRoot.querySelector('.third-outside');
@@ -40,7 +40,7 @@ describe('Tab navigation without tabindex', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-toggle/tabindex-toggle.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation without tabindex', () => {
         browser.url(URL);
     });
 
-    it('should support tabindex toggling', function() {
-        const secondOutside = browser.$(function() {
+    it('should support tabindex toggling', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-toggle')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation without tabindex', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -30,7 +30,7 @@ describe('Tab navigation without tabindex', () => {
         assert.equal(className, 'first-inside');
 
         // Toggle the tabindex <x-child tabindex="-1">
-        const toggle = browser.$(function() {
+        const toggle = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-toggle')
                 .shadowRoot.querySelector('.toggle');
@@ -40,7 +40,7 @@ describe('Tab navigation without tabindex', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        className = browser.execute(function() {
+        className = browser.execute(function () {
             var container = document.activeElement;
             var input = container.shadowRoot.activeElement;
             return input.className;
@@ -53,7 +53,7 @@ describe('Tab navigation without tabindex', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        className = browser.execute(function() {
+        className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-after-inside-click/tabindex-zero-after-inside-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-after-inside-click/tabindex-zero-after-inside-click.spec.js
@@ -12,15 +12,15 @@ describe('Tab navigation when tabindex 0 after inside click', () => {
         browser.url(URL);
     });
 
-    it('should continue delegating focus (forward)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue delegating focus (forward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-after-inside-click')
                 .shadowRoot.querySelector('integration-child')
                 .shadowRoot.querySelector('.second-inside');
         });
         secondInside.click();
-        const secondOutside = browser.$(function() {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-after-inside-click')
                 .shadowRoot.querySelector('.second-outside');
@@ -29,7 +29,7 @@ describe('Tab navigation when tabindex 0 after inside click', () => {
 
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -39,15 +39,15 @@ describe('Tab navigation when tabindex 0 after inside click', () => {
         assert.equal(className, 'first-inside');
     });
 
-    it('should continue delegating focus (backward)', function() {
-        const secondInside = browser.$(function() {
+    it('should continue delegating focus (backward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-after-inside-click')
                 .shadowRoot.querySelector('integration-child')
                 .shadowRoot.querySelector('.second-inside');
         });
         secondInside.click();
-        const thirdOutside = browser.$(function() {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-after-inside-click')
                 .shadowRoot.querySelector('.third-outside');
@@ -55,7 +55,7 @@ describe('Tab navigation when tabindex 0 after inside click', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when tabindex 0', () => {
         browser.url(URL);
     });
 
-    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (forward)', function() {
-        const firstInput = browser.$(function() {
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (forward)', function () {
+        const firstInput = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-internal-tabindex-negative')
                 .shadowRoot.querySelector('.first');
@@ -22,7 +22,7 @@ describe('Tab navigation when tabindex 0', () => {
 
         browser.keys(['Tab']);
 
-        var tagName = browser.execute(function() {
+        var tagName = browser.execute(function () {
             var container = document.activeElement;
             var parent = container.shadowRoot.activeElement;
             var input = parent.shadowRoot.activeElement;
@@ -32,8 +32,8 @@ describe('Tab navigation when tabindex 0', () => {
         assert.equal(tagName, 'INPUT');
     });
 
-    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (backward)', function() {
-        const lastInput = browser.$(function() {
+    it('should skip internal elements contained by a negative tabindex subtree when delegating focus (backward)', function () {
+        const lastInput = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-internal-tabindex-negative')
                 .shadowRoot.querySelector('.last');
@@ -42,7 +42,7 @@ describe('Tab navigation when tabindex 0', () => {
 
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var tagName = browser.execute(function() {
+        var tagName = browser.execute(function () {
             var container = document.activeElement;
             var parent = container.shadowRoot.activeElement;
             var input = parent.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal/tabindex-zero-internal.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal/tabindex-zero-internal.spec.js
@@ -12,8 +12,8 @@ describe('Internal tab navigation when tabindex 0', () => {
         browser.url(URL);
     });
 
-    it('should navigate (forward)', function() {
-        const secondInside = browser.$(function() {
+    it('should navigate (forward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-internal')
                 .shadowRoot.querySelector('integration-child')
@@ -22,7 +22,7 @@ describe('Internal tab navigation when tabindex 0', () => {
         secondInside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -32,8 +32,8 @@ describe('Internal tab navigation when tabindex 0', () => {
         assert.equal(className, 'third-inside');
     });
 
-    it('should navigate (backward)', function() {
-        const secondInside = browser.$(function() {
+    it('should navigate (backward)', function () {
+        const secondInside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero-internal')
                 .shadowRoot.querySelector('integration-child')
@@ -42,7 +42,7 @@ describe('Internal tab navigation when tabindex 0', () => {
         secondInside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero/tabindex-zero.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero/tabindex-zero.spec.js
@@ -12,8 +12,8 @@ describe('Tab navigation when tabindex 0', () => {
         browser.url(URL);
     });
 
-    it('should delegate focus (forward)', function() {
-        const secondOutside = browser.$(function() {
+    it('should delegate focus (forward)', function () {
+        const secondOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero')
                 .shadowRoot.querySelector('.second-outside');
@@ -21,7 +21,7 @@ describe('Tab navigation when tabindex 0', () => {
         secondOutside.click();
         browser.keys(['Tab']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;
@@ -31,8 +31,8 @@ describe('Tab navigation when tabindex 0', () => {
         assert.equal(className, 'first-inside');
     });
 
-    it('should delegate focus (backward)', function() {
-        const thirdOutside = browser.$(function() {
+    it('should delegate focus (backward)', function () {
+        const thirdOutside = browser.$(function () {
             return document
                 .querySelector('integration-tabindex-zero')
                 .shadowRoot.querySelector('.third-outside');
@@ -40,7 +40,7 @@ describe('Tab navigation when tabindex 0', () => {
         thirdOutside.click();
         browser.keys(['Shift', 'Tab', 'Shift']);
 
-        var className = browser.execute(function() {
+        var className = browser.execute(function () {
             var container = document.activeElement;
             var child = container.shadowRoot.activeElement;
             var input = child.shadowRoot.activeElement;

--- a/packages/integration-tests/src/components/dom/test-element-from-point/element-from-point.spec.js
+++ b/packages/integration-tests/src/components/dom/test-element-from-point/element-from-point.spec.js
@@ -12,15 +12,15 @@ describe('shadow root element from point should return correct element', () => {
         browser.url(URL);
     });
 
-    it('should return correct shadow elements', function() {
-        browser.execute(function() {
+    it('should return correct shadow elements', function () {
+        browser.execute(function () {
             document
                 .querySelector('integration-element-from-point')
                 .shadowRoot.querySelector('.shadow-element-from-point')
                 .click();
         });
         browser.waitUntil(() => {
-            const indicator = browser.$(function() {
+            const indicator = browser.$(function () {
                 return document
                     .querySelector('integration-element-from-point')
                     .shadowRoot.querySelector('.correct-shadow-element-indicator');
@@ -29,15 +29,15 @@ describe('shadow root element from point should return correct element', () => {
         });
     });
 
-    it('should return correct document elements', function() {
-        browser.execute(function() {
+    it('should return correct document elements', function () {
+        browser.execute(function () {
             document
                 .querySelector('integration-element-from-point')
                 .shadowRoot.querySelector('.document-from-point')
                 .click();
         });
         browser.waitUntil(() => {
-            const indicator = browser.$(function() {
+            const indicator = browser.$(function () {
                 return document
                     .querySelector('integration-element-from-point')
                     .shadowRoot.querySelector('.correct-document-element-indicator');

--- a/packages/integration-tests/src/components/events/test-change-event-composed/change-event-composed.spec.js
+++ b/packages/integration-tests/src/components/events/test-change-event-composed/change-event-composed.spec.js
@@ -13,9 +13,9 @@ describe('Composed change event', () => {
         browser.url(URL);
     });
 
-    it('should be composed: false', function() {
+    it('should be composed: false', function () {
         // Force native "change" event to fire
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-change-event-composed')
                 .shadowRoot.querySelector('input')
@@ -23,7 +23,7 @@ describe('Composed change event', () => {
         });
         browser.keys('foo');
         $('body').click();
-        const div = browser.$(function() {
+        const div = browser.$(function () {
             return document
                 .querySelector('integration-change-event-composed')
                 .shadowRoot.querySelector('.verify-not-composed');

--- a/packages/integration-tests/src/components/events/test-clipboard-event-composed/clipboard-event-composed.spec.js
+++ b/packages/integration-tests/src/components/events/test-clipboard-event-composed/clipboard-event-composed.spec.js
@@ -24,7 +24,7 @@ describe('clipboard-event-composed polyfill', () => {
     // This test suite relies on the Selection API which is not supported in ie11
     if (browser.config.capabilities.commonName !== 'ie11') {
         it('copy event should be composed', () => {
-            browser.$(function() {
+            browser.$(function () {
                 window.getSelection().selectAllChildren(document.body);
             });
 
@@ -39,7 +39,7 @@ describe('clipboard-event-composed polyfill', () => {
         });
 
         it('paste event should be composed', () => {
-            browser.$(function() {
+            browser.$(function () {
                 window.getSelection().selectAllChildren(document.body);
             });
 

--- a/packages/integration-tests/src/components/events/test-focusin-composed-true/focusin-composed-true.spec.js
+++ b/packages/integration-tests/src/components/events/test-focusin-composed-true/focusin-composed-true.spec.js
@@ -13,15 +13,15 @@ describe('Composed focusin event', () => {
         browser.url(URL);
     });
 
-    it('standard event should be composed', function() {
-        const input = browser.$(function() {
+    it('standard event should be composed', function () {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-focusin-composed-true')
                 .shadowRoot.querySelector('input');
         });
         input.click();
         $('body').click();
-        const focusInComposed = browser.$(function() {
+        const focusInComposed = browser.$(function () {
             return document
                 .querySelector('integration-focusin-composed-true')
                 .shadowRoot.querySelector('.focus-in-composed');
@@ -30,13 +30,13 @@ describe('Composed focusin event', () => {
     });
 
     it('custom event should not be composed', () => {
-        const button = browser.$(function() {
+        const button = browser.$(function () {
             return document
                 .querySelector('integration-focusin-composed-true')
                 .shadowRoot.querySelector('button');
         });
         button.click();
-        const customFocusInNotComposed = browser.$(function() {
+        const customFocusInNotComposed = browser.$(function () {
             return document
                 .querySelector('integration-focusin-composed-true')
                 .shadowRoot.querySelector('.custom-focus-in-not-composed');

--- a/packages/integration-tests/src/components/events/test-focusout-composed-true/focusout-composed-true.spec.js
+++ b/packages/integration-tests/src/components/events/test-focusout-composed-true/focusout-composed-true.spec.js
@@ -13,8 +13,8 @@ describe('Composed focusout event', () => {
         browser.url(URL);
     });
 
-    it('standard event should be composed', function() {
-        const input = browser.$(function() {
+    it('standard event should be composed', function () {
+        const input = browser.$(function () {
             return document
                 .querySelector('integration-focusout-composed-true')
                 .shadowRoot.querySelector('input');
@@ -23,7 +23,7 @@ describe('Composed focusout event', () => {
         input.click();
         $('body').click();
 
-        const focusInComposed = browser.$(function() {
+        const focusInComposed = browser.$(function () {
             return document
                 .querySelector('integration-focusout-composed-true')
                 .shadowRoot.querySelector('.focus-out-composed');
@@ -31,13 +31,13 @@ describe('Composed focusout event', () => {
         assert.deepEqual(focusInComposed.getText(), 'Focus Out Composed');
     });
     it('custom event shoud not be composed', () => {
-        const button = browser.$(function() {
+        const button = browser.$(function () {
             return document
                 .querySelector('integration-focusout-composed-true')
                 .shadowRoot.querySelector('button');
         });
         button.click();
-        const customFocusInNotComposed = browser.$(function() {
+        const customFocusInNotComposed = browser.$(function () {
             return document
                 .querySelector('integration-focusout-composed-true')
                 .shadowRoot.querySelector('.custom-focus-out-not-composed');

--- a/packages/integration-tests/src/components/events/test-retarget-body-related-target/retarget-body-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-body-related-target/retarget-body-related-target.spec.js
@@ -14,13 +14,13 @@ describe('Retarget relatedTarget', () => {
     });
 
     it('should have correct relatedTarget when body was focused', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document.body.focus();
         });
         browser.keys(['Tab']);
         browser.keys(['Tab']);
         browser.keys(['Tab']);
-        const indicator = browser.$(function() {
+        const indicator = browser.$(function () {
             return document
                 .querySelector('integration-retarget-body-related-target')
                 .shadowRoot.querySelector('.related-target-tagname');

--- a/packages/integration-tests/src/components/events/test-retarget-null-related-target/retarget-null-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-null-related-target/retarget-null-related-target.spec.js
@@ -14,7 +14,7 @@ describe('Retarget relatedTarget', () => {
     it('should not throw when relatedTarget is null', () => {
         browser.keys(['Tab']);
         browser.waitUntil(() => {
-            const text = browser.execute(function() {
+            const text = browser.execute(function () {
                 return document
                     .querySelector('integration-retarget-null-related-target')
                     .shadowRoot.querySelector('.related-target-tabname').textContent;

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -14,7 +14,7 @@ describe('Retarget relatedTarget', () => {
     });
 
     it('should retarget relatedTarget from a foreign shadow', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-retarget-related-target')
                 .shadowRoot.querySelector('integration-child')
@@ -22,7 +22,7 @@ describe('Retarget relatedTarget', () => {
                 .focus();
         });
         browser.keys(['Shift', 'Tab', 'Shift']);
-        const indicator = browser.$(function() {
+        const indicator = browser.$(function () {
             return document
                 .querySelector('integration-retarget-related-target')
                 .shadowRoot.querySelector('.related-target-tabname');

--- a/packages/integration-tests/src/components/events/test-retarget-slotted-custom-element-related-target/retarget-slotted-custom-element-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-slotted-custom-element-related-target/retarget-slotted-custom-element-related-target.spec.js
@@ -14,7 +14,7 @@ describe('Retarget relatedTarget', () => {
     });
 
     it('should retarget relatedTarget from slotted custom element', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-retarget-slotted-custom-element-related-target')
                 .shadowRoot.querySelector('integration-child')
@@ -22,7 +22,7 @@ describe('Retarget relatedTarget', () => {
                 .focus();
         });
         browser.keys(['Shift', 'Tab', 'Shift']);
-        const indicator = browser.$(function() {
+        const indicator = browser.$(function () {
             return document
                 .querySelector('integration-retarget-slotted-custom-element-related-target')
                 .shadowRoot.querySelector('integration-parent')

--- a/packages/integration-tests/src/components/events/test-retarget-slotted-input-related-target/retarget-slotted-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-slotted-input-related-target/retarget-slotted-related-target.spec.js
@@ -14,14 +14,14 @@ describe('Retarget relatedTarget', () => {
     });
 
     it('should have correct relatedTarget from slotted input', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-retarget-slotted-input-related-target')
                 .shadowRoot.querySelector('.slotted-input')
                 .focus();
         });
         browser.keys(['Shift', 'Tab', 'Shift']);
-        const indicator = browser.$(function() {
+        const indicator = browser.$(function () {
             return document
                 .querySelector('integration-retarget-slotted-input-related-target')
                 .shadowRoot.querySelector('integration-parent')

--- a/packages/integration-tests/src/components/events/test-slotted-event-target/slotted-event-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-slotted-event-target/slotted-event-target.spec.js
@@ -13,15 +13,15 @@ describe('Event target in slot elements', () => {
         browser.url(URL);
     });
 
-    it('should receive event with correct target', function() {
-        const select = browser.$(function() {
+    it('should receive event with correct target', function () {
+        const select = browser.$(function () {
             return document
                 .querySelector('integration-slotted-event-target')
                 .shadowRoot.querySelector('select');
         });
         select.selectByVisibleText('Second');
 
-        const element = browser.$(function() {
+        const element = browser.$(function () {
             return document
                 .querySelector('integration-slotted-event-target')
                 .shadowRoot.querySelector('.target-is-select');

--- a/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-method-suite/wired-method-suite.spec.js
@@ -14,7 +14,7 @@ describe('Component with a wired method', () => {
     });
 
     it('should display data correctly', () => {
-        const todoText = browser.execute(function() {
+        const todoText = browser.execute(function () {
             return document
                 .querySelector('integration-wired-method-suite')
                 .shadowRoot.querySelector('integration-wired-method').shadowRoot.textContent;
@@ -23,7 +23,7 @@ describe('Component with a wired method', () => {
     });
 
     it('should update data correctly', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-wired-method-suite')
                 .shadowRoot.querySelector('button')
@@ -31,7 +31,7 @@ describe('Component with a wired method', () => {
         });
         browser.waitUntil(
             () => {
-                const todoText = browser.execute(function() {
+                const todoText = browser.execute(function () {
                     return document
                         .querySelector('integration-wired-method-suite')
                         .shadowRoot.querySelector(

--- a/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
+++ b/packages/integration-tests/src/components/wired/test-wired-prop-suite/wired-prop-suite.spec.js
@@ -14,7 +14,7 @@ describe('Component with a wired property', () => {
     });
 
     it('should display data correctly', () => {
-        const todoText = browser.execute(function() {
+        const todoText = browser.execute(function () {
             return document
                 .querySelector('integration-wired-prop-suite')
                 .shadowRoot.querySelector('integration-wired-prop').shadowRoot.textContent;
@@ -23,7 +23,7 @@ describe('Component with a wired property', () => {
     });
 
     it('should update data correctly', () => {
-        browser.execute(function() {
+        browser.execute(function () {
             document
                 .querySelector('integration-wired-prop-suite')
                 .shadowRoot.querySelector('button')
@@ -31,7 +31,7 @@ describe('Component with a wired property', () => {
         });
         browser.waitUntil(
             () => {
-                const todoText = browser.execute(function() {
+                const todoText = browser.execute(function () {
                     return document
                         .querySelector('integration-wired-prop-suite')
                         .shadowRoot.querySelector('integration-wired-prop').shadowRoot.textContent;

--- a/packages/integration-tests/src/shared/templates.js
+++ b/packages/integration-tests/src/shared/templates.js
@@ -1,4 +1,4 @@
-exports.app = function(cmpName) {
+exports.app = function (cmpName) {
     return `
         import { createElement } from 'lwc';
         import Cmp from 'integration/${cmpName}';
@@ -11,7 +11,7 @@ exports.app = function(cmpName) {
     `;
 };
 
-exports.todoApp = function(cmpName) {
+exports.todoApp = function (cmpName) {
     return `
         import { createElement } from 'lwc';
         import Cmp from 'integration/${cmpName}';
@@ -35,7 +35,7 @@ const SHADOW_POLYFILL = `
     </script>
 `;
 
-exports.html = function(cmpName, isCompat) {
+exports.html = function (cmpName, isCompat) {
     return `
         <html>
             <head>
@@ -54,7 +54,7 @@ exports.html = function(cmpName, isCompat) {
     `;
 };
 
-exports.wireServiceHtml = function(cmpName, isCompat) {
+exports.wireServiceHtml = function (cmpName, isCompat) {
     return `
         <html>
             <head>

--- a/packages/integration-tests/src/shared/todo.js
+++ b/packages/integration-tests/src/shared/todo.js
@@ -16,7 +16,7 @@ function getSubject(initialValue, initialError) {
     }
 
     var observable = {
-        subscribe: function(obs) {
+        subscribe: function (obs) {
             observer = obs;
             if (initialValue) {
                 next(initialValue);
@@ -25,7 +25,7 @@ function getSubject(initialValue, initialError) {
                 error(initialError);
             }
             return {
-                unsubscribe: function() {},
+                unsubscribe: function () {},
             };
         },
     };
@@ -55,7 +55,7 @@ var TODO = [
     // intentionally skip 5
     generateTodo(6, false),
     generateTodo(7, false),
-].reduce(function(acc, value) {
+].reduce(function (acc, value) {
     acc[value.id] = value;
     return acc;
 }, {});
@@ -74,32 +74,32 @@ function getObservable(config) {
     return getSubject(todo).observable;
 }
 
-const getTodo = function() {};
+const getTodo = function () {};
 
 register(getTodo, function getTodoWireAdapter(wiredEventTarget) {
     var subscription;
     var config;
     wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: undefined }));
     var observer = {
-        next: function(data) {
+        next: function (data) {
             wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: data, error: undefined }));
         },
-        error: function(error) {
+        error: function (error) {
             wiredEventTarget.dispatchEvent(
                 new ValueChangedEvent({ data: undefined, error: error })
             );
         },
     };
-    wiredEventTarget.addEventListener('connect', function() {
+    wiredEventTarget.addEventListener('connect', function () {
         var observable = getObservable(config);
         if (observable) {
             subscription = observable.subscribe(observer);
         }
     });
-    wiredEventTarget.addEventListener('disconnect', function() {
+    wiredEventTarget.addEventListener('disconnect', function () {
         subscription.unsubscribe();
     });
-    wiredEventTarget.addEventListener('config', function(newConfig) {
+    wiredEventTarget.addEventListener('config', function (newConfig) {
         config = newConfig;
         if (subscription) {
             subscription.unsubscribe();

--- a/packages/lwc/scripts/build.js
+++ b/packages/lwc/scripts/build.js
@@ -41,7 +41,7 @@ function buildEngineTargets(targets) {
     const dir = path.join(distDirectory, 'engine');
     const engineConfig = { input, name, targetName, dir };
 
-    return targets.map(bundleConfig => buildBundleConfig(engineConfig, bundleConfig));
+    return targets.map((bundleConfig) => buildBundleConfig(engineConfig, bundleConfig));
 }
 
 function buildSyntheticShadow(targets) {
@@ -51,7 +51,7 @@ function buildSyntheticShadow(targets) {
     const dir = path.join(distDirectory, 'synthetic-shadow');
     const engineConfig = { input, name, targetName, dir };
 
-    return targets.map(bundleConfig => buildBundleConfig(engineConfig, bundleConfig));
+    return targets.map((bundleConfig) => buildBundleConfig(engineConfig, bundleConfig));
 }
 
 function buildWireService(targets) {
@@ -61,7 +61,7 @@ function buildWireService(targets) {
     const dir = path.join(distDirectory, 'wire-service');
     const engineConfig = { input, name, targetName, dir };
 
-    return targets.map(bundleConfig => buildBundleConfig(engineConfig, bundleConfig));
+    return targets.map((bundleConfig) => buildBundleConfig(engineConfig, bundleConfig));
 }
 
 // -- Build -------------------------------------------------------------------

--- a/packages/lwc/scripts/utils/child_worker.js
+++ b/packages/lwc/scripts/utils/child_worker.js
@@ -6,14 +6,14 @@
  */
 const { rollupConfig, generateTarget } = require('./rollup');
 
-module.exports = function(config, callback) {
+module.exports = function (config, callback) {
     const targetConfig = rollupConfig(config);
 
     generateTarget(targetConfig)
         .then(() => {
             callback(null, { config, pid: `${process.pid}` });
         })
-        .catch(err => {
+        .catch((err) => {
             callback(err);
         });
 };

--- a/packages/lwc/scripts/utils/generate_targets.js
+++ b/packages/lwc/scripts/utils/generate_targets.js
@@ -21,8 +21,8 @@ module.exports = function generateTargets(targets, opts = {}) {
     let jobsCompleted = 0;
 
     return new Promise((resolve, reject) => {
-        targets.forEach(config => {
-            workers(config, err => {
+        targets.forEach((config) => {
+            workers(config, (err) => {
                 if (err) {
                     return reject(err);
                 }

--- a/packages/perf-benchmarks/best-plugins/synthetic-shadow.js
+++ b/packages/perf-benchmarks/best-plugins/synthetic-shadow.js
@@ -9,7 +9,7 @@ const SYNTHETIC_IMPORT = 'import "@lwc/synthetic-shadow";';
  * BEST-ROLLUP-PLUGIN
  * This module make sure all test run with synthetic-shadow enabled
  */
-module.exports = function() {
+module.exports = function () {
     let input;
     return {
         name: 'synthetic-shadow',

--- a/packages/perf-benchmarks/src/tableStore.js
+++ b/packages/perf-benchmarks/src/tableStore.js
@@ -104,7 +104,7 @@ export default class Store {
     }
 
     delete(id) {
-        const idx = this.data.findIndex(d => d.id == id);
+        const idx = this.data.findIndex((d) => d.id == id);
         this.data.splice(idx, 1);
     }
 
@@ -140,7 +140,7 @@ export default class Store {
             const d4 = this.data[4];
             const d9 = this.data[9];
 
-            var newData = this.data.map(function(data, i) {
+            var newData = this.data.map(function (data, i) {
                 if (i === 4) {
                     return d9;
                 } else if (i === 9) {

--- a/packages/perf-benchmarks/src/utils.js
+++ b/packages/perf-benchmarks/src/utils.js
@@ -34,8 +34,8 @@ export function nextFrame(cb) {
     setTimeout(cb, 0);
 }
 
-export const insertTableComponent = function(el, container = document.body) {
-    return new Promise(resolve => {
+export const insertTableComponent = function (el, container = document.body) {
+    return new Promise((resolve) => {
         container.appendChild(el);
         nextFrame(() => {
             resolve(el);
@@ -43,6 +43,6 @@ export const insertTableComponent = function(el, container = document.body) {
     });
 };
 
-export const destroyTableComponent = function(el) {
+export const destroyTableComponent = function (el) {
     return el && el.parentElement.removeChild(el);
 };

--- a/scripts/eslint-plugin/rules/no-production-assert.js
+++ b/scripts/eslint-plugin/rules/no-production-assert.js
@@ -21,7 +21,7 @@ module.exports = {
                 const isAssertCallExpression = sourceCode.getText(node).startsWith('assert.');
 
                 if (isAssertCallExpression) {
-                    const isGuarded = context.getAncestors().some(ancestor => {
+                    const isGuarded = context.getAncestors().some((ancestor) => {
                         return (
                             ancestor.type === 'IfStatement' &&
                             sourceCode.getText(ancestor.test) ===

--- a/scripts/release_canary_npm.js
+++ b/scripts/release_canary_npm.js
@@ -73,7 +73,7 @@ function generateUrl(packageName, sha) {
 }
 
 function pushPackage({ sha, packageName, packageTar }) {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
         const url = generateUrl(packageName, sha);
         S3.putObject(
             {
@@ -83,7 +83,7 @@ function pushPackage({ sha, packageName, packageTar }) {
                 Expires: new Date(Date.now() + RELEASE_TTL),
                 ContentType: lookup(url) || undefined,
             },
-            function(err) {
+            function (err) {
                 if (err) {
                     reject(err);
                 } else {
@@ -106,11 +106,11 @@ async function run() {
         throw new Error('You must provide at least a path');
     }
 
-    const absPaths = customPaths.map(p => path.resolve(cwd, p));
+    const absPaths = customPaths.map((p) => path.resolve(cwd, p));
     const pkgs = absPaths.reduce((l, p) => {
         const dirs = fs.readdirSync(p);
-        const filtered = dirs.filter(d => !d.startsWith('.') && !d.startsWith('@'));
-        const map = filtered.map(f => ({ name: f, dir: path.dirname(path.join(p, f)) }));
+        const filtered = dirs.filter((d) => !d.startsWith('.') && !d.startsWith('@'));
+        const map = filtered.map((f) => ({ name: f, dir: path.dirname(path.join(p, f)) }));
         return [...l, ...map];
     }, []);
 
@@ -134,9 +134,9 @@ async function run() {
             pkgJson.version = `${version}-canary+${sha}`;
 
             // Rewrite dependencies
-            ['dependencies', 'devDependencies'].forEach(key => {
+            ['dependencies', 'devDependencies'].forEach((key) => {
                 if (pkgJson[key]) {
-                    Object.keys(pkgJson[key]).forEach(dep => {
+                    Object.keys(pkgJson[key]).forEach((dep) => {
                         if (PACKAGE_DEPENDENCIES.has(dep)) {
                             pkgJson[key][dep] = HOST + '/' + generateUrl(dep, sha);
                         }
@@ -160,6 +160,6 @@ async function run() {
     }
 }
 
-run().catch(function(err) {
+run().catch(function (err) {
     console.log(err);
 });

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -20,9 +20,9 @@ const fs = require('fs');
 const { execSync } = require('child_process');
 const { isBinaryFileSync } = require('isbinaryfile');
 
-const getFileContents = path => fs.readFileSync(path, { encoding: 'utf-8' });
-const isDirectory = path => fs.lstatSync(path).isDirectory();
-const createRegExp = pattern => new RegExp(pattern);
+const getFileContents = (path) => fs.readFileSync(path, { encoding: 'utf-8' });
+const isDirectory = (path) => fs.lstatSync(path).isDirectory();
+const createRegExp = (pattern) => new RegExp(pattern);
 
 const IGNORED_EXTENSIONS = [
     'lock',
@@ -79,7 +79,7 @@ const IGNORED_EXTENSIONS = [
     'ipynb',
     'htm',
     'toml',
-].map(extension => createRegExp(`.${extension}$`));
+].map((extension) => createRegExp(`.${extension}$`));
 
 const GENERIC_IGNORED_PATTERNS = [
     '(^|/)\\.[^/]+(/|$)',
@@ -129,14 +129,12 @@ function needsCopyrightHeader(file) {
 }
 
 function check() {
-    const allFiles = execSync('git ls-files', { encoding: 'utf-8' })
-        .trim()
-        .split('\n');
+    const allFiles = execSync('git ls-files', { encoding: 'utf-8' }).trim().split('\n');
 
     const invalidFiles = allFiles.filter(
-        file =>
-            INCLUDED_PATTERNS.some(pattern => pattern.test(file)) &&
-            !IGNORED_PATTERNS.some(pattern => pattern.test(file)) &&
+        (file) =>
+            INCLUDED_PATTERNS.some((pattern) => pattern.test(file)) &&
+            !IGNORED_PATTERNS.some((pattern) => pattern.test(file)) &&
             !isDirectory(file) &&
             !isBinaryFileSync(file) &&
             needsCopyrightHeader(file)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10022,15 +10022,15 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
   integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
+
+prettier@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
 
 pretty-format@^25.2.1, pretty-format@^25.3.0:
   version "25.3.0"


### PR DESCRIPTION
## Details

Update to prettier version to 2.x

The following is a comparison of the number of changed files where prettier is updated to 2.x in both cases. The breaking change here is that a space between the `function` identifier and its argument parenthesis is added without being configurable:

- `"arrowParens": "always"` (new default) results in 235 changed files with 854 additions and 850 deletions
- `"arrowParens": "avoid"` results in 147 changed files with 526 additions and 527 deletions

Going with the new default will result in 37% more changed files and 38% more changed lines.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7109631