### PR TITLE
fix(wire-service): wired field dont triggers rehydration

### DIFF
--- a/packages/@lwc/engine/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine/src/framework/decorators/wire.ts
@@ -6,7 +6,7 @@
  */
 import { assert } from '@lwc/shared';
 import { ComponentInterface } from '../component';
-import { componentValueObserved } from '../mutation-tracker';
+import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
 import { WireAdapterConstructor } from '../wiring';
 
@@ -35,11 +35,16 @@ export function internalWireFieldDecorator(key: string): PropertyDescriptor {
         set(this: ComponentInterface, value: any) {
             const vm = getAssociatedVM(this);
             /**
-             * intentionally ignoring the reactivity here since this is just
+             * Reactivity for wired fields is provided in wiring.
+             * We intentionally add reactivity here since this is just
              * letting the author to do the wrong thing, but it will keep our
              * system to be backward compatible.
              */
-            vm.cmpFields[key] = value;
+            if (value !== vm.cmpFields[key]) {
+                vm.cmpFields[key] = value;
+
+                componentValueMutated(vm, key);
+            }
         },
         enumerable: true,
         configurable: true,

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -234,6 +234,25 @@ describe('wired fields', () => {
                 expect(staticValue.textContent).toBe('modified value');
             });
     });
+
+    it('should rerender component when wired field is mutated from within the component', () => {
+        BroadcastAdapter.clearInstances();
+        const elm = createElement('x-bc-consumer', { is: BroadcastConsumer });
+        document.body.appendChild(elm);
+        BroadcastAdapter.broadcastData('expected value');
+
+        return Promise.resolve()
+            .then(() => {
+                const staticValue = elm.shadowRoot.querySelector('span');
+                expect(staticValue.textContent).toBe('expected value');
+
+                elm.setWiredPropToValue('modified value');
+            })
+            .then(() => {
+                const staticValue = elm.shadowRoot.querySelector('span');
+                expect(staticValue.textContent).toBe('modified value');
+            });
+    });
 });
 
 describe('wired methods', () => {

--- a/packages/integration-karma/test/wire/wiring/x/broadcastConsumer/broadcastConsumer.js
+++ b/packages/integration-karma/test/wire/wiring/x/broadcastConsumer/broadcastConsumer.js
@@ -45,6 +45,11 @@ export default class BroadcastConsumer extends LightningElement {
         this.wiredProp.data = newValue;
     }
 
+    @api
+    setWiredPropToValue(value) {
+        this.wiredProp = value;
+    }
+
     get WiredPropValue() {
         const propValue = this.wiredProp || '';
 


### PR DESCRIPTION
## Details
This PR fixes an issue in which when a wired field is modified from the component code, it does not triggers rehydration on the component.

Example
```html
<template>{wiredField}</template>
```
```js
import { LightningElement, wire, api } from 'lwc';
import { Foo } from 'bar/baz';

export default class Example extends LightningElement {
    @wire(Foo) wiredField;

    @api
    forceRerender() {
          this.wiredField = Math.random();
    }
}
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`