### PR TITLE
doc(module-resolver): Fix typo in README

### DIFF
--- a/packages/@lwc/module-resolver/README.md
+++ b/packages/@lwc/module-resolver/README.md
@@ -17,7 +17,7 @@ Synchronously resolve an LWC module from its specifier.
 ```js
 import { resolveModule } from '@lwc/module-resolver';
 
-const result = resolveModule('x-foo', './index.js');
+const result = resolveModule('x/foo', './index.js');
 console.log(result);
 ```
 


### PR DESCRIPTION
## Details

Fixing module name typo in README, the module resolver accepts a module name not the associated module tag name.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅