### PR TITLE
refactor(engine): reuse existing types

### DIFF
--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -145,12 +145,14 @@ export interface LightningElementConstructor {
 export declare var LightningElement: LightningElementConstructor;
 
 type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
-    Pick<EventTarget, 'dispatchEvent' | 'addEventListener' | 'removeEventListener'> &
-    Pick<Node, 'isConnected'> &
     Pick<
-        Element,
+        HTMLElement,
+        | 'accessKey'
+        | 'addEventListener'
         | 'classList'
-        | 'id'
+        | 'dir'
+        | 'dispatchEvent'
+        | 'draggable'
         | 'getAttribute'
         | 'getAttributeNS'
         | 'getBoundingClientRect'
@@ -158,16 +160,20 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
         | 'getElementsByTagName'
         | 'hasAttribute'
         | 'hasAttributeNS'
+        | 'hidden'
+        | 'id'
+        | 'isConnected'
+        | 'lang'
         | 'querySelector'
         | 'querySelectorAll'
         | 'removeAttribute'
         | 'removeAttributeNS'
+        | 'removeEventListener'
         | 'setAttribute'
         | 'setAttributeNS'
-    > &
-    Pick<
-        HTMLElement,
-        'accessKey' | 'dir' | 'draggable' | 'hidden' | 'lang' | 'spellcheck' | 'tabIndex' | 'title'
+        | 'spellcheck'
+        | 'tabIndex'
+        | 'title'
     >;
 
 interface AccessibleElementTheGoodParts {

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -176,6 +176,8 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
         | 'title'
     >;
 
+// Defined separately from HTMLElementTheGoodParts because, as of May 2020, the typescript interface
+// for Element does not include these
 interface AccessibleElementTheGoodParts {
     ariaActiveDescendant: string | null;
     ariaAtomic: string | null;

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -301,7 +301,9 @@ BaseLightningElementConstructor.prototype = {
         return elm.dispatchEvent.apply(elm, arguments);
     },
     addEventListener(
-        ...[type, listener, options]: Parameters<typeof EventTarget.prototype.addEventListener>
+        type: string,
+        listener: EventListener,
+        options?: boolean | AddEventListenerOptions
     ) {
         const vm = getAssociatedVM(this);
         if (process.env.NODE_ENV !== 'production') {
@@ -323,7 +325,9 @@ BaseLightningElementConstructor.prototype = {
         vm.elm.addEventListener(type, wrappedListener, options);
     },
     removeEventListener(
-        ...[type, listener, options]: Parameters<typeof EventTarget.prototype.addEventListener>
+        type: string,
+        listener: EventListener,
+        options?: boolean | AddEventListenerOptions
     ) {
         const vm = getAssociatedVM(this);
         const wrappedListener = getWrappedComponentsListener(vm, listener as EventListener);
@@ -341,7 +345,7 @@ BaseLightningElementConstructor.prototype = {
         // @ts-ignore type-mismatch
         return elm.hasAttributeNS.apply(elm, arguments);
     },
-    removeAttribute(...[attrName]: Parameters<typeof Element.prototype.removeAttribute>) {
+    removeAttribute(attrName: string) {
         const elm = getLinkedElement(this);
         unlockAttribute(elm, attrName);
         // Typescript does not like it when you treat the `arguments` object as an array
@@ -349,7 +353,7 @@ BaseLightningElementConstructor.prototype = {
         elm.removeAttribute.apply(elm, arguments);
         lockAttribute(elm, attrName);
     },
-    removeAttributeNS(...[_ns, attrName]: Parameters<typeof Element.prototype.removeAttributeNS>) {
+    removeAttributeNS(_namespace: string | null, attrName: string) {
         const elm = getLinkedElement(this);
         unlockAttribute(elm, attrName);
         // Typescript does not like it when you treat the `arguments` object as an array
@@ -369,7 +373,7 @@ BaseLightningElementConstructor.prototype = {
         // @ts-ignore type-mismatch
         return elm.getAttributeNS.apply(elm, arguments);
     },
-    setAttribute(...[attrName]: Parameters<typeof Element.prototype.setAttribute>) {
+    setAttribute(attrName: string) {
         const elm = getLinkedElement(this);
         if (process.env.NODE_ENV !== 'production') {
             const vm = getAssociatedVM(this);
@@ -384,7 +388,7 @@ BaseLightningElementConstructor.prototype = {
         elm.setAttribute.apply(elm, arguments);
         lockAttribute(elm, attrName);
     },
-    setAttributeNS(...[_ns, attrName]: Parameters<typeof Element.prototype.setAttributeNS>) {
+    setAttributeNS(_namespace: string | null, attrName: string) {
         const elm = getLinkedElement(this);
         if (process.env.NODE_ENV !== 'production') {
             const vm = getAssociatedVM(this);


### PR DESCRIPTION
## Details

Use typescript utility methods to reuse existing types.

These changes came about from the discussion in https://github.com/salesforce/lwc/pull/1847

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7391508