### PR TITLE
fix(wire-service): legacy adapters config calls with same config

### DIFF
--- a/packages/@lwc/wire-service/src/__tests__/index.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/index.spec.ts
@@ -140,6 +140,7 @@ describe('WireEventTarget from register', () => {
                 dispatchEvent: jest.fn(),
             };
             dataCallback.$$DeprecatedWiredElementHostKey$$ = wiredElementMock;
+            dataCallback.$$DeprecatedWiredParamsMetaKey$$ = [];
             const adapterFactory = (wireEvtTarget: WireEventTarget) =>
                 (wireEventTarget = wireEvtTarget);
 
@@ -213,7 +214,10 @@ describe('WireEventTarget from register', () => {
                     (wireEventTarget = wireEvtTarget);
 
                 register(adapterId, adapterFactory);
-                const adapter = new adapterId.adapter(() => {});
+
+                const dataCallback = jest.fn();
+                dataCallback.$$DeprecatedWiredParamsMetaKey$$ = [];
+                const adapter = new adapterId.adapter(dataCallback);
 
                 const listener = jest.fn();
                 wireEventTarget.addEventListener(eventType, listener);

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -102,6 +102,14 @@ function isValidConfig(config: Record<string, any>, params: string[]): boolean {
     return params.length === 0 || params.some((param) => !isUndefined(config[param]));
 }
 
+function isDifferentConfig(
+    newConfig: Record<string, any>,
+    oldConfig: Record<string, any>,
+    params: string[]
+) {
+    return params.some((param) => newConfig[param] !== oldConfig[param]);
+}
+
 export class WireAdapter {
     private callback: dataCallback;
     private readonly wiredElementHost: EventTarget;
@@ -204,10 +212,15 @@ export class WireAdapter {
             }
         }
 
-        this.currentConfig = config;
-        forEach.call(this.configuring, (listener) => {
-            listener.call(undefined, config);
-        });
+        if (
+            isUndefined(this.currentConfig) ||
+            isDifferentConfig(config, this.currentConfig, this.dynamicParamsNames)
+        ) {
+            this.currentConfig = config;
+            forEach.call(this.configuring, (listener) => {
+                listener.call(undefined, config);
+            });
+        }
     }
 
     connect() {

--- a/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -2,6 +2,7 @@ import { createElement } from 'lwc';
 
 import StaticWiredProps from 'x/staticWiredProps';
 import DynamicWiredProps from 'x/dynamicWiredProps';
+import SameConfigCase from 'x/sameConfigCase';
 
 describe('legacy wire adapters (register call)', () => {
     describe('with static config', () => {
@@ -102,6 +103,64 @@ describe('legacy wire adapters (register call)', () => {
                 const calls = elm.mixedAllParamsUndefinedCalls;
                 expect(calls.length).toBe(0);
                 done();
+            }, 0);
+        });
+
+        // This following 2 test cases can occur in two scenarios:
+        // 1. Because a config param depends on multiple values, some of them change but generates the same config value
+        // 2. An issue presented today with the @api decorator, in which whenever the api property is set,
+        //    it will force the reactivity system to notify it as a mutation on the component.
+        //
+        // With the current wire protocol:
+        // Case 1) is valid for new wire adapters and should be handled at the adapter level.
+        // Case 2) is a loophole in the engine today, but it can be closed without the risk of compromising existing components.
+        //
+        // With the previous wire protocol:
+        // 1) was not possible to reproduce, a config param could only depend on one property from the component, and since
+        //    now is possible, existing adapters may behave incorrectly.
+        // 2) was handled at the wire-protocol level and existing adapters may behave incorrectly.
+        it('should not call config when the generated config is the same as the last one (case 1)', (done) => {
+            const elm = createElement('x-same-config', { is: SameConfigCase });
+            elm.a = 3;
+            elm.b = 2;
+
+            setTimeout(() => {
+                const firstResult = elm.resultMultipleDependenciesForConfig;
+                expect(firstResult.sum).toBe(5);
+
+                elm.a = 1;
+                elm.b = 4;
+
+                setTimeout(() => {
+                    const secondResult = elm.resultMultipleDependenciesForConfig;
+
+                    // Based on the RFC: every time that `adapter.update()` is invoked, a new config object will
+                    // be provided as a first argument, no identity is preserved in this case.
+                    expect(firstResult).toBe(secondResult);
+
+                    done();
+                });
+            });
+        });
+
+        it('should not call config when the generated config is the same as the last one (case 2)', (done) => {
+            const elm = createElement('x-same-config', { is: SameConfigCase });
+            elm.a = 3;
+
+            setTimeout(() => {
+                const firstResult = elm.resultApiValueDependency;
+                expect(firstResult.a).toBe(3);
+
+                // setting same api value
+                elm.a = 3;
+
+                setTimeout(() => {
+                    const secondResult = elm.resultApiValueDependency;
+
+                    expect(firstResult).toBe(secondResult);
+
+                    done();
+                }, 0);
             }, 0);
         });
     });

--- a/packages/integration-karma/test/wire/legacy-adapters/x/sameConfigCase/sameConfigCase.html
+++ b/packages/integration-karma/test/wire/legacy-adapters/x/sameConfigCase/sameConfigCase.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/wire/legacy-adapters/x/sameConfigCase/sameConfigCase.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/x/sameConfigCase/sameConfigCase.js
@@ -1,0 +1,25 @@
+import { LightningElement, wire, api } from 'lwc';
+import { EchoWireAdapter } from 'x/echoWireAdapter';
+
+export default class SameConfigCase extends LightningElement {
+    @api a;
+    @api b;
+
+    get sum() {
+        return (parseInt(this.a) || 0) + (parseInt(this.b) || 0);
+    }
+
+    @wire(EchoWireAdapter, { sum: '$sum', static: 1, staticComplexParam: ['a', 'b'] })
+    _resultMultipleDependenciesForConfig;
+
+    @wire(EchoWireAdapter, { a: '$a' })
+    _resultApiValueDependency;
+
+    @api get resultMultipleDependenciesForConfig() {
+        return this._resultMultipleDependenciesForConfig;
+    }
+
+    @api get resultApiValueDependency() {
+        return this._resultApiValueDependency;
+    }
+}


### PR DESCRIPTION
## Details
This PR addresses an issue in which legacy adapters config get called with the same config values.

This issue can occur in two scenarios:
1. Because a config dynamic param depends on multiple values, some of the dependencies change but generates the same config value.
2. An issue presented today with the @api decorator, in which whenever the api property is set, it will force the reactivity system to notify it as a mutation on the component, even if is the same value.

With the current wire protocol:
Case 1) is valid for new wire adapters and should be handled at the adapter level.
Case 2) is a loophole in the engine today, but it cannot be closed without the risk of compromising existing components. Also, the new wire adapters should handle this case.

With the previous wire protocol:
1) was not possible to reproduce, a config param could only depend on one property from the component, and since now is possible, existing adapters may behave incorrectly.
2) was handled at the wire-protocol level and existing adapters may behave incorrectly because they are not ready to handle this scenario.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`