### PR TITLE
docs: add homepage and repository links in each package.json

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -1,6 +1,15 @@
 {
     "name": "@lwc/babel-plugin-component",
     "description": "Babel plugin to transform a LWC module",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/babel-plugin-component"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "version": "1.6.6",
     "main": "src/index.js",
     "typings": "types/index.d.ts",

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/compiler",
     "version": "1.6.6",
     "description": "LWC compiler",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/compiler"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "license": "MIT",

--- a/packages/@lwc/engine/package.json
+++ b/packages/@lwc/engine/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/engine",
     "version": "1.6.6",
     "description": "LWC Engine",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/engine"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/engine.cjs.js",
     "module": "dist/engine.js",
     "typings": "types/index.d.ts",

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/errors",
     "version": "1.6.6",
     "description": "LWC Error Utilities",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/errors"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/commonjs/index.js",
     "license": "MIT",
     "typings": "dist/types/index.d.ts",

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/features",
     "version": "1.6.6",
     "description": "LWC Features Flags",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/features"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/flags.cjs.js",
     "module": "dist/flags.js",
     "typings": "types/flags.d.ts",

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -1,6 +1,15 @@
 {
     "name": "@lwc/module-resolver",
     "description": "Resolves paths for LWC components",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/module-resolver"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "version": "1.6.6",
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/rollup-plugin",
     "version": "1.6.6",
     "description": "Rollup plugin to compile LWC",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/rollup-plugin"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "src/index.js",
     "license": "MIT",
     "scripts": {

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/shared",
     "version": "1.6.6",
     "description": "Utilities and methods that are shared across packages",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/shared"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "typings": "types/index.d.ts",

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/style-compiler",
     "version": "1.6.6",
     "description": "Transform style sheet to be consumed by the LWC engine",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/style-compiler"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "license": "MIT",
     "main": "dist/commonjs/index.js",
     "types": "dist/types/index.d.ts",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/synthetic-shadow",
     "version": "1.6.6",
     "description": "Synthetic Shadow Root for LWC",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/synthetic-shadow"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "license": "MIT",
     "main": "index.js",
     "module": "dist/synthetic-shadow.js",

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/template-compiler",
     "version": "1.6.6",
     "description": "Template compiler package",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/template-compiler"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "license": "MIT",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -2,6 +2,15 @@
     "name": "@lwc/wire-service",
     "version": "1.6.6",
     "description": "@wire service",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/@lwc/wire-service"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "license": "MIT",
     "main": "dist/wire-service.cjs.js",
     "module": "dist/wire-service.js",

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -2,6 +2,15 @@
     "name": "lwc",
     "version": "1.6.6",
     "description": "Lightning Web Components (LWC)",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc.git",
+        "directory": "packages/lwc"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc/issues"
+    },
     "main": "index.js",
     "module": "dist/engine/esm/es2017/engine.js",
     "typings": "types.d.ts",


### PR DESCRIPTION
This is important because it improves the UX on npmjs.org with a link
back to the git repository and lwc homepage.


## Details
For example, the following screenshots compare what the npm page looks like for LWC vs React. There is no way from npm to directly find more details or log bugs with the project:

![image](https://user-images.githubusercontent.com/1566869/83173069-7b503e00-a0e6-11ea-8e47-de720cb51cb0.png)

![image](https://user-images.githubusercontent.com/1566869/83173082-7ee3c500-a0e6-11ea-8c00-5e8ec6667793.png)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
<!--Work ID in text, no links -->
