### PR TITLE
feat(babel-plugin-component): add new renderComponent API

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/component.spec.js
@@ -88,15 +88,13 @@ describe('Element import', () => {
     );
 
     pluginTest(
-        'allows importing supported apis from "lwc"',
+        'allows importing supported apis from "@lwc/engine-core"',
         `
         import {
             api,
             track,
             wire,
-            createElement,
             LightningElement,
-            buildCustomElementConstructor,
             getComponentDef,
             getComponentConstructor,
             isComponentConstructor,
@@ -107,7 +105,36 @@ describe('Element import', () => {
     `,
         {
             output: {
-                code: `import { api, track, wire, createElement, LightningElement, buildCustomElementConstructor, getComponentDef, getComponentConstructor, isComponentConstructor, readonly, register, unwrap } from "lwc";`,
+                code: `import { api, track, wire, LightningElement, getComponentDef, getComponentConstructor, isComponentConstructor, readonly, register, unwrap } from "lwc";`,
+            },
+        }
+    );
+
+    pluginTest(
+        'allows importing supported apis from "@lwc/engine-dom"',
+        `
+        import {
+            createElement,
+            buildCustomElementConstructor,
+        } from "lwc";
+    `,
+        {
+            output: {
+                code: `import { createElement,buildCustomElementConstructor } from "lwc";`,
+            },
+        }
+    );
+
+    pluginTest(
+        'allows importing supported apis from "@lwc/engine-server"',
+        `
+        import {
+            renderComponent,
+        } from "lwc";
+    `,
+        {
+            output: {
+                code: `import { renderComponent } from "lwc";`,
             },
         }
     );

--- a/packages/@lwc/babel-plugin-component/src/constants.js
+++ b/packages/@lwc/babel-plugin-component/src/constants.js
@@ -35,8 +35,8 @@ const LWC_PACKAGE_EXPORTS = {
 };
 
 const LWC_SUPPORTED_APIS = new Set([
-    'buildCustomElementConstructor',
-    'createElement',
+    // From "@lwc/engine-core"
+    ...Object.values(LWC_PACKAGE_EXPORTS),
     'getComponentDef',
     'getComponentConstructor',
     'isComponentConstructor',
@@ -45,7 +45,13 @@ const LWC_SUPPORTED_APIS = new Set([
     'register',
     'setFeatureFlagForTest',
     'unwrap',
-    ...Object.values(LWC_PACKAGE_EXPORTS),
+
+    // From "@lwc/engine-dom"
+    'buildCustomElementConstructor',
+    'createElement',
+
+    // From "@lwc/engine-server"
+    'renderComponent',
 ]);
 
 const LWC_DECORATORS = [


### PR DESCRIPTION
## Details

Add new `renderComponent` API to the `@lwc/babel-plugin-component` allow list.

As a side note, I really think this should be the job of a new linting rule, should not be part of the compiler. It's maybe something we should attempt to migrate for the next release.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 