### PR TITLE
perf(template-compiler): optimize parse phase of the template-compiler

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -20,12 +20,14 @@
         "test": "jest"
     },
     "devDependencies": {
+        "@types/estree": "0.0.45",
         "@types/he": "^1.1.1"
     },
     "files": [
         "dist/"
     ],
     "dependencies": {
+        "acorn": "~8.0.1",
         "@babel/generator": "~7.1.5",
         "@babel/parser": "~7.1.5",
         "@babel/template": "~7.1.2",

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -27,7 +27,6 @@
         "dist/"
     ],
     "dependencies": {
-        "acorn": "~8.0.1",
         "@babel/generator": "~7.1.5",
         "@babel/parser": "~7.1.5",
         "@babel/template": "~7.1.2",
@@ -35,6 +34,7 @@
         "@babel/types": "~7.1.5",
         "@lwc/errors": "1.7.13",
         "@lwc/shared": "1.7.13",
+        "acorn": "~8.0.1",
         "esutils": "~2.0.3",
         "he": "~1.2.0",
         "parse5-with-errors": "4.0.3-beta1"

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/error-multi-level-expression/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/error-multi-level-expression/actual.html
@@ -1,0 +1,7 @@
+<template>
+    <template iterator:x={items}>
+        <template iterator:y={items}>
+            <div key={y.value.id} class={x.next}></div>
+        </template>
+    </template>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/error-multi-level-expression/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/error-multi-level-expression/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1073,
+            "message": "Invalid expression {x.next} - LWC1073: Template expression doesn't allow to modify iterators",
+            "level": 1,
+            "location": {
+                "line": 4,
+                "column": 35,
+                "start": 117,
+                "length": 14
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/error-computed-attribute/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/error-computed-attribute/metadata.json
@@ -1,8 +1,8 @@
 {
     "warnings": [
         {
-            "code": 1060,
-            "message": "Invalid expression {classNames[0]} - LWC1060: Template expression doesn't allow NumericLiteral",
+            "code": 1038,
+            "message": "Invalid expression {classNames[0]} - LWC1038: Template expression doesn't allow computed property access",
             "level": 1,
             "location": {
                 "line": 3,

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -384,6 +384,44 @@ describe('expression', () => {
         });
     });
 
+    it('allows trailing semicolon', () => {
+        const { warnings } = parseTemplate(`<template>{foo;}</template>`);
+        expect(warnings).toHaveLength(0);
+    });
+
+    it('allows trailing spaces', () => {
+        const { warnings } = parseTemplate(`<template>{   foo   }</template>`);
+        expect(warnings).toHaveLength(0);
+    });
+
+    it('allows trailing semicolon with spaces', () => {
+        const { warnings } = parseTemplate(`<template>{ foo ;   }</template>`);
+        expect(warnings).toHaveLength(0);
+    });
+
+    it('allows parenthesis', () => {
+        let result = parseTemplate(`<template>{ ((foo)) }</template>`);
+        expect(result.warnings).toHaveLength(0);
+
+        result = parseTemplate(`<template>{ ((foo.bar)) }</template>`);
+        expect(result.warnings).toHaveLength(0);
+
+        result = parseTemplate(`<template>{ ((foo).bar) }</template>`);
+        expect(result.warnings).toHaveLength(0);
+
+        result = parseTemplate(`<template>{ ((foo).bar); }</template>`);
+        expect(result.warnings).toHaveLength(0);
+    });
+
+    it('forbid empty expression', () => {
+        const { warnings } = parseTemplate(`<template>{  }</template>`);
+        expect(warnings[0]).toMatchObject({
+            level: DiagnosticLevel.Error,
+            message: `LWC1083: Error parsing template expression: Invalid expression {  } - Unexpected token (1:3)`,
+            location: EXPECTED_LOCATION,
+        });
+    });
+
     it('quoted expression ambiguity error', () => {
         const { warnings } = parseTemplate(`<template><input title="{myValue}" /></template>`);
         expect(warnings[0].message).toMatch(`Ambiguous attribute value title="{myValue}"`);

--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -384,18 +384,24 @@ describe('expression', () => {
         });
     });
 
-    it('allows trailing semicolon', () => {
-        const { warnings } = parseTemplate(`<template>{foo;}</template>`);
-        expect(warnings).toHaveLength(0);
+    it('forbids trailing semicolon', () => {
+        let result = parseTemplate(`<template>{foo;}</template>`);
+        expect(result.warnings[0]).toMatchObject({
+            level: DiagnosticLevel.Error,
+            message: `Invalid expression {foo;} - LWC1074: Multiple expressions found`,
+            location: EXPECTED_LOCATION,
+        });
+
+        result = parseTemplate(`<template>{ foo ;   }</template>`);
+        expect(result.warnings[0]).toMatchObject({
+            level: DiagnosticLevel.Error,
+            message: `Invalid expression { foo ;   } - LWC1074: Multiple expressions found`,
+            location: EXPECTED_LOCATION,
+        });
     });
 
     it('allows trailing spaces', () => {
         const { warnings } = parseTemplate(`<template>{   foo   }</template>`);
-        expect(warnings).toHaveLength(0);
-    });
-
-    it('allows trailing semicolon with spaces', () => {
-        const { warnings } = parseTemplate(`<template>{ foo ;   }</template>`);
         expect(warnings).toHaveLength(0);
     });
 
@@ -408,9 +414,15 @@ describe('expression', () => {
 
         result = parseTemplate(`<template>{ ((foo).bar) }</template>`);
         expect(result.warnings).toHaveLength(0);
+    });
 
-        result = parseTemplate(`<template>{ ((foo).bar); }</template>`);
-        expect(result.warnings).toHaveLength(0);
+    it('forbid incorrect parenthesis', () => {
+        const { warnings } = parseTemplate(`<template>{foo)}</template>`);
+        expect(warnings[0]).toMatchObject({
+            level: DiagnosticLevel.Error,
+            message: `Invalid expression {foo)} - LWC1083: Error parsing template expression: Unexpected end of expression`,
+            location: EXPECTED_LOCATION,
+        });
     });
 
     it('forbid empty expression', () => {

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -6,7 +6,7 @@
  */
 import * as types from '@babel/types';
 import * as esutils from 'esutils';
-import { parse } from 'acorn';
+import {Node, parseExpressionAt} from 'acorn';
 import estree from 'estree';
 
 import { ParserDiagnostics, invariant, generateCompilerError } from '@lwc/errors';
@@ -22,6 +22,7 @@ export const EXPRESSION_SYMBOL_END = '}';
 
 const VALID_EXPRESSION_RE = /^{.+}$/;
 const POTENTIAL_EXPRESSION_RE = /^.?{.+}.*$/;
+const WHITESPACES_RE = /\s/;
 
 const ITERATOR_NEXT_KEY = 'next';
 
@@ -33,62 +34,96 @@ export function isPotentialExpression(source: string): boolean {
     return !!source.match(POTENTIAL_EXPRESSION_RE);
 }
 
+function isEsTreeIdentifier(node: estree.BaseNode): node is estree.Identifier {
+    return node.type === 'Identifier';
+}
+
+function isEsTreeMemberExpression(node: estree.BaseNode): node is estree.MemberExpression {
+    return node.type === 'MemberExpression';
+}
+
 function validateExpression(
     node: estree.BaseNode,
     element: IRNode,
     allowComputedMemberExpression: boolean
-): node is estree.MemberExpression | estree.Identifier {
-    const isValidNode = node.type === 'Identifier' || node.type === 'MemberExpression';
+) {
+    const isValidNode = isEsTreeIdentifier(node) || isEsTreeMemberExpression(node);
     invariant(isValidNode, ParserDiagnostics.INVALID_NODE, [node.type]);
 
-    if (node.type === 'MemberExpression') {
-        const expression = node as estree.MemberExpression;
-
+    if (isEsTreeMemberExpression(node)) {
         invariant(
-            allowComputedMemberExpression || !expression.computed,
+            allowComputedMemberExpression || !node.computed,
             ParserDiagnostics.COMPUTED_PROPERTY_ACCESS_NOT_ALLOWED
         );
 
+        const { object, property } = node;
+
         // Validate if the expression is modifying an iterator (only the leftmost). Ex: it.next in it.next.foo
-        if (expression.object.type === 'Identifier' && expression.property.type === 'Identifier') {
-            // .object and .property are ensured to be Identifiers.
-            const propertyIdentifier = (expression.property as unknown) as TemplateIdentifier;
-            const objectIdentifier = (expression.object as unknown) as TemplateIdentifier;
+        if (isEsTreeIdentifier(object) && isEsTreeIdentifier(property)) {
             invariant(
-                !isBoundToIterator(objectIdentifier, element) ||
-                    propertyIdentifier.name !== ITERATOR_NEXT_KEY,
+                property.name !== ITERATOR_NEXT_KEY ||
+                !isBoundToIterator((object as unknown) as TemplateIdentifier, element),
                 ParserDiagnostics.MODIFYING_ITERATORS_NOT_ALLOWED
             );
         } else {
-            validateExpression(expression.object, element, allowComputedMemberExpression);
+            validateExpression(object, element, allowComputedMemberExpression);
+        }
+    }
+}
+
+function validateSourceIsParsedExpression(source: string, parsedExpression: Node) {
+    if (parsedExpression.end === (source.length - 1)) {
+        return;
+    }
+
+    let leadingParenthesis = 0;
+    let n = parsedExpression.start;
+    let i;
+
+    for (i = 0; i < n; i++) {
+        if (source[i] === '(') {
+            leadingParenthesis++;
         }
     }
 
-    return true;
-}
+    i = parsedExpression.end;
+    n = source.length - 1;
+    while (i < n) {
+        const character = source[i];
 
-function getParsedExpression(ast: estree.Node, element: IRNode, state: State): TemplateExpression {
-    const hasMultipleExpressions = ast.type === 'Program' && ast.body.length !== 1;
-    invariant(!hasMultipleExpressions, ParserDiagnostics.MULTIPLE_EXPRESSIONS);
+        if (character === ')') {
+            leadingParenthesis--;
+        } else if (character === ';') {
+            // A potential multiple expression: the rest of the string should be whitespaces.
+            // Note: all expressions ends with "}", therefore this loop will stop.
+            i++;
+            while (WHITESPACES_RE.test(source[i])) i++;
 
-    const expressionStatement = (ast as estree.Program).body[0];
-    invariant(expressionStatement.type === 'ExpressionStatement', ParserDiagnostics.INVALID_NODE, [
-        expressionStatement.type,
-    ]);
+            invariant(
+                i === n && leadingParenthesis === 0,
+                ParserDiagnostics.MULTIPLE_EXPRESSIONS
+            );
+        } else {
+            invariant(
+                WHITESPACES_RE.test(character),
+                ParserDiagnostics.TEMPLATE_EXPRESSION_PARSING_ERROR,
+                ['Unexpected end of expression']
+            )
+        }
 
-    const expression = (expressionStatement as estree.ExpressionStatement).expression;
-
-    validateExpression(expression, element, state.config.experimentalComputedMemberExpression);
-
-    return (expression as unknown) as TemplateExpression;
+        i++;
+    }
 }
 
 // FIXME: Avoid throwing errors and return it properly
 export function parseExpression(source: string, element: IRNode, state: State): TemplateExpression {
     try {
-        const parsed = parse(source.substr(1, source.length - 2), { ecmaVersion: 2020 });
+        const parsed = parseExpressionAt(source, 1, { ecmaVersion: 2020 });
 
-        return getParsedExpression(parsed as estree.Node, element, state);
+        validateSourceIsParsedExpression(source, parsed);
+        validateExpression(parsed, element, state.config.experimentalComputedMemberExpression);
+        
+        return (parsed as unknown) as TemplateExpression;
     } catch (err) {
         err.message = `Invalid expression ${source} - ${err.message}`;
         throw err;

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -6,7 +6,7 @@
  */
 import * as types from '@babel/types';
 import * as esutils from 'esutils';
-import {Node, parseExpressionAt} from 'acorn';
+import { Node, parseExpressionAt } from 'acorn';
 import estree from 'estree';
 
 import { ParserDiagnostics, invariant, generateCompilerError } from '@lwc/errors';
@@ -62,7 +62,7 @@ function validateExpression(
         if (isEsTreeIdentifier(object) && isEsTreeIdentifier(property)) {
             invariant(
                 property.name !== ITERATOR_NEXT_KEY ||
-                !isBoundToIterator((object as unknown) as TemplateIdentifier, element),
+                    !isBoundToIterator((object as unknown) as TemplateIdentifier, element),
                 ParserDiagnostics.MODIFYING_ITERATORS_NOT_ALLOWED
             );
         } else {
@@ -72,7 +72,7 @@ function validateExpression(
 }
 
 function validateSourceIsParsedExpression(source: string, parsedExpression: Node) {
-    if (parsedExpression.end === (source.length - 1)) {
+    if (parsedExpression.end === source.length - 1) {
         return;
     }
 
@@ -99,16 +99,13 @@ function validateSourceIsParsedExpression(source: string, parsedExpression: Node
             i++;
             while (WHITESPACES_RE.test(source[i])) i++;
 
-            invariant(
-                i === n && leadingParenthesis === 0,
-                ParserDiagnostics.MULTIPLE_EXPRESSIONS
-            );
+            invariant(i === n && leadingParenthesis === 0, ParserDiagnostics.MULTIPLE_EXPRESSIONS);
         } else {
             invariant(
                 WHITESPACES_RE.test(character),
                 ParserDiagnostics.TEMPLATE_EXPRESSION_PARSING_ERROR,
                 ['Unexpected end of expression']
-            )
+            );
         }
 
         i++;
@@ -122,7 +119,7 @@ export function parseExpression(source: string, element: IRNode, state: State): 
 
         validateSourceIsParsedExpression(source, parsed);
         validateExpression(parsed, element, state.config.experimentalComputedMemberExpression);
-        
+
         return (parsed as unknown) as TemplateExpression;
     } catch (err) {
         err.message = `Invalid expression ${source} - ${err.message}`;

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -90,33 +90,19 @@ export function isComponentProp(identifier: TemplateIdentifier, node?: IRNode): 
     return isComponentProp(identifier, node.parent);
 }
 
-const memoizedIterators = new WeakMap<IRNode, string | null>();
-
-function getIteratorName(node?: IRNode): string | null {
-    if (!node) {
-        return null;
-    } else {
-        let iteratorName = memoizedIterators.get(node);
-        if (iteratorName !== undefined) {
-            return iteratorName;
-        }
-
-        if (isElement(node)) {
-            const { forOf } = node;
-            if (forOf) {
-                memoizedIterators.set(node, forOf.iterator.name);
-
-                return forOf.iterator.name;
-            }
-        }
-
-        iteratorName = getIteratorName(node.parent);
-        memoizedIterators.set(node, iteratorName);
-
-        return iteratorName;
-    }
-}
-
 export function isBoundToIterator(identifier: TemplateIdentifier, node?: IRNode): boolean {
-    return getIteratorName(node) === identifier.name;
+    if (!node) {
+        return false;
+    }
+
+    // Make sure the identifier is not bound to any iteration variable
+    if (isElement(node)) {
+        const { forOf } = node;
+        if (forOf) {
+            return Boolean(forOf.iterator.name === identifier.name);
+        }
+    }
+
+    // Delegate to parent component if no binding is found at this point
+    return isBoundToIterator(identifier, node.parent);
 }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -90,17 +90,12 @@ export function isComponentProp(identifier: TemplateIdentifier, node?: IRNode): 
     return isComponentProp(identifier, node.parent);
 }
 
-export function isBoundToIterator(identifier: TemplateIdentifier, anode: IRNode): boolean {
+export function isBoundToIterator(identifierName: string, anode: IRNode): boolean {
     let node: IRNode | undefined = anode;
-    let isBoundToIteratorResult = false;
 
-    do {
-        if (isElement(node)) {
-            const { forOf } = node;
-            isBoundToIteratorResult = Boolean(forOf && forOf.iterator.name === identifier.name);
-        }
+    while (node && !(isElement(node) && node.forOf?.iterator.name === identifierName)) {
         node = node.parent;
-    } while (node && !isBoundToIteratorResult);
+    }
 
-    return isBoundToIteratorResult;
+    return node !== undefined;
 }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -90,19 +90,17 @@ export function isComponentProp(identifier: TemplateIdentifier, node?: IRNode): 
     return isComponentProp(identifier, node.parent);
 }
 
-export function isBoundToIterator(identifier: TemplateIdentifier, node?: IRNode): boolean {
-    if (!node) {
-        return false;
-    }
+export function isBoundToIterator(identifier: TemplateIdentifier, anode: IRNode): boolean {
+    let node: IRNode | undefined = anode;
+    let isBoundToIteratorResult = false;
 
-    // Make sure the identifier is not bound to any iteration variable
-    if (isElement(node)) {
-        const { forOf } = node;
-        if (forOf) {
-            return Boolean(forOf.iterator.name === identifier.name);
+    do {
+        if (isElement(node)) {
+            const { forOf } = node;
+            isBoundToIteratorResult = Boolean(forOf && forOf.iterator.name === identifier.name);
         }
-    }
+        node = node.parent;
+    } while (node && !isBoundToIteratorResult);
 
-    // Delegate to parent component if no binding is found at this point
-    return isBoundToIterator(identifier, node.parent);
+    return isBoundToIteratorResult;
 }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -90,19 +90,33 @@ export function isComponentProp(identifier: TemplateIdentifier, node?: IRNode): 
     return isComponentProp(identifier, node.parent);
 }
 
-export function isBoundToIterator(identifier: TemplateIdentifier, node?: IRNode): boolean {
+const memoizedIterators = new WeakMap<IRNode, string | null>();
+
+function getIteratorName(node?: IRNode): string | null {
     if (!node) {
-        return false;
-    }
-
-    // Make sure the identifier is not bound to any iteration variable
-    if (isElement(node)) {
-        const { forOf } = node;
-        if (forOf) {
-            return Boolean(forOf.iterator.name === identifier.name);
+        return null;
+    } else {
+        let iteratorName = memoizedIterators.get(node);
+        if (iteratorName !== undefined) {
+            return iteratorName;
         }
-    }
 
-    // Delegate to parent component if no binding is found at this point
-    return isBoundToIterator(identifier, node.parent);
+        if (isElement(node)) {
+            const { forOf } = node;
+            if (forOf) {
+                memoizedIterators.set(node, forOf.iterator.name);
+
+                return forOf.iterator.name;
+            }
+        }
+
+        iteratorName = getIteratorName(node.parent);
+        memoizedIterators.set(node, iteratorName);
+
+        return iteratorName;
+    }
+}
+
+export function isBoundToIterator(identifier: TemplateIdentifier, node?: IRNode): boolean {
+    return getIteratorName(node) === identifier.name;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3562,6 +3562,11 @@ acorn@^7.3.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
+acorn@~8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.1.tgz#d7e8eca9b71d5840db0e7e415b3b2b20e250f938"
+  integrity sha512-dmKn4pqZ29iQl2Pvze1zTrps2luvls2PBY//neO2WJ0s10B3AxJXshN+Ph7B4GrhfGhHXrl4dnUwyNNXQcnWGQ==
+
 adm-zip@~0.4.3:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"


### PR DESCRIPTION
## Details
Currently, the template compiler relies on babylon and babel-traverse to parse and validate each template expression.

This PR improves the performance of the parsing phase by:

1. Use a [acorn](https://github.com/acornjs/acorn) instead of babel to parse template expressions: this operation is pretty slow. Even simple expression `a.b.c.d.e` it can take up to 1 ms to parse a single expression.

2. Replace babel-traverse with a custom traversal to validate the template expression.

With this PR (1 + 2) the overall template parsing (compiling) phase is improved by 40% (25%)

<details>
  <summary><b>Performance comparison tables</b></summary>
  
### parsing, measuring average out of 50:

|       |Current	|This PR	|%	|
|---	|---	|---	|---	|
|record-layout-20-fields	|14	|8	|42.85714	|
|record-layout-60-fields	|40	|24	|40	|
|record-layout-300-fields	|207	|124	|40.09662	|

### compile (parsing+codegen), measuring average out of 50:

|	|Current	|expr parser(1)	|%	|
|---	|---	|---	|---	|
|record-layout-20-fields	|23	|17	|26.08696	|
|record-layout-60-fields	|66	|49	|25.75758	|
|record-layout-300-fields	|349	|254	|27.22063	|


</details>


## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

Currently the template parser supports expressions ending in `;`, ex: `<template>{foo;}</template>`; with this PR, this will no longer be supported. allowing `;` give a false impression that the template expression might accept multiple expression.



## GUS work item
@W-4238292
