### PR TITLE
feat(engine-server): Add parameter check to renderComponent

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -20,7 +20,7 @@ describe('renderComponent', () => {
         'asserts the first parameter is a string (type: %p)',
         (value) => {
             expect(() => renderComponent(value as any, Test, {})).toThrow(
-                `"renderComponent" expects a string as first parameter but received ${value}.`
+                `"renderComponent" expects a string as the first parameter but instead received ${value}.`
             );
         }
     );
@@ -29,7 +29,7 @@ describe('renderComponent', () => {
         'asserts the seconds parameter is a function (type: %p)',
         (value) => {
             expect(() => renderComponent('x-test', value as any, {})).toThrow(
-                `"renderComponent" expects a valid component constructor as second parameter but received ${value}.`
+                `"renderComponent" expects a valid component constructor as the second parameter but instead received ${value}.`
             );
         }
     );
@@ -38,7 +38,7 @@ describe('renderComponent', () => {
         'asserts the third parameter is an object (type: %p)',
         (value) => {
             expect(() => renderComponent('x-test', Test, value as any)).toThrow(
-                `"renderComponent" expected an object as third parameter but received ${value}.`
+                `"renderComponent" expects an object as the third parameter but instead received ${value}.`
             );
         }
     );

--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -1,0 +1,38 @@
+import { renderComponent, LightningElement } from '../index';
+
+class Test extends LightningElement {}
+
+describe('renderComponent', () => {
+    it('returns the rendered tree as string', () => {
+        expect(renderComponent('x-test', Test)).toBe(
+            '<x-test><template shadow-root></template></x-test>'
+        );
+    });
+
+    it.each([undefined, null, 1, {}, () => {}])(
+        'asserts the first parameter is a string (type: %p)',
+        (value) => {
+            expect(() => renderComponent(value as any, Test, {})).toThrow(
+                `"renderComponent" expects a string as first parameter but received ${value}.`
+            );
+        }
+    );
+
+    it.each([undefined, null, 1, 'test', {}])(
+        'asserts the seconds parameter is a function (type: %p)',
+        (value) => {
+            expect(() => renderComponent('x-test', value as any, {})).toThrow(
+                `"renderComponent" expects a valid component constructor as second parameter but received ${value}.`
+            );
+        }
+    );
+
+    it.each([null, 1, 'test', () => {}])(
+        'asserts the third parameter is an object (type: %p)',
+        (value) => {
+            expect(() => renderComponent('x-test', Test, value as any)).toThrow(
+                `"renderComponent" expected an object as third parameter but received ${value}.`
+            );
+        }
+    );
+});

--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
 import { renderComponent, LightningElement } from '../index';
 
 class Test extends LightningElement {}

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -23,19 +23,19 @@ export function renderComponent(
 ): string {
     if (!isString(tagName)) {
         throw new TypeError(
-            `"renderComponent" expects a string as first parameter but received ${tagName}.`
+            `"renderComponent" expects a string as the first parameter but instead received ${tagName}.`
         );
     }
 
     if (!isFunction(Ctor)) {
         throw new TypeError(
-            `"renderComponent" expects a valid component constructor as second parameter but received ${Ctor}.`
+            `"renderComponent" expects a valid component constructor as the second parameter but instead received ${Ctor}.`
         );
     }
 
     if (!isObject(props) || isNull(props)) {
         throw new TypeError(
-            `"renderComponent" expected an object as third parameter but received ${props}.`
+            `"renderComponent" expects an object as the third parameter but instead received ${props}.`
         );
     }
 

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -11,6 +11,7 @@ import {
     setElementProto,
     LightningElement,
 } from '@lwc/engine-core';
+import { isString, isFunction, isObject, isNull } from '@lwc/shared';
 
 import { renderer } from '../renderer';
 import { serializeElement } from '../serializer';
@@ -18,8 +19,26 @@ import { serializeElement } from '../serializer';
 export function renderComponent(
     tagName: string,
     Ctor: typeof LightningElement,
-    props: { [name: string]: any }
+    props: { [name: string]: any } = {}
 ): string {
+    if (!isString(tagName)) {
+        throw new TypeError(
+            `"renderComponent" expects a string as first parameter but received ${tagName}.`
+        );
+    }
+
+    if (!isFunction(Ctor)) {
+        throw new TypeError(
+            `"renderComponent" expects a valid component constructor as second parameter but received ${Ctor}.`
+        );
+    }
+
+    if (!isObject(props) || isNull(props)) {
+        throw new TypeError(
+            `"renderComponent" expected an object as third parameter but received ${props}.`
+        );
+    }
+
     const element = renderer.createElement(tagName);
 
     const def = getComponentInternalDef(Ctor);


### PR DESCRIPTION
## Details

This PR adds runtime checks for the `renderComponent` API and make the third parameter optional.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7773530
