### PR TITLE
fix(wire-service): reduce compiled component code

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -121,7 +121,7 @@ describe('Implicit mode', () => {
                   wire: {
                     recordData: {
                       adapter: getRecord,
-                      params: [],
+                      dynamic: [],
                       config: function($cmp) {
                         return {
                           id: 1

--- a/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/implicit-explicit.spec.js
@@ -121,10 +121,7 @@ describe('Implicit mode', () => {
                   wire: {
                     recordData: {
                       adapter: getRecord,
-                      params: {},
-                      static: {
-                        id: 1
-                      },
+                      params: [],
                       config: function($cmp) {
                         return {
                           id: 1

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -34,12 +34,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1"
-                      },
-                      static: {
-                        key2: ["fixed", "array"]
-                      },
+                      params: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["fixed", "array"],
@@ -87,10 +82,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {},
-                      static: {
-                        key1: importedValue
-                      },
+                      params: [],
                       config: function($cmp) {
                         return {
                           key1: importedValue
@@ -135,13 +127,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1.prop2",
-                        key3: "p1.p2"
-                      },
-                      static: {
-                        key2: ["fixed", "array"]
-                      },
+                      params: ["key1","key3"],
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         let v2 = $cmp.p1;
@@ -190,12 +176,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1.prop2.prop3.prop4"
-                      },
-                      static: {
-                        key2: ["fixed", "array"]
-                      },
+                      params: ["key1"],
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         return {
@@ -247,20 +228,59 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop",
-                        key2: "prop"
-                      },
-                      static: {
-                        key3: "fixed",
-                        key4: ["fixed", "array"]
-                      },
+                      params: ["key1","key2"],
                       config: function($cmp) {
                         return {
                           key3: "fixed",
                           key4: ["fixed", "array"],
                           key1: $cmp.prop,
                           key2: $cmp.prop
+                        };
+                      }
+                    }
+                  }
+                });
+
+                export default _registerComponent(Test, {
+                  tmpl: _tmpl
+                });
+`,
+            },
+        }
+    );
+
+    pluginTest(
+        'transforms object properties as string literal',
+        `
+        import { wire } from 'lwc';
+        import { getFoo } from 'data-service';
+        export default class Test {
+            @wire(getFoo, { "key 1": "$prop", "key 2": ["fixed", 'array']})
+            wiredProp;
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+                import _tmpl from "./test.html";
+                import { getFoo } from "data-service";
+
+                class Test {
+                  constructor() {
+                    this.wiredProp = void 0;
+                  }
+                }
+
+                _registerDecorators(Test, {
+                  wire: {
+                    wiredProp: {
+                      adapter: getFoo,
+                      params: ["key 1"],
+                      config: function($cmp) {
+                        return {
+                          "key 2": ["fixed", "array"],
+                          "key 1": $cmp.prop,
                         };
                       }
                     }
@@ -343,8 +363,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: {},
-                      static: {},
+                      params: [],
                       config: function($cmp) {
                         return {};
                       }
@@ -386,8 +405,7 @@ describe('Transform property', () => {
                 wire: {
                   wiredProp: {
                     adapter: Foo.Bar,
-                    params: {},
-                    static: {},
+                    params: [],
                     config: function($cmp) {
                       return {};
                     }
@@ -429,8 +447,7 @@ describe('Transform property', () => {
               wire: {
                 wiredProp: {
                   adapter: Foo.Bar,
-                  params: {},
-                  static: {},
+                  params: [],
                   config: function($cmp) {
                     return {};
                   }
@@ -604,11 +621,7 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          params: {
-                            key1: "prop1.a b",
-                            key2: "p1.p2"
-                          },
-                          static: {},
+                          params: ["key1","key2"],
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             let v2 = $cmp.p1;
@@ -656,12 +669,7 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          params: {
-                            key1: "prop1..prop2"
-                          },
-                          static: {
-                            key2: ["fixed", "array"]
-                          },
+                          params: ["key1"],
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             return {
@@ -759,12 +767,7 @@ describe('Transform property', () => {
                   wire: {
                     wired1: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1"
-                      },
-                      static: {
-                        key2: ["fixed"]
-                      },
+                      params: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],
@@ -774,12 +777,7 @@ describe('Transform property', () => {
                     },
                     wired2: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1"
-                      },
-                      static: {
-                        key2: ["array"]
-                      },
+                      params: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["array"],
@@ -825,12 +823,7 @@ describe('Transform method', () => {
                   wire: {
                     wiredMethod: {
                       adapter: getFoo,
-                      params: {
-                        key1: "prop1"
-                      },
-                      static: {
-                        key2: ["fixed"]
-                      },
+                      params: ["key1"],
                       method: 1,
                       config: function($cmp) {
                         return {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/wire-decorator.spec.js
@@ -34,7 +34,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: ["key1"],
+                      dynamic: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["fixed", "array"],
@@ -82,7 +82,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: [],
+                      dynamic: [],
                       config: function($cmp) {
                         return {
                           key1: importedValue
@@ -127,7 +127,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: ["key1","key3"],
+                      dynamic: ["key1","key3"],
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         let v2 = $cmp.p1;
@@ -176,7 +176,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: ["key1"],
+                      dynamic: ["key1"],
                       config: function($cmp) {
                         let v1 = $cmp.prop1;
                         return {
@@ -228,7 +228,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: ["key1","key2"],
+                      dynamic: ["key1","key2"],
                       config: function($cmp) {
                         return {
                           key3: "fixed",
@@ -276,7 +276,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: ["key 1"],
+                      dynamic: ["key 1"],
                       config: function($cmp) {
                         return {
                           "key 2": ["fixed", "array"],
@@ -363,7 +363,7 @@ describe('Transform property', () => {
                   wire: {
                     wiredProp: {
                       adapter: getFoo,
-                      params: [],
+                      dynamic: [],
                       config: function($cmp) {
                         return {};
                       }
@@ -405,7 +405,7 @@ describe('Transform property', () => {
                 wire: {
                   wiredProp: {
                     adapter: Foo.Bar,
-                    params: [],
+                    dynamic: [],
                     config: function($cmp) {
                       return {};
                     }
@@ -447,7 +447,7 @@ describe('Transform property', () => {
               wire: {
                 wiredProp: {
                   adapter: Foo.Bar,
-                  params: [],
+                  dynamic: [],
                   config: function($cmp) {
                     return {};
                   }
@@ -621,7 +621,7 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          params: ["key1","key2"],
+                          dynamic: ["key1","key2"],
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             let v2 = $cmp.p1;
@@ -669,7 +669,7 @@ describe('Transform property', () => {
                       wire: {
                         wiredProp: {
                           adapter: getFoo,
-                          params: ["key1"],
+                          dynamic: ["key1"],
                           config: function($cmp) {
                             let v1 = $cmp["prop1"];
                             return {
@@ -767,7 +767,7 @@ describe('Transform property', () => {
                   wire: {
                     wired1: {
                       adapter: getFoo,
-                      params: ["key1"],
+                      dynamic: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["fixed"],
@@ -777,7 +777,7 @@ describe('Transform property', () => {
                     },
                     wired2: {
                       adapter: getFoo,
-                      params: ["key1"],
+                      dynamic: ["key1"],
                       config: function($cmp) {
                         return {
                           key2: ["array"],
@@ -823,7 +823,7 @@ describe('Transform method', () => {
                   wire: {
                     wiredMethod: {
                       adapter: getFoo,
-                      params: ["key1"],
+                      dynamic: ["key1"],
                       method: 1,
                       config: function($cmp) {
                         return {

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -153,14 +153,16 @@ function buildWireConfigValue(t, wiredValues) {
             }
 
             if (wiredValue.params) {
+                const dynamicParamNames = wiredValue.params.map(p => {
+                    return t.stringLiteral(
+                        t.isIdentifier(p.key) ? p.key.name : p.key.value
+                    );
+                });
                 wireConfig.push(
-                    t.objectProperty(t.identifier('params'), t.objectExpression(wiredValue.params))
-                );
-            }
-
-            if (wiredValue.static) {
-                wireConfig.push(
-                    t.objectProperty(t.identifier('static'), t.objectExpression(wiredValue.static))
+                    t.objectProperty(
+                        t.identifier('params'),
+                        t.arrayExpression(dynamicParamNames)
+                    )
                 );
             }
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -157,7 +157,7 @@ function buildWireConfigValue(t, wiredValues) {
                     return t.stringLiteral(t.isIdentifier(p.key) ? p.key.name : p.key.value);
                 });
                 wireConfig.push(
-                    t.objectProperty(t.identifier('params'), t.arrayExpression(dynamicParamNames))
+                    t.objectProperty(t.identifier('dynamic'), t.arrayExpression(dynamicParamNames))
                 );
             }
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.js
@@ -153,16 +153,11 @@ function buildWireConfigValue(t, wiredValues) {
             }
 
             if (wiredValue.params) {
-                const dynamicParamNames = wiredValue.params.map(p => {
-                    return t.stringLiteral(
-                        t.isIdentifier(p.key) ? p.key.name : p.key.value
-                    );
+                const dynamicParamNames = wiredValue.params.map((p) => {
+                    return t.stringLiteral(t.isIdentifier(p.key) ? p.key.name : p.key.value);
                 });
                 wireConfig.push(
-                    t.objectProperty(
-                        t.identifier('params'),
-                        t.arrayExpression(dynamicParamNames)
-                    )
+                    t.objectProperty(t.identifier('params'), t.arrayExpression(dynamicParamNames))
                 );
             }
 

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -48,7 +48,7 @@ interface WireCompilerDef {
     method?: number;
     adapter: WireAdapterConstructor;
     config: ConfigCallback;
-    params?: string[];
+    dynamic?: string[];
 }
 interface RegisterDecoratorMeta {
     readonly publicMethods?: MethodCompilerMeta;
@@ -216,7 +216,7 @@ export function registerDecorators(
     }
     if (!isUndefined(wire)) {
         for (const fieldOrMethodName in wire) {
-            const { adapter, method, config: configCallback, params = [] } = wire[
+            const { adapter, method, config: configCallback, dynamic = [] } = wire[
                 fieldOrMethodName
             ];
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
@@ -232,7 +232,7 @@ export function registerDecorators(
                     throw new Error();
                 }
                 wiredMethods[fieldOrMethodName] = descriptor;
-                storeWiredMethodMeta(descriptor, adapter, configCallback, params);
+                storeWiredMethodMeta(descriptor, adapter, configCallback, dynamic);
             } else {
                 if (process.env.NODE_ENV !== 'production') {
                     assert.isTrue(
@@ -243,7 +243,7 @@ export function registerDecorators(
                 }
                 descriptor = internalWireFieldDecorator(fieldOrMethodName);
                 wiredFields[fieldOrMethodName] = descriptor;
-                storeWiredFieldMeta(descriptor, adapter, configCallback, params);
+                storeWiredFieldMeta(descriptor, adapter, configCallback, dynamic);
                 defineProperty(proto, fieldOrMethodName, descriptor);
             }
         }

--- a/packages/@lwc/engine/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine/src/framework/decorators/register.ts
@@ -14,7 +14,6 @@ import {
     getOwnPropertyDescriptor,
     toString,
     isFalse,
-    keys,
 } from '@lwc/shared';
 import { ComponentConstructor } from '../component';
 import { internalWireFieldDecorator } from './wire';
@@ -49,7 +48,7 @@ interface WireCompilerDef {
     method?: number;
     adapter: WireAdapterConstructor;
     config: ConfigCallback;
-    params?: Record<string, any>;
+    params?: string[];
 }
 interface RegisterDecoratorMeta {
     readonly publicMethods?: MethodCompilerMeta;
@@ -217,7 +216,7 @@ export function registerDecorators(
     }
     if (!isUndefined(wire)) {
         for (const fieldOrMethodName in wire) {
-            const { adapter, method, config: configCallback, params = {} } = wire[
+            const { adapter, method, config: configCallback, params = [] } = wire[
                 fieldOrMethodName
             ];
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
@@ -233,7 +232,7 @@ export function registerDecorators(
                     throw new Error();
                 }
                 wiredMethods[fieldOrMethodName] = descriptor;
-                storeWiredMethodMeta(descriptor, adapter, configCallback, keys(params));
+                storeWiredMethodMeta(descriptor, adapter, configCallback, params);
             } else {
                 if (process.env.NODE_ENV !== 'production') {
                     assert.isTrue(
@@ -244,7 +243,7 @@ export function registerDecorators(
                 }
                 descriptor = internalWireFieldDecorator(fieldOrMethodName);
                 wiredFields[fieldOrMethodName] = descriptor;
-                storeWiredFieldMeta(descriptor, adapter, configCallback, keys(params));
+                storeWiredFieldMeta(descriptor, adapter, configCallback, params);
                 defineProperty(proto, fieldOrMethodName, descriptor);
             }
         }

--- a/packages/@lwc/engine/src/framework/wiring.ts
+++ b/packages/@lwc/engine/src/framework/wiring.ts
@@ -107,8 +107,8 @@ function createContextWatcher(
 }
 
 function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
-    const { method, adapter, configCallback, params } = wireDef;
-    const hasDynamicParams = params.length > 0;
+    const { method, adapter, configCallback, dynamic } = wireDef;
+    const hasDynamicParams = dynamic.length > 0;
     const { component } = vm;
     const dataCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
@@ -121,7 +121,7 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
         value: vm.elm,
     });
     defineProperty(dataCallback, DeprecatedWiredParamsMeta, {
-        value: params,
+        value: dynamic,
     });
 
     runWithBoundaryProtection(
@@ -200,7 +200,7 @@ type WireAdapterSchemaValue = 'optional' | 'required';
 interface WireDef {
     method?: (data: any) => void;
     adapter: WireAdapterConstructor;
-    params: string[];
+    dynamic: string[];
     configCallback: ConfigCallback;
 }
 
@@ -234,7 +234,7 @@ export function storeWiredMethodMeta(
     descriptor: PropertyDescriptor,
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback,
-    params: string[]
+    dynamic: string[]
 ) {
     // support for callable adapters
     if ((adapter as any).adapter) {
@@ -245,7 +245,7 @@ export function storeWiredMethodMeta(
         adapter,
         method,
         configCallback,
-        params,
+        dynamic,
     };
     WireMetaMap.set(descriptor, def);
 }
@@ -254,7 +254,7 @@ export function storeWiredFieldMeta(
     descriptor: PropertyDescriptor,
     adapter: WireAdapterConstructor,
     configCallback: ConfigCallback,
-    params: string[]
+    dynamic: string[]
 ) {
     // support for callable adapters
     if ((adapter as any).adapter) {
@@ -263,7 +263,7 @@ export function storeWiredFieldMeta(
     const def: WireFieldDef = {
         adapter,
         configCallback,
-        params,
+        dynamic,
     };
     WireMetaMap.set(descriptor, def);
 }


### PR DESCRIPTION
## Details
Today the compiled code for a component using wire includes information that's not used by the engine, this is the `static` property and the source of value for dynamic parameters on the config. 

Example component:

```js
import { wire } from 'lwc';
import { getFoo } from 'data-service';
export default class Test {
    @wire(getFoo, { dynamicKey: "$prop", staticKey: "fixed value" })
     wiredProp;
}
```
today compiles into:
```js
// ...
_registerDecorators(Test, {
    wire: {
        wiredProp: {
            adapter: getFoo,
            static: {
                staticKey: "fixed value"
            },
            params: {
                dynamicKey: "prop"
            },
            config: function($cmp) {
                return {
                    staticKey: "fixed value",
                    dynamicKey: $cmp.prop,
                };
            }
        }
    }
});
```

This PR transforms the output of a compiled component, reducing the size of the compiled code of a component using wire by removing the `static` property and transforming the `params` into an array containing the names of dynamic parameters in the config:
```js
// ...
_registerDecorators(Test, {
    wire: {
        wiredProp: {
            adapter: getFoo,
            params: ["dynamicKey"],
            config: function($cmp) {
                return {
                    staticKey: "fixed value",
                    dynamicKey: $cmp.prop,
                };
            }
        }
    }
});
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`