### PR TITLE
test: Fix failures due to Chrome 81 and Firefox 75 releases

### DIFF
--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -29,7 +29,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
 
     expect(() => {
         elm.dispatch('event');
-    }).toThrowError(TypeError);
+    }).toThrowError(Error);
 });
 
 it('should throw when event is dispatched during construction', function() {

--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -29,11 +29,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
 
     expect(() => {
         elm.dispatch('event');
-    }).toThrowError(
-        Error,
-        // Error message covers chrome, firefox, Safari, IE11, Safari 10.0.0
-        /Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'|Argument 1 \('event'\) to EventTarget.dispatchEvent must be an instance of Event|Argument 1 of EventTarget\.dispatchEvent is not an object|Invalid argument|Type error/
-    );
+    }).toThrowError(TypeError);
 });
 
 it('should throw when event is dispatched during construction', function() {

--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -29,7 +29,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
 
     expect(() => {
         elm.dispatch('event');
-    }).toThrowError(Error);
+    }).toThrowError();
 });
 
 it('should throw when event is dispatched during construction', function() {

--- a/packages/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -54,7 +54,11 @@ const ariaPropertiesMapping = {
     ariaPressed: 'aria-pressed',
     ariaReadOnly: 'aria-readonly',
     ariaRequired: 'aria-required',
-    ariaSelected: 'aria-selected',
+
+    // Disabling ariaSelected check because Chrome currently reflect the property to the aria-sort
+    // attribute: https://bugs.chromium.org/p/chromium/issues/detail?id=914469
+    // ariaSelected: 'aria-selected',
+
     ariaSort: 'aria-sort',
     ariaValueMax: 'aria-valuemax',
     ariaValueMin: 'aria-valuemin',


### PR DESCRIPTION
## Details

* Disabling ariaSelected check because Chrome currently reflect the property to the aria-sort attribute: https://bugs.chromium.org/p/chromium/issues/detail?id=914469

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7391508
