### PR TITLE
refactor(engine): Remove restriction coupled with engine internal

### DIFF
--- a/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -1,5 +1,4 @@
-import { LightningElement } from 'lwc';
-import { createElement } from 'lwc';
+import { createElement, LightningElement } from 'lwc';
 
 import Test from 'x/test';
 
@@ -32,7 +31,7 @@ it('should throw an error if the parameter is not an instance of Event', () => {
     }).toThrowError();
 });
 
-it('should throw when event is dispatched during construction', function () {
+it('should not throw when event is dispatched during construction', function () {
     class Test extends LightningElement {
         constructor() {
             super();
@@ -41,10 +40,7 @@ it('should throw when event is dispatched during construction', function () {
     }
     expect(() => {
         createElement('x-test', { is: Test });
-    }).toThrowErrorDev(
-        Error,
-        /this.dispatchEvent\(\) should not be called during the construction of the custom element for <x-test> because no one is listening just yet/
-    );
+    }).not.toThrow();
 });
 
 function testInvalidEvent(reason, name) {

--- a/packages/integration-karma/test/component/LightningElement.isConnected/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.isConnected/index.spec.js
@@ -44,7 +44,7 @@ describe('Basic DOM manipulation cases', () => {
 });
 
 describe('isConnected in life cycle callbacks', () => {
-    it('accessing isConnected in constructor should return false', () => {
+    it('should return false in the constructor', () => {
         let actual;
         class Test extends LightningElement {
             constructor() {
@@ -55,7 +55,7 @@ describe('isConnected in life cycle callbacks', () => {
         createElement('x-test', { is: Test });
         expect(actual).toBe(false);
     });
-    it('isConnected in connectedCallback should return true', () => {
+    it('should return true in the connectedCallback', () => {
         let actual;
         class Test extends LightningElement {
             connectedCallback() {
@@ -66,7 +66,7 @@ describe('isConnected in life cycle callbacks', () => {
         document.body.appendChild(elm);
         expect(actual).toBe(true);
     });
-    it('accessing isConnected in renderedCallback after initial insertion should return true', () => {
+    it('should return true in renderedCallback after the initial insertion', () => {
         let actual;
 
         class Test extends LightningElement {

--- a/packages/integration-karma/test/component/LightningElement.isConnected/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.isConnected/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement, LightningElement } from 'lwc';
+
 describe('Basic DOM manipulation cases', () => {
     let context;
     let elm;
@@ -43,38 +44,33 @@ describe('Basic DOM manipulation cases', () => {
 });
 
 describe('isConnected in life cycle callbacks', () => {
-    it('accessing isConnected in constructor will throw', () => {
+    it('accessing isConnected in constructor should return false', () => {
+        let actual;
         class Test extends LightningElement {
             constructor() {
                 super();
-                this.isConnected;
+                actual = this.isConnected;
             }
         }
-        expect(() => {
-            createElement('x-test', { is: Test });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this\.isConnected should not be accessed during the construction phase of the custom element <x-test>\. The value will always be false for Lightning Web Components constructed using lwc.createElement\(\)\./
-        );
-    });
-    it('accessing isConnected in renderedCallback will throw', () => {
-        class Test extends LightningElement {
-            renderedCallback() {
-                this.isConnected;
-            }
-        }
-        const elm = createElement('x-test', { is: Test });
-        expect(() => {
-            document.body.appendChild(elm);
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this\.isConnected should not be accessed during the renderedCallback of the custom element <x-test>\. The value will always be true\./
-        );
+        createElement('x-test', { is: Test });
+        expect(actual).toBe(false);
     });
     it('isConnected in connectedCallback should return true', () => {
         let actual;
         class Test extends LightningElement {
             connectedCallback() {
+                actual = this.isConnected;
+            }
+        }
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        expect(actual).toBe(true);
+    });
+    it('accessing isConnected in renderedCallback after initial insertion should return true', () => {
+        let actual;
+
+        class Test extends LightningElement {
+            renderedCallback() {
                 actual = this.isConnected;
             }
         }


### PR DESCRIPTION
## Details

In preparation for the DOM decoupling, we will need to move the restrictions to the `engine-dom` package. The main issue with moving the current restriction outside the `engine-core` is that the restriction are heavily relying on `engine-core` internals that are unsafe to expose.

This PR removes all the restrictions leveraging engine internals. Fortunately, all the restriction leveraging internals are only there to enforce best practices and can be migrated to linting rules if necessary. The rest of the restriction should be simple enough to implement without having access to the engine internals.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7552459