### PR TITLE
fix(engine-server): Match declarative shadow output with latest spec

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-boolean>
-  <template shadow-root>
+  <template shadowroot="open">
     <input type="checkbox" required readonly checked />
   </template>
 </x-attribute-boolean>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-aria/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-aria/expected.html
@@ -1,12 +1,12 @@
 <x-attribute-component-aria>
-  <template shadow-root>
+  <template shadowroot="open">
     <x-child
       role="progressbar"
       aria-valuemin="0"
       aria-valuemax="100"
       aria-valuenow="20"
     >
-      <template shadow-root></template>
+      <template shadowroot="open"></template>
     </x-child>
   </template>
 </x-attribute-component-aria>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-component-global-html>
-  <template shadow-root>
+  <template shadowroot="open">
     <x-child
       data-test="test"
       accesskey="A"
@@ -13,7 +13,7 @@
       class="foo bar"
       style="color: red; background: blue;"
     >
-      <template shadow-root>
+      <template shadowroot="open">
         Passthrough properties:
         <ul>
           <li>Title: foo</li>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-dynamic>
-  <template shadow-root>
+  <template shadowroot="open">
     <div data-foo="foo" class="foo" style="color: red;"></div>
   </template>
 </x-attribute-dynamic>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-global-html>
-  <template shadow-root>
+  <template shadowroot="open">
     <div
       accesskey="A"
       contenteditable="true"

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-live-bindings/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-live-bindings/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-live-bindings>
-  <template shadow-root>
+  <template shadowroot="open">
     <p>
       Checked:
       <input type="checkbox" checked />

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-static/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-static/expected.html
@@ -1,5 +1,5 @@
 <x-attribute-static>
-  <template shadow-root>
+  <template shadowroot="open">
     <div
       data-foo="foo"
       class="foo bar foo-bar"

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
@@ -1,20 +1,22 @@
 <x-attribute-style>
-  <template shadow-root>
+  <template shadowroot="open">
     <div style="color: red;"></div>
     <div style="color: blue; background: black; border: 1px solid red;"></div>
     <div
       style="border-width: 1px; border-style: solid; border-color: red;"
     ></div>
     <div style="color: salmon; background-color: chocolate;"></div>
-    <x-child style="color: red;"><template shadow-root></template></x-child>
+    <x-child style="color: red;">
+      <template shadowroot="open"></template>
+    </x-child>
     <x-child style="color: blue; background: black; border: 1px solid red;">
-      <template shadow-root></template>
+      <template shadowroot="open"></template>
     </x-child>
     <x-child style="border-width: 1px; border-style: solid; border-color: red;">
-      <template shadow-root></template>
+      <template shadowroot="open"></template>
     </x-child>
     <x-child style="color: salmon; background-color: chocolate;">
-      <template shadow-root></template>
+      <template shadowroot="open"></template>
     </x-child>
   </template>
 </x-attribute-style>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attributes-aria/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attributes-aria/expected.html
@@ -1,5 +1,5 @@
 <x-attributes-aria>
-  <template shadow-root>
+  <template shadowroot="open">
     <span id="label-id-0">This is a section</span>
     <div aria-describedby="label-id-0">I am section</div>
     <div

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/component/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/component/expected.html
@@ -1,5 +1,7 @@
 <x-component>
-  <template shadow-root>
-    <x-child><template shadow-root>I am a child component</template></x-child>
+  <template shadowroot="open">
+    <x-child>
+      <template shadowroot="open">I am a child component</template>
+    </x-child>
   </template>
 </x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/computed/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/computed/expected.html
@@ -1,1 +1,1 @@
-<x-computed><template shadow-root>7 + 3 = 10</template></x-computed>
+<x-computed><template shadowroot="open">7 + 3 = 10</template></x-computed>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/expected.html
@@ -1,0 +1,5 @@
+<x-delegates-focus>
+  <template shadowroot="open" shadowrootdelegatesfocus>
+    <button>Focus!</button>
+  </template>
+</x-delegates-focus>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/modules/x/delegates-focus/delegates-focus.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/modules/x/delegates-focus/delegates-focus.html
@@ -1,0 +1,3 @@
+<template>
+    <button>Focus!</button>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/modules/x/delegates-focus/delegates-focus.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/delegates-focus/modules/x/delegates-focus/delegates-focus.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class DelegatesFocus extends LightningElement {
+    static delegatesFocus = true;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-block/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-block/expected.html
@@ -1,5 +1,5 @@
 <x-for-each-block>
-  <template shadow-root>
+  <template shadowroot="open">
     <ul>
       <li>0 - paris</li>
       <li>1 - london</li>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-child-nested/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-child-nested/expected.html
@@ -1,27 +1,26 @@
 <x-for-each-child-nested>
-    <template shadow-root>
-      <ol>
-        <li>
-          europe
-          <x-child>
-            <template shadow-root>
-              <li>0 - paris</li>
-              <li>1 - london</li>
-              <li>2 - rome</li>
-            </template>
-          </x-child>
-        </li>
-        <li>
-          asia
-          <x-child>
-            <template shadow-root>
-              <li>0 - tokyo</li>
-              <li>1 - kuala lumpur</li>
-              <li>2 - singapore</li>
-            </template>
-          </x-child>
-        </li>
-      </ol>
-    </template>
-  </x-for-each-child-nested>
-  
+  <template shadowroot="open">
+    <ol>
+      <li>
+        europe
+        <x-child>
+          <template shadowroot="open">
+            <li>0 - paris</li>
+            <li>1 - london</li>
+            <li>2 - rome</li>
+          </template>
+        </x-child>
+      </li>
+      <li>
+        asia
+        <x-child>
+          <template shadowroot="open">
+            <li>0 - tokyo</li>
+            <li>1 - kuala lumpur</li>
+            <li>2 - singapore</li>
+          </template>
+        </x-child>
+      </li>
+    </ol>
+  </template>
+</x-for-each-child-nested>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-nested/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-nested/expected.html
@@ -1,5 +1,5 @@
 <x-for-each-nested>
-  <template shadow-root>
+  <template shadowroot="open">
     <ol>
       <li>
         europe

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list/expected.html
@@ -1,3 +1,3 @@
 <x-getter-class-list class="a c d-e">
-  <template shadow-root></template>
+  <template shadowroot="open"></template>
 </x-getter-class-list>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
@@ -1,3 +1,3 @@
 <x-getter-is-connected>
-  <template shadow-root>Is connected? true</template>
+  <template shadowroot="open">Is connected? true</template>
 </x-getter-is-connected>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-block/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-block/expected.html
@@ -1,1 +1,1 @@
-<x-if-block><template shadow-root>I am rendered!</template></x-if-block>
+<x-if-block><template shadowroot="open">I am rendered!</template></x-if-block>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot-content/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot-content/expected.html
@@ -1,21 +1,21 @@
 <x-if-conditional-slot-content>
-  <template shadow-root>
+  <template shadowroot="open">
     <div class="active-if-blocks">
       <x-conditional-slot-content>
-        <template shadow-root>
+        <template shadowroot="open">
           <x-slotted>
-            <template shadow-root><slot></slot></template>
+            <template shadowroot="open"><slot></slot></template>
             Testing if:true
             <x-child>
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Should be slotted when true === true
             </x-child>
           </x-slotted>
           <x-slotted>
-            <template shadow-root><slot></slot></template>
+            <template shadowroot="open"><slot></slot></template>
             Testing if:false
             <x-child>
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Should be slotted when false === false
             </x-child>
           </x-slotted>
@@ -24,12 +24,12 @@
     </div>
     <div class="inactive-if-blocks">
       <x-conditional-slot-content>
-        <template shadow-root>
+        <template shadowroot="open">
           <x-slotted>
-            <template shadow-root><slot></slot></template>
+            <template shadowroot="open"><slot></slot></template>
           </x-slotted>
           <x-slotted>
-            <template shadow-root><slot></slot></template>
+            <template shadowroot="open"><slot></slot></template>
           </x-slotted>
         </template>
       </x-conditional-slot-content>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot/expected.html
@@ -1,21 +1,21 @@
 <x-if-conditional-slot>
-  <template shadow-root>
+  <template shadowroot="open">
     <div class="active-if-blocks">
       <x-parent>
-        <template shadow-root>
+        <template shadowroot="open">
           <x-slotted>
-            <template shadow-root>
+            <template shadowroot="open">
               Should be active when true === true
               <slot name="trueslot"></slot>
               Should be active when false === false
               <slot name="falseslot"></slot>
             </template>
             <x-child slot="trueslot" class="slotted-child">
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Testing if:true
             </x-child>
             <x-child slot="falseslot" class="slotted-child">
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Testing if:false
             </x-child>
           </x-slotted>
@@ -24,15 +24,15 @@
     </div>
     <div class="inactive-if-blocks">
       <x-parent>
-        <template shadow-root>
+        <template shadowroot="open">
           <x-slotted>
-            <template shadow-root></template>
+            <template shadowroot="open"></template>
             <x-child slot="trueslot" class="slotted-child">
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Testing if:true
             </x-child>
             <x-child slot="falseslot" class="slotted-child">
-              <template shadow-root><slot></slot></template>
+              <template shadowroot="open"><slot></slot></template>
               Testing if:false
             </x-child>
           </x-slotted>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-custom-element-child/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-custom-element-child/expected.html
@@ -1,15 +1,15 @@
 <x-if-custom-element-child>
-  <template shadow-root>
+  <template shadowroot="open">
     <div class="active-if-blocks">
       <x-custom-element-child>
-        <template shadow-root>
+        <template shadowroot="open">
           <x-child>
-            <template shadow-root>
+            <template shadowroot="open">
               Custom element child x-child-test-false
             </template>
           </x-child>
           <x-child>
-            <template shadow-root>
+            <template shadowroot="open">
               Custom element child x-child-test-true
             </template>
           </x-child>
@@ -18,7 +18,7 @@
     </div>
     <div class="inactive-if-blocks">
       <x-custom-element-child>
-        <template shadow-root></template>
+        <template shadowroot="open"></template>
       </x-custom-element-child>
     </div>
   </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-element-child/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-element-child/expected.html
@@ -1,15 +1,15 @@
 <x-if-element-child>
-  <template shadow-root>
+  <template shadowroot="open">
     <div class="active-if-blocks">
       <x-element-child>
-        <template shadow-root>
+        <template shadowroot="open">
           <div class="div-false"></div>
           <div class="div-true"></div>
         </template>
       </x-element-child>
     </div>
     <div class="inactive-if-blocks">
-      <x-element-child><template shadow-root></template></x-element-child>
+      <x-element-child><template shadowroot="open"></template></x-element-child>
     </div>
   </template>
 </x-if-element-child>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/iterator-block/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/iterator-block/expected.html
@@ -1,5 +1,5 @@
 <x-iterator-block>
-  <template shadow-root>
+  <template shadowroot="open">
     <ul>
       <li>
         <div class="list-first"></div>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
@@ -1,5 +1,5 @@
 <x-lifecycle-hooks>
-  <template shadow-root>
+  <template shadowroot="open">
     <ul>
       <li>constructor</li>
       <li>connectedCallback</li>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-dom-manual/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-dom-manual/expected.html
@@ -1,3 +1,3 @@
 <x-lwc-dom-manual>
-  <template shadow-root><div></div></template>
+  <template shadowroot="open"><div></div></template>
 </x-lwc-dom-manual>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-dynamic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-dynamic/expected.html
@@ -1,5 +1,7 @@
 <x-lwc-dynamic>
-  <template shadow-root>
-    <x-lazy><template shadow-root>Test dynamic component!</template></x-lazy>
+  <template shadowroot="open">
+    <x-lazy>
+      <template shadowroot="open">Test dynamic component!</template>
+    </x-lazy>
   </template>
 </x-lwc-dynamic>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/method-get-attribute/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/method-get-attribute/expected.html
@@ -1,13 +1,13 @@
 <x-method-get-attribute>
-  <template shadow-root>
+  <template shadowroot="open">
     <x-child>
-      <template shadow-root><p>Value: null</p></template>
+      <template shadowroot="open"><p>Value: null</p></template>
     </x-child>
     <x-child data-attr="true">
-      <template shadow-root><p>Value: true</p></template>
+      <template shadowroot="open"><p>Value: true</p></template>
     </x-child>
     <x-child data-attr="foo">
-      <template shadow-root><p>Value: foo</p></template>
+      <template shadowroot="open"><p>Value: foo</p></template>
     </x-child>
   </template>
 </x-method-get-attribute>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/method-remove-attribute/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/method-remove-attribute/expected.html
@@ -1,3 +1,3 @@
 <x-method-remove-attribute data-a data-c>
-  <template shadow-root></template>
+  <template shadowroot="open"></template>
 </x-method-remove-attribute>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/method-set-attribute/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/method-set-attribute/expected.html
@@ -6,5 +6,5 @@
   data-empty-string
   data-override="override"
 >
-  <template shadow-root></template>
+  <template shadowroot="open"></template>
 </x-method-set-attribute>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/methods-noop/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/methods-noop/expected.html
@@ -1,1 +1,1 @@
-<x-methods-noop><template shadow-root></template></x-methods-noop>
+<x-methods-noop><template shadowroot="open"></template></x-methods-noop>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/methods-unsupported/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/methods-unsupported/expected.html
@@ -1,1 +1,3 @@
-<x-methods-unsupported><template shadow-root></template></x-methods-unsupported>
+<x-methods-unsupported>
+  <template shadowroot="open"></template>
+</x-methods-unsupported>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/expected.html
@@ -1,1 +1,1 @@
-<x-rehydration><template shadow-root>0</template></x-rehydration>
+<x-rehydration><template shadowroot="open">0</template></x-rehydration>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-fallback/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-fallback/expected.html
@@ -1,7 +1,7 @@
 <x-slots-fallback>
-  <template shadow-root>
+  <template shadowroot="open">
     <x-receiver>
-      <template shadow-root>
+      <template shadowroot="open">
         <div>
           With fallback:
           <slot name="with-fallback">I am the slot fallback</slot>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots/expected.html
@@ -1,7 +1,7 @@
 <x-slots>
-  <template shadow-root>
+  <template shadowroot="open">
     <x-receiver>
-      <template shadow-root>
+      <template shadowroot="open">
         <div>
           Default slot:
           <slot></slot>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles/expected.html
@@ -1,5 +1,5 @@
 <x-styles>
-  <template shadow-root>
+  <template shadowroot="open">
     <style type="text/css">
       :host {
         color: red;

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/text-interpolation/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/text-interpolation/expected.html
@@ -1,5 +1,5 @@
 <x-text-interpolation>
-  <template shadow-root>
+  <template shadowroot="open">
     <p>Public property: public-prop</p>
     <p>Private property: private-prop</p>
   </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/text-static/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/text-static/expected.html
@@ -1,1 +1,3 @@
-<x-text-static><template shadow-root>Static text</template></x-text-static>
+<x-text-static>
+  <template shadowroot="open">Static text</template>
+</x-text-static>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
@@ -1,1 +1,3 @@
-<x-wire><template shadow-root>Wire adapter invoked: false</template></x-wire>
+<x-wire>
+  <template shadowroot="open">Wire adapter invoked: false</template>
+</x-wire>

--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -12,7 +12,7 @@ class Test extends LightningElement {}
 describe('renderComponent', () => {
     it('returns the rendered tree as string', () => {
         expect(renderComponent('x-test', Test)).toBe(
-            '<x-test><template shadow-root></template></x-test>'
+            '<x-test><template shadowroot="open"></template></x-test>'
         );
     });
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -82,10 +82,12 @@ export const renderer: Renderer<HostNode, HostElement> = {
         return parent.children[nodeIndex + 1] || null;
     },
 
-    attachShadow(element) {
+    attachShadow(element, config) {
         element.shadowRoot = {
             type: HostNodeType.ShadowRoot,
             children: [],
+            mode: config.mode,
+            delegatesFocus: !!config.delegatesFocus,
         };
 
         return (element.shadowRoot as any) as HostNode;

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -30,7 +30,13 @@ function serializeChildNodes(children: HostChildNode[]): string {
 }
 
 function serializeShadowRoot(shadowRoot: HostShadowRoot): string {
-    return `<template shadow-root>${serializeChildNodes(shadowRoot.children)}</template>`;
+    const attrs = [`shadowroot="${shadowRoot.mode}"`];
+
+    if (shadowRoot.delegatesFocus) {
+        attrs.push('shadowrootdelegatesfocus');
+    }
+
+    return `<template ${attrs.join(' ')}>${serializeChildNodes(shadowRoot.children)}</template>`;
 }
 
 export function serializeElement(element: HostElement): string {

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -26,6 +26,8 @@ export interface HostAttribute {
 export interface HostShadowRoot {
     type: HostNodeType.ShadowRoot;
     children: HostChildNode[];
+    mode: 'open' | 'closed';
+    delegatesFocus: boolean;
 }
 
 export interface HostElement {


### PR DESCRIPTION
## Details

This PR changes the `@lwc/engine-server` format to match the latest version of the [Declarative shadow DOM proposal](https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md#feature-detection-and-polyfilling). It also adds support for the `delegatesFocus` property serialization.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.` - This is not a breaking change since the `@lwc/engine-server` is still an experimental package and the serialization format is subject to change.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7799955
