### PR TITLE
fix(synthetic-shadow): node.contains should return true for self

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -414,6 +414,14 @@ defineProperties(Node.prototype, {
     },
     contains: {
         value(this: Node, otherNode: Node): boolean {
+            // 1. Node.prototype.contains() returns true if otherNode is an inclusive descendant
+            //    spec: https://dom.spec.whatwg.org/#dom-node-contains
+            // 2. This normalizes the behavior of this api across all browsers.
+            //    In IE11, a disconnected dom element without children invoking contains() on self, returns false
+            if (this === otherNode) {
+                return true;
+            }
+
             if (!featureFlags.ENABLE_NODE_PATCH) {
                 if (otherNode == null) {
                     return false;

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.contains.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.contains.spec.js
@@ -75,4 +75,50 @@ describe('Node.contains', () => {
         expect(div.contains(undefined)).toBe(false);
         expect(div.contains(null)).toBe(false);
     });
+
+    describe('connected nodes', () => {
+        it('should return true for self, when self is a simple dom node', () => {
+            const div = document.createElement('div');
+            document.body.appendChild(div);
+            expect(div.contains(div)).toBe(true);
+        });
+
+        it('should return true for self, when self is a shadowed node', () => {
+            const elm = createElement('x-foo', { is: Test });
+            document.body.appendChild(elm);
+            const div = elm.shadowRoot.querySelector('div');
+            expect(div.contains(div)).toBe(true);
+        });
+
+        it('should return true for self, when self is a custom element', () => {
+            const elm = createElement('x-foo', { is: Test });
+            document.body.appendChild(elm);
+            expect(elm.contains(elm)).toBe(true);
+        });
+
+        it('should return true for self, when self is a shadowRoot', () => {
+            const elm = createElement('x-foo', { is: Test });
+            document.body.appendChild(elm);
+            const shadowRoot = elm.shadowRoot;
+            expect(shadowRoot.contains(shadowRoot)).toBe(true);
+        });
+    });
+
+    describe('disconnected nodes', () => {
+        it('should return true for self, when self is a simple dom node', () => {
+            const div = document.createElement('div');
+            expect(div.contains(div)).toBe(true);
+        });
+
+        it('should return true for self, when self is a custom element', () => {
+            const elm = createElement('x-foo', { is: Test });
+            expect(elm.contains(elm)).toBe(true);
+        });
+
+        it('should return true for self, when self is a shadowRoot', () => {
+            const elm = createElement('x-foo', { is: Test });
+            const shadowRoot = elm.shadowRoot;
+            expect(shadowRoot.contains(shadowRoot)).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Details
- fixes #1791
Per the [spec](https://dom.spec.whatwg.org/#dom-node-contains) for Node.prototype.contains(otherNode), the return value should be true if otherNode is an inclusive descendant.

- Normalize the behavior of `contains()` for a disconnected DOM element across all browsers.
 In IE11, for a disconnected DOM element which has never had child nodes, calling contains() on self will return false. For all other browsers, contains() returns true. This PR normalizes the behavior to return true across all browsers.
https://jsbin.com/cikubej/edit?html,js,console
```js
const div = document.createElement('div');
div.contains(div); // should return true
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7391508
