### PR TITLE
test(engine): Add tests for locker hooks

### DIFF
--- a/packages/integration-karma/test/integrations/locker/index.spec.js
+++ b/packages/integration-karma/test/integrations/locker/index.spec.js
@@ -1,11 +1,114 @@
 import { createElement } from 'lwc';
 
 import LockerIntegration from 'x/lockerIntegration';
+import LockerHooks, { hooks } from 'x/lockerHooks';
 
 it('should support Locker integration which uses a wrapped LightningElement base class', () => {
     const elm = createElement('x-secure-parent', { is: LockerIntegration });
     document.body.appendChild(elm);
+
     // Verifying that shadow tree was created to ensure the component class was successfully processed
     const actual = elm.querySelector('div.secure');
     expect(actual).toBeDefined();
+});
+
+describe('Locker hooks', () => {
+    const {
+        getHook: originalGetHook,
+        setHook: originalSetHook,
+        callHook: originalCallHook,
+    } = hooks;
+
+    beforeEach(() => {
+        spyOn(hooks, 'getHook').and.callThrough();
+        spyOn(hooks, 'setHook').and.callThrough();
+        spyOn(hooks, 'callHook').and.callThrough();
+    });
+
+    afterEach(() => {
+        hooks.getHook = originalGetHook;
+        hooks.setHook = originalSetHook;
+        hooks.callHook = originalCallHook;
+    });
+
+    describe('getHook', () => {
+        it('invokes getHook when reading a public property', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            elm.publicProp;
+
+            expect(hooks.getHook).toHaveBeenCalledTimes(1);
+            expect(hooks.getHook).toHaveBeenCalledWith(jasmine.any(Object), 'publicProp');
+        });
+
+        it('invokes getHook when reading a public property via an accessor', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            elm.publicAccessor;
+
+            expect(hooks.getHook).toHaveBeenCalledTimes(1);
+            expect(hooks.getHook).toHaveBeenCalledWith(jasmine.any(Object), 'publicAccessor');
+        });
+    });
+
+    describe('setHook', () => {
+        it('invokes setHook when assigning a public property', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            elm.publicProp = 1;
+
+            expect(hooks.setHook).toHaveBeenCalledTimes(1);
+            expect(hooks.setHook).toHaveBeenCalledWith(jasmine.any(Object), 'publicProp', 1);
+        });
+
+        it('invokes setHook when assigning a public property via an accessor', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            elm.publicAccessor = 1;
+
+            expect(hooks.setHook).toHaveBeenCalledTimes(1);
+            expect(hooks.setHook).toHaveBeenCalledWith(jasmine.any(Object), 'publicAccessor', 1);
+        });
+    });
+
+    describe('callHook', () => {
+        it('invokes callHook when invoking a public method', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            elm.publicMethod(1, 'foo');
+
+            expect(hooks.callHook).toHaveBeenCalledTimes(1);
+            expect(hooks.callHook).toHaveBeenCalledWith(
+                jasmine.any(Object),
+                jasmine.any(Function),
+                [1, 'foo']
+            );
+        });
+
+        it('should invoke callHook for all the lifecycle hooks', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+
+            document.body.appendChild(elm);
+            document.body.removeChild(elm);
+
+            expect(hooks.callHook).toHaveBeenCalledTimes(4);
+
+            const invokedMethods = hooks.callHook.calls.allArgs().map(([_, method]) => method.name);
+            expect(invokedMethods).toEqual([
+                'connectedCallback',
+                'render',
+                'renderedCallback',
+                'disconnectedCallback',
+            ]);
+        });
+
+        it('should invoke callHook when invoking event handlers', () => {
+            const elm = createElement('x-hooks', { is: LockerHooks });
+            document.body.appendChild(elm);
+
+            const evt = new CustomEvent('test');
+            elm.shadowRoot.querySelector('div').dispatchEvent(evt);
+
+            expect(hooks.callHook).toHaveBeenCalledWith(
+                jasmine.any(Object),
+                jasmine.any(Function),
+                [evt]
+            );
+        });
+    });
 });

--- a/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.html
+++ b/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.html
@@ -1,0 +1,3 @@
+<template>
+    <div ontest={handleTest}></div>
+</template>

--- a/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.js
+++ b/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.js
@@ -1,4 +1,5 @@
 import { LightningElement, api } from 'lwc';
+import template from './lockerHooks.html';
 
 export const hooks = {
     getHook: (target, property) => target[property],
@@ -31,6 +32,9 @@ export default class LockerHooks extends LightningElement {
     // Test lifecycle hooks
     connectedCallback() {}
     renderedCallback() {}
+    render() {
+        return template;
+    }
     disconnectedCallback() {}
 
     // Test event handler

--- a/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.js
+++ b/packages/integration-karma/test/integrations/locker/x/lockerHooks/lockerHooks.js
@@ -1,0 +1,38 @@
+import { LightningElement, api } from 'lwc';
+
+export const hooks = {
+    getHook: (target, property) => target[property],
+    setHook: (target, property, value) => (target[property] = value),
+    callHook: (target, method, args) => method.apply(target, args),
+};
+
+export default class LockerHooks extends LightningElement {
+    @api publicProp;
+
+    _privateProp;
+
+    @api
+    get publicAccessor() {
+        return this._privateProp;
+    }
+    set publicAccessor(value) {
+        this._privateProp = value;
+    }
+
+    @api
+    publicMethod(...args) {
+        return args;
+    }
+
+    constructor() {
+        super(hooks);
+    }
+
+    // Test lifecycle hooks
+    connectedCallback() {}
+    renderedCallback() {}
+    disconnectedCallback() {}
+
+    // Test event handler
+    handleTest() {}
+}


### PR DESCRIPTION
## Details

This PR is a follow up to #1892. It adds missing tests for Locker hooks into the engine.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7391508
