### PR TITLE
test: Wire service does not call config when params are undefined

### DIFF
--- a/packages/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -37,6 +37,7 @@ function testAriaProperty(property, attribute) {
     });
 }
 
+// test is this passes on the ci
 const ariaPropertiesMapping = {
     ariaAutoComplete: 'aria-autocomplete',
     ariaChecked: 'aria-checked',

--- a/packages/integration-karma/test/wire/reactive-params.spec.js
+++ b/packages/integration-karma/test/wire/reactive-params.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 
 import CascadeWiredProps from 'x/cascadeWiredProps';
+import SimpleWiredProps from 'x/simpleWiredComponent';
 
 describe('@wire reactive parameters', () => {
     if (process.env.COMPAT !== true) {
@@ -19,4 +20,20 @@ describe('@wire reactive parameters', () => {
             document.body.appendChild(elm);
         });
     }
+
+    // in the current wire service, this fails, because it does not calls the config.
+    // in the wire reform, it does call the config, with undefined in the parameters.
+    it('should not trigger config with undefined params', done => {
+        const elm = createElement('x-simple-wire', { is: SimpleWiredProps });
+
+        elm.addEventListener('dependantwirevalue', evt => {
+            const secondWireValue = evt.detail.providedValue;
+
+            expect(secondWireValue.firstParam).toBe('undefined');
+            done();
+        });
+
+        // elm.setSimpleWireConfig('jose');
+        document.body.appendChild(elm);
+    });
 });

--- a/packages/integration-karma/test/wire/x/simpleWiredComponent/simpleWiredComponent.html
+++ b/packages/integration-karma/test/wire/x/simpleWiredComponent/simpleWiredComponent.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/wire/x/simpleWiredComponent/simpleWiredComponent.js
+++ b/packages/integration-karma/test/wire/x/simpleWiredComponent/simpleWiredComponent.js
@@ -1,0 +1,29 @@
+import { LightningElement, wire, api } from 'lwc';
+import { EchoWireAdapter } from 'x/echoWireAdapter';
+
+export default class SimpleWiredProps extends LightningElement {
+    configValue = null;
+    firstParamValue;
+
+    @wire(EchoWireAdapter, {
+        firstParam: '$firstParamValue',
+    })
+    simpleWire(providedValue) {
+        this.configValue = providedValue;
+        this.dispatchEvent(
+            new CustomEvent('dependantwirevalue', {
+                detail: { providedValue },
+            })
+        );
+    }
+
+    @api
+    getSimpleWireConfig() {
+        return this.configValue;
+    }
+
+    @api
+    setSimpleWireConfig(value) {
+        this.firstParamValue = value;
+    }
+}


### PR DESCRIPTION
## Details
When having a component that uses a wire adapter.

```js
import { LightningElement, wire, api } from 'lwc';
import { EchoWireAdapter } from 'x/echoWireAdapter';

export default class SimpleWiredProps extends LightningElement {
    firstParamValue;

    @wire(EchoWireAdapter, {
        firstParam: '$firstParamValue',
    })
    simpleWire(providedValue) {
        this.configValue = providedValue;
    }
}
```

The EchoWireAdapter config event is never initially called, when all of the config parameters are `undefined`. Once you change at least one, the config event is triggered.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`