### PR TITLE
feat: Profiler Support

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -36,6 +36,7 @@ export { registerDecorators } from './decorators/register';
 export { unwrap } from './membrane';
 export { sanitizeAttribute } from './secure-template';
 export { getComponentDef, isComponentConstructor } from './def';
+export { profilerControl as __unstable__ProfilerControl } from './profiler';
 
 // Types -------------------------------------------------------------------------------------------
 export type { Renderer } from './renderer';

--- a/packages/@lwc/engine-core/src/framework/performance-timing.ts
+++ b/packages/@lwc/engine-core/src/framework/performance-timing.ts
@@ -9,7 +9,7 @@ import { isUndefined } from '@lwc/shared';
 import { VM } from './vm';
 import { getComponentTag } from '../shared/format';
 
-type MeasurementPhase =
+export type MeasurementPhase =
     | 'constructor'
     | 'render'
     | 'patch'

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -11,7 +11,7 @@ function noop(_opId: number, _phase: number, _cmpName: string, _vm_idx: number) 
 
 let logOperation = noop;
 
-export const enum OperationId {
+export enum OperationId {
     constructor = 0,
     render = 1,
     patch = 2,

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { startMeasure, endMeasure, MeasurementPhase } from './performance-timing';
+import { VM } from './vm';
+
+function noop(_opId: number, _phase: number, _cmpName: string, _vm_idx: number) {}
+
+let logOperation = noop;
+
+export const enum OperationId {
+    constructor = 0,
+    render = 1,
+    patch = 2,
+    connectedCallback = 3,
+    renderedCallback = 4,
+    disconnectedCallback = 5,
+    errorCallback = 6,
+}
+
+const enum Phase {
+    Start = 0,
+    Stop = 1,
+}
+
+const opIdToMeasurementPhaseMappingArray: MeasurementPhase[] = [
+    'constructor',
+    'render',
+    'patch',
+    'connectedCallback',
+    'renderedCallback',
+    'disconnectedCallback',
+    'errorCallback',
+];
+
+let profilerEnabled = false;
+let logMarks = false;
+let bufferLogging = false;
+
+if (process.env.NODE_ENV !== 'production') {
+    profilerEnabled = true;
+    logMarks = true;
+    bufferLogging = false;
+}
+
+const profilerStateCallbacks: ((arg0: boolean) => void)[] = [];
+
+function trackProfilerState(callback: (arg0: boolean) => void) {
+    callback(profilerEnabled);
+    profilerStateCallbacks.push(callback);
+}
+
+function logOperationStart(opId: OperationId, vm: VM) {
+    if (logMarks) {
+        startMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
+    }
+    if (bufferLogging) {
+        const cmpName = getComponentName(vm);
+        logOperation(opId, Phase.Start, cmpName, vm.idx);
+    }
+}
+
+function logOperationEnd(opId: OperationId, vm: VM) {
+    if (logMarks) {
+        endMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
+    }
+    if (bufferLogging) {
+        const cmpName = getComponentName(vm);
+        logOperation(opId, Phase.Stop, cmpName, vm.idx);
+    }
+}
+
+function getComponentName(vm: VM) {
+    try {
+        return vm.elm.tagName;
+    } catch (error) {
+        return 'invalid-tag-name';
+    }
+}
+
+function enableProfiler() {
+    profilerEnabled = true;
+    bufferLogging = true;
+    notifyProfilerStateChange();
+}
+
+function disableProfiler() {
+    if (process.env.NODE_ENV !== 'production') {
+        // in non-prod mode we want to keep logging marks
+        profilerEnabled = true;
+        logMarks = true;
+        bufferLogging = false;
+    } else {
+        profilerEnabled = false;
+        bufferLogging = false;
+        logMarks = false;
+    }
+    notifyProfilerStateChange();
+}
+
+function notifyProfilerStateChange() {
+    for (let i = 0; i < profilerStateCallbacks.length; i++) {
+        profilerStateCallbacks[i](profilerEnabled);
+    }
+}
+
+function attachBuffer(
+    bufferCallback: (_opId: number, _phase: number, _cmpName: string, _vm_idx: number) => void
+) {
+    logOperation = bufferCallback;
+    bufferLogging = true;
+}
+
+function detachBuffer() {
+    const currentLogOperation = logOperation;
+    logOperation = noop;
+    bufferLogging = false;
+    return currentLogOperation;
+}
+
+const profilerControl = {
+    enableProfiler,
+    disableProfiler,
+    attachBuffer,
+    detachBuffer,
+};
+
+export { logOperationStart, logOperationEnd, trackProfilerState, profilerControl };

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -21,7 +21,7 @@ export enum OperationId {
     errorCallback = 6,
 }
 
-const enum Phase {
+enum Phase {
     Start = 0,
     Stop = 1,
 }

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -27,7 +27,7 @@ import {
     getStylesheetsContent,
     updateSyntheticShadowAttributes,
 } from './stylesheet';
-import { startMeasure, endMeasure } from './performance-timing';
+import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 
 export interface Template {
     (api: RenderAPI, cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
@@ -57,6 +57,9 @@ export function getVMBeingRendered(): VM | null {
 export function setVMBeingRendered(vm: VM | null) {
     vmBeingRendered = vm;
 }
+
+let profilerEnabled = false;
+trackProfilerState((t) => (profilerEnabled = t));
 
 function validateSlots(vm: VM, html: Template) {
     if (process.env.NODE_ENV === 'production') {
@@ -106,8 +109,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         () => {
             // pre
             vmBeingRendered = vm;
-            if (process.env.NODE_ENV !== 'production') {
-                startMeasure('render', vm);
+            if (profilerEnabled) {
+                logOperationStart(OperationId.render, vm);
             }
         },
         () => {
@@ -175,8 +178,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
             // post
             isUpdatingTemplate = isUpdatingTemplateInception;
             vmBeingRendered = vmOfTemplateBeingUpdatedInception;
-            if (process.env.NODE_ENV !== 'production') {
-                endMeasure('render', vm);
+            if (profilerEnabled) {
+                logOperationEnd(OperationId.render, vm);
             }
         }
     );

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -26,6 +26,7 @@ export {
     sanitizeAttribute,
     getComponentDef,
     isComponentConstructor,
+    __unstable__ProfilerControl,
 } from '@lwc/engine-core';
 
 // Engine-dom public APIs --------------------------------------------------------------------------

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -1,0 +1,102 @@
+import { createElement } from 'lwc';
+import Container from 'x/container';
+
+describe('Profiler Sanity Test', () => {
+    afterEach(() => {
+        LWC.__unstable__ProfilerControl.detachBuffer();
+        LWC.__unstable__ProfilerControl.disableProfiler();
+    });
+
+    const X_CONTAINER = 'X-CONTAINER';
+    const X_ERROR_CHILD = 'X-ERROR-CHILD';
+    const X_ITEM = 'X-ITEM';
+
+    const OperationId = {
+        constructor: 0,
+        render: 1,
+        patch: 2,
+        connectedCallback: 3,
+        renderedCallback: 4,
+        disconnectedCallback: 5,
+        errorCallback: 6,
+    };
+
+    const Phase = {
+        Start: 0,
+        Stop: 1,
+    };
+
+    async function generateContainer() {
+        const elm = createElement(X_CONTAINER.toLowerCase(), { is: Container });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+        return elm;
+    }
+
+    function enableProfilerAndRegisterBuffer() {
+        const profilerControl = LWC.__unstable__ProfilerControl;
+        const events = [];
+        profilerControl.enableProfiler();
+        profilerControl.attachBuffer((opId, phase, name) => {
+            events.push({ opId, phase, name });
+        });
+        return events;
+    }
+
+    function matchEventsOfTypeFor(opId, name, profilerEvents) {
+        const filteredEvents = profilerEvents.filter((e) => e.name === name && e.opId === opId);
+        const expectedEvents = [
+            { opId, phase: Phase.Start, name },
+            { opId, phase: Phase.Stop, name },
+        ];
+        expect(filteredEvents).toEqual(expectedEvents);
+    }
+
+    it('container first render without activating list', async () => {
+        const profilerEvents = enableProfilerAndRegisterBuffer();
+        await generateContainer();
+
+        matchEventsOfTypeFor(OperationId.constructor, X_CONTAINER, profilerEvents);
+        matchEventsOfTypeFor(OperationId.render, X_CONTAINER, profilerEvents);
+        matchEventsOfTypeFor(OperationId.patch, X_CONTAINER, profilerEvents);
+        matchEventsOfTypeFor(OperationId.connectedCallback, X_CONTAINER, profilerEvents);
+        matchEventsOfTypeFor(OperationId.renderedCallback, X_CONTAINER, profilerEvents);
+    });
+
+    it('activate children in iteration in container', async () => {
+        const elm = await generateContainer();
+        const profilerEvents = enableProfilerAndRegisterBuffer();
+        const activateListButton = elm.shadowRoot.querySelector('.profiler-renderList');
+
+        activateListButton.click();
+        await Promise.resolve();
+
+        // the parent container will have a patch and render event
+        matchEventsOfTypeFor(OperationId.patch, X_CONTAINER, profilerEvents);
+        matchEventsOfTypeFor(OperationId.render, X_CONTAINER, profilerEvents);
+        // the child item will have the usual lifecycle
+        matchEventsOfTypeFor(OperationId.constructor, X_ITEM, profilerEvents);
+        matchEventsOfTypeFor(OperationId.render, X_ITEM, profilerEvents);
+        matchEventsOfTypeFor(OperationId.patch, X_ITEM, profilerEvents);
+    });
+
+    it('error callback counted properly', async () => {
+        const elm = await generateContainer();
+        const profilerEvents = enableProfilerAndRegisterBuffer();
+        const errorButton = elm.shadowRoot
+            .querySelector(X_ERROR_CHILD.toLowerCase())
+            .shadowRoot.querySelector('button');
+
+        try {
+            errorButton.click();
+        } catch (e) {
+            // do nothing
+        }
+
+        const expectedEvents = [
+            { opId: OperationId.errorCallback, phase: Phase.Start, name: X_ERROR_CHILD },
+            { opId: OperationId.errorCallback, phase: Phase.Stop, name: X_ERROR_CHILD },
+        ];
+        expect(profilerEvents).toEqual(expectedEvents);
+    });
+});

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -71,9 +71,6 @@ describe('Profiler Sanity Test', () => {
         activateListButton.click();
         await Promise.resolve();
 
-        // the parent container will have a patch and render event
-        matchEventsOfTypeFor(OperationId.patch, X_CONTAINER, profilerEvents);
-        matchEventsOfTypeFor(OperationId.render, X_CONTAINER, profilerEvents);
         // the child item will have the usual lifecycle
         matchEventsOfTypeFor(OperationId.constructor, X_ITEM, profilerEvents);
         matchEventsOfTypeFor(OperationId.render, X_ITEM, profilerEvents);

--- a/packages/integration-karma/test/profiler/sanity/x/container/container.html
+++ b/packages/integration-karma/test/profiler/sanity/x/container/container.html
@@ -1,0 +1,18 @@
+<template>
+    <div>Profiler Sanity</div>
+    <div>
+        <x-error-child class="profiler-error">
+            Make child throw error
+        </x-error-child>
+    </div>
+    <button class="profiler-renderList" onclick={enableList}>
+        Render Children List
+    </button>
+    <ul if:true={renderList}>
+        <template for:each={items} for:item="item">
+            <li key={item.id}>
+                <x-item id={item.id}></x-item>
+            </li>
+        </template>
+    </ul>
+</template>

--- a/packages/integration-karma/test/profiler/sanity/x/container/container.js
+++ b/packages/integration-karma/test/profiler/sanity/x/container/container.js
@@ -1,0 +1,21 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {
+    renderList = false;
+    items = [{ id: 1 }];
+    connectedCallback() {
+        // do nothing
+    }
+
+    renderedCallback() {
+        // do nothing
+    }
+
+    errorCallback() {
+        // do nothing
+    }
+
+    enableList() {
+        this.renderList = true;
+    }
+}

--- a/packages/integration-karma/test/profiler/sanity/x/errorChild/errorChild.html
+++ b/packages/integration-karma/test/profiler/sanity/x/errorChild/errorChild.html
@@ -1,0 +1,4 @@
+<template>
+    <slot></slot>
+    <button onclick={throwError}>Throw Error</button>
+</template>

--- a/packages/integration-karma/test/profiler/sanity/x/errorChild/errorChild.js
+++ b/packages/integration-karma/test/profiler/sanity/x/errorChild/errorChild.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class ErrorChild extends LightningElement {
+    throwError() {
+        throw new Error();
+    }
+}

--- a/packages/integration-karma/test/profiler/sanity/x/item/item.html
+++ b/packages/integration-karma/test/profiler/sanity/x/item/item.html
@@ -1,0 +1,3 @@
+<template>
+    <div>List item: {id}</div>
+</template>

--- a/packages/integration-karma/test/profiler/sanity/x/item/item.js
+++ b/packages/integration-karma/test/profiler/sanity/x/item/item.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Item extends LightningElement {
+    @api id;
+}


### PR DESCRIPTION
## Details

Adding experimental support for production profiling of lwc component lifecycle ui thread usage

The [performance-timing rfc](https://github.com/salesforce/lwc-rfcs/blob/master/text/0102-performance-timing.md) implementation made it easy to visualize lwc lifecycle events in chrome dev tools. Unfortunately the methodology (browser performance marks) of instrumenting these events was resource heavy, resulting in more than 30% degradation in lwc performance metrics. Thus this collection is only possible in DEV mode. 

The information collected in these lifecycle events that can be used to understand part of why a customer scenario is slow in production and to get back information on how much cpu was used by lwc lifecycle phases and what components were responsible for that. If we couple this information with the time spent servicing data requests for components, we can get a reasonable estimate of end to end loading performance of a component. 

Instead of pushing data to performance.mark and performance.measure api that can take significant time and limit you only to a single string to contain information on the component, we're going allow a user to use their own buffer to collect this data in production. On possibility is to use a TypedArray buffer to store the events. Using a TypedArray [is 10x faster](https://jsperf.com/perf-mark-vs-buffer) compared to using measure and mark APIs.

The data needs to be pushed to an external buffer as we plan to use this single buffer to collect time ordered events from the "Lightning Data Service" and Aura to build a full picture of component CPU and network cost on pages. 

This benefit of a profiler that can be turned on and off on demand is that we can sample data collection and minimize the performance impact on end users.

The api is being labeled as `__unstable__ProfilerControl` because it will be changing in the future as we learn from collecting data in production.

ProfilerControl has the following methods
* enableProfiler: Turn on profiler
* disableProfiler: Turn off the profiler
* attachBuffer: Attach a collector buffer to the profiler
* detachBuffer: Detach the current buffer from the profiler

This collector buffer being attached will need to know the internals of LWC operations and how to map integer operation IDs to lifecycle phases of an LWC component

### Performance Impact
It's expected that there will be no performance impact at all when the profiler is disabled by default in production mode 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-7039632
