### PR TITLE
fix(synthetic-shadow): dont add key for slotted text vnode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -616,7 +616,9 @@ export function allocateInSlot(vm: VM, children: VNodes) {
         // which might have similar keys. Each vnode will always have a key that
         // starts with a numeric character from compiler. In this case, we add a unique
         // notation for slotted vnodes keys, e.g.: `@foo:1:1`
-        vnode.key = `@${slotName}:${vnode.key}`;
+        if (!isUndefined(vnode.key)) {
+            vnode.key = `@${slotName}:${vnode.key}`;
+        }
         ArrayPush.call(vnodes, vnode);
     }
     if (isFalse(vm.isDirty)) {

--- a/packages/integration-karma/test/rendering/slotted-text-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/slotted-text-diffing/index.spec.js
@@ -1,0 +1,24 @@
+import { createElement } from 'lwc';
+import Container from 'x/container';
+
+describe('Dynamic diffing algo for slotted text', () => {
+    it('should not confuse text vnodes when moving elements', function () {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.textContent).toBe('first textDisplay Boolean Value: truesecond text');
+        elm.toggleVisibility();
+
+        return Promise.resolve()
+            .then(() => {
+                const text = elm.shadowRoot.textContent;
+                expect(text).toBe('Display Boolean Value: false');
+
+                elm.toggleVisibility();
+            })
+            .then(() => {
+                const text = elm.shadowRoot.textContent;
+                expect(text).toBe('first textDisplay Boolean Value: truesecond text');
+            });
+    });
+});

--- a/packages/integration-karma/test/rendering/slotted-text-diffing/x/child/child.html
+++ b/packages/integration-karma/test/rendering/slotted-text-diffing/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <slot></slot>
+</template>

--- a/packages/integration-karma/test/rendering/slotted-text-diffing/x/child/child.js
+++ b/packages/integration-karma/test/rendering/slotted-text-diffing/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {}

--- a/packages/integration-karma/test/rendering/slotted-text-diffing/x/container/container.html
+++ b/packages/integration-karma/test/rendering/slotted-text-diffing/x/container/container.html
@@ -1,0 +1,11 @@
+<template>
+    <x-child>
+        <template if:true={visible}>
+            <span>first text</span>
+        </template>
+        Display Boolean Value: {visible}
+        <template if:true={visible}>
+            <span>second text</span>
+        </template>
+    </x-child>
+</template>

--- a/packages/integration-karma/test/rendering/slotted-text-diffing/x/container/container.js
+++ b/packages/integration-karma/test/rendering/slotted-text-diffing/x/container/container.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Container extends LightningElement {
+    visible = true;
+
+    @api toggleVisibility() {
+        this.visible = !this.visible;
+    }
+}


### PR DESCRIPTION
## Details

When vnodes are allocated in slots (synthetic-shadow only), the process [rewrites the vnode key](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/engine-core/src/framework/vm.ts#L618), in the case of text vnodes (they don't have key), it will make 2 different text vnodes in the same slot, to have the same key.

Later on in [this section](https://github.com/salesforce/lwc/blob/master/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts#L123-L145) diffing algo, [createKeyToOldIdx](https://github.com/salesforce/lwc/blob/538e6143b040880e7d3df771c863c5e5c5b91c19/packages/%40lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts#L34) will map incorrectly those 2 nodes, causing the algo to patch the incorrect vnode, which eventually triggers an error.

This PR fixes the issue by not adding the slot key for text nodes.


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`