### PR TITLE
fix: dedupe import statements on compilation

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -18,9 +18,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {
@@ -58,10 +57,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators2 } from "lwc";
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators2, registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Outer {
                   constructor() {
@@ -113,9 +110,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   get publicGetter() {
@@ -187,9 +183,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                    import { registerDecorators as _registerDecorators } from "lwc";
+                    import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                     import _tmpl from "./test.html";
-                    import { registerComponent as _registerComponent } from "lwc";
                     
                     class Test {
                         get first() {
@@ -245,9 +240,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                    import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                     import _tmpl from "./test.html";
-                    import { registerComponent as _registerComponent } from "lwc";
                     
                     class Test {
                     set first(value) {}
@@ -299,9 +293,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {
@@ -366,9 +359,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Text {
                   constructor() {
@@ -494,9 +486,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {
@@ -597,9 +588,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {
@@ -773,9 +763,8 @@ describe('Transform method', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   foo() {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
@@ -55,8 +55,7 @@ describe('Element import', () => {
             output: {
                 code: `
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement as Component } from "lwc";
+                import { registerComponent as _registerComponent, LightningElement as Component } from "lwc";
 
                 class Test extends Component {}
 
@@ -112,9 +111,7 @@ describe('Element import', () => {
             },
         }
     );
-});
 
-describe('render method', () => {
     pluginTest(
         'inject render method',
         `
@@ -125,8 +122,7 @@ describe('render method', () => {
             output: {
                 code: `
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
+                import { registerComponent as _registerComponent, LightningElement } from "lwc";
 
                 class Test extends LightningElement {}
 
@@ -173,8 +169,7 @@ describe('render method', () => {
             output: {
                 code: `
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
+                import { registerComponent as _registerComponent, LightningElement } from "lwc";
 
                 class Test extends LightningElement {
                   render() {}
@@ -192,17 +187,14 @@ describe('render method', () => {
         'only inject render in the exported class',
         `
         import { LightningElement } from 'lwc';
-
         class Test1 extends LightningElement {}
-
         export default class Test2 extends LightningElement {}
     `,
         {
             output: {
                 code: `
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
+                import { registerComponent as _registerComponent, LightningElement } from "lwc";
 
                 class Test1 extends LightningElement {}
 

--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -18,8 +18,7 @@ describe('Transforms', () => {
             output: {
                 code: `
             import _tmpl from "./test.html";
-            import { registerComponent as _registerComponent } from "lwc";
-            import { LightningElement } from "lwc";
+            import { registerComponent as _registerComponent, LightningElement } from "lwc";
             export default _registerComponent(class extends LightningElement {}, {
               tmpl: _tmpl
             });
@@ -37,10 +36,8 @@ describe('Transforms', () => {
         {
             output: {
                 code: `
-            import { registerDecorators as _registerDecorators } from "lwc";
+            import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
             import _tmpl from "./test.html";
-            import { registerComponent as _registerComponent } from "lwc";
-            import { LightningElement } from "lwc";
 
             class Test extends LightningElement {
               constructor(...args) {
@@ -109,10 +106,8 @@ describe('Implicit mode', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
                 import { getRecord } from "recordDataService";
 
                 class Test extends LightningElement {
@@ -159,10 +154,8 @@ describe('Implicit mode', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
 
                 class Test extends LightningElement {
                   constructor(...args) {
@@ -198,10 +191,8 @@ describe('Implicit mode', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { LightningElement } from "lwc";
 
                 class Test extends mixin(LightningElement) {
                   constructor(...args) {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -31,10 +31,8 @@ describe('observed fields', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import {  registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { createElement } from "lwc";
 
                 class Test {
                   constructor() {
@@ -96,10 +94,8 @@ describe('observed fields', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { createElement } from "lwc";
                 
                 class Test {
                   constructor() {
@@ -153,10 +149,8 @@ describe('observed fields', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { createElement } from "lwc";
                 const PREFIX = "prefix";
                 
                 class Test {
@@ -192,10 +186,8 @@ describe('observed fields', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { createElement } from "lwc";
                 
                 class Test {
                   constructor() {
@@ -283,9 +275,7 @@ describe('observed fields', () => {
             output: {
                 code: `
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
-                import { registerDecorators as _registerDecorators } from "lwc";
-                import { createElement } from "lwc";
+                import { registerComponent as _registerComponent, registerDecorators as _registerDecorators, createElement } from "lwc";
                 
                 const Test = _registerDecorators(
                   class {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
@@ -18,9 +18,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {
@@ -55,9 +54,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
 
                 class Test {
                   constructor() {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -20,9 +20,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -74,9 +73,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import importedValue from "ns/module";
                 import { getFoo } from "data-service";
                 
@@ -125,9 +123,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -182,9 +179,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -241,9 +237,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -339,9 +334,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -384,9 +378,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-              import { registerDecorators as _registerDecorators } from "lwc";
+              import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
               import _tmpl from "./test.html";
-              import { registerComponent as _registerComponent } from "lwc";
               import { Foo } from "data-service";
 
               class Test {
@@ -429,9 +422,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-            import { registerDecorators as _registerDecorators } from "lwc";
+            import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
             import _tmpl from "./test.html";
-            import { registerComponent as _registerComponent } from "lwc";
             import { Foo } from "data-service";
 
             class Test {
@@ -496,9 +488,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                    import { registerDecorators as _registerDecorators } from "lwc";
+                    import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                     import _tmpl from "./test.html";
-                    import { registerComponent as _registerComponent } from "lwc";
                     import { getFoo } from "data-service";
 
                     class Test {
@@ -608,9 +599,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                    import { registerDecorators as _registerDecorators } from "lwc";
+                    import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                     import _tmpl from "./test.html";
-                    import { registerComponent as _registerComponent } from "lwc";
                     import { getFoo } from "data-service";
 
                     class Test {
@@ -662,9 +652,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                    import { registerDecorators as _registerDecorators } from "lwc";
+                    import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                     import _tmpl from "./test.html";
-                    import { registerComponent as _registerComponent } from "lwc";
                     import { getFoo } from "data-service";
 
                     class Test {
@@ -766,9 +755,8 @@ describe('Transform property', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {
@@ -838,9 +826,8 @@ describe('Transform method', () => {
         {
             output: {
                 code: `
-                import { registerDecorators as _registerDecorators } from "lwc";
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent } from "lwc";
                 import { getFoo } from "data-service";
 
                 class Test {

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 module.exports = function dedupeImports(path) {
     const body = path.get('body');
     const importStatements = body.filter((s) => s.isImportDeclaration());

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -1,0 +1,15 @@
+module.exports = function dedupeImports(path) {
+    const body = path.get('body');
+    const importStatements = body.filter((s) => s.isImportDeclaration());
+    const visited = new Map();
+    importStatements.forEach((importPath) => {
+        const sourceLiteral = importPath.node.source;
+        if (visited.has(sourceLiteral.value)) {
+            const visitedImport = visited.get(sourceLiteral.value);
+            visitedImport.node.specifiers.push(...importPath.node.specifiers);
+            importPath.remove();
+        } else {
+            visited.set(sourceLiteral.value, importPath);
+        }
+    });
+};

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -4,16 +4,43 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-module.exports = function dedupeImports(path) {
+
+function defaultImport(t, specifiers) {
+    const defaultImport = specifiers.find((s) => t.isImportDefaultSpecifier(s));
+    return defaultImport && defaultImport.local.name;
+}
+
+module.exports = function dedupeImports({ types: t }, path) {
     const body = path.get('body');
     const importStatements = body.filter((s) => s.isImportDeclaration());
     const visited = new Map();
+
     importStatements.forEach((importPath) => {
         const sourceLiteral = importPath.node.source;
+        // If we have seen the same source, we will try to dedupe it
         if (visited.has(sourceLiteral.value)) {
             const visitedImport = visited.get(sourceLiteral.value);
-            visitedImport.node.specifiers.push(...importPath.node.specifiers);
-            importPath.remove();
+            const visitedSpecifiers = visitedImport.node.specifiers;
+            const visitedDefaultImport = defaultImport(t, visitedSpecifiers);
+
+            // We merge all the named imports unless is a default with the same name
+            let canImportBeRemoved = true;
+            importPath.node.specifiers.forEach((s) => {
+                if (visitedDefaultImport && t.isImportDefaultSpecifier(s)) {
+                    if (visitedDefaultImport !== s.local.name) {
+                        canImportBeRemoved = false;
+                    }
+                } else {
+                    visitedSpecifiers.push(s);
+                }
+            });
+
+            if (canImportBeRemoved) {
+                importPath.remove();
+            }
+
+            // We need to sort the imports due to a bug in babel where default must be first
+            visitedSpecifiers.sort((a) => (t.isImportDefaultSpecifier(a) ? -1 : 1));
         } else {
             visited.set(sourceLiteral.value, importPath);
         }

--- a/packages/@lwc/babel-plugin-component/src/post-process/index.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/index.js
@@ -5,4 +5,5 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const transform = require('./transform');
-module.exports = { transform };
+const dedupeImports = require('./dedupe-imports');
+module.exports = { transform, dedupeImports };

--- a/packages/@lwc/babel-plugin-component/src/program.js
+++ b/packages/@lwc/babel-plugin-component/src/program.js
@@ -6,7 +6,7 @@
  */
 const classProperty = require('@babel/plugin-proposal-class-properties')['default'];
 const { invalidDecorators } = require('./decorators');
-const { transform: postProcess } = require('./post-process');
+const { transform: postProcess, dedupeImports } = require('./post-process');
 
 function exit(api) {
     return {
@@ -23,6 +23,7 @@ function exit(api) {
                 ]);
 
                 path.traverse(visitors, state);
+                dedupeImports(path);
             },
         },
     };

--- a/packages/@lwc/babel-plugin-component/src/program.js
+++ b/packages/@lwc/babel-plugin-component/src/program.js
@@ -23,7 +23,7 @@ function exit(api) {
                 ]);
 
                 path.traverse(visitors, state);
-                dedupeImports(path);
+                dedupeImports(api, path);
             },
         },
     };

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -23,8 +23,7 @@ it('should apply transformation for valid javascript file', async () => {
 
     const expected = `
         import _tmpl from "./foo.html";
-        import { registerComponent as _registerComponent } from "lwc";
-        import { LightningElement } from 'lwc';
+        import { registerComponent as _registerComponent, LightningElement } from "lwc";
         class Foo extends LightningElement {}
         export default _registerComponent(Foo, {
             tmpl: _tmpl

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -101,7 +101,6 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
             if (!filter(id)) {
                 return;
             }
-
             // If we don't find the moduleId, just resolve the module name/namespace
             const moduleEntry = getModuleQualifiedName(id, mergedPluginOptions);
 


### PR DESCRIPTION
## Details

Each of the internal transforms on the compiler might add a named import from "lwc", which makes duplicated entries on the final output. While this ends up being tree-shaked by rollup, its just unnecessary work an problematic when dealing with raw ES6 modules.

This PR dedupes any named import from the same source specifier.

Before we output this:
```js
import { registerDecorators as _registerDecorators } from "lwc";
import { registerComponent as _registerComponent } from "lwc";
```

Now we output this:
```js
import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
```

Note that this is not really for user land code, since we already have linting rules, but rather to the internals of our transforms.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
