### PR TITLE
fix: slotted content of slotted custom element within if not visible …

### DIFF
--- a/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine/src/3rdparty/snabbdom/types.ts
@@ -54,6 +54,8 @@ export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
     clonedElement?: undefined;
+    // copy of the last allocated children.
+    aChildren?: VNodes;
 }
 
 export interface VText extends VNode {

--- a/packages/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/integration-karma/test/template/directive-if/index.spec.js
@@ -2,6 +2,7 @@ import { createElement } from 'lwc';
 import XTest from 'x/test';
 import XSlotted from 'x/slotted';
 import NestedRenderConditional from 'x/nestedRenderConditional';
+import MultipleSlot from 'x/multipleSlot';
 
 describe('if:true directive', () => {
     it('should render if the value is truthy', () => {
@@ -126,6 +127,40 @@ describe('if:true directive', () => {
                 });
         });
     }
+
+    it('should continue rendering content for nested slots after multiple rehydrations', () => {
+        const elm = createElement('x-multiple-slot', { is: MultipleSlot });
+        document.body.appendChild(elm);
+        const multipleSlotLevel1 = elm.shadowRoot.querySelector('x-multiple-slot-level1');
+        const textToggleButton = elm.shadowRoot.querySelector('.textToggle');
+
+        textToggleButton.click();
+
+        return Promise.resolve()
+            .then(() => {
+                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
+                    .querySelector('slot')
+                    .assignedElements()[0];
+
+                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
+                // hide the slot
+                textToggleButton.click();
+            })
+            .then(() => {
+                const slotLevel1 = multipleSlotLevel1.shadowRoot.querySelector('slot');
+
+                expect(slotLevel1).toBe(null);
+                // show the slot
+                textToggleButton.click();
+            })
+            .then(() => {
+                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
+                    .querySelector('slot')
+                    .assignedElements()[0];
+
+                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
+            });
+    });
 });
 
 describe('if:false directive', () => {

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.html
@@ -1,0 +1,9 @@
+<template>
+    <button class="textToggle" onclick={toggleSlottedText}>Toggle slotted text</button>
+
+    <x-multiple-slot-level1>
+        <x-multiple-slot-level2>
+            text in multiple level slot
+        </x-multiple-slot-level2>
+    </x-multiple-slot-level1>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlot/multipleSlot.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class MultipleSlot extends LightningElement {
+    toggleSlottedText() {
+        this.template.querySelector('x-multiple-slot-level1').toggle();
+    }
+}

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.html
@@ -1,0 +1,7 @@
+<template>
+    <template if:true={visible}>
+        <section>
+            <slot></slot>
+        </section>
+    </template>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel1/multipleSlotLevel1.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class MultipleSlotLevel1 extends LightningElement {
+    visible = false;
+
+    @api
+    toggle() {
+        this.visible = !this.visible;
+    }
+}

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.html
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.html
@@ -1,0 +1,3 @@
+<template>
+    <slot></slot>
+</template>

--- a/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.js
+++ b/packages/integration-karma/test/template/directive-if/x/multipleSlotLevel2/multipleSlotLevel2.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class MultipleSlotLevel2 extends LightningElement {}


### PR DESCRIPTION
…(#1787)

cherrypicks 19b759c623b87d99a18a1cb4908c13ad818b9a85

## Details
When passing slotted content to a custom element which is also slotted and wrapped in a `if:true={foo}` directive and toggle the if multiple times, the passed slot content stops being visible after the second toggle. You can see a repro here: https://developer.salesforce.com/docs/component-library/tools/playground/mFcLmzSYw/37/edit

The main issue is that the `vnode` for the slotted custom element is being reused, and during slot allocation the first time, `vnode.children` is being emptied. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
