### PR TITLE
fix: cache definition for constructor with circular dependency

### DIFF
--- a/packages/@lwc/engine/src/framework/def.ts
+++ b/packages/@lwc/engine/src/framework/def.ts
@@ -223,7 +223,12 @@ export function getComponentInternalDef(Ctor: unknown, name?: string): Component
 
     if (isUndefined(def)) {
         if (isCircularModuleDependency(Ctor)) {
-            Ctor = resolveCircularModuleDependency(Ctor);
+            const resolvedCtor = resolveCircularModuleDependency(Ctor);
+            def = getComponentInternalDef(resolvedCtor);
+            // Cache the unresolved component ctor too. The next time if the same unresolved ctor is used,
+            // look up the definition in cache instead of re-resolving and recreating the def.
+            CtorToDefMap.set(Ctor, def);
+            return def;
         }
 
         if (!isComponentConstructor(Ctor)) {

--- a/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.html
+++ b/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.html
@@ -1,3 +1,3 @@
 <template>
-    <div class='child'></div>
+    <div class='child'>{aTrackedProperty} {aPublicProperty}</div>
 </template>

--- a/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.js
+++ b/packages/integration-karma/test/component/auraIntegration/x/childMarkedAsCircular/childMarkedAsCircular.js
@@ -1,5 +1,13 @@
-import { LightningElement } from 'lwc';
-class Child extends LightningElement {}
+import { LightningElement, track, api } from 'lwc';
+class Child extends LightningElement {
+    normalProperty;
+
+    @track
+    aTrackedProperty = 'Hello, welcome to the child component';
+
+    @api
+    aPublicProperty;
+}
 
 export default function tmp() {
     return Child;

--- a/packages/integration-karma/test/component/auraIntegration/x/parent/parent.html
+++ b/packages/integration-karma/test/component/auraIntegration/x/parent/parent.html
@@ -1,4 +1,5 @@
 <template>
     <div></div>
     <x-child-marked-as-circular></x-child-marked-as-circular>
+    <x-child-marked-as-circular></x-child-marked-as-circular>
 </template>

--- a/packages/integration-karma/test/component/lockerIntegration/x/child/child.html
+++ b/packages/integration-karma/test/component/lockerIntegration/x/child/child.html
@@ -1,1 +1,3 @@
-<template></template>
+<template>
+    {aTrackedProperty} {aPublicProperty}
+</template>

--- a/packages/integration-karma/test/component/lockerIntegration/x/child/child.js
+++ b/packages/integration-karma/test/component/lockerIntegration/x/child/child.js
@@ -1,4 +1,4 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api, track } from 'lwc';
 import Template from './child.html';
 function SecureBase() {
     if (this instanceof SecureBase) {
@@ -9,6 +9,14 @@ function SecureBase() {
 }
 SecureBase.__circular__ = true;
 class Child extends SecureBase {
+    normalProperty;
+
+    @track
+    aTrackedProperty = 'Hello, welcome to the child component';
+
+    @api
+    aPublicProperty;
+
     render() {
         return Template;
     }


### PR DESCRIPTION
## Details
For component constructor with a circular dependency, the definition gathered is being cached with the resolved constructor as the key.
This becomes an issue when the unresolved constructor is reused the second time. The component def is recalculated unnecessarily.

Follow up to #1751 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
<!--Work ID in text, no links -->
