### PR TITLE
fix(wire-service): legacy adapters initial config invoked incorrectly

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -130,7 +130,6 @@ describe('Implicit mode', () => {
                       static: {
                         id: 1
                       },
-                      hasParams: false,
                       config: function($cmp) {
                         return {
                           id: 1

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -61,7 +61,6 @@ describe('observed fields', () => {
                   wire: {
                     wiredProp: {
                       adapter: createElement,
-                      hasParams: false,
                       config: function($cmp) {
                         return {};
                       }
@@ -119,7 +118,6 @@ describe('observed fields', () => {
                   wire: {
                     function: {
                       adapter: createElement,
-                      hasParams: false,
                       config: function($cmp) {
                          return {};
                       }
@@ -312,7 +310,6 @@ describe('observed fields', () => {
                     wire: {
                       wiredProp: {
                         adapter: createElement,
-                        hasParams: false,
                         config: function($cmp) {
                           return {};
                         }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -41,7 +41,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed", "array"],
@@ -94,7 +93,6 @@ describe('Transform property', () => {
                       static: {
                         key1: importedValue
                       },
-                      hasParams: false,
                       config: function($cmp) {
                         return {
                           key1: importedValue
@@ -147,7 +145,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         let v2 = $cmp.p1;
@@ -203,7 +200,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         return {
@@ -264,7 +260,6 @@ describe('Transform property', () => {
                         key3: "fixed",
                         key4: ["fixed", "array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key3: "fixed",
@@ -356,7 +351,6 @@ describe('Transform property', () => {
                       adapter: getFoo,
                       params: {},
                       static: {},
-                      hasParams: false,
                       config: function($cmp) {
                         return {};
                       }
@@ -401,7 +395,6 @@ describe('Transform property', () => {
                     adapter: Foo.Bar,
                     params: {},
                     static: {},
-                    hasParams: false,
                     config: function($cmp) {
                       return {};
                     }
@@ -446,7 +439,6 @@ describe('Transform property', () => {
                   adapter: Foo.Bar,
                   params: {},
                   static: {},
-                  hasParams: false,
                   config: function($cmp) {
                     return {};
                   }
@@ -511,7 +503,6 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          hasParams: false,
                           config: function($cmp) {
                             return {};
                           }
@@ -628,7 +619,6 @@ describe('Transform property', () => {
                             key2: "p1.p2"
                           },
                           static: {},
-                          hasParams: true,
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             let v2 = $cmp.p1;
@@ -683,7 +673,6 @@ describe('Transform property', () => {
                           static: {
                             key2: ["fixed", "array"]
                           },
-                          hasParams: true,
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             return {
@@ -788,7 +777,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["fixed"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],
@@ -804,7 +792,6 @@ describe('Transform property', () => {
                       static: {
                         key2: ["array"]
                       },
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["array"],
@@ -858,7 +845,6 @@ describe('Transform method', () => {
                         key2: ["fixed"]
                       },
                       method: 1,
-                      hasParams: true,
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -168,12 +168,6 @@ function buildWireConfigValue(t, wiredValues) {
                 wireConfig.push(t.objectProperty(t.identifier('method'), t.numericLiteral(1)));
             }
 
-            wireConfig.push(
-                t.objectProperty(
-                    t.identifier('hasParams'),
-                    t.booleanLiteral(!!wiredValue.params && wiredValue.params.length > 0)
-                )
-            );
             wireConfig.push(getGeneratedConfig(t, wiredValue));
 
             return t.objectProperty(

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -217,7 +217,9 @@ export function registerDecorators(
     }
     if (!isUndefined(wire)) {
         for (const fieldOrMethodName in wire) {
-            const { adapter, method, config: configCallback, params = {} } = wire[fieldOrMethodName];
+            const { adapter, method, config: configCallback, params = {} } = wire[
+                fieldOrMethodName
+            ];
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
             if (method === 1) {
                 if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -14,6 +14,7 @@ import {
     getOwnPropertyDescriptor,
     toString,
     isFalse,
+    keys,
 } from '@lwc/shared';
 import { ComponentConstructor } from '../component';
 import { internalWireFieldDecorator } from './wire';
@@ -48,7 +49,7 @@ interface WireCompilerDef {
     method?: number;
     adapter: WireAdapterConstructor;
     config: ConfigCallback;
-    hasParams: boolean;
+    params?: Record<string, any>;
 }
 interface RegisterDecoratorMeta {
     readonly publicMethods?: MethodCompilerMeta;
@@ -216,7 +217,7 @@ export function registerDecorators(
     }
     if (!isUndefined(wire)) {
         for (const fieldOrMethodName in wire) {
-            const { adapter, method, config: configCallback, hasParams } = wire[fieldOrMethodName];
+            const { adapter, method, config: configCallback, params = {} } = wire[fieldOrMethodName];
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
             if (method === 1) {
                 if (process.env.NODE_ENV !== 'production') {
@@ -230,7 +231,7 @@ export function registerDecorators(
                     throw new Error();
                 }
                 wiredMethods[fieldOrMethodName] = descriptor;
-                storeWiredMethodMeta(descriptor, adapter, configCallback, hasParams);
+                storeWiredMethodMeta(descriptor, adapter, configCallback, keys(params));
             } else {
                 if (process.env.NODE_ENV !== 'production') {
                     assert.isTrue(
@@ -241,7 +242,7 @@ export function registerDecorators(
                 }
                 descriptor = internalWireFieldDecorator(fieldOrMethodName);
                 wiredFields[fieldOrMethodName] = descriptor;
-                storeWiredFieldMeta(descriptor, adapter, configCallback, hasParams);
+                storeWiredFieldMeta(descriptor, adapter, configCallback, keys(params));
                 defineProperty(proto, fieldOrMethodName, descriptor);
             }
         }

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -12,6 +12,7 @@ import { invokeComponentCallback } from './invoker';
 import { dispatchEvent } from '../../dom/src/env/dom';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
+const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
 
 const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
 function noop(): void {}
@@ -106,7 +107,7 @@ function createContextWatcher(
 }
 
 function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
-    const { method, adapter, configCallback, hasParams } = wireDef;
+    const { method, adapter, configCallback, params } = wireDef;
     const { component } = vm;
     const dataCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
@@ -117,6 +118,9 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
     // Workaround to pass the component element associated to this wire adapter instance.
     defineProperty(dataCallback, DeprecatedWiredElementHost, {
         value: vm.elm,
+    });
+    defineProperty(dataCallback, DeprecatedWiredParamsMeta, {
+        value: params,
     });
 
     runWithBoundaryProtection(
@@ -151,7 +155,7 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
         updateConnectorConfig(configCallback(component));
     };
 
-    if (hasParams) {
+    if (params.length > 0) {
         // This wire has dynamic parameters: we wait for the component instance is created and its values set
         // in order to call the update(config) method.
         Promise.resolve().then(() => {
@@ -195,7 +199,7 @@ type WireAdapterSchemaValue = 'optional' | 'required';
 interface WireDef {
     method?: (data: any) => void;
     adapter: WireAdapterConstructor;
-    hasParams: boolean;
+    params: string[];
     configCallback: ConfigCallback;
 }
 
@@ -229,7 +233,7 @@ export function storeWiredMethodMeta(
     descriptor: PropertyDescriptor,
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback,
-    hasParams: boolean
+    params: string[]
 ) {
     // support for callable adapters
     if ((adapter as any).adapter) {
@@ -240,7 +244,7 @@ export function storeWiredMethodMeta(
         adapter,
         method,
         configCallback,
-        hasParams,
+        params,
     };
     WireMetaMap.set(descriptor, def);
 }
@@ -249,7 +253,7 @@ export function storeWiredFieldMeta(
     descriptor: PropertyDescriptor,
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback,
-    hasParams: boolean
+    params: string[]
 ) {
     // support for callable adapters
     if ((adapter as any).adapter) {
@@ -258,7 +262,7 @@ export function storeWiredFieldMeta(
     const def: WireFieldDef = {
         adapter,
         configCallback,
-        hasParams,
+        params,
     };
     WireMetaMap.set(descriptor, def);
 }

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -108,6 +108,7 @@ function createContextWatcher(
 
 function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
     const { method, adapter, configCallback, params } = wireDef;
+    const hasDynamicParams = params.length > 0;
     const { component } = vm;
     const dataCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
@@ -155,7 +156,7 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
         updateConnectorConfig(configCallback(component));
     };
 
-    if (params.length > 0) {
+    if (hasDynamicParams) {
         // This wire has dynamic parameters: we wait for the component instance is created and its values set
         // in order to call the update(config) method.
         Promise.resolve().then(() => {

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -98,7 +98,7 @@ function isEmptyConfig(config: Record<string, any>): boolean {
 }
 
 function isValidConfig(config: Record<string, any>, params: string[]): boolean {
-    return params.length === 0 || params.some(key => !isUndefined(config[key]));
+    return params.length === 0 || params.some((key) => !isUndefined(config[key]));
 }
 
 export class WireAdapter {

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -98,13 +98,14 @@ function isEmptyConfig(config: Record<string, any>): boolean {
 }
 
 function isValidConfig(config: Record<string, any>, params: string[]): boolean {
-    return params.length === 0 || params.some((key) => !isUndefined(config[key]));
+    // The config is valid if there is no params, or if exist a param for which config[param] !== undefined.
+    return params.length === 0 || params.some((param) => !isUndefined(config[param]));
 }
 
 export class WireAdapter {
     private callback: dataCallback;
     private readonly wiredElementHost: EventTarget;
-    private readonly wireParamsMeta: string[];
+    private readonly dynamicParamsNames: string[];
 
     private connecting: NoArgumentListener[] = [];
     private disconnecting: NoArgumentListener[] = [];
@@ -133,7 +134,7 @@ export class WireAdapter {
     constructor(callback: dataCallback) {
         this.callback = callback;
         this.wiredElementHost = callback[DeprecatedWiredElementHost];
-        this.wireParamsMeta = callback[DeprecatedWiredParamsMeta];
+        this.dynamicParamsNames = callback[DeprecatedWiredParamsMeta];
         this.eventTarget = {
             addEventListener: (type: string, listener: WireEventTargetListener): void => {
                 switch (type) {
@@ -198,7 +199,7 @@ export class WireAdapter {
             // the config on the wire adapter should not be called until one of them changes.
             this.isFirstUpdate = false;
 
-            if (!isEmptyConfig(config) && !isValidConfig(config, this.wireParamsMeta)) {
+            if (!isEmptyConfig(config) && !isValidConfig(config, this.dynamicParamsNames)) {
                 return;
             }
         }

--- a/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -19,12 +19,10 @@ describe('legacy wire adapters (register call)', () => {
             expect(calls[0]).toEqual({});
         });
 
-        // Note: In the legacy adapters with static config, this check was not enforced, they always get called.
-        // With the wire reform, this case will be treated the same as when it has dynamic($) parameters.
-        it('should not call config when all props of config config are undefined', () => {
+        it('should call config when all props of config are undefined', () => {
             const elm = createElement('x-simple-wire', { is: StaticWiredProps });
             const calls = elm.allUndefinedPropsInConfigCalls;
-            expect(calls.length).toBe(0);
+            expect(calls.length).toBe(1);
         });
 
         it('should call config when at least one prop in config is defined', () => {
@@ -92,6 +90,19 @@ describe('legacy wire adapters (register call)', () => {
                     expect(calls[0]).toEqual({ p1: undefined, p2: 'test' });
                     done();
                 }, 0);
+            }, 0);
+        });
+    });
+
+
+    describe('with dynamic and static config', () => {
+        it('should not call config when initially all props from params in config are undefined', done => {
+            const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+
+            setTimeout(() => {
+                const calls = elm.mixedAllParamsUndefinedCalls;
+                expect(calls.length).toBe(0);
+                done();
             }, 0);
         });
     });

--- a/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -94,9 +94,8 @@ describe('legacy wire adapters (register call)', () => {
         });
     });
 
-
     describe('with dynamic and static config', () => {
-        it('should not call config when initially all props from params in config are undefined', done => {
+        it('should not call config when initially all props from params in config are undefined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
 
             setTimeout(() => {

--- a/packages/integration-karma/test/wire/legacy-adapters/x/dynamicWiredProps/dynamicWiredProps.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/x/dynamicWiredProps/dynamicWiredProps.js
@@ -4,6 +4,7 @@ import { EchoWireAdapter } from 'x/echoWireAdapter';
 export default class DynamicWiredProps extends LightningElement {
     _allUndefinedConfigCalls = [];
     _someDefinedConfigCalls = [];
+    _mixedAllParamsUndefinedCalls = [];
     p1;
     p2;
     p3 = 'test';
@@ -18,12 +19,21 @@ export default class DynamicWiredProps extends LightningElement {
         this._someDefinedConfigCalls.push(providedValue);
     }
 
+    @wire(EchoWireAdapter, { p1: '$p1', p3: '$p2', staticParam: ['test'] })
+    mixedAllParamsUndefined(providedValue) {
+        this._mixedAllParamsUndefinedCalls.push(providedValue);
+    }
+
     @api get allUndefinedConfigCalls() {
         return this._allUndefinedConfigCalls;
     }
 
     @api get someDefinedConfigCalls() {
         return this._someDefinedConfigCalls;
+    }
+
+    @api get mixedAllParamsUndefinedCalls() {
+        return this._mixedAllParamsUndefinedCalls;
     }
 
     @api


### PR DESCRIPTION
## Details
This PR fixes an issue with legacy wire adapters in which adapters `config` is invoked when all the dynamic params of the config are `undefined`.

Before this PR, Legacy wire adapters with both, dynamic and static config values, are being called when all of the dynamic parameters are `undefined`, this behavior is different compared to the previous wire protocol (before wire-reform).

Some components are making extra server calls due this issue. Notice that this something that the adapter authors needs to handle once they fully adopt the wire-reform.

Example:

```js
class Foo extends LightningElement {
   customerId;

   handleSelectCustomerId(event) {
      this.customerId = event.detail.customerId;
   }

   // on first render, it will trigger a "get orders request" without customer id (for example)
   @wire(GetOrders, { customerId: '$customerId', itemsPerPage: 10 }) orders;
}
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
