### PR TITLE
feat(engine-server): Disable wire adapters in SSR

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -296,7 +296,7 @@ export function createVM<HostNode, HostElement>(
     createComponent(vm, def.ctor);
 
     // Initializing the wire decorator per instance only when really needed
-    if (hasWireAdapters(vm)) {
+    if (isFalse(renderer.ssr) && hasWireAdapters(vm)) {
         installWireAdapters(vm);
     }
 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
@@ -1,0 +1,1 @@
+<x-wire><template shadow-root>Wire adapter invoked: false</template></x-wire>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/adapter.js
@@ -1,0 +1,5 @@
+export let isAdapterInvoked = false;
+
+export function adapter() {
+    isAdapterInvoked = true;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/wire.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/wire.html
@@ -1,0 +1,3 @@
+<template>
+    Wire adapter invoked: {isAdapterInvoked}
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/wire.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/wire.js
@@ -1,0 +1,12 @@
+import { LightningElement, wire } from 'lwc';
+
+import { adapter, isAdapterInvoked } from './adapter';
+
+export default class Wire extends LightningElement {
+    @wire(adapter)
+    wiredProp;
+
+    get isAdapterInvoked() {
+        return isAdapterInvoked;
+    }
+}


### PR DESCRIPTION
## Details

This PR disables wire adapter execution when running in SSR mode.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7532187
