### PR TITLE
feat(engine): identifiable reactive objects and component instances

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@lwc/features": "1.7.3",
         "@lwc/shared": "1.7.3",
-        "observable-membrane": "0.26.1"
+        "observable-membrane": "1.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -38,6 +38,8 @@ import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import { HTMLElementConstructor } from './base-bridge-element';
+import { tagPropertyKey } from './membrane';
+import { EmptyObject } from './utils';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -211,6 +213,9 @@ function BaseLightningElementConstructor(this: LightningElement): LightningEleme
         vm.setHook = setHook;
         vm.getHook = getHook;
     }
+
+    // Making the component instance a live value when using Locker to support expandos.
+    defineProperty(component, tagPropertyKey, EmptyObject);
 
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -7,6 +7,8 @@
 import ObservableMembrane from 'observable-membrane';
 import { valueObserved, valueMutated } from './mutation-tracker';
 
+export const tagPropertyKey = Symbol.for('@@lockerLiveValue');
+
 function valueDistortion(value: any) {
     return value;
 }
@@ -15,6 +17,7 @@ export const reactiveMembrane = new ObservableMembrane({
     valueObserved,
     valueMutated,
     valueDistortion,
+    tagPropertyKey,
 });
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -9510,10 +9510,10 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-observable-membrane@0.26.1:
-  version "0.26.1"
-  resolved "http://npm.lwcjs.org/observable-membrane/-/observable-membrane-0.26.1/5619a7b2f4b0414d62b3e6cc2ea65734a08cce7a.tgz#5619a7b2f4b0414d62b3e6cc2ea65734a08cce7a"
-  integrity sha512-fBxLHtd0pUFI/rKh6Dfn9fxjEgY4NkRIqlPEKa9fR28rC9CQDfQ5P+t292CtAArtXOQ1mF8Nq9m1cF52IdN8DA==
+observable-membrane@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.0.0.tgz#f468308bb733b58e87ff4d3958c642e045b123c2"
+  integrity sha512-+oGaWNOGLR0xoOkYDB3B0AbXgFkyzaNCMgnxhA6EUu3G3gSpmhqDo18VMF2hehaLKlJmur1Iup/U0+OKKer6wg==
 
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Details

This PR enables vnext to function with LWC:

* [x] add a tag to any reactive proxy (read/write and read/only alike).
* [x] add a tag to component's instances to support expandos and other mutations.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
