### PR TITLE
fix(wire-service): call wired methods without calling hooks

### DIFF
--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -8,7 +8,6 @@ import { assert, isUndefined, ArrayPush, defineProperty, defineProperties } from
 import { ComponentInterface } from './component';
 import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
 import { VM, runWithBoundaryProtection } from './vm';
-import { invokeComponentCallback } from './invoker';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
@@ -61,7 +60,16 @@ function createFieldDataCallback(vm: VM, name: string) {
 function createMethodDataCallback(vm: VM, method: (data: any) => any) {
     return (value: any) => {
         // dispatching new value into the wired method
-        invokeComponentCallback(vm, method, [value]);
+        runWithBoundaryProtection(
+            vm,
+            vm.owner,
+            noop,
+            () => {
+                // job
+                method.apply(vm.component, [value]);
+            },
+            noop
+        );
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -66,7 +66,7 @@ function createMethodDataCallback(vm: VM, method: (data: any) => any) {
             noop,
             () => {
                 // job
-                method.apply(vm.component, [value]);
+                method.call(vm.component, value);
             },
             noop
         );


### PR DESCRIPTION
## Details
With the wire reform we started calling wired methods via `invokeComponentCallback` instead of directly. `invokeComponentCallback` executes locker hooks, which in turns changes the identity of the method arguments (the data in this case); this breaks some adapters implementation.

This PR start calling component methods without executing the hooks, to fix an issue with existing wire adapters that rely in the identity of the provided data.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`