### PR TITLE
refactor(engine): Remove usused field validation

### DIFF
--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -54,12 +54,6 @@ export interface Template {
      */
     stylesheets?: StylesheetFactory[];
 
-    /**
-     * List of property names that are accessed of the component instance
-     * from the template.
-     */
-    ids?: string[];
-
     stylesheetTokens?: {
         /**
          * HTML attribute that need to be applied to the host element. This attribute is used for the

--- a/packages/@lwc/engine/src/framework/template.ts
+++ b/packages/@lwc/engine/src/framework/template.ts
@@ -9,7 +9,6 @@ import {
     ArrayUnshift,
     assert,
     create,
-    forEach,
     isArray,
     isFunction,
     isNull,
@@ -104,26 +103,6 @@ function validateSlots(vm: VM, html: any) {
     }
 }
 
-function validateFields(vm: VM, html: Template) {
-    if (process.env.NODE_ENV === 'production') {
-        // this method should never leak to prod
-        throw new ReferenceError();
-    }
-    const { component } = vm;
-
-    // validating identifiers used by template that should be provided by the component
-    const { ids = [] } = html;
-    forEach.call(ids, (propName: string) => {
-        if (!(propName in component)) {
-            // eslint-disable-next-line lwc-internal/no-production-assert
-            logError(
-                `The template rendered by ${vm} references \`this.${propName}\`, which is not declared. Check for a typo in the template.`,
-                vm
-            );
-        }
-    });
-}
-
 export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(
@@ -188,13 +167,6 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
                             hostAttribute,
                             shadowAttribute
                         );
-                    }
-
-                    if (process.env.NODE_ENV !== 'production') {
-                        // one time operation for any new template returned by render()
-                        // so we can warn if the template is attempting to use a binding
-                        // that is not provided by the component instance.
-                        validateFields(vm, html);
                     }
                 }
 


### PR DESCRIPTION
## Details

This PR removes the field validation logic from the template evaluation. This code is never executed because the template compiler never produced a list with all the identifiers used in it.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7391508
