### PR TITLE
fix: use resolved constructor during creating of template elements

### DIFF
--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -194,7 +194,7 @@ export function createViewModelHook(vnode: VCustomElement) {
         // into each element from the template, so they can be styled accordingly.
         setElementShadowToken(elm, shadowAttribute);
     }
-    createVM(elm, ctor, {
+    createVM(elm, def.ctor, {
         mode,
         owner,
     });

--- a/packages/integration-karma/test/component/auraIntegration/AuraIntegration.spec.js
+++ b/packages/integration-karma/test/component/auraIntegration/AuraIntegration.spec.js
@@ -1,0 +1,12 @@
+import { createElement } from 'lwc';
+import Parent from 'x/parent';
+
+it('should support component class marked to be resolved as circular reference', () => {
+    const elm = createElement('x-parent', { is: Parent });
+    document.body.appendChild(elm);
+    // Verifying that shadow tree was created to ensure the component class was successfully processed
+    const actual = elm.shadowRoot
+        .querySelector('x-child-marked-as-circular')
+        .shadowRoot.querySelector('.child');
+    expect(actual).toBeDefined();
+});

--- a/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.html
+++ b/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.html
@@ -1,0 +1,3 @@
+<template>
+    <div class='child'></div>
+</template>

--- a/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.js
+++ b/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+class Child extends LightningElement {}
+
+export default function tmp() {
+    return Child;
+}
+tmp.__circular__ = true;

--- a/packages/integration-karma/test/component/auraIntegration/x/parent/parent.html
+++ b/packages/integration-karma/test/component/auraIntegration/x/parent/parent.html
@@ -1,0 +1,4 @@
+<template>
+    <div></div>
+    <x-child-marked-as-circular></x-child-marked-as-circular>
+</template>

--- a/packages/integration-karma/test/component/auraIntegration/x/parent/parent.js
+++ b/packages/integration-karma/test/component/auraIntegration/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}

--- a/packages/integration-karma/test/component/lockerIntegration/x/child/child.html
+++ b/packages/integration-karma/test/component/lockerIntegration/x/child/child.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/component/lockerIntegration/x/child/child.js
+++ b/packages/integration-karma/test/component/lockerIntegration/x/child/child.js
@@ -1,0 +1,20 @@
+import { LightningElement } from 'lwc';
+import Template from './child.html';
+function SecureBase() {
+    if (this instanceof SecureBase) {
+        LightningElement.prototype.constructor.call(this);
+    } else {
+        return LightningElement;
+    }
+}
+SecureBase.__circular__ = true;
+class Child extends SecureBase {
+    render() {
+        return Template;
+    }
+}
+
+export default function tmp() {
+    return Child;
+}
+tmp.__circular__ = true;

--- a/packages/integration-karma/test/component/lockerIntegration/x/lockerIntegration/lockerIntegration.html
+++ b/packages/integration-karma/test/component/lockerIntegration/x/lockerIntegration/lockerIntegration.html
@@ -1,3 +1,4 @@
 <template>
     <div class="secure"></div>
+    <x-child></x-child>
 </template>


### PR DESCRIPTION
## Details
For a component class that has been marked to have a circular reference, the engine resolves the constructor and caches it as part of the component def. During creation of elements found in a template, currently the unresolved constructor is being used. This PR uses the resolved constructor from the component definition.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

This is a follow up to https://github.com/salesforce/lwc/pull/1751

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7391508
