### PR TITLE
perf(engine): avoid multiple getComponentInternalDef lookups

### DIFF
--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -194,9 +194,10 @@ export function createViewModelHook(vnode: VCustomElement) {
         // into each element from the template, so they can be styled accordingly.
         setElementShadowToken(elm, shadowAttribute);
     }
-    createVM(elm, def.ctor, {
+    createVM(elm, def, {
         mode,
         owner,
+        isRoot: false,
     });
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(

--- a/packages/@lwc/engine/src/framework/upgrade.ts
+++ b/packages/@lwc/engine/src/framework/upgrade.ts
@@ -115,10 +115,10 @@ export function createElement(
     const def = getComponentInternalDef(Ctor);
     setElementProto(element, def);
 
-    createVM(element, def.ctor, {
+    createVM(element, def, {
         mode: options.mode !== 'closed' ? 'open' : 'closed',
-        isRoot: true,
         owner: null,
+        isRoot: true,
     });
 
     setHiddenField(element, ConnectingSlot, connectRootElement);

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -22,13 +22,7 @@ import {
     setHiddenField,
     getOwnPropertyNames,
 } from '@lwc/shared';
-import { getComponentInternalDef } from './def';
-import {
-    createComponent,
-    renderComponent,
-    ComponentConstructor,
-    markComponentAsDirty,
-} from './component';
+import { createComponent, renderComponent, markComponentAsDirty } from './component';
 import { addCallbackToNextTick, EmptyObject, EmptyArray, useSyntheticShadow } from './utils';
 import { invokeServiceHook, Services } from './services';
 import { invokeComponentCallback, invokeComponentRenderedCallback } from './invoker';
@@ -202,11 +196,11 @@ export function removeVM(vm: VM) {
 
 export function createVM(
     elm: HTMLElement,
-    Ctor: ComponentConstructor,
+    def: ComponentDef,
     options: {
         mode: 'open' | 'closed';
-        isRoot?: boolean;
         owner: VM | null;
+        isRoot: boolean;
     }
 ): VM {
     if (process.env.NODE_ENV !== 'production') {
@@ -215,7 +209,6 @@ export function createVM(
             `VM creation requires a DOM element instead of ${elm}.`
         );
     }
-    const def = getComponentInternalDef(Ctor);
     const { isRoot, mode, owner } = options;
     idx += 1;
     const uninitializedVm: UninitializedVM = {
@@ -256,7 +249,7 @@ export function createVM(
     }
 
     // create component instance associated to the vm and the element
-    createComponent(uninitializedVm, Ctor);
+    createComponent(uninitializedVm, def.ctor);
 
     // link component to the wire service
     const initializedVm = uninitializedVm as VM;

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -41,18 +41,18 @@ export function deprecatedBuildCustomElementConstructor(
 }
 
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {
-    const { props, bridge: BaseElement } = getComponentInternalDef(Ctor);
+    const def = getComponentInternalDef(Ctor);
 
     // generating the hash table for attributes to avoid duplicate fields
     // and facilitate validation and false positives in case of inheritance.
     const attributeToPropMap: Record<string, string> = {};
-    for (const propName in props) {
+    for (const propName in def.props) {
         attributeToPropMap[getAttrNameFromPropName(propName)] = propName;
     }
-    return class extends BaseElement {
+    return class extends def.bridge {
         constructor() {
             super();
-            createVM(this, Ctor, {
+            createVM(this, def, {
                 mode: 'open',
                 isRoot: true,
                 owner: null,


### PR DESCRIPTION
## Details

This PR attempts to optimize the `createVM` method by removing the need to look up the component definition for each invocation. It appears that all the invokers of `createVM` already have an handle the component definition under construction. By passing the definition each of the constructors to this method it avoids an extra lookup to the def registry.

This PR also forces the `isRoot` property to be present in the config to force monomorphism at runtime. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7391508
