### PR TITLE
fix(babel-component-plugin): handle importing the entire module contents

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const pluginTest = require('./utils/test-transform').pluginTest(require('../index'));
+
+describe('deduping imports', () => {
+    pluginTest(
+        'should handle the simple case',
+        `
+            import { foo, bar } from 'foo';
+            import { baz } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import { foo, bar, baz } from 'foo';
+                `,
+            },
+        }
+    );
+
+    pluginTest(
+        'should support importing the entire contents for a module',
+        `
+            import { foo, bar } from 'foo';
+            import * as Foo from 'foo';
+            import { baz } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import { foo, bar, baz } from 'foo';
+                import * as Foo from 'foo';
+                `,
+            },
+        }
+    );
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -62,13 +62,29 @@ describe('deduping imports', () => {
         `   import { baz } from 'foo';
             import buzz, { foo, bar } from 'foo';
             import * as Foo from 'foo';
-            
+
         `,
         {
             output: {
                 code: `
                 import buzz, { baz, foo, bar } from 'foo';
                 import * as Foo from 'foo';
+                `,
+            },
+        }
+    );
+
+    pluginTest(
+        'should handle both default and importing the entire contents for a module',
+        `
+            import defaultExport, * as name from 'foo';
+            import { baz } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import defaultExport, * as name from 'foo';
+                import { baz } from 'foo';
                 `,
             },
         }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -38,4 +38,21 @@ describe('deduping imports', () => {
             },
         }
     );
+
+    pluginTest(
+        'should support importing names and default',
+        `
+            import buzz, { foo, bar } from 'foo';
+            import * as Foo from 'foo';
+            import { baz } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import buzz, { foo, bar, baz } from 'foo';
+                import * as Foo from 'foo';
+                `,
+            },
+        }
+    );
 });

--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -55,4 +55,22 @@ describe('deduping imports', () => {
             },
         }
     );
+
+    pluginTest(
+        'should support importing names and default',
+
+        `   import { baz } from 'foo';
+            import buzz, { foo, bar } from 'foo';
+            import * as Foo from 'foo';
+            
+        `,
+        {
+            output: {
+                code: `
+                import buzz, { baz, foo, bar } from 'foo';
+                import * as Foo from 'foo';
+                `,
+            },
+        }
+    );
 });

--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -91,6 +91,23 @@ describe('deduping imports', () => {
     );
 
     pluginTest(
+        'should handle multiple defaults of the same export',
+        `
+            import defaultExport1, * as name from 'foo';
+            import defaultExport2, { foo } from 'foo';
+            import { bar as bar2 } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import defaultExport1, * as name from 'foo';
+                import defaultExport2, { foo, bar as bar2 } from 'foo';
+                `,
+            },
+        }
+    );
+
+    pluginTest(
         'should handle an alias of an export',
         `
             import { foo, bar as baz } from 'foo';

--- a/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/dedupe-imports.spec.js
@@ -89,4 +89,36 @@ describe('deduping imports', () => {
             },
         }
     );
+
+    pluginTest(
+        'should handle an alias of an export',
+        `
+            import { foo, bar as baz } from 'foo';
+            import defaultExport, * as name from 'foo';
+            import { bif } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import { foo, bar as baz, bif } from 'foo';
+                import defaultExport, * as name from 'foo';
+                `,
+            },
+        }
+    );
+
+    pluginTest(
+        'should handle multiple aliases of the same export',
+        `
+            import { foo, bar as bar1 } from 'foo';
+            import { bar as bar2 } from 'foo';
+        `,
+        {
+            output: {
+                code: `
+                import { foo, bar as bar1, bar as bar2 } from 'foo';
+                `,
+            },
+        }
+    );
 });

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -17,6 +17,12 @@ module.exports = function dedupeImports({ types: t }, path) {
 
     importStatements.forEach((importPath) => {
         const sourceLiteral = importPath.node.source;
+
+        // If the import is of the type import * as X, just ignore it since we can't dedupe
+        if (t.isImportNamespaceSpecifier(importPath.node.specifiers[0])) {
+            return;
+        }
+
         // If we have seen the same source, we will try to dedupe it
         if (visited.has(sourceLiteral.value)) {
             const visitedImport = visited.get(sourceLiteral.value);

--- a/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/dedupe-imports.js
@@ -19,7 +19,7 @@ module.exports = function dedupeImports({ types: t }, path) {
         const sourceLiteral = importPath.node.source;
 
         // If the import is of the type import * as X, just ignore it since we can't dedupe
-        if (t.isImportNamespaceSpecifier(importPath.node.specifiers[0])) {
+        if (importPath.node.specifiers.some(t.isImportNamespaceSpecifier)) {
             return;
         }
 


### PR DESCRIPTION
## Details

Handle the case where all the contents of a module is imported when deduping imports.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7258582