### PR TITLE
fix(engine): make reactive objects and component instances identifiable

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@lwc/features": "1.7.11",
         "@lwc/shared": "1.7.11",
-        "observable-membrane": "0.26.1"
+        "observable-membrane": "1.0.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -38,6 +38,8 @@ import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import { HTMLElementConstructor } from './base-bridge-element';
+import { lockerLivePropertyKey } from './membrane';
+import { EmptyObject } from './utils';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -211,6 +213,9 @@ function BaseLightningElementConstructor(this: LightningElement): LightningEleme
         vm.setHook = setHook;
         vm.getHook = getHook;
     }
+
+    // Making the component instance a live value when using Locker to support expandos.
+    defineProperty(component, lockerLivePropertyKey, EmptyObject);
 
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -7,6 +7,8 @@
 import ObservableMembrane from 'observable-membrane';
 import { valueObserved, valueMutated } from './mutation-tracker';
 
+export const lockerLivePropertyKey = Symbol.for('@@lockerLiveValue');
+
 function valueDistortion(value: any) {
     return value;
 }
@@ -15,6 +17,7 @@ export const reactiveMembrane = new ObservableMembrane({
     valueObserved,
     valueMutated,
     valueDistortion,
+    tagPropertyKey: lockerLivePropertyKey,
 });
 
 /**

--- a/packages/integration-karma/test/integrations/locker/index.spec.js
+++ b/packages/integration-karma/test/integrations/locker/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 
 import LockerIntegration from 'x/lockerIntegration';
+import LockerLiveComponent from 'x/lockerLiveComponent';
 import LockerHooks, { hooks } from 'x/lockerHooks';
 
 it('should support Locker integration which uses a wrapped LightningElement base class', () => {
@@ -110,5 +111,13 @@ describe('Locker hooks', () => {
                 [evt]
             );
         });
+    });
+});
+
+describe('Locker live objects', () => {
+    it('should report the component instance as live to support expandos', () => {
+        const elm = createElement('x-live', { is: LockerLiveComponent });
+        document.body.appendChild(elm);
+        expect(elm.hasMarker()).toBe(true);
     });
 });

--- a/packages/integration-karma/test/integrations/locker/x/lockerLiveComponent/lockerLiveComponent.js
+++ b/packages/integration-karma/test/integrations/locker/x/lockerLiveComponent/lockerLiveComponent.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+const marker = Symbol.for('@@lockerLiveValue');
+
+export default class Foo extends LightningElement {
+    @api hasMarker() {
+        return Object.hasOwnProperty.call(this, marker);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10462,10 +10462,10 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-observable-membrane@0.26.1:
-  version "0.26.1"
-  resolved "http://npm.lwcjs.org/observable-membrane/-/observable-membrane-0.26.1/5619a7b2f4b0414d62b3e6cc2ea65734a08cce7a.tgz#5619a7b2f4b0414d62b3e6cc2ea65734a08cce7a"
-  integrity sha512-fBxLHtd0pUFI/rKh6Dfn9fxjEgY4NkRIqlPEKa9fR28rC9CQDfQ5P+t292CtAArtXOQ1mF8Nq9m1cF52IdN8DA==
+observable-membrane@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.0.1.tgz#1041074136d5d62b0fc488880bed1c3680674ec5"
+  integrity sha512-AlPC0ZuEuBYt9LSbsBGOz0rpIjkdbIH5JQMLHZrmCRkUedfVoNSFQXLYso+hXxWrRqwEhxEkQuYNg6Pch3hmqQ==
 
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
~NOTE: this PR is not ready yet. We need to get a new version of observable membrane first.~

## Details

This PR enables vnext to function with LWC:

* [x] add a tag to any reactive proxy (read/write and read/only alike).
* [x] add a tag to component's instances to support expandos and other mutations.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.
