### PR TITLE
fix(engine-server): use globalThis to attach polyfills

### DIFF
--- a/packages/@lwc/engine-server/src/polyfills.ts
+++ b/packages/@lwc/engine-server/src/polyfills.ts
@@ -5,16 +5,18 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { defineProperties, globalThis } from '@lwc/shared';
+
 /**
  * The following constructor might be used in either the constructor or the connectedCallback. In
  * order to ensure that the component evaluates, we attach those mock constructors to the global
  * object.
  */
-(function () {
+if (typeof Event !== 'function' && typeof CustomEvent !== 'function') {
     class Event {}
     class CustomEvent extends Event {}
 
-    Object.defineProperties(global, {
+    defineProperties(globalThis, {
         Event: {
             value: Event,
             configurable: true,
@@ -26,4 +28,4 @@
             writable: true,
         },
     });
-})();
+}

--- a/packages/@lwc/features/src/runtime.ts
+++ b/packages/@lwc/features/src/runtime.ts
@@ -5,15 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import features, { FeatureFlagLookup, FeatureFlagValue } from './flags';
-import { create, isFalse, isTrue, isUndefined } from '@lwc/shared';
-import { getGlobalThis } from './global-this';
+import { create, isFalse, isTrue, isUndefined, globalThis } from '@lwc/shared';
 
-const _globalThis: any = getGlobalThis();
-if (!_globalThis.lwcRuntimeFlags) {
-    Object.defineProperty(_globalThis, 'lwcRuntimeFlags', { value: create(null) });
+if (!globalThis.lwcRuntimeFlags) {
+    Object.defineProperty(globalThis, 'lwcRuntimeFlags', { value: create(null) });
 }
 
-const runtimeFlags: FeatureFlagLookup = _globalThis.lwcRuntimeFlags;
+const runtimeFlags: FeatureFlagLookup = globalThis.lwcRuntimeFlags;
 
 // This function is not supported for use within components and is meant for
 // configuring runtime feature flags during app initialization.

--- a/packages/@lwc/shared/src/global-this.ts
+++ b/packages/@lwc/shared/src/global-this.ts
@@ -5,18 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-// Cached reference to globalThis
-let _globalThis: any;
-
-if (typeof globalThis === 'object') {
-    _globalThis = globalThis;
-}
-
-export function getGlobalThis() {
-    if (typeof _globalThis === 'object') {
-        return _globalThis;
+// Inspired from: https://mathiasbynens.be/notes/globalthis
+const _globalThis = (function (): any {
+    // On recent browsers, `globalThis` is already defined. In this case return it directly.
+    if (typeof globalThis === 'object') {
+        return globalThis;
     }
 
+    let _globalThis: any;
     try {
         // eslint-disable-next-line no-extend-native
         Object.defineProperty(Object.prototype, '__magic__', {
@@ -26,8 +22,8 @@ export function getGlobalThis() {
             configurable: true,
         });
 
-        // @ts-ignore
         // __magic__ is undefined in Safari 10 and IE10 and older.
+        // @ts-ignore
         // eslint-disable-next-line no-undef
         _globalThis = __magic__;
 
@@ -36,12 +32,15 @@ export function getGlobalThis() {
     } catch (ex) {
         // In IE8, Object.defineProperty only works on DOM objects.
     } finally {
-        // If the magic above fails for some reason we assume that we are in a
-        // legacy browser. Assume `window` exists in this case.
+        // If the magic above fails for some reason we assume that we are in a legacy browser.
+        // Assume `window` exists in this case.
         if (typeof _globalThis === 'undefined') {
+            // @ts-ignore
             _globalThis = window;
         }
     }
 
     return _globalThis;
-}
+})();
+
+export { _globalThis as globalThis };

--- a/packages/@lwc/shared/src/index.ts
+++ b/packages/@lwc/shared/src/index.ts
@@ -8,6 +8,7 @@ import * as assert from './assert';
 
 export * from './aria';
 export * from './language';
+export * from './global-this';
 export * from './fields';
 export * from './void-elements';
 export * from './html-attributes';


### PR DESCRIPTION
## Details

This PR replace changes the way `@lwc/engine-server` attaches `Event` and `CustomEvent` polyfills are attached to the host environment global object. Currently on those polyfills are attached to the `global` object, this object is specific to Node.js environment. With this PR, the `global` object is replaced with `globalThis` to be compatible with other environments than Node.js.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7552574
