### PR TITLE
refactor(engine): Rearrange engine-core and engine-dom boundaries 

### DIFF
--- a/packages/@lwc/engine/dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine/dom/src/apis/build-custom-element-constructor.ts
@@ -7,8 +7,6 @@
 
 import { create, isUndefined, keys } from '@lwc/shared';
 
-import { LightningElement } from './lightning-element';
-
 import {
     createVM,
     connectRootElement,
@@ -16,6 +14,7 @@ import {
     getAttrNameFromPropName,
     getComponentInternalDef,
     isAttributeLocked,
+    LightningElement,
 } from '../../../src';
 
 type ComponentConstructor = typeof LightningElement;

--- a/packages/@lwc/engine/dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine/dom/src/apis/create-element.ts
@@ -19,14 +19,14 @@ import {
 } from '@lwc/shared';
 
 import {
+    getComponentInternalDef,
+    setElementProto,
     getAssociatedVMIfPresent,
     createVM,
     connectRootElement,
     disconnectRootElement,
-} from '../../../src/framework/vm';
-
-import { LightningElement } from '../../src';
-import { getComponentInternalDef, setElementProto } from '../../../src/framework/def';
+    LightningElement,
+} from '../../../src';
 
 type NodeSlotCallback = (element: Node) => void;
 

--- a/packages/@lwc/engine/dom/src/apis/get-component-constructor.ts
+++ b/packages/@lwc/engine/dom/src/apis/get-component-constructor.ts
@@ -6,8 +6,7 @@
  */
 
 import { isUndefined } from '@lwc/shared';
-import { LightningElement } from '../../src';
-import { getAssociatedVMIfPresent } from '../../../src/framework/vm';
+import { getAssociatedVMIfPresent, LightningElement } from '../../../src';
 
 /**
  * EXPERIMENTAL: This function provides access to the component constructor, given an HTMLElement.

--- a/packages/@lwc/engine/dom/src/apis/get-component-constructor.ts
+++ b/packages/@lwc/engine/dom/src/apis/get-component-constructor.ts
@@ -6,6 +6,7 @@
  */
 
 import { isUndefined } from '@lwc/shared';
+
 import { getAssociatedVMIfPresent, LightningElement } from '../../../src';
 
 /**

--- a/packages/@lwc/engine/dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine/dom/src/apis/is-node-from-template.ts
@@ -7,7 +7,7 @@
 
 import { isFalse, isUndefined } from '@lwc/shared';
 
-import { useSyntheticShadow } from '../env/shadow-dom';
+import { useSyntheticShadow } from '../env/dom';
 
 /**
  * EXPERIMENTAL: This function detects whether or not a Node is controlled by a LWC template. This

--- a/packages/@lwc/engine/dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine/dom/src/apis/is-node-from-template.ts
@@ -7,7 +7,7 @@
 
 import { isFalse, isUndefined } from '@lwc/shared';
 
-import { useSyntheticShadow } from '../../../src/framework/utils';
+import { useSyntheticShadow } from '../env/shadow-dom';
 
 /**
  * EXPERIMENTAL: This function detects whether or not a Node is controlled by a LWC template. This

--- a/packages/@lwc/engine/dom/src/apis/lightning-element.ts
+++ b/packages/@lwc/engine/dom/src/apis/lightning-element.ts
@@ -6,9 +6,8 @@
  */
 import { defineProperty, freeze, isUndefined, seal } from '@lwc/shared';
 
-import { buildCustomElementConstructor } from './build-custom-element-constructor';
-
 import { LightningElement } from '../../../src';
+import { buildCustomElementConstructor } from './build-custom-element-constructor';
 
 type ComponentConstructor = typeof LightningElement;
 type HTMLElementConstructor = typeof HTMLElement;

--- a/packages/@lwc/engine/dom/src/env/dom.ts
+++ b/packages/@lwc/engine/dom/src/env/dom.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const dispatchEvent =
-    'EventTarget' in window ? EventTarget.prototype.dispatchEvent : Node.prototype.dispatchEvent; // IE11
+import { hasOwnProperty } from '@lwc/shared';
 
-export { dispatchEvent };
+export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');
+
+export const dispatchEvent =
+    'EventTarget' in window ? EventTarget.prototype.dispatchEvent : Node.prototype.dispatchEvent; // IE11

--- a/packages/@lwc/engine/dom/src/env/shadow-dom.ts
+++ b/packages/@lwc/engine/dom/src/env/shadow-dom.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { hasOwnProperty } from '@lwc/shared';
+
+export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');

--- a/packages/@lwc/engine/dom/src/env/shadow-dom.ts
+++ b/packages/@lwc/engine/dom/src/env/shadow-dom.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2020, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-import { hasOwnProperty } from '@lwc/shared';
-
-export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');

--- a/packages/@lwc/engine/dom/src/index.ts
+++ b/packages/@lwc/engine/dom/src/index.ts
@@ -9,6 +9,7 @@
 import './polyfills/proxy-concat/main';
 import './polyfills/aria-properties/main';
 
+// Engine-core public APIs -------------------------------------------------------------------------
 export {
     createContextProvider,
     register,
@@ -27,7 +28,7 @@ export {
     isComponentConstructor,
 } from '../../src';
 
-// Public APIs -------------------------------------------------------------------------------------
+// Engine-dom public APIs --------------------------------------------------------------------------
 export { deprecatedBuildCustomElementConstructor as buildCustomElementConstructor } from './apis/build-custom-element-constructor';
 export { createElement } from './apis/create-element';
 export { getComponentConstructor } from './apis/get-component-constructor';

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -58,7 +58,7 @@ import {
 } from './hooks';
 import { isComponentConstructor } from './def';
 
-import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
+import { useSyntheticShadow } from '../../dom/src/env/dom';
 
 export interface ElementCompilerData extends VNodeData {
     key: Key;

--- a/packages/@lwc/engine/src/framework/api.ts
+++ b/packages/@lwc/engine/src/framework/api.ts
@@ -24,7 +24,7 @@ import {
 import { logError } from '../shared/logger';
 import { invokeEventListener } from './invoker';
 import { getVMBeingRendered } from './template';
-import { EmptyArray, EmptyObject, useSyntheticShadow } from './utils';
+import { EmptyArray, EmptyObject } from './utils';
 import { getAssociatedVM, runConnectedCallback, SlotSet, VM, VMState } from './vm';
 import { ComponentConstructor } from './component';
 import {
@@ -57,6 +57,8 @@ import {
     markAsDynamicChildren,
 } from './hooks';
 import { isComponentConstructor } from './def';
+
+import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
 
 export interface ElementCompilerData extends VNodeData {
     key: Key;

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isArray, isNull, isTrue, isUndefined } from '@lwc/shared';
-import { EmptyArray, useSyntheticShadow } from './utils';
+import { EmptyArray } from './utils';
 import {
     rerenderVM,
     createVM,
@@ -27,6 +27,8 @@ import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef, setElementProto } from './def';
+
+import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
 
 const noop = () => void 0;
 

--- a/packages/@lwc/engine/src/framework/hooks.ts
+++ b/packages/@lwc/engine/src/framework/hooks.ts
@@ -28,7 +28,7 @@ import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdo
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef, setElementProto } from './def';
 
-import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
+import { useSyntheticShadow } from '../../dom/src/env/dom';
 
 const noop = () => void 0;
 

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -11,7 +11,7 @@ import * as api from './api';
 import { EmptyArray } from './utils';
 import { VM } from './vm';
 
-import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
+import { useSyntheticShadow } from '../../dom/src/env/dom';
 import { removeAttribute, setAttribute } from '../../dom/src/env/element';
 /**
  * Function producing style based on a host and a shadow selector. This function is invoked by

--- a/packages/@lwc/engine/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine/src/framework/stylesheet.ts
@@ -8,8 +8,10 @@ import { assert, create, emptyString, forEach, isArray, isUndefined } from '@lwc
 import { VNode } from '../3rdparty/snabbdom/types';
 
 import * as api from './api';
-import { EmptyArray, useSyntheticShadow } from './utils';
+import { EmptyArray } from './utils';
 import { VM } from './vm';
+
+import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
 import { removeAttribute, setAttribute } from '../../dom/src/env/element';
 /**
  * Function producing style based on a host and a shadow selector. This function is invoked by

--- a/packages/@lwc/engine/src/framework/utils.ts
+++ b/packages/@lwc/engine/src/framework/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayPush, create, hasOwnProperty, isFunction, seal } from '@lwc/shared';
+import { ArrayPush, create, isFunction, seal } from '@lwc/shared';
 
 type Callback = () => void;
 
@@ -42,8 +42,6 @@ export function addCallbackToNextTick(callback: Callback) {
     }
     ArrayPush.call(nextTickCallbackQueue, callback);
 }
-
-export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');
 
 export function guid(): string {
     function s4() {

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -46,8 +46,7 @@ import { LightningElement } from './base-lightning-element';
 import { getErrorComponentStack } from '../shared/format';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 
-import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
-import { ShadowRootInnerHTMLSetter } from '../../dom/src/env/dom';
+import { useSyntheticShadow } from '../../dom/src/env/dom';
 
 export interface SlotSet {
     [key: string]: VNodes;

--- a/packages/@lwc/engine/src/framework/vm.ts
+++ b/packages/@lwc/engine/src/framework/vm.ts
@@ -23,7 +23,7 @@ import {
     getOwnPropertyNames,
 } from '@lwc/shared';
 import { createComponent, renderComponent, markComponentAsDirty } from './component';
-import { addCallbackToNextTick, EmptyObject, EmptyArray, useSyntheticShadow } from './utils';
+import { addCallbackToNextTick, EmptyObject, EmptyArray } from './utils';
 import { invokeServiceHook, Services } from './services';
 import { invokeComponentCallback, invokeComponentRenderedCallback } from './invoker';
 
@@ -45,6 +45,9 @@ import { ReactiveObserver } from './mutation-tracker';
 import { LightningElement } from './base-lightning-element';
 import { getErrorComponentStack } from '../shared/format';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
+
+import { useSyntheticShadow } from '../../dom/src/env/shadow-dom';
+import { ShadowRootInnerHTMLSetter } from '../../dom/src/env/dom';
 
 export interface SlotSet {
     [key: string]: VNodes;


### PR DESCRIPTION
## Details

This PR rearranges the imports from the engine-core and engine-dom:
- All the imports from engine-dom now go through the engine-core main entry point
- The `useSyntheticShadow` value is now part of engine-dom since it is injected at runtime into engine-core.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7552459
