### PR TITLE
fix: unambiguity for root module scope

### DIFF
--- a/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
@@ -263,7 +263,7 @@ describe('resolution override', () => {
 
         expect(() => resolveModule('test', dirname, opts)).toThrowErrorWithCode(
             LWC_CONFIG_ERROR_CODE,
-            `Invalid LWC configuration in "${dirname}". Invalid module record. Module record must be an object, instead got "foo/test".`
+            `Invalid LWC configuration in "inline_config". Invalid module record. Module record must be an object, instead got "foo/test".`
         );
     });
 });

--- a/packages/@lwc/module-resolver/src/errors.ts
+++ b/packages/@lwc/module-resolver/src/errors.ts
@@ -17,7 +17,7 @@ export class LwcConfigError extends Error {
     scope: string;
     code = 'LWC_CONFIG_ERROR';
 
-    constructor(message: string, { scope }: { scope: string }) {
+    constructor(message: string, { scope = 'inline_config' }: { scope?: string }) {
         super(`Invalid LWC configuration in "${scope}". ${message}`);
         this.scope = scope;
     }

--- a/packages/@lwc/module-resolver/src/errors.ts
+++ b/packages/@lwc/module-resolver/src/errors.ts
@@ -17,7 +17,7 @@ export class LwcConfigError extends Error {
     scope: string;
     code = 'LWC_CONFIG_ERROR';
 
-    constructor(message: string, { scope = 'inline_config' }: { scope?: string }) {
+    constructor(message: string, { scope = 'inline_config' }: { scope: string }) {
         super(`Invalid LWC configuration in "${scope}". ${message}`);
         this.scope = scope;
     }

--- a/packages/@lwc/module-resolver/src/errors.ts
+++ b/packages/@lwc/module-resolver/src/errors.ts
@@ -17,7 +17,7 @@ export class LwcConfigError extends Error {
     scope: string;
     code = 'LWC_CONFIG_ERROR';
 
-    constructor(message: string, { scope = 'inline_config' }: { scope: string }) {
+    constructor(message: string, { scope }: { scope: string }) {
         super(`Invalid LWC configuration in "${scope}". ${message}`);
         this.scope = scope;
     }

--- a/packages/@lwc/module-resolver/src/resolve-module.ts
+++ b/packages/@lwc/module-resolver/src/resolve-module.ts
@@ -212,7 +212,7 @@ export function resolveModule(
 
     let modules = lwcConfig.modules || [];
     if (config) {
-        const userConfig = normalizeConfig(config, rootDir);
+        const userConfig = normalizeConfig(config);
         modules = mergeModules(userConfig.modules, modules);
     }
 

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -68,9 +68,9 @@ export function getModuleEntry(
 
 export function normalizeConfig(
     config: Partial<ModuleResolverConfig>,
-    scope: string
+    scope?: string
 ): ModuleResolverConfig {
-    const rootDir = config.rootDir ? path.resolve(config.rootDir) : process.cwd();
+    const rootDir = config.rootDir ? path.resolve(config.rootDir) : scope || process.cwd();
     const modules = config.modules || [];
     const normalizedModules = modules.map((m) => {
         if (!isObject(m)) {

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -78,7 +78,7 @@ export function normalizeConfig(
                 `Invalid module record. Module record must be an object, instead got ${JSON.stringify(
                     m
                 )}.`,
-                { scope }
+                { scope: scope || 'inline_config' }
             );
         }
         return isDirModuleRecord(m) ? { ...m, dir: path.resolve(rootDir, m.dir) } : m;


### PR DESCRIPTION
## Details

This PR fixes a minor ambiguity in the module resolution where root modules get the wrong scope path from userland:

There are you types of modules provided by `resolveModule`: The modules that are coming directly from the config in userland, and the modules that are discovered from the dirname scoped importer. This PR fixes the bug where we resolve the config userland dir modules against the wrong rootDir path (scoped) creating the wrong absolute paths for user land provided modules.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
