### PR TITLE
fix(synthetic-shadow): nested components with negative tabindex

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -256,7 +256,6 @@ export function enableKeyboardFocusNavigationRoutines(): void {
 
 function skipHostHandler(event: FocusEvent) {
     if (letBrowserHandleFocus) {
-        asyncEnableFocusNavigation();
         return;
     }
 
@@ -302,22 +301,8 @@ function skipHostHandler(event: FocusEvent) {
     }
 }
 
-// Async because the current implementation relies on the capture phase of the focusin event and we
-// don't want to enable the focus navigation logic until the capture phase is complete.
-let asyncEnableFocusNavigationTimer: number | undefined;
-function asyncEnableFocusNavigation() {
-    if (!isUndefined(asyncEnableFocusNavigationTimer)) {
-        return;
-    }
-    asyncEnableFocusNavigationTimer = setTimeout(() => {
-        asyncEnableFocusNavigationTimer = undefined;
-        enableKeyboardFocusNavigationRoutines();
-    });
-}
-
 function skipShadowHandler(event: FocusEvent) {
     if (letBrowserHandleFocus) {
-        asyncEnableFocusNavigation();
         return;
     }
 
@@ -419,9 +404,6 @@ function bindDocumentMousedownMouseupHandlers(elm: Node) {
             true
         );
 
-        // Although our sequential focus navigation routines also unset this
-        // flag, we need a backup plan in case they don't execute (e.g., the
-        // click doesn't result in focus entering the shadow).
         addEventListener.call(
             ownerDocument,
             'mouseup',

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -256,7 +256,7 @@ export function enableKeyboardFocusNavigationRoutines(): void {
 
 function skipHostHandler(event: FocusEvent) {
     if (letBrowserHandleFocus) {
-        enableKeyboardFocusNavigationRoutines();
+        asyncEnableFocusNavigation();
         return;
     }
 
@@ -302,9 +302,22 @@ function skipHostHandler(event: FocusEvent) {
     }
 }
 
+// Async because the current implementation relies on the capture phase of the focusin event and we
+// don't want to enable the focus navigation logic until the capture phase is complete.
+let asyncEnableFocusNavigationTimer: number | undefined;
+function asyncEnableFocusNavigation() {
+    if (!isUndefined(asyncEnableFocusNavigationTimer)) {
+        return;
+    }
+    asyncEnableFocusNavigationTimer = setTimeout(() => {
+        asyncEnableFocusNavigationTimer = undefined;
+        enableKeyboardFocusNavigationRoutines();
+    });
+}
+
 function skipShadowHandler(event: FocusEvent) {
     if (letBrowserHandleFocus) {
-        enableKeyboardFocusNavigationRoutines();
+        asyncEnableFocusNavigation();
         return;
     }
 

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/child/child.html
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <input placeholder="child">
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/child/child.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/nested-tabindex-negative/nested-tabindex-negative.html
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/nested-tabindex-negative/nested-tabindex-negative.html
@@ -1,0 +1,4 @@
+<template>
+    <button>focus this and then click input</button>
+    <integration-parent tabindex="-1"></integration-parent>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/nested-tabindex-negative/nested-tabindex-negative.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/nested-tabindex-negative/nested-tabindex-negative.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/parent/parent.html
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/parent/parent.html
@@ -1,0 +1,3 @@
+<template>
+    <integration-child tabindex="-1"></integration-child>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/parent/parent.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/integration/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/nested-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-nested-tabindex-negative/nested-tabindex-negative.spec.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+
+const URL = '/nested-tabindex-negative';
+
+describe('nested components with negative tabindex', () => {
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should focus the input when clicked', function () {
+        browser.keys(['Tab']); // focus button
+        const input = browser.$(function () {
+            return document
+                .querySelector('integration-nested-tabindex-negative')
+                .shadowRoot.querySelector('integration-parent')
+                .shadowRoot.querySelector('integration-child')
+                .shadowRoot.querySelector('input');
+        });
+        input.click(); // click into input
+        const active = browser.$(function () {
+            return document
+                .querySelector('integration-nested-tabindex-negative')
+                .shadowRoot.querySelector('integration-parent')
+                .shadowRoot.querySelector('integration-child').shadowRoot.activeElement;
+        });
+        assert.equal(active.getTagName(), 'input');
+    });
+});


### PR DESCRIPTION
## Details

This change fixes a bug where two clicks were required to focus on an input when the input was rendered inside two nested components with negative tabindexes.

To keep things simple for click-focusing, we currently use a global flag to bypass the first invocation of our focus navigation logic on every `mousedown`. If the flag is true, the focus navigation logic sets the flag to false and NOOPs. This system breaks down for nested components because the focus navigation logic is invoked for every component that receives the `focusin` event during the capture phase. The first `focusin` handler sets the flag to false, and as the event bubbles down to the target, other `focusin` handlers end up executing under the assumption that we need to redirect the focus that is about to enter the component.

This change removes the logic to re-enable the polyfill from `skipHostHandler` and `skipShadowHandler`, since it's reasonable to assume that we can rely on a `mouseup` event for each `mousedown` event (DnD accounted for).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:

* Have tests for the proposed changes been added? ✅ 

## GUS work item

W-7824424
