### PR TITLE
fix(engine): throw when unmounting malformed component

### DIFF
--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -459,20 +459,24 @@ function runDisconnectedCallback(vm: VM) {
 function runShadowChildNodesDisconnectedCallback(vm: VM) {
     const { velements: vCustomElementCollection } = vm;
 
-    // Reporting disconnection for every child in inverse order since they are inserted in reserved order.
+    // Reporting disconnection for every child in inverse order since they are
+    // inserted in reserved order.
     for (let i = vCustomElementCollection.length - 1; i >= 0; i -= 1) {
         const { elm } = vCustomElementCollection[i];
 
         // There are two cases where the element could be undefined:
-        // * when there is an error during the construction phase, and an error boundary picks it, there is a
-        //   possibility that the VCustomElement is not properly initialized, and therefore is should be ignored.
-        // * when slotted custom element is not used by the element where it is slotted into it, as a result, the custom
-        //    element was never initialized.
+        // * when there is an error during the construction phase, and an error
+        //   boundary picks it, there is a possibility that the VCustomElement
+        //   is not properly initialized, and therefore is should be ignored.
+        // * when slotted custom element is not used by the element where it is
+        //   slotted into it, as  a result, the custom element was never
+        //   initialized.
         if (!isUndefined(elm)) {
             const childVM = getAssociatedVMIfPresent(elm);
 
-            // [W-6981076] The VM associated with the element might be associated undefined in the case where the VM
-            // failed in the middle of its creation, eg: constructor throwing before invoking super().
+            // The VM associated with the element might be associated undefined
+            // in the case where the VM failed in the middle of its creation,
+            // eg: constructor throwing before invoking super().
             if (!isUndefined(childVM)) {
                 resetComponentStateWhenRemoved(childVM);
             }

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -458,18 +458,24 @@ function runDisconnectedCallback(vm: VM) {
 
 function runShadowChildNodesDisconnectedCallback(vm: VM) {
     const { velements: vCustomElementCollection } = vm;
-    // reporting disconnection for every child in inverse order since they are inserted in reserved order
+
+    // Reporting disconnection for every child in inverse order since they are inserted in reserved order.
     for (let i = vCustomElementCollection.length - 1; i >= 0; i -= 1) {
-        const elm = vCustomElementCollection[i].elm;
+        const { elm } = vCustomElementCollection[i];
+
         // There are two cases where the element could be undefined:
-        // * when there is an error during the construction phase, and an
-        //   error boundary picks it, there is a possibility that the VCustomElement
-        //   is not properly initialized, and therefore is should be ignored.
-        // * when slotted custom element is not used by the element where it is slotted
-        //   into it, as a result, the custom element was never initialized.
+        // * when there is an error during the construction phase, and an error boundary picks it, there is a
+        //   possibility that the VCustomElement is not properly initialized, and therefore is should be ignored.
+        // * when slotted custom element is not used by the element where it is slotted into it, as a result, the custom
+        //    element was never initialized.
         if (!isUndefined(elm)) {
-            const childVM = getAssociatedVM(elm);
-            resetComponentStateWhenRemoved(childVM);
+            const childVM = getAssociatedVMIfPresent(elm);
+
+            // [W-6981076] The VM associated with the element might be associated undefined in the case where the VM
+            // failed in the middle of its creation, eg: constructor throwing before invoking super().
+            if (!isUndefined(childVM)) {
+                resetComponentStateWhenRemoved(childVM);
+            }
         }
     }
 }

--- a/packages/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement/index.spec.js
@@ -3,6 +3,7 @@ import { createElement } from 'lwc';
 
 import NotInvokingSuper from 'x/notInvokingSuper';
 import NotReturningThis from 'x/notReturningThis';
+import ParentThrowingBeforeSuper from 'x/parentThrowingBeforeSuper';
 
 it('should throw when trying to invoke the constructor manually', () => {
     expect(() => {
@@ -43,4 +44,11 @@ it('should fail when the constructor return an instance of LightningElement', ()
         TypeError,
         'Invalid component constructor, the class should extend LightningElement.'
     );
+});
+
+it("[W-6981076] shouldn't throw when a component with an invalid child in unmounted", () => {
+    const elm = createElement('x-parent-throwing-before-super', { is: ParentThrowingBeforeSuper });
+
+    expect(() => document.body.appendChild(elm)).toThrowError(/Throwing before calling super/);
+    expect(() => document.body.removeChild(elm)).not.toThrow();
 });

--- a/packages/integration-karma/test/component/LightningElement/x/childThrowingBeforeSuper/childThrowingBeforeSuper.js
+++ b/packages/integration-karma/test/component/LightningElement/x/childThrowingBeforeSuper/childThrowingBeforeSuper.js
@@ -1,0 +1,10 @@
+import { LightningElement } from 'lwc';
+
+export default class ChildThrowingBeforeSuper extends LightningElement {
+    constructor() {
+        throw new Error('Throwing before calling super');
+
+        // eslint-disable-next-line no-unreachable
+        super();
+    }
+}

--- a/packages/integration-karma/test/component/LightningElement/x/parentThrowingBeforeSuper/parentThrowingBeforeSuper.html
+++ b/packages/integration-karma/test/component/LightningElement/x/parentThrowingBeforeSuper/parentThrowingBeforeSuper.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child-throwing-before-super></x-child-throwing-before-super>
+</template>

--- a/packages/integration-karma/test/component/LightningElement/x/parentThrowingBeforeSuper/parentThrowingBeforeSuper.js
+++ b/packages/integration-karma/test/component/LightningElement/x/parentThrowingBeforeSuper/parentThrowingBeforeSuper.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class ParentThrowingBeforeSuper extends LightningElement {}


### PR DESCRIPTION
## Details

This PR fixes a bug where the engine was throwing when attempting to unmount a malformed component. It is expected from the engine that even if a component is in an invalid state it should be unmounted and recreated safely.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-6981076
