### PR TITLE
test: update test for dispatchEvent type error

### DIFF
--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -29,11 +29,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
 
     expect(() => {
         elm.dispatch('event');
-    }).toThrowError(
-        Error,
-        // Error message covers chrome, firefox, Safari, IE11, Safari 10.0.0
-        /Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'|Argument 1 \('event'\) to EventTarget.dispatchEvent must be an instance of Event|Argument 1 of EventTarget\.dispatchEvent is not an object|Invalid argument|Type error/
-    );
+    }).toThrowError(TypeError);
 });
 
 it('should throw when event is dispatched during construction', function() {


### PR DESCRIPTION
## Details

Test started failing after FF updated their error message in v45.0. Updated the test to just verify that a TypeError is thrown.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7391508