### PR TITLE
docs: add mutationobserver guidance

### DIFF
--- a/packages/@lwc/synthetic-shadow/README.md
+++ b/packages/@lwc/synthetic-shadow/README.md
@@ -8,8 +8,10 @@ This is a polyfill for ShadowRoot that was tailor-made for LWC in order to meet 
 
 -   Default content for `<slot>` elements is always empty.
 -   `slotchange` is only available directly on the slot (it doesn't bubble as in the case of the native implementation)
--   Dispatch events directly on the ShadowRoot instance are not allowed because they will always leak into the host, and we have no way to contain them.
+-   Dispatching events directly on the `ShadowRoot` instance isn't allowed because the events will always leak into the host, and we have no way to contain them.
+-   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you may cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements. 
 
 ## Missing features
 
 TBD
+

--- a/packages/@lwc/synthetic-shadow/README.md
+++ b/packages/@lwc/synthetic-shadow/README.md
@@ -9,7 +9,7 @@ This is a polyfill for ShadowRoot that was tailor-made for LWC in order to meet 
 -   Default content for `<slot>` elements is always empty.
 -   `slotchange` is only available directly on the slot (it doesn't bubble as in the case of the native implementation)
 -   Dispatching events directly on the `ShadowRoot` instance isn't allowed because the events will always leak into the host, and we have no way to contain them.
--   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you will cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements. 
+-   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you will cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements.
 
 ## Missing features
 

--- a/packages/@lwc/synthetic-shadow/README.md
+++ b/packages/@lwc/synthetic-shadow/README.md
@@ -9,9 +9,8 @@ This is a polyfill for ShadowRoot that was tailor-made for LWC in order to meet 
 -   Default content for `<slot>` elements is always empty.
 -   `slotchange` is only available directly on the slot (it doesn't bubble as in the case of the native implementation)
 -   Dispatching events directly on the `ShadowRoot` instance isn't allowed because the events will always leak into the host, and we have no way to contain them.
--   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you may cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements. 
+-   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you will cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements. 
 
 ## Missing features
 
 TBD
-


### PR DESCRIPTION
## Details
If you use a mutation observer, disconnect it to prevent a memory leak. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? N/A
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7138094
