### PR TITLE
fix(engine-core): export wire types used in WireAdapter

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -39,4 +39,11 @@ export { getComponentDef, isComponentConstructor } from './def';
 
 // Types -------------------------------------------------------------------------------------------
 export type { Renderer } from './renderer';
-export type { DataCallback, WireAdapter, WireAdapterConstructor } from './wiring';
+export type {
+    ConfigValue as WireConfigValue,
+    ContextValue as WireContextValue,
+    DataCallback,
+    WireAdapter,
+    WireAdapterConstructor,
+    WireAdapterSchemaValue,
+} from './wiring';

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -217,7 +217,7 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireAdapter {
 }
 
 export type DataCallback = (value: any) => void;
-type ConfigValue = Record<string, any>;
+export type ConfigValue = Record<string, any>;
 
 export interface WireAdapter {
     update(config: ConfigValue, context?: ContextValue): void;
@@ -225,7 +225,7 @@ export interface WireAdapter {
     disconnect(): void;
 }
 
-type WireAdapterSchemaValue = 'optional' | 'required';
+export type WireAdapterSchemaValue = 'optional' | 'required';
 
 interface WireDef {
     method?: (data: any) => void;

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { WireAdapter, DataCallback } from '@lwc/engine-core';
+import { WireConfigValue, WireAdapter, DataCallback } from '@lwc/engine-core';
 import { ValueChangedEvent } from './value-changed-event';
 
 const { freeze, defineProperty, isExtensible } = Object;
@@ -196,7 +196,7 @@ class LegacyWireAdapterBridge implements WireAdapter {
 
     protected eventTarget: WireEventTarget;
 
-    update(config: Record<string, any>) {
+    update(config: WireConfigValue) {
         if (this.isFirstUpdate) {
             // this is a special case for legacy wire adapters: when all the config params are undefined,
             // the config on the wire adapter should not be called until one of them changes.


### PR DESCRIPTION
## Details
This PR adds `WireConfigValue`, `WireContextValue` and `WireAdapterSchemaValue` to the export list of `engine-core`.

The new exported types  are used with `WireAdapter` and `WireAdapterConstructor`.

Completes issue #1909 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`