### PR TITLE
fix(module-resolver): validate ModuleRecord data type

### DIFF
--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -12,6 +12,7 @@
         "dist/"
     ],
     "dependencies": {
+        "@lwc/shared": "1.5.2",
         "resolve": "~1.15.1"
     },
     "publishConfig": {

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -12,7 +12,6 @@
         "dist/"
     ],
     "dependencies": {
-        "@lwc/shared": "1.5.2",
         "resolve": "~1.15.1"
     },
     "publishConfig": {

--- a/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
@@ -256,4 +256,14 @@ describe('resolution override', () => {
             `Invalid LWC configuration in "${dirname}". Unknown module record "{}"`
         );
     });
+
+    test('throw when the module record is non-object', () => {
+        const dirname = fixture('no-config');
+        const opts: any = { modules: ['foo/test'] };
+
+        expect(() => resolveModule('test', dirname, opts)).toThrowErrorWithCode(
+            LWC_CONFIG_ERROR_CODE,
+            `Invalid LWC configuration in "${dirname}". Invalid module record. Module record has to be an object, instead got "foo/test".`
+        );
+    });
 });

--- a/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
@@ -263,7 +263,7 @@ describe('resolution override', () => {
 
         expect(() => resolveModule('test', dirname, opts)).toThrowErrorWithCode(
             LWC_CONFIG_ERROR_CODE,
-            `Invalid LWC configuration in "${dirname}". Invalid module record. Module record has to be an object, instead got "foo/test".`
+            `Invalid LWC configuration in "${dirname}". Invalid module record. Module record must be an object, instead got "foo/test".`
         );
     });
 });

--- a/packages/@lwc/module-resolver/src/index.ts
+++ b/packages/@lwc/module-resolver/src/index.ts
@@ -212,7 +212,7 @@ export function resolveModule(
 
     let modules = lwcConfig.modules || [];
     if (config) {
-        const userConfig = normalizeConfig(config);
+        const userConfig = normalizeConfig(config, rootDir);
         modules = mergeModules(userConfig.modules, modules);
     }
 

--- a/packages/@lwc/module-resolver/src/shared.ts
+++ b/packages/@lwc/module-resolver/src/shared.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export function isObject(obj: any): obj is object {
+    return typeof obj === 'object';
+}

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -75,7 +75,7 @@ export function normalizeConfig(
     const normalizedModules = modules.map((m) => {
         if (!isObject(m)) {
             throw new LwcConfigError(
-                `Invalid module record. Module record has to be an object, instead got ${JSON.stringify(
+                `Invalid module record. Module record must be an object, instead got ${JSON.stringify(
                     m
                 )}.`,
                 { scope }

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -7,6 +7,8 @@
 import path from 'path';
 import fs from 'fs';
 
+import { isObject } from '@lwc/shared';
+
 import { LwcConfigError } from './errors';
 
 import {
@@ -66,12 +68,23 @@ export function getModuleEntry(
     );
 }
 
-export function normalizeConfig(config: Partial<ModuleResolverConfig>): ModuleResolverConfig {
+export function normalizeConfig(
+    config: Partial<ModuleResolverConfig>,
+    scope: string
+): ModuleResolverConfig {
     const rootDir = config.rootDir ? path.resolve(config.rootDir) : process.cwd();
     const modules = config.modules || [];
-    const normalizedModules = modules.map((m) =>
-        isDirModuleRecord(m) ? { ...m, dir: path.resolve(rootDir, m.dir) } : m
-    );
+    const normalizedModules = modules.map((m) => {
+        if (!isObject(m)) {
+            throw new LwcConfigError(
+                `Invalid module record. Module record has to be an object, instead got ${JSON.stringify(
+                    m
+                )}.`,
+                { scope }
+            );
+        }
+        return isDirModuleRecord(m) ? { ...m, dir: path.resolve(rootDir, m.dir) } : m;
+    });
 
     return {
         modules: normalizedModules,

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -7,10 +7,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import { isObject } from '@lwc/shared';
-
 import { LwcConfigError } from './errors';
-
 import {
     LwcConfig,
     ModuleRecord,
@@ -21,6 +18,7 @@ import {
     RegistryEntry,
     InnerResolverOptions,
 } from './types';
+import { isObject } from './shared';
 
 const PACKAGE_JSON = 'package.json';
 const LWC_CONFIG_FILE = 'lwc.config.json';


### PR DESCRIPTION
## Details
With the new module-resolver, configuration passed to module-resolver and @lwc/rollup-plugin are expected to have ModuleRecords of object type. Prior configs where the ModuleRecord was a string would through an unhandled exception.
This PR checks the type of ModuleRecord and throws an error if its invalid.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7391508
