### PR TITLE
fix(wire-context): consumerDisconnectedCallback called with duplicates

### DIFF
--- a/packages/@lwc/engine-core/src/framework/context-provider.ts
+++ b/packages/@lwc/engine-core/src/framework/context-provider.ts
@@ -6,17 +6,17 @@
  */
 import { isUndefined, ArrayIndexOf } from '@lwc/shared';
 import { guid } from './utils';
-import { WireAdapterConstructor, ContextValue, getAdapterToken, setAdapterToken } from './wiring';
+import {
+    WireAdapterConstructor,
+    ContextValue,
+    getAdapterToken,
+    setAdapterToken,
+    WireContextRegistrationEvent,
+} from './wiring';
 
-interface WireContextInternalProtocolEventDetails {
-    setNewContext(newContext: ContextValue): void;
-    provideDisconnectedCallback(disconnectCallback: () => void): void;
-}
 interface ContextConsumer {
     provide(newContext: ContextValue): void;
 }
-
-interface WireContextEvent extends CustomEvent<WireContextInternalProtocolEventDetails> {}
 
 interface ContextProviderOptions {
     consumerConnectedCallback: (consumer: ContextConsumer) => void;
@@ -42,8 +42,8 @@ export function createContextProvider(adapter: WireAdapterConstructor) {
         const { consumerConnectedCallback, consumerDisconnectedCallback } = options;
         elm.addEventListener(
             adapterContextToken as string,
-            ((evt: WireContextEvent) => {
-                const { setNewContext, provideDisconnectedCallback } = evt.detail;
+            ((evt: WireContextRegistrationEvent) => {
+                const { setNewContext, setDisconnectedCallback } = evt;
 
                 const consumer: ContextConsumer = {
                     provide(newContext) {
@@ -55,7 +55,7 @@ export function createContextProvider(adapter: WireAdapterConstructor) {
                         consumerDisconnectedCallback(consumer);
                     }
                 };
-                provideDisconnectedCallback(disconnectCallback);
+                setDisconnectedCallback(disconnectCallback);
 
                 consumerConnectedCallback(consumer);
                 evt.stopImmediatePropagation();

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -90,17 +90,22 @@ function createContextWatcher(
         // must be listening for a special dom event with the name corresponding to the value of
         // `adapterContextToken`, which will remain secret and internal to this file only to
         // guarantee that the linkage can be forged.
-        const internalDomEvent = new CustomEvent(adapterContextToken, {
-            bubbles: true,
-            composed: true,
-            detail(newContext: ContextValue, disconnectCallback: () => void) {
-                // adds this callback into the disconnect bucket so it gets disconnected from parent
-                // the the element hosting the wire is disconnected
-                ArrayPush.call(wiredDisconnecting, disconnectCallback);
+        const detail = {
+            setNewContext(newContext: ContextValue) {
                 // eslint-disable-next-line lwc-internal/no-invalid-todo
                 // TODO: dev-mode validation of config based on the adapter.contextSchema
                 callbackWhenContextIsReady(newContext);
             },
+            provideDisconnectedCallback(disconnectCallback: () => void) {
+                // adds this callback into the disconnect bucket so it gets disconnected from parent
+                // the the element hosting the wire is disconnected
+                ArrayPush.call(wiredDisconnecting, disconnectCallback);
+            },
+        };
+        const internalDomEvent = new CustomEvent(adapterContextToken, {
+            bubbles: true,
+            composed: true,
+            detail,
         });
         renderer.dispatchEvent(elm, internalDomEvent);
     });

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -102,12 +102,12 @@ function createContextWatcher(
                 ArrayPush.call(wiredDisconnecting, disconnectCallback);
             },
         };
-        const internalDomEvent = new CustomEvent(adapterContextToken, {
+        const contextRegistrationEvent = new CustomEvent(adapterContextToken, {
             bubbles: true,
             composed: true,
             detail,
         });
-        renderer.dispatchEvent(elm, internalDomEvent);
+        renderer.dispatchEvent(elm, contextRegistrationEvent);
     });
 }
 

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isUndefined, ArrayPush, defineProperty } from '@lwc/shared';
+import { assert, isUndefined, ArrayPush, defineProperty, defineProperties } from '@lwc/shared';
 import { ComponentInterface } from './component';
 import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
 import { VM, runWithBoundaryProtection } from './vm';
@@ -15,6 +15,36 @@ const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
 
 const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
 function noop(): void {}
+
+interface WireContextInternalProtocolPayload {
+    setNewContext(newContext: ContextValue): void;
+    setDisconnectedCallback(disconnectCallback: () => void): void;
+}
+
+export interface WireContextRegistrationEvent
+    extends CustomEvent<undefined>,
+        WireContextInternalProtocolPayload {}
+
+function createWireContextRegistrationEvent(
+    adapterContextToken: string,
+    { setNewContext, setDisconnectedCallback }: WireContextInternalProtocolPayload
+): WireContextRegistrationEvent {
+    const event = new CustomEvent<undefined>(adapterContextToken, {
+        bubbles: true,
+        composed: true,
+    });
+
+    defineProperties(event, {
+        setNewContext: {
+            value: setNewContext,
+        },
+        setDisconnectedCallback: {
+            value: setDisconnectedCallback,
+        },
+    });
+
+    return event as WireContextRegistrationEvent;
+}
 
 function createFieldDataCallback(vm: VM, name: string) {
     const { cmpFields } = vm;
@@ -90,22 +120,17 @@ function createContextWatcher(
         // must be listening for a special dom event with the name corresponding to the value of
         // `adapterContextToken`, which will remain secret and internal to this file only to
         // guarantee that the linkage can be forged.
-        const detail = {
+        const contextRegistrationEvent = createWireContextRegistrationEvent(adapterContextToken, {
             setNewContext(newContext: ContextValue) {
                 // eslint-disable-next-line lwc-internal/no-invalid-todo
                 // TODO: dev-mode validation of config based on the adapter.contextSchema
                 callbackWhenContextIsReady(newContext);
             },
-            provideDisconnectedCallback(disconnectCallback: () => void) {
+            setDisconnectedCallback(disconnectCallback: () => void) {
                 // adds this callback into the disconnect bucket so it gets disconnected from parent
                 // the the element hosting the wire is disconnected
                 ArrayPush.call(wiredDisconnecting, disconnectCallback);
             },
-        };
-        const contextRegistrationEvent = new CustomEvent(adapterContextToken, {
-            bubbles: true,
-            composed: true,
-            detail,
         });
         renderer.dispatchEvent(elm, contextRegistrationEvent);
     });

--- a/packages/integration-karma/test/context/simple-context.spec.js
+++ b/packages/integration-karma/test/context/simple-context.spec.js
@@ -27,9 +27,9 @@ describe('Simple Custom Context Provider', () => {
         // not providing context intentionally
         div.appendChild(elm);
 
-        expect(spy.connected.calls.count()).toBe(1);
+        expect(spy.connected).toHaveBeenCalledTimes(1);
         div.removeChild(elm);
-        expect(spy.disconnected.calls.count()).toBe(1);
+        expect(spy.disconnected).toHaveBeenCalledTimes(1);
     });
 
     it('should not call disconnect with same consumer when multiple contexts are set', function () {
@@ -48,7 +48,7 @@ describe('Simple Custom Context Provider', () => {
         expect(() => {
             div.removeChild(elm);
         }).not.toThrowError();
-        expect(spy.disconnected.calls.count()).toBe(1);
+        expect(spy.disconnected).toHaveBeenCalledTimes(1);
     });
 
     it('should provide "missing" as the default value when no provider is installed', function () {

--- a/packages/integration-karma/test/context/simple-context.spec.js
+++ b/packages/integration-karma/test/context/simple-context.spec.js
@@ -12,6 +12,45 @@ describe('Simple Custom Context Provider', () => {
         div.appendChild(elm);
         expect(elm.shadowRoot.textContent).toBe('ready');
     });
+
+    it('should call disconnect when no context value is provided', function () {
+        const div = document.createElement('div');
+        const elm = createElement('x-consumer', { is: Consumer });
+        document.body.appendChild(div);
+
+        const spy = {
+            connected: jasmine.createSpy('connected'),
+            disconnected: jasmine.createSpy('disconnected'),
+        };
+
+        installCustomContext(div, spy, true);
+        // not providing context intentionally
+        div.appendChild(elm);
+
+        expect(spy.connected.calls.count()).toBe(1);
+        div.removeChild(elm);
+        expect(spy.disconnected.calls.count()).toBe(1);
+    });
+
+    it('should not call disconnect with same consumer when multiple contexts are set', function () {
+        const div = document.createElement('div');
+        const elm = createElement('x-consumer', { is: Consumer });
+        document.body.appendChild(div);
+
+        const spy = {
+            disconnected: jasmine.createSpy('disconnected'),
+        };
+        installCustomContext(div, spy);
+        setCustomContext(div, 'almost ready');
+        div.appendChild(elm);
+        setCustomContext(div, 'ready');
+
+        expect(() => {
+            div.removeChild(elm);
+        }).not.toThrowError();
+        expect(spy.disconnected.calls.count()).toBe(1);
+    });
+
     it('should provide "missing" as the default value when no provider is installed', function () {
         const div = document.createElement('div');
         const elm = createElement('x-consumer', { is: Consumer });

--- a/packages/integration-karma/test/context/x/simpleProvider/simpleProvider.js
+++ b/packages/integration-karma/test/context/x/simpleProvider/simpleProvider.js
@@ -68,17 +68,27 @@ function getContextData(eventTarget) {
 
 const contextualizer = createContextProvider(WireAdapter);
 
-export function installCustomContext(target) {
+/**
+ * Note: spy and skipInitialProvision parameters (and all code related to them) are meant for test purposes only,
+ *       and should not be part of other implementations based on this reference implementation.
+ */
+export function installCustomContext(target, spy, skipInitialProvision) {
+    const { connected = () => {}, disconnected = () => {} } = spy || {};
+
     contextualizer(target, {
         consumerConnectedCallback(consumer) {
+            connected();
             // once the first consumer gets connected, then we create the contextData object
             const contextData = getContextData(target);
             // registering the new consumer
             contextData.consumers.push(consumer);
             // push the current value
-            consumer.provide({ value: contextData.value });
+            if (!skipInitialProvision) {
+                consumer.provide({ value: contextData.value });
+            }
         },
         consumerDisconnectedCallback(consumer) {
+            disconnected();
             const contextData = getContextData(target);
             const i = contextData.consumers.indexOf(consumer);
             if (i >= 0) {


### PR DESCRIPTION
## Details
This PR fixes 2 issues in [Context Provider for wire adapters](https://github.com/salesforce/lwc-rfcs/blob/master/text/0000-wire-reform.md#context-provider-for-wire-adapters):

1. When no context value is provided, the `consumerDisconnectedCallback` is not called during disconnecting the context consumer wire.
2. After setting multiple context values in the same provider, and disconnecting the contextual wire, `consumerDisconnectedCallback` is incorrectly called multiple times with repeated consumers.

Both issues have the same root cause, which is in how the `disconnectCallback` is provided.

This PR fixes those issues by separating the provision of a new context value, and the provision of the `disconnectedCallback`.


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`