### PR TITLE
fix(engine-server): isConnected should not be `true` during construction

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -25,6 +25,7 @@ export {
     connectRootElement,
     disconnectRootElement,
     getAssociatedVMIfPresent,
+    isConnected,
 } from './vm';
 
 // Internal APIs used by compiled code -------------------------------------------------------------

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -25,7 +25,6 @@ export {
     connectRootElement,
     disconnectRootElement,
     getAssociatedVMIfPresent,
-    isConnected,
 } from './vm';
 
 // Internal APIs used by compiled code -------------------------------------------------------------

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -150,7 +150,7 @@ export interface VM<N = HostNode, E = HostElement> {
     ) => any;
 }
 
-type VMAssociable = Node | LightningElement | ComponentInterface;
+type VMAssociable = HostNode | LightningElement | ComponentInterface;
 
 let idx: number = 0;
 
@@ -321,6 +321,11 @@ export function getAssociatedVM(obj: VMAssociable): VM {
     }
 
     return vm!;
+}
+
+export function isConnected(obj: VMAssociable): boolean {
+    const vm = getAssociatedVM(obj);
+    return vm.state === VMState.connected;
 }
 
 export function getAssociatedVMIfPresent(obj: VMAssociable): VM | undefined {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -323,11 +323,6 @@ export function getAssociatedVM(obj: VMAssociable): VM {
     return vm!;
 }
 
-export function isConnected(obj: VMAssociable): boolean {
-    const vm = getAssociatedVM(obj);
-    return vm.state === VMState.connected;
-}
-
 export function getAssociatedVMIfPresent(obj: VMAssociable): VM | undefined {
     const maybeVm = getHiddenField(obj, ViewModelReflection);
 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
@@ -1,7 +1,8 @@
 <x-getter-is-connected>
   <template shadowroot="open">
     <ul>
-      <li>connectedCallback</li>
+      <li>constructor: false</li>
+      <li>connectedCallback: true</li>
     </ul>
   </template>
 </x-getter-is-connected>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
@@ -3,6 +3,7 @@
     <ul>
       <li>constructor: false</li>
       <li>connectedCallback: true</li>
+      <li>render: true</li>
     </ul>
   </template>
 </x-getter-is-connected>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
@@ -1,3 +1,7 @@
 <x-getter-is-connected>
-  <template shadowroot="open">Is connected? true</template>
+  <template shadowroot="open">
+    <ul>
+      <li>connectedCallback</li>
+    </ul>
+  </template>
 </x-getter-is-connected>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.html
@@ -1,3 +1,5 @@
 <template>
-    Is connected? {isComponentConnected}
+    <ul>
+        <li for:each={hooks} for:item="hook" key={hook}>{hook}</li>
+    </ul>
 </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
@@ -1,9 +1,20 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, track } from 'lwc';
 
-export default class GetterIsConnected extends LightningElement {
-    isComponentConnected;
+export default class extends LightningElement {
+    @track
+    hooks = [];
+
+    constructor() {
+        super();
+
+        if (this.isConnected) {
+            this.hooks.push('constructor');
+        }
+    }
 
     connectedCallback() {
-        this.isComponentConnected = this.isConnected;
+        if (this.isConnected) {
+            this.hooks.push('connectedCallback');
+        }
     }
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
@@ -1,4 +1,5 @@
 import { LightningElement, track } from 'lwc';
+import tmpl from './getter-is-connected.html';
 
 export default class extends LightningElement {
     @track
@@ -11,5 +12,10 @@ export default class extends LightningElement {
 
     connectedCallback() {
         this.hooks.push(`connectedCallback: ${this.isConnected}`);
+    }
+
+    render() {
+        this.hooks.push(`render: ${this.isConnected}`);
+        return tmpl;
     }
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/modules/x/getter-is-connected/getter-is-connected.js
@@ -6,15 +6,10 @@ export default class extends LightningElement {
 
     constructor() {
         super();
-
-        if (this.isConnected) {
-            this.hooks.push('constructor');
-        }
+        this.hooks.push(`constructor: ${this.isConnected}`);
     }
 
     connectedCallback() {
-        if (this.isConnected) {
-            this.hooks.push('connectedCallback');
-        }
+        this.hooks.push(`connectedCallback: ${this.isConnected}`);
     }
 }

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -15,6 +15,18 @@ import { isString, isFunction, isObject, isNull } from '@lwc/shared';
 
 import { renderer } from '../renderer';
 import { serializeElement } from '../serializer';
+import { HostElement, HostNodeType } from '../types';
+
+const FakeRootElement: HostElement = {
+    type: HostNodeType.Element,
+    name: 'fake-root-element',
+    namespace: 'ssr',
+    parent: null,
+    shadowRoot: null,
+    children: [],
+    attributes: [],
+    eventListeners: {},
+};
 
 export function renderComponent(
     tagName: string,
@@ -54,6 +66,8 @@ export function renderComponent(
     for (const [key, value] of Object.entries(props)) {
         (element as any)[key] = value;
     }
+
+    element.parent = FakeRootElement;
 
     connectRootElement(element);
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -11,7 +11,7 @@ import {
     isGlobalHtmlAttribute,
     isAriaAttribute,
 } from '@lwc/shared';
-import { Renderer, getAttrNameFromPropName } from '@lwc/engine-core';
+import { Renderer, getAttrNameFromPropName, isConnected } from '@lwc/engine-core';
 
 import { HostNode, HostElement, HostAttribute, HostNodeType } from './types';
 import { classNameToTokenList, tokenListToClassName } from './utils/classes';
@@ -291,8 +291,8 @@ export const renderer: Renderer<HostNode, HostElement> = {
         ) as CSSStyleDeclaration;
     },
 
-    isConnected() {
-        return true;
+    isConnected(node: HostNode) {
+        return isConnected(node);
     },
 
     insertGlobalStylesheet() {

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -11,7 +11,7 @@ import {
     isGlobalHtmlAttribute,
     isAriaAttribute,
 } from '@lwc/shared';
-import { Renderer, getAttrNameFromPropName, isConnected } from '@lwc/engine-core';
+import { Renderer, getAttrNameFromPropName } from '@lwc/engine-core';
 
 import { HostNode, HostElement, HostAttribute, HostNodeType } from './types';
 import { classNameToTokenList, tokenListToClassName } from './utils/classes';
@@ -292,7 +292,7 @@ export const renderer: Renderer<HostNode, HostElement> = {
     },
 
     isConnected(node: HostNode) {
-        return isConnected(node);
+        return !isNull(node.parent);
     },
 
     insertGlobalStylesheet() {


### PR DESCRIPTION
## Details

When rendering on the server, `isConnected` should reflect the current vm state.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:

* Have tests for the proposed changes been added? ✅ 

## GUS work item

W-7532119