### PR TITLE
refactor(engine): remove dependency on Element.prototype.tagName

### DIFF
--- a/packages/@lwc/engine/dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine/dom/src/apis/create-element.ts
@@ -116,6 +116,7 @@ export function createElement(
     setElementProto(element, def);
 
     createVM(element, def, {
+        tagName: sel,
         mode: options.mode !== 'closed' ? 'open' : 'closed',
         owner: null,
         isRoot: true,

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -185,7 +185,7 @@ export function createViewModelHook(vnode: VCustomElement) {
         // to do here since this hook is called right after invoking `document.createElement`.
         return;
     }
-    const { mode, ctor, owner } = vnode;
+    const { sel, mode, ctor, owner } = vnode;
     const def = getComponentInternalDef(ctor);
     setElementProto(elm, def);
     if (isTrue(useSyntheticShadow)) {
@@ -198,6 +198,7 @@ export function createViewModelHook(vnode: VCustomElement) {
         mode,
         owner,
         isRoot: false,
+        tagName: sel,
     });
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -58,6 +58,8 @@ export enum VMState {
 }
 
 export interface UninitializedVM {
+    /** Custom element tag name */
+    readonly tagName: string;
     /** Component Element Back-pointer */
     readonly elm: HTMLElement;
     /** Component Definition */
@@ -201,6 +203,7 @@ export function createVM(
         mode: 'open' | 'closed';
         owner: VM | null;
         isRoot: boolean;
+        tagName: string;
     }
 ): VM {
     if (process.env.NODE_ENV !== 'production') {
@@ -209,7 +212,7 @@ export function createVM(
             `VM creation requires a DOM element instead of ${elm}.`
         );
     }
-    const { isRoot, mode, owner } = options;
+    const { isRoot, mode, owner, tagName } = options;
     idx += 1;
     const uninitializedVm: UninitializedVM = {
         // component creation index is defined once, and never reset, it can
@@ -222,6 +225,7 @@ export function createVM(
         mode,
         def,
         owner,
+        tagName,
         elm,
         data: EmptyObject,
         context: create(null),

--- a/packages/@lwc/engine/src/framework/wc.ts
+++ b/packages/@lwc/engine/src/framework/wc.ts
@@ -56,6 +56,7 @@ export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLE
                 mode: 'open',
                 isRoot: true,
                 owner: null,
+                tagName: this.tagName,
             });
         }
         connectedCallback() {

--- a/packages/@lwc/engine/src/shared/format.ts
+++ b/packages/@lwc/engine/src/shared/format.ts
@@ -9,13 +9,7 @@ import { isNull, ArrayJoin, ArrayPush, StringToLowerCase } from '@lwc/shared';
 import { UninitializedVM } from '../framework/vm';
 
 export function getComponentTag(vm: UninitializedVM): string {
-    // Element.prototype.tagName getter might be poisoned. We need to use a try/catch to protect the
-    // engine internal when accessing the tagName property.
-    try {
-        return `<${StringToLowerCase.call(vm.elm.tagName)}>`;
-    } catch (error) {
-        return '<invalid-tag-name>';
-    }
+    return `<${StringToLowerCase.call(vm.tagName)}>`;
 }
 
 // TODO [#1695]: Unify getComponentStack and getErrorComponentStack


### PR DESCRIPTION
## Details

This PR removes the dependency on `Element.prototype.tagName` to look up the component name. The tag name is now stored directly on the `VM`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7552459
