### PR TITLE
fix: slotted content of slotted custom element within if not visible

### DIFF
--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -54,6 +54,7 @@ export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
     clonedElement?: undefined;
+    aChildren?: VNodes;
 }
 
 export interface VText extends VNode {

--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -54,10 +54,7 @@ export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
     clonedElement?: undefined;
-    // This VCustomElement may be reused when is part of the slot content in another slotted VCustomElement.
-    // Since the slotted vnodes of this VCustomElement are emptied when first allocated (synthetic-shadow only),
-    // when this VCustomElement is reused in the future it will render incorrectly the slotted content.
-    // This property is to keep reference of the allocated children by this VCustomElement.
+    // copy of the last allocated children.
     aChildren?: VNodes;
 }
 

--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -54,6 +54,10 @@ export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
     clonedElement?: undefined;
+    // This VCustomElement may be reused when is part of the slot content in another slotted VCustomElement.
+    // Since the slotted vnodes of this VCustomElement are emptied when first allocated (synthetic-shadow only),
+    // when this VCustomElement is reused in the future it will render incorrectly the slotted content.
+    // This property is to keep reference of the allocated children by this VCustomElement.
     aChildren?: VNodes;
 }
 

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -161,11 +161,17 @@ export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
 
 export function allocateChildrenHook(vnode: VCustomElement) {
     const vm = getAssociatedVM(vnode.elm!);
-    const { children } = vnode;
+    // When allocating slotted custom element children, we need to look for a previous allocation
+    // in case the vnode is being reused, because the vnode children will be emptied in this routine
+    // when called with a newly created vnode.
+    const children = vnode.aChildren || vnode.children;
+
     vm.aChildren = children;
     if (isTrue(useSyntheticShadow)) {
         // slow path
         allocateInSlot(vm, children);
+        // save the allocated children in case this vnode is reused.
+        vnode.aChildren = children;
         // every child vnode is now allocated, and the host should receive none directly, it receives them via the shadow!
         vnode.children = EmptyArray;
     }

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -161,9 +161,16 @@ export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
 
 export function allocateChildrenHook(vnode: VCustomElement) {
     const vm = getAssociatedVM(vnode.elm!);
-    // When allocating slotted custom element children, we need to look for a previous allocation
-    // in case the vnode is being reused, because the vnode children will be emptied in this routine
-    // when called with a newly created vnode.
+    // A component with slots will re-render because:
+    // 1- There is a change of the internal state.
+    // 2- There is a change on the external api (ex: slots)
+    //
+    // In case #1, the vnodes in the cmpSlots will be reused since they didn't changed. This routine emptied the
+    // slotted children when those VCustomElement were rendered and therefore in subsequent calls to allocate children
+    // in a reused VCustomElement, there won't be any slotted children.
+    // For those cases, we will use the reference for allocated children stored when rendering the fresh VCustomElement.
+    //
+    // In case #2, we will always get a fresh VCustomElement.
     const children = vnode.aChildren || vnode.children;
 
     vm.aChildren = children;

--- a/packages/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/integration-karma/test/template/directive-if/index.spec.js
@@ -128,7 +128,7 @@ describe('if:true directive', () => {
         });
     }
 
-    it('should render slot content multiple levels deep when toggled 2 times', () => {
+    it('should continue rendering content for nested slots after multiple rehydrations', () => {
         const elm = createElement('x-multiple-slot', { is: MultipleSlot });
         document.body.appendChild(elm);
         elm.shadowRoot.querySelector('.textToggle').click();
@@ -138,12 +138,11 @@ describe('if:true directive', () => {
                 expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');
                 // hide the slot
                 elm.shadowRoot.querySelector('.textToggle').click();
-                return Promise.resolve();
             })
             .then(() => {
+                expect(elm.shadowRoot.textContent).not.toContain('text in multiple level slot');
                 // show the slot
                 elm.shadowRoot.querySelector('.textToggle').click();
-                return Promise.resolve();
             })
             .then(() => {
                 expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');

--- a/packages/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/integration-karma/test/template/directive-if/index.spec.js
@@ -131,21 +131,34 @@ describe('if:true directive', () => {
     it('should continue rendering content for nested slots after multiple rehydrations', () => {
         const elm = createElement('x-multiple-slot', { is: MultipleSlot });
         document.body.appendChild(elm);
-        elm.shadowRoot.querySelector('.textToggle').click();
+        const multipleSlotLevel1 = elm.shadowRoot.querySelector('x-multiple-slot-level1');
+        const textToggleButton = elm.shadowRoot.querySelector('.textToggle');
+
+        textToggleButton.click();
 
         return Promise.resolve()
             .then(() => {
-                expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');
+                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
+                    .querySelector('slot')
+                    .assignedElements()[0];
+
+                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
                 // hide the slot
-                elm.shadowRoot.querySelector('.textToggle').click();
+                textToggleButton.click();
             })
             .then(() => {
-                expect(elm.shadowRoot.textContent).not.toContain('text in multiple level slot');
+                const slotLevel1 = multipleSlotLevel1.shadowRoot.querySelector('slot');
+
+                expect(slotLevel1).toBe(null);
                 // show the slot
-                elm.shadowRoot.querySelector('.textToggle').click();
+                textToggleButton.click();
             })
             .then(() => {
-                expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');
+                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
+                    .querySelector('slot')
+                    .assignedElements()[0];
+
+                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
             });
     });
 });

--- a/packages/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/integration-karma/test/template/directive-if/index.spec.js
@@ -2,6 +2,7 @@ import { createElement } from 'lwc';
 import XTest from 'x/test';
 import XSlotted from 'x/slotted';
 import NestedRenderConditional from 'x/nestedRenderConditional';
+import MultipleSlot from 'x/multipleSlot';
 
 describe('if:true directive', () => {
     it('should render if the value is truthy', () => {
@@ -126,6 +127,28 @@ describe('if:true directive', () => {
                 });
         });
     }
+
+    it('should render slot content multiple levels deep when toggled 2 times', () => {
+        const elm = createElement('x-multiple-slot', { is: MultipleSlot });
+        document.body.appendChild(elm);
+        elm.shadowRoot.querySelector('.textToggle').click();
+
+        return Promise.resolve()
+            .then(() => {
+                expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');
+                // hide the slot
+                elm.shadowRoot.querySelector('.textToggle').click();
+                return Promise.resolve();
+            })
+            .then(() => {
+                // show the slot
+                elm.shadowRoot.querySelector('.textToggle').click();
+                return Promise.resolve();
+            })
+            .then(() => {
+                expect(elm.shadowRoot.textContent).toContain('text in multiple level slot');
+            });
+    });
 });
 
 describe('if:false directive', () => {

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.html
@@ -1,0 +1,9 @@
+<template>
+    <button class="textToggle" onclick={toggleSlottedText}>Toggle slotted text</button>
+
+    <x-multiple-slot-level1>
+        <x-multiple-slot-level2>
+            text in multiple level slot
+        </x-multiple-slot-level2>
+    </x-multiple-slot-level1>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class MultipleSlot extends LightningElement {
+    toggleSlottedText() {
+        this.template.querySelector('x-multiple-slot-level1').toggle();
+    }
+}

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
@@ -1,7 +1,7 @@
 <template>
     <template if:true={visible}>
-        <section data-visible={visible}>
-            <slot data-visible={visible}></slot>
+        <section>
+            <slot></slot>
         </section>
     </template>
 </template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
@@ -1,0 +1,7 @@
+<template>
+    <template if:true={visible}>
+        <section data-visible={visible}>
+            <slot data-visible={visible}></slot>
+        </section>
+    </template>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class MultipleSlotLevel1 extends LightningElement {
+    visible = false;
+
+    @api
+    toggle() {
+        this.visible = !this.visible;
+    }
+}

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.html
@@ -1,0 +1,3 @@
+<template>
+    <slot></slot>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class MultipleSlotLevel2 extends LightningElement {}


### PR DESCRIPTION
 after being toggled 2 times.


## Details
When passing slotted content to a custom element which is also slotted and wrapped in a `if:true={foo}` directive and toggle the if multiple times, the passed slot content stops being visible after the second toggle. You can see a repro here: https://developer.salesforce.com/docs/component-library/tools/playground/mFcLmzSYw/37/edit

The main issue is that the `vnode` for the slotted custom element is being reused, and during slot allocation the first time, `vnode.children` is being emptied. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
