### PR TITLE
refactor(engine-core): Rework style injection

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -45,15 +45,11 @@ export interface VElement extends VNode {
     elm: Element | undefined;
     text: undefined;
     key: Key;
-    // TODO [#1364]: support the ability to provision a cloned StyleElement
-    // for native shadow as a perf optimization
-    clonedElement?: HTMLStyleElement;
 }
 
 export interface VCustomElement extends VElement {
     mode: 'closed' | 'open';
     ctor: any;
-    clonedElement?: undefined;
     // copy of the last allocated children.
     aChildren?: VNodes;
 }

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -111,14 +111,10 @@ const ElementHook: Hooks<VElement> = {
     create: (vnode) => {
         const {
             sel,
-            clonedElement,
             data: { ns },
             owner: { renderer },
         } = vnode;
-
-        // TODO [#1364]: supporting the ability to inject a cloned StyleElement via a vnode this is
-        // used for style tags for native shadow
-        const elm = isUndefined(clonedElement) ? renderer.createElement(sel, ns) : clonedElement;
+        const elm = renderer.createElement(sel, ns);
 
         linkNodeToShadow(elm, vnode);
         fallbackElmHook(elm, vnode);

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -42,13 +42,12 @@ export interface Renderer<N = HostNode, E = HostElement> {
     getElementsByClassName(element: E, names: string): HTMLCollection;
     isConnected(node: N): boolean;
     tagName(element: E): string;
-
+    insertGlobalStylesheet(content: string): void;
     assertInstanceOfHTMLElement?(elm: any, msg: string): void;
 }
 
 // This is a temporary workaround to get the @lwc/engine-server to evaluate in node without having
 // to inject at runtime.
-export const documentObject: Document = typeof document !== 'undefined' ? document : ({} as any);
 export const HTMLElementConstructor: typeof HTMLElement =
     typeof HTMLElement !== 'undefined' ? HTMLElement : (function () {} as any);
 export const HTMLElementPrototype = HTMLElementConstructor.prototype;

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -11,7 +11,6 @@ import { VM } from './vm';
 import * as api from './api';
 import { Template } from './template';
 import { EmptyArray } from './utils';
-import { documentObject } from './renderer';
 
 /**
  * Function producing style based on a host and a shadow selector. This function is invoked by
@@ -43,18 +42,6 @@ function getCachedStyleElement(styleContent: string): HTMLStyleElement {
     }
 
     return fragment.cloneNode(true).firstChild as HTMLStyleElement;
-}
-
-const globalStyleParent = documentObject.head || documentObject.body || documentObject;
-const InsertedGlobalStyleContent: Record<string, true> = create(null);
-
-function insertGlobalStyle(styleContent: string) {
-    // inserts the global style when needed, otherwise does nothing
-    if (isUndefined(InsertedGlobalStyleContent[styleContent])) {
-        InsertedGlobalStyleContent[styleContent] = true;
-        const elm = createStyleElement(styleContent);
-        globalStyleParent.appendChild(elm);
-    }
 }
 
 function createStyleVNode(elm: HTMLStyleElement) {
@@ -127,9 +114,11 @@ export function getStylesheetsContent(vm: VM, template: Template): string[] {
 }
 
 export function evaluateCSS(vm: VM, stylesheets: string[]): VNode | null {
-    if (vm.renderer.syntheticShadow) {
+    const { renderer } = vm;
+
+    if (renderer.syntheticShadow) {
         for (let i = 0; i < stylesheets.length; i++) {
-            insertGlobalStyle(stylesheets[i]);
+            renderer.insertGlobalStylesheet(stylesheets[i]);
         }
 
         return null;

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -22,7 +22,7 @@ type StylesheetFactory = (
 ) => string;
 
 /**
- * The list of stylesheets associated with a template. Each entry either a StylesheetFactory or a
+ * The list of stylesheets associated with a template. Each entry is either a StylesheetFactory or a
  * TemplateStylesheetFactory a given stylesheet depends on other external stylesheets (via the
  * @import CSS declaration).
  */

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -34,33 +34,35 @@ function createShadowStyleVNode(content: string): VNode {
     );
 }
 
-/**
- * Reset the styling token applied to the host element.
- */
-export function resetStyleAttributes(vm: VM): void {
-    const { context, elm, renderer } = vm;
+export function updateSyntheticShadowAttributes(vm: VM, template: Template) {
+    const { elm, context, renderer } = vm;
+    const { stylesheets: newStylesheets, stylesheetTokens: newStylesheetTokens } = template;
 
-    // Remove the style attribute currently applied to the host element.
+    let newHostAttribute: string | undefined;
+    let newShadowAttribute: string | undefined;
+
+    // Reset the styling token applied to the host element.
     const oldHostAttribute = context.hostAttribute;
     if (!isUndefined(oldHostAttribute)) {
         renderer.removeAttribute(elm, oldHostAttribute);
     }
 
-    // Reset the scoping attributes associated to the context.
-    context.hostAttribute = context.shadowAttribute = undefined;
-}
+    // Apply the new template styling token to the host element, if the new template has any
+    // associated stylesheets.
+    if (
+        !isUndefined(newStylesheetTokens) &&
+        !isUndefined(newStylesheets) &&
+        newStylesheets.length !== 0
+    ) {
+        newHostAttribute = newStylesheetTokens.hostAttribute;
+        newShadowAttribute = newStylesheetTokens.shadowAttribute;
 
-/**
- * Apply/Update the styling token applied to the host element.
- */
-export function applyStyleAttributes(vm: VM, hostAttribute: string, shadowAttribute: string): void {
-    const { context, elm, renderer } = vm;
+        renderer.setAttribute(elm, newHostAttribute, '');
+    }
 
-    // Remove the style attribute currently applied to the host element.
-    renderer.setAttribute(elm, hostAttribute, '');
-
-    context.hostAttribute = hostAttribute;
-    context.shadowAttribute = shadowAttribute;
+    // Update the styling tokens present on the context object.
+    context.hostAttribute = newHostAttribute;
+    context.shadowAttribute = newShadowAttribute;
 }
 
 export function getStylesheetsContent(vm: VM, template: Template): string[] {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -23,7 +23,7 @@ import { SlotSet, TemplateCache, VM, resetShadowRoot, runWithBoundaryProtection 
 import { EmptyArray } from './utils';
 import { isTemplateRegistered, registerTemplate } from './secure-template';
 import {
-    evaluateCSS,
+    createStylesheet,
     StylesheetFactory,
     applyStyleAttributes,
     resetStyleAttributes,
@@ -156,7 +156,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
                         applyStyleAttributes(vm, hostAttribute, shadowAttribute);
                         // Caching style vnode so it can be reused on every render
                         const stylesheetsContent = getStylesheetsContent(vm, html);
-                        context.styleVNode = evaluateCSS(vm, stylesheetsContent);
+                        context.styleVNode = createStylesheet(vm, stylesheetsContent);
                     }
                 }
 

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -52,7 +52,7 @@ export interface Template {
     /** The list of slot names used in the template. */
     slots?: string[];
     /** The stylesheet associated with the template. */
-    stylesheets?: StylesheetFactory[];
+    stylesheets?: (StylesheetFactory | StylesheetFactory[])[];
     /** The stylesheet tokens used for synthetic shadow style scoping. */
     stylesheetTokens?: {
         /** HTML attribute that need to be applied to the host element. This attribute is used for

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -22,27 +22,12 @@ import { SlotSet, TemplateCache, VM, resetShadowRoot, runWithBoundaryProtection 
 import { EmptyArray } from './utils';
 import { isTemplateRegistered, registerTemplate } from './secure-template';
 import {
+    TemplateStylesheetFactories,
     createStylesheet,
-    StylesheetFactory,
     getStylesheetsContent,
     updateSyntheticShadowAttributes,
 } from './stylesheet';
 import { startMeasure, endMeasure } from './performance-timing';
-
-export let isUpdatingTemplate: boolean = false;
-
-let vmBeingRendered: VM | null = null;
-export function getVMBeingRendered(): VM | null {
-    return vmBeingRendered;
-}
-export function setVMBeingRendered(vm: VM | null) {
-    vmBeingRendered = vm;
-}
-export function isVMBeingRendered(vm: VM) {
-    return vm === vmBeingRendered;
-}
-
-export { registerTemplate };
 
 export interface Template {
     (api: RenderAPI, cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
@@ -50,7 +35,7 @@ export interface Template {
     /** The list of slot names used in the template. */
     slots?: string[];
     /** The stylesheet associated with the template. */
-    stylesheets?: Array<StylesheetFactory | StylesheetFactory[]>;
+    stylesheets?: TemplateStylesheetFactories;
     /** The stylesheet tokens used for synthetic shadow style scoping. */
     stylesheetTokens?: {
         /** HTML attribute that need to be applied to the host element. This attribute is used for
@@ -62,6 +47,18 @@ export interface Template {
         shadowAttribute: string;
     };
 }
+
+export let isUpdatingTemplate: boolean = false;
+
+let vmBeingRendered: VM | null = null;
+export function getVMBeingRendered(): VM | null {
+    return vmBeingRendered;
+}
+export function setVMBeingRendered(vm: VM | null) {
+    vmBeingRendered = vm;
+}
+
+export { registerTemplate };
 
 function validateSlots(vm: VM, html: Template) {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -27,6 +27,7 @@ import {
     StylesheetFactory,
     applyStyleAttributes,
     resetStyleAttributes,
+    getStylesheetsContent,
 } from './stylesheet';
 import { startMeasure, endMeasure } from './performance-timing';
 
@@ -154,12 +155,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
                         const { hostAttribute, shadowAttribute } = stylesheetTokens;
                         applyStyleAttributes(vm, hostAttribute, shadowAttribute);
                         // Caching style vnode so it can be reused on every render
-                        context.styleVNode = evaluateCSS(
-                            vm,
-                            stylesheets,
-                            hostAttribute,
-                            shadowAttribute
-                        );
+                        const stylesheetsContent = getStylesheetsContent(vm, html);
+                        context.styleVNode = evaluateCSS(vm, stylesheetsContent);
                     }
                 }
 

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -20,7 +20,7 @@ import * as api from './api';
 import { RenderAPI } from './api';
 import { SlotSet, TemplateCache, VM, resetShadowRoot, runWithBoundaryProtection } from './vm';
 import { EmptyArray } from './utils';
-import { isTemplateRegistered, registerTemplate } from './secure-template';
+import { isTemplateRegistered } from './secure-template';
 import {
     TemplateStylesheetFactories,
     createStylesheet,
@@ -57,8 +57,6 @@ export function getVMBeingRendered(): VM | null {
 export function setVMBeingRendered(vm: VM | null) {
     vmBeingRendered = vm;
 }
-
-export { registerTemplate };
 
 function validateSlots(vm: VM, html: Template) {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -5,8 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { assert, hasOwnProperty, isUndefined } from '@lwc/shared';
+import { assert, hasOwnProperty, isUndefined, create } from '@lwc/shared';
 import { Renderer } from '@lwc/engine-core';
+
+const globalStylesheets: { [content: string]: true } = create(null);
+const globalStylesheetsParentElement: Element = document.head || document.body || document;
 
 // TODO [#0]: Evaluate how we can extract the `$shadowToken$` property name in a shared package
 // to avoid having to synchronize it between the different modules.
@@ -123,6 +126,20 @@ export const renderer: Renderer<Node, Element> = {
 
     tagName(element: Element): string {
         return element.tagName;
+    },
+
+    insertGlobalStylesheet(content: string): void {
+        if (!isUndefined(globalStylesheets[content])) {
+            return;
+        }
+
+        globalStylesheets[content] = true;
+
+        const elm = document.createElement('style');
+        elm.type = 'text/css';
+        elm.textContent = content;
+
+        globalStylesheetsParentElement.appendChild(elm);
     },
 
     assertInstanceOfHTMLElement(elm: any, msg: string) {

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -213,7 +213,7 @@ export const renderer: Renderer<HostNode, HostElement> = {
     },
 
     insertGlobalStylesheet() {
-        // Noop on SSR (for now). This need to be reevaluated whenever we will implement support for 
+        // Noop on SSR (for now). This need to be reevaluated whenever we will implement support for
         // synthetic shadow.
     },
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -212,11 +212,16 @@ export const renderer: Renderer<HostNode, HostElement> = {
         return element.name;
     },
 
+    insertGlobalStylesheet() {
+        // Noop on SSR (for now). This need to be reevaluated whenever we will implement support for 
+        // synthetic shadow.
+    },
+
     addEventListener() {
-        /* Noop on SSR */
+        // Noop on SSR.
     },
     removeEventListener() {
-        /* Noop on SSR */
+        // Noop on SSR.
     },
 
     dispatchEvent: unsupportedMethod('dispatchEvent'),

--- a/packages/integration-karma/test/bundle/css_only/index.spec.js
+++ b/packages/integration-karma/test/bundle/css_only/index.spec.js
@@ -1,5 +1,7 @@
 import { createElement } from 'lwc';
+
 import Container from 'x/cssContainer';
+import ContainerComposition from 'x/cssContainerComposition';
 
 describe('CSS only modules', () => {
     it('CSS should be applied', function () {
@@ -14,6 +16,22 @@ describe('CSS only modules', () => {
             expect(styles.borderBottomStyle).toContain('dashed');
             expect(styles.color).toContain('rgb(255, 0, 0)');
             expect(styles.backgroundColor).toContain('rgb(138, 43, 226)');
+        });
+    });
+
+    it('should support CSS only module referencing other CSS only modules', () => {
+        const elm = createElement('x-css-container-composition', { is: ContainerComposition });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            const p = elm.shadowRoot.querySelector('p');
+            expect(window.getComputedStyle(p).borderBottomStyle).toContain('dashed');
+
+            const div = elm.shadowRoot.querySelector('div');
+            expect(window.getComputedStyle(div).borderBottomStyle).toContain('dashed');
+
+            const span = elm.shadowRoot.querySelector('span');
+            expect(window.getComputedStyle(span).borderBottomStyle).toContain('dashed');
         });
     });
 });

--- a/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.css
+++ b/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.css
@@ -1,0 +1,5 @@
+@import 'x/onlyCssComposition';
+
+div {
+    border: 1px dashed blue;
+}

--- a/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.html
+++ b/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.html
@@ -1,0 +1,5 @@
+<template>
+    <p></p>
+    <span></span>
+    <div></div>
+</template>

--- a/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.js
+++ b/packages/integration-karma/test/bundle/css_only/x/cssContainerComposition/cssContainerComposition.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class CssContainerComposition extends LightningElement {}

--- a/packages/integration-karma/test/bundle/css_only/x/onlyCssComposition/onlyCssComposition.css
+++ b/packages/integration-karma/test/bundle/css_only/x/onlyCssComposition/onlyCssComposition.css
@@ -1,0 +1,5 @@
+@import 'x/onlyCss';
+
+span {
+    border: 1px dashed red;
+}


### PR DESCRIPTION
## Details

This PR reworks how styles are injected in LWC components:
- **for synthetic shadow**, the stylesheets are injected via a new API on the renderer: `insertGlobalStylesheet`. This method abstracts away how stylesheets should be injected. In the case of `@lwc/engine-dom`, the stylesheets are injected at the document level while. In the case of `@lwc/engine-server`, the stylesheets can be gathered to produce the final HTML output.

- **for native shadow**, the stylesheet clone has been removed because the performance gain is almost non-existent. All the evergreen browsers, when creating a new stylesheet will reuse existing CSSOM if the string content has already been parsed. I also didn't measure any performance boost that `Node.prototype.cloneNode` could gives compared to `Document.prototype.createElement` ([benchmark](https://gist.github.com/pmdartus/30ff9db2d61dd7f73861b2e7208fea7e)). Removing this specific code path, make the code completely decoupled from the DOM and doesn't require new capabilities to be added to the renderer.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7532176
