### PR TITLE
fix(typescript): add createElement ts definition

### DIFF
--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+
+import { HTMLElement } from '@lwc/template-compiler/dist/types/shared/types';
+
 /**
  * Lightning Web Components core module
  */
@@ -167,4 +170,9 @@ declare module 'lwc' {
      * @param config configuration object for the accessor
      */
     export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
+
+    export function createElement(
+        sel: string,
+        options: { is: typeof LightningElement; mode?: 'open' | 'closed' }
+    ): HTMLElement;
 }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { HTMLElement } from '@lwc/template-compiler/dist/types/shared/types';
 
 /**
  * Lightning Web Components core module


### PR DESCRIPTION
## Details
This PR will add a typescript definition for the `createElement` method of the lwc module. The definition is based on this [signature](https://github.com/salesforce/lwc/blob/6a8d6063def11ce2cd80b309c08aa801f100bcee/packages/%40lwc/engine-dom/src/apis/create-element.ts#L86)
![image](https://user-images.githubusercontent.com/25188632/88403143-5c3df780-cd89-11ea-92a9-9dbf544f4cc5.png)


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added?  ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
There is no GUS WI for this change
