### PR TITLE
build: use typescript library version es2018 as default

### DIFF
--- a/packages/@lwc/engine/tsconfig.json
+++ b/packages/@lwc/engine/tsconfig.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "outDir": "types",
-        "lib": ["dom", "es2015", "es2016", "es2017", "es2018"]
+        "lib": ["dom", "es2018"]
     },
 
     "include": ["dom/src/", "src/"]

--- a/packages/@lwc/features/tsconfig.json
+++ b/packages/@lwc/features/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../../tsconfig.json",
     "compilerOptions": {
         "baseUrl": ".",
-        "outDir": "types"
+        "outDir": "types",
+        "lib": ["dom", "es2018"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/features/tsconfig.json
+++ b/packages/@lwc/features/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../../../tsconfig.json",
+
     "compilerOptions": {
         "baseUrl": ".",
         "outDir": "types",

--- a/packages/@lwc/synthetic-shadow/tsconfig.json
+++ b/packages/@lwc/synthetic-shadow/tsconfig.json
@@ -1,4 +1,9 @@
 {
     "extends": "../../../tsconfig.json",
+
+    "compilerOptions": {
+        "lib": ["dom", "es2018"]
+    },
+
     "include": ["src/"]
 }

--- a/packages/@lwc/wire-service/tsconfig.json
+++ b/packages/@lwc/wire-service/tsconfig.json
@@ -3,11 +3,11 @@
 
     "compilerOptions": {
         "outDir": "types",
-
         "baseUrl": ".",
         "paths": {
             "lwc": ["../engine"]
-        }
+        },
+        "lib": ["dom", "es2018"]
     },
 
     "include": ["src/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
 
-    "target": "es2018",
+    "lib": ["es2018"],
   },
 
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
 
+    "target": "es2018",
     "lib": ["es2018"],
   },
 


### PR DESCRIPTION
## Details

Using `es2018` as the default since we haven't completely moved off of node v10. We can bump this to `es2019` once we've fully transitioned to node v12.

https://node.green/

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7391508