### PR TITLE
fix(wire-service): consecutive update calls with same config values

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -130,7 +130,6 @@ describe('Implicit mode', () => {
                       static: {
                         id: 1
                       },
-                      hasParams: false,
                       config: function($cmp) {
                         return {
                           id: 1

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -61,7 +61,6 @@ describe('observed fields', () => {
                   wire: {
                     wiredProp: {
                       adapter: createElement,
-                      hasParams: false,
                       config: function($cmp) {
                         return {};
                       }
@@ -119,7 +118,6 @@ describe('observed fields', () => {
                   wire: {
                     function: {
                       adapter: createElement,
-                      hasParams: false,
                       config: function($cmp) {
                          return {};
                       }
@@ -312,7 +310,6 @@ describe('observed fields', () => {
                     wire: {
                       wiredProp: {
                         adapter: createElement,
-                        hasParams: false,
                         config: function($cmp) {
                           return {};
                         }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -41,7 +41,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed", "array"],
@@ -94,7 +93,6 @@ describe('Transform property', () => {
                       static: {
                         key1: importedValue
                       },
-                      hasParams: false,
                       config: function($cmp) {
                         return {
                           key1: importedValue
@@ -147,7 +145,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         let v2 = $cmp.p1;
@@ -203,7 +200,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         return {
@@ -264,7 +260,6 @@ describe('Transform property', () => {
                         key3: "fixed",
                         key4: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key3: "fixed",
@@ -356,7 +351,6 @@ describe('Transform property', () => {
                       adapter: getFoo,
                       params: {},
                       static: {},
-                      hasParams: false,
                       config: function($cmp) {
                         return {};
                       }
@@ -401,7 +395,6 @@ describe('Transform property', () => {
                     adapter: Foo.Bar,
                     params: {},
                     static: {},
-                    hasParams: false,
                     config: function($cmp) {
                       return {};
                     }
@@ -446,7 +439,6 @@ describe('Transform property', () => {
                   adapter: Foo.Bar,
                   params: {},
                   static: {},
-                  hasParams: false,
                   config: function($cmp) {
                     return {};
                   }
@@ -511,7 +503,6 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          hasParams: false,
                           config: function($cmp) {
                             return {};
                           }
@@ -628,7 +619,6 @@ describe('Transform property', () => {
                             key2: "p1.p2"
                           },
                           static: {},
-                          hasParams: true,
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             let v2 = $cmp.p1;
@@ -683,7 +673,6 @@ describe('Transform property', () => {
                           static: {
                             key2: ["fixed", "array"]
                           },
-                          hasParams: true,
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             return {
@@ -788,7 +777,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],
@@ -804,7 +792,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["array"],
@@ -858,7 +845,6 @@ describe('Transform method', () => {
                         key2: ["fixed"]
                       },
                       method: 1,
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -168,12 +168,6 @@ function buildWireConfigValue(t, wiredValues) {
                 wireConfig.push(t.objectProperty(t.identifier('method'), t.numericLiteral(1)));
             }
 
-            wireConfig.push(
-                t.objectProperty(
-                    t.identifier('hasParams'),
-                    t.booleanLiteral(!!wiredValue.params && wiredValue.params.length > 0)
-                )
-            );
             wireConfig.push(getGeneratedConfig(t, wiredValue));
 
             return t.objectProperty(

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -14,6 +14,7 @@ import {
     getOwnPropertyDescriptor,
     toString,
     isFalse,
+    keys,
 } from '@lwc/shared';
 import { ComponentConstructor } from '../component';
 import { internalWireFieldDecorator } from './wire';
@@ -48,7 +49,7 @@ interface WireCompilerDef {
     method?: number;
     adapter: WireAdapterConstructor;
     config: ConfigCallback;
-    hasParams: boolean;
+    params?: Record<string, any>;
 }
 interface RegisterDecoratorMeta {
     readonly publicMethods?: MethodCompilerMeta;
@@ -216,7 +217,9 @@ export function registerDecorators(
     }
     if (!isUndefined(wire)) {
         for (const fieldOrMethodName in wire) {
-            const { adapter, method, config: configCallback, hasParams } = wire[fieldOrMethodName];
+            const { adapter, method, config: configCallback, params = {} } = wire[
+                fieldOrMethodName
+            ];
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
             if (method === 1) {
                 if (process.env.NODE_ENV !== 'production') {
@@ -230,7 +233,7 @@ export function registerDecorators(
                     throw new Error();
                 }
                 wiredMethods[fieldOrMethodName] = descriptor;
-                storeWiredMethodMeta(descriptor, adapter, configCallback, hasParams);
+                storeWiredMethodMeta(descriptor, adapter, configCallback, keys(params));
             } else {
                 if (process.env.NODE_ENV !== 'production') {
                     assert.isTrue(
@@ -241,7 +244,7 @@ export function registerDecorators(
                 }
                 descriptor = internalWireFieldDecorator(fieldOrMethodName);
                 wiredFields[fieldOrMethodName] = descriptor;
-                storeWiredFieldMeta(descriptor, adapter, configCallback, hasParams);
+                storeWiredFieldMeta(descriptor, adapter, configCallback, keys(params));
                 defineProperty(proto, fieldOrMethodName, descriptor);
             }
         }

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -8,6 +8,8 @@ import { BroadcastAdapter } from 'x/broadcastAdapter';
 
 import InheritedMethods from 'x/inheritedMethods';
 
+import SameConfigComponent from 'x/sameConfig';
+
 const ComponentClass = AdapterConsumer;
 const AdapterId = EchoWireAdapter;
 
@@ -210,6 +212,29 @@ describe('wiring', () => {
                         done();
                     }, 5);
                 });
+        });
+
+        it('should not trigger update when config does not change', done => {
+            const elm = createElement('x-same-config', { is: SameConfigComponent });
+            elm.a = 3;
+            elm.b = 2;
+
+            const spy = [];
+            EchoWireAdapter.setSpy(spy);
+
+            setTimeout(() => {
+                expect(spy.length).toBe(1); // first update
+                expect(elm.result).toBe(5);
+
+                elm.a = 1;
+                elm.b = 4;
+
+                setTimeout(() => {
+                    expect(spy.length).toBe(1); // no extra call with the config
+
+                    done();
+                }, 0);
+            }, 0);
         });
     });
 });

--- a/packages/integration-karma/test/wire/wiring/x/sameConfig/sameConfig.html
+++ b/packages/integration-karma/test/wire/wiring/x/sameConfig/sameConfig.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/wire/wiring/x/sameConfig/sameConfig.js
+++ b/packages/integration-karma/test/wire/wiring/x/sameConfig/sameConfig.js
@@ -1,0 +1,20 @@
+import { LightningElement, api, wire } from 'lwc';
+import { EchoWireAdapter } from 'x/echoAdapter';
+
+export default class SameConfig extends LightningElement {
+    @api a;
+    @api b;
+
+    @api get result() {
+        return this._result;
+    }
+
+    get sum() {
+        return (parseInt(this.a) || 0) + (parseInt(this.b) || 0);
+    }
+
+    @wire(EchoWireAdapter, { sum: '$sum', static: 1, staticComplexParam: ['a', 'b'] })
+    setResult(config) {
+        this._result = config.sum;
+    }
+}


### PR DESCRIPTION
## Details
This PR fixes an issue in which the update method of the wire adapter is being called sequentially with the same config.

Ex: 
```
instance.update({ sum: 5 });
instance.update({ sum: 5 });
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`