### PR TITLE
refactor(engine): move common aria-related code into shared package

### DIFF
--- a/packages/@lwc/engine/dom/src/polyfills/aria-properties/main.ts
+++ b/packages/@lwc/engine/dom/src/polyfills/aria-properties/main.ts
@@ -4,65 +4,11 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { AriaPropNameToAttrNameMap, keys } from '@lwc/shared';
 import { detect } from './detect';
 import { patch } from './polyfill';
 
-// Global Aria and Role Properties derived from ARIA and Role Attributes.
-// https://wicg.github.io/aom/spec/aria-reflection.html
-export const ElementPrototypeAriaPropertyNames = [
-    'ariaAutoComplete',
-    'ariaChecked',
-    'ariaCurrent',
-    'ariaDisabled',
-    'ariaExpanded',
-    'ariaHasPopup',
-    'ariaHidden',
-    'ariaInvalid',
-    'ariaLabel',
-    'ariaLevel',
-    'ariaMultiLine',
-    'ariaMultiSelectable',
-    'ariaOrientation',
-    'ariaPressed',
-    'ariaReadOnly',
-    'ariaRequired',
-    'ariaSelected',
-    'ariaSort',
-    'ariaValueMax',
-    'ariaValueMin',
-    'ariaValueNow',
-    'ariaValueText',
-    'ariaLive',
-    'ariaRelevant',
-    'ariaAtomic',
-    'ariaBusy',
-    'ariaActiveDescendant',
-    'ariaControls',
-    'ariaDescribedBy',
-    'ariaFlowTo',
-    'ariaLabelledBy',
-    'ariaOwns',
-    'ariaPosInSet',
-    'ariaSetSize',
-    'ariaColCount',
-    'ariaColIndex',
-    'ariaDetails',
-    'ariaErrorMessage',
-    'ariaKeyShortcuts',
-    'ariaModal',
-    'ariaPlaceholder',
-    'ariaRoleDescription',
-    'ariaRowCount',
-    'ariaRowIndex',
-    'ariaRowSpan',
-    'ariaColSpan',
-    'role',
-];
-
-/**
- * Note: Attributes aria-dropeffect and aria-grabbed were deprecated in
- * ARIA 1.1 and do not have corresponding IDL attributes.
- */
+const ElementPrototypeAriaPropertyNames = keys(AriaPropNameToAttrNameMap);
 
 for (let i = 0, len = ElementPrototypeAriaPropertyNames.length; i < len; i += 1) {
     const propName = ElementPrototypeAriaPropertyNames[i];

--- a/packages/@lwc/engine/dom/src/polyfills/aria-properties/polyfill.ts
+++ b/packages/@lwc/engine/dom/src/polyfills/aria-properties/polyfill.ts
@@ -4,18 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { setAttribute, removeAttribute, getAttribute, hasAttribute } from '../../env/element';
+import { hasOwnProperty, AriaPropNameToAttrNameMap } from '@lwc/shared';
 
-// this regular expression is used to transform aria props into aria attributes because
-// that doesn't follow the regular transformation process. e.g.: `aria-labeledby` <=> `ariaLabelBy`
-const ARIA_REGEX = /^aria/;
+import { setAttribute, removeAttribute, getAttribute, hasAttribute } from '../../env/element';
 
 type NormalizedAttributeValue = string | null;
 type AriaPropMap = Record<string, NormalizedAttributeValue>;
 
 const nodeToAriaPropertyValuesMap: WeakMap<HTMLElement, AriaPropMap> = new WeakMap();
-const { hasOwnProperty } = Object.prototype;
-const { replace: StringReplace, toLowerCase: StringToLowerCase } = String.prototype;
 
 function getAriaPropertyMap(elm: HTMLElement): AriaPropMap {
     let map = nodeToAriaPropertyValuesMap.get(elm);
@@ -29,7 +25,7 @@ function getAriaPropertyMap(elm: HTMLElement): AriaPropMap {
 }
 
 function getNormalizedAriaPropertyValue(value: any): NormalizedAttributeValue {
-    return value == null ? null : value + '';
+    return value == null ? null : String(value);
 }
 
 function createAriaPropertyPropertyDescriptor(
@@ -69,8 +65,7 @@ export function patch(propName: string) {
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
     // @ts-ignore type-mismatch
-    const replaced = StringReplace.call(propName, ARIA_REGEX, 'aria-');
-    const attrName = StringToLowerCase.call(replaced);
+    const attrName = AriaPropNameToAttrNameMap[propName];
     const descriptor = createAriaPropertyPropertyDescriptor(propName, attrName);
     Object.defineProperty(Element.prototype, propName, descriptor);
 }

--- a/packages/@lwc/engine/src/framework/attributes.ts
+++ b/packages/@lwc/engine/src/framework/attributes.ts
@@ -9,7 +9,8 @@ import {
     create,
     forEach,
     isUndefined,
-    AriaPropertyNames,
+    AriaAttrNameToPropNameMap,
+    AriaPropNameToAttrNameMap,
     StringReplace,
     StringToLowerCase,
 } from '@lwc/shared';
@@ -149,18 +150,14 @@ export const globalHTMLProperties: {
     },
 });
 
-const AttrNameToPropNameMap: Record<string, string> = create(null);
-const PropNameToAttrNameMap: Record<string, string> = create(null);
-
-// Synthetic creation of all AOM property descriptors for Custom Elements
-forEach.call(AriaPropertyNames, (propName: string) => {
-    // Typescript is inferring the wrong function type for this particular
-    // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-    // @ts-ignore type-mismatch
-    const attrName = StringToLowerCase.call(StringReplace.call(propName, /^aria/, 'aria-'));
-    AttrNameToPropNameMap[attrName] = propName;
-    PropNameToAttrNameMap[propName] = attrName;
-});
+const AttrNameToPropNameMap: Record<string, string> = assign(
+    create(null),
+    AriaAttrNameToPropNameMap
+);
+const PropNameToAttrNameMap: Record<string, string> = assign(
+    create(null),
+    AriaPropNameToAttrNameMap
+);
 
 forEach.call(defaultDefHTMLPropertyNames, (propName) => {
     const attrName = StringToLowerCase.call(propName);

--- a/packages/@lwc/engine/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine/src/framework/base-lightning-element.ts
@@ -23,6 +23,7 @@ import {
     defineProperty,
     isUndefined,
     isObject,
+    AccessibleElementProperties,
 } from '@lwc/shared';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import {
@@ -176,59 +177,7 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
         | 'title'
     >;
 
-// Defined separately from HTMLElementTheGoodParts because, as of May 2020, the typescript interface
-// for Element does not include these
-interface AccessibleElementTheGoodParts {
-    ariaActiveDescendant: string | null;
-    ariaAtomic: string | null;
-    ariaAutoComplete: string | null;
-    ariaBusy: string | null;
-    ariaChecked: string | null;
-    ariaColCount: string | null;
-    ariaColIndex: string | null;
-    ariaColSpan: string | null;
-    ariaControls: string | null;
-    ariaCurrent: string | null;
-    ariaDescribedBy: string | null;
-    ariaDetails: string | null;
-    ariaDisabled: string | null;
-    ariaErrorMessage: string | null;
-    ariaExpanded: string | null;
-    ariaFlowTo: string | null;
-    ariaHasPopup: string | null;
-    ariaHidden: string | null;
-    ariaInvalid: string | null;
-    ariaKeyShortcuts: string | null;
-    ariaLabel: string | null;
-    ariaLabelledBy: string | null;
-    ariaLevel: string | null;
-    ariaLive: string | null;
-    ariaModal: string | null;
-    ariaMultiLine: string | null;
-    ariaMultiSelectable: string | null;
-    ariaOrientation: string | null;
-    ariaOwns: string | null;
-    ariaPlaceholder: string | null;
-    ariaPosInSet: string | null;
-    ariaPressed: string | null;
-    ariaReadOnly: string | null;
-    ariaRelevant: string | null;
-    ariaRequired: string | null;
-    ariaRoleDescription: string | null;
-    ariaRowCount: string | null;
-    ariaRowIndex: string | null;
-    ariaRowSpan: string | null;
-    ariaSelected: string | null;
-    ariaSetSize: string | null;
-    ariaSort: string | null;
-    ariaValueMax: string | null;
-    ariaValueMin: string | null;
-    ariaValueNow: string | null;
-    ariaValueText: string | null;
-    role: string | null;
-}
-
-export interface LightningElement extends HTMLElementTheGoodParts, AccessibleElementTheGoodParts {
+export interface LightningElement extends HTMLElementTheGoodParts, AccessibleElementProperties {
     template: ShadowRoot;
     render(): Template;
     connectedCallback?(): void;

--- a/packages/@lwc/engine/src/framework/html-properties.ts
+++ b/packages/@lwc/engine/src/framework/html-properties.ts
@@ -9,7 +9,8 @@ import {
     forEach,
     getPropertyDescriptor,
     isUndefined,
-    AriaPropertyNames,
+    keys,
+    AriaPropNameToAttrNameMap,
 } from '@lwc/shared';
 import { defaultDefHTMLPropertyNames } from './attributes';
 
@@ -21,7 +22,7 @@ import { defaultDefHTMLPropertyNames } from './attributes';
  */
 export const HTMLElementOriginalDescriptors: PropertyDescriptorMap = create(null);
 
-forEach.call(AriaPropertyNames, (propName: string) => {
+forEach.call(keys(AriaPropNameToAttrNameMap), (propName: string) => {
     // Note: intentionally using our in-house getPropertyDescriptor instead of getOwnPropertyDescriptor here because
     // in IE11, some properties are on Element.prototype instead of HTMLElement, just to be sure.
     const descriptor = getPropertyDescriptor(HTMLElement.prototype, propName);

--- a/packages/@lwc/shared/src/aria.ts
+++ b/packages/@lwc/shared/src/aria.ts
@@ -66,8 +66,6 @@ const AriaPropertyNames = [
     'role',
 ];
 
-// We should eventually use the typescript Pick utility to reuse ambient Aria property types when
-// the typescript interface for Element is updated to include them.
 export interface AccessibleElementProperties {
     ariaActiveDescendant: string | null;
     ariaAtomic: string | null;
@@ -137,5 +135,5 @@ export {
 };
 
 export function isAriaAttribute(attrName: string) {
-    return Boolean(AttrNameToPropNameMap[attrName]);
+    return attrName in AttrNameToPropNameMap;
 }

--- a/packages/@lwc/shared/src/aria.ts
+++ b/packages/@lwc/shared/src/aria.ts
@@ -5,9 +5,18 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-// Global Aria and Role Properties derived from ARIA and Role Attributes.
-// https://wicg.github.io/aom/spec/aria-reflection.html
-export const AriaPropertyNames = [
+import { create, forEach, StringReplace, StringToLowerCase } from './language';
+
+/**
+ * According to the following list, there are 48 aria attributes of which two (ariaDropEffect and
+ * ariaGrabbed) are deprecated:
+ * https://www.w3.org/TR/wai-aria-1.1/#x6-6-definitions-of-states-and-properties-all-aria-attributes
+ *
+ * The above list of 46 aria attributes is consistent with the following resources:
+ * https://github.com/w3c/aria/pull/708/files#diff-eacf331f0ffc35d4b482f1d15a887d3bR11060
+ * https://wicg.github.io/aom/spec/aria-reflection.html
+ */
+const AriaPropertyNames = [
     'ariaActiveDescendant',
     'ariaAtomic',
     'ariaAutoComplete',
@@ -56,3 +65,77 @@ export const AriaPropertyNames = [
     'ariaValueText',
     'role',
 ];
+
+// We should eventually use the typescript Pick utility to reuse ambient Aria property types when
+// the typescript interface for Element is updated to include them.
+export interface AccessibleElementProperties {
+    ariaActiveDescendant: string | null;
+    ariaAtomic: string | null;
+    ariaAutoComplete: string | null;
+    ariaBusy: string | null;
+    ariaChecked: string | null;
+    ariaColCount: string | null;
+    ariaColIndex: string | null;
+    ariaColSpan: string | null;
+    ariaControls: string | null;
+    ariaCurrent: string | null;
+    ariaDescribedBy: string | null;
+    ariaDetails: string | null;
+    ariaDisabled: string | null;
+    ariaErrorMessage: string | null;
+    ariaExpanded: string | null;
+    ariaFlowTo: string | null;
+    ariaHasPopup: string | null;
+    ariaHidden: string | null;
+    ariaInvalid: string | null;
+    ariaKeyShortcuts: string | null;
+    ariaLabel: string | null;
+    ariaLabelledBy: string | null;
+    ariaLevel: string | null;
+    ariaLive: string | null;
+    ariaModal: string | null;
+    ariaMultiLine: string | null;
+    ariaMultiSelectable: string | null;
+    ariaOrientation: string | null;
+    ariaOwns: string | null;
+    ariaPlaceholder: string | null;
+    ariaPosInSet: string | null;
+    ariaPressed: string | null;
+    ariaReadOnly: string | null;
+    ariaRelevant: string | null;
+    ariaRequired: string | null;
+    ariaRoleDescription: string | null;
+    ariaRowCount: string | null;
+    ariaRowIndex: string | null;
+    ariaRowSpan: string | null;
+    ariaSelected: string | null;
+    ariaSetSize: string | null;
+    ariaSort: string | null;
+    ariaValueMax: string | null;
+    ariaValueMin: string | null;
+    ariaValueNow: string | null;
+    ariaValueText: string | null;
+    role: string | null;
+}
+
+const AttrNameToPropNameMap: Record<string, string> = create(null);
+const PropNameToAttrNameMap: Record<string, string> = create(null);
+
+// Synthetic creation of all AOM property descriptors for Custom Elements
+forEach.call(AriaPropertyNames, (propName) => {
+    // Typescript infers the wrong function type for this particular overloaded method:
+    // https://github.com/Microsoft/TypeScript/issues/27972
+    // @ts-ignore type-mismatch
+    const attrName = StringToLowerCase.call(StringReplace.call(propName, /^aria/, 'aria-'));
+    AttrNameToPropNameMap[attrName] = propName;
+    PropNameToAttrNameMap[propName] = attrName;
+});
+
+export {
+    AttrNameToPropNameMap as AriaAttrNameToPropNameMap,
+    PropNameToAttrNameMap as AriaPropNameToAttrNameMap,
+};
+
+export function isAriaAttribute(attrName: string) {
+    return Boolean(AttrNameToPropNameMap[attrName]);
+}

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -6,6 +6,7 @@
  */
 import * as parse5 from 'parse5-with-errors';
 import { ParserDiagnostics, generateCompilerError } from '@lwc/errors';
+import { isAriaAttribute } from '@lwc/shared';
 
 import { toPropertyName } from '../shared/utils';
 
@@ -23,7 +24,6 @@ import {
     DATA_RE,
     SVG_NAMESPACE_URI,
     SUPPORTED_SVG_TAGS,
-    ARIA_RE,
     GLOBAL_ATTRIBUTE_SET,
     ATTRS_PROPS_TRANFORMS,
     HTML_ATTRIBUTES_REVERSE_LOOKUP,
@@ -195,10 +195,6 @@ export function removeAttribute(el: IRElement, pattern: string | RegExp): void {
             ? attributeName(attr) !== pattern
             : !attributeName(attr).match(pattern)
     );
-}
-
-function isAriaAttribute(attrName: string): boolean {
-    return attrName === 'role' || ARIA_RE.test(attrName);
 }
 
 export function isProhibitedIsAttribute(attrName: string): boolean {

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { AriaAttrNameToPropNameMap } from '@lwc/shared';
+
 import { HTML_ATTRIBUTE_ELEMENT_MAP } from './utils/html-element-attributes';
 import { HTML_ELEMENTS, HTML_VOID_ELEMENTS } from './utils/html-elements';
 
@@ -43,7 +45,7 @@ const ATTRIBUTE_NAME_CHAR = [
     '\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD',
     '\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040',
 ].join('');
-export const ARIA_RE = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
+
 export const DATA_RE = new RegExp('^(data)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
 
 export const SUPPORTED_SVG_TAGS = new Set([
@@ -161,8 +163,6 @@ export const DASHED_TAGNAME_ELEMENT_SET = new Set([
 ]);
 
 export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
-    // These have to be quoted because aria- attributes below are quoted
-    // Our linting doesn't like to mix quoted and un-quoted property names
     accesskey: 'accessKey',
     readonly: 'readOnly',
     tabindex: 'tabIndex',
@@ -179,58 +179,7 @@ export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     novalidate: 'noValidate',
     usemap: 'useMap',
     for: 'htmlFor',
-    // According to the following list, there are 48 aria attributes (of which 2 are deprecated):
-    // https://www.w3.org/TR/wai-aria-1.1/#x6-6-definitions-of-states-and-properties-all-aria-attributes
-    // This list of 46 non-deprecated aria attributes is consistent with the following proposal:
-    // https://github.com/w3c/aria/pull/708/files#diff-eacf331f0ffc35d4b482f1d15a887d3bR11060
-    'aria-activedescendant': 'ariaActiveDescendant',
-    'aria-atomic': 'ariaAtomic',
-    'aria-autocomplete': 'ariaAutoComplete',
-    'aria-busy': 'ariaBusy',
-    'aria-checked': 'ariaChecked',
-    'aria-colcount': 'ariaColCount',
-    'aria-colindex': 'ariaColIndex',
-    'aria-colspan': 'ariaColSpan',
-    'aria-controls': 'ariaControls',
-    'aria-current': 'ariaCurrent',
-    'aria-describedby': 'ariaDescribedBy',
-    'aria-details': 'ariaDetails',
-    'aria-disabled': 'ariaDisabled',
-    //  'aria-dropeffect': 'ariaDropEffect', /* Deprecated in ARIA 1.1 */
-    'aria-errormessage': 'ariaErrorMessage',
-    'aria-expanded': 'ariaExpanded',
-    'aria-flowto': 'ariaFlowTo',
-    //  'aria-grabbed': 'ariaGrabbed', /* Deprecated in ARIA 1.1 */
-    'aria-haspopup': 'ariaHasPopup',
-    'aria-hidden': 'ariaHidden',
-    'aria-invalid': 'ariaInvalid',
-    'aria-keyshortcuts': 'ariaKeyShortcuts',
-    'aria-label': 'ariaLabel',
-    'aria-labelledby': 'ariaLabelledBy',
-    'aria-level': 'ariaLevel',
-    'aria-live': 'ariaLive',
-    'aria-modal': 'ariaModal',
-    'aria-multiline': 'ariaMultiLine',
-    'aria-multiselectable': 'ariaMultiSelectable',
-    'aria-orientation': 'ariaOrientation',
-    'aria-owns': 'ariaOwns',
-    'aria-placeholder': 'ariaPlaceholder',
-    'aria-posinset': 'ariaPosInSet',
-    'aria-pressed': 'ariaPressed',
-    'aria-readonly': 'ariaReadOnly',
-    'aria-relevant': 'ariaRelevant',
-    'aria-required': 'ariaRequired',
-    'aria-roledescription': 'ariaRoleDescription',
-    'aria-rowcount': 'ariaRowCount',
-    'aria-rowindex': 'ariaRowIndex',
-    'aria-rowspan': 'ariaRowSpan',
-    'aria-selected': 'ariaSelected',
-    'aria-setsize': 'ariaSetSize',
-    'aria-sort': 'ariaSort',
-    'aria-valuemax': 'ariaValueMax',
-    'aria-valuemin': 'ariaValueMin',
-    'aria-valuenow': 'ariaValueNow',
-    'aria-valuetext': 'ariaValueText',
+    ...AriaAttrNameToPropNameMap,
 };
 
 export const DISALLOWED_HTML_TAGS = new Set(['base', 'link', 'meta', 'script', 'title']);


### PR DESCRIPTION
## Details

This long-overdue refactor better positions ourselves for the engine-core/engine-dom split.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7552459