### PR TITLE
fix(lwc): add wire reform type

### DIFF
--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -182,25 +182,19 @@ declare module 'lwc' {
     export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
 
     type WireConfigValue = Record<string, any>;
-    type WireContextValue = Record<string, any>;
+    type ContextValue = Record<string, any>;
 
     interface WireAdapter {
-        update(config: WireConfigValue, context?: WireContextValue): void;
+        update(config: WireConfigValue, context?: ContextValue): void;
         connect(): void;
         disconnect(): void;
     }
 
     type WireDataCallback = (value: any) => void;
     type WireAdapterSchemaValue = 'optional' | 'required';
-    type ContextValue = Record<string, any>;
 
     interface ContextConsumer {
         provide(newContext: ContextValue): void;
-    }
-
-    interface ContextProviderOptions {
-        consumerConnectedCallback: (consumer: ContextConsumer) => void;
-        consumerDisconnectedCallback?: (consumer: ContextConsumer) => void;
     }
 
     interface ContextProviderOptions {
@@ -214,11 +208,7 @@ declare module 'lwc' {
         contextSchema?: Record<string, WireAdapterSchemaValue>;
     }
 
-    type createContextProviderReturnFn = (
-        elm: EventTarget,
-        options: ContextProviderOptions
-    ) => void;
-    export function createContextProvider(
-        config: WireAdapterConstructor
-    ): createContextProviderReturnFn;
+    type Contextualizer = (elm: EventTarget, options: ContextProviderOptions) => void;
+
+    export function createContextProvider(config: WireAdapterConstructor): Contextualizer;
 }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -209,6 +209,5 @@ declare module 'lwc' {
     }
 
     type Contextualizer = (elm: EventTarget, options: ContextProviderOptions) => void;
-
     export function createContextProvider(config: WireAdapterConstructor): Contextualizer;
 }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -181,20 +181,20 @@ declare module 'lwc' {
      */
     export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
 
-    type ConfigValue = Record<string, any>;
-    type ContextValue = Record<string, any>;
+    type WireConfigValue = Record<string, any>;
+    type WireContextValue = Record<string, any>;
 
     interface WireAdapter {
-        update(config: ConfigValue, context?: ContextValue): void;
+        update(config: WireConfigValue, context?: WireContextValue): void;
         connect(): void;
         disconnect(): void;
     }
 
-    type DataCallback = (value: any) => void;
+    type WireDataCallback = (value: any) => void;
     type WireAdapterSchemaValue = 'optional' | 'required';
 
     interface WireAdapterConstructor {
-        new (callback: DataCallback): WireAdapter;
+        new (callback: WireDataCallback): WireAdapter;
         configSchema?: Record<string, WireAdapterSchemaValue>;
         contextSchema?: Record<string, WireAdapterSchemaValue>;
     }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -7,6 +7,8 @@
 /**
  * Lightning Web Components core module
  */
+import { WireAdapterConstructor } from '../@lwc/engine-core/src/framework/wiring';
+
 declare module 'lwc' {
     // backwards compatible type used for the old days when TS didn't support `event.composed`
     interface ComposableEvent extends Event {
@@ -178,4 +180,6 @@ declare module 'lwc' {
      * @param config configuration object for the accessor
      */
     export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
+
+    export function createContextProvider(config: WireAdapterConstructor): void;
 }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -192,6 +192,21 @@ declare module 'lwc' {
 
     type WireDataCallback = (value: any) => void;
     type WireAdapterSchemaValue = 'optional' | 'required';
+    type ContextValue = Record<string, any>;
+
+    interface ContextConsumer {
+        provide(newContext: ContextValue): void;
+    }
+
+    interface ContextProviderOptions {
+        consumerConnectedCallback: (consumer: ContextConsumer) => void;
+        consumerDisconnectedCallback?: (consumer: ContextConsumer) => void;
+    }
+
+    interface ContextProviderOptions {
+        consumerConnectedCallback: (consumer: ContextConsumer) => void;
+        consumerDisconnectedCallback?: (consumer: ContextConsumer) => void;
+    }
 
     interface WireAdapterConstructor {
         new (callback: WireDataCallback): WireAdapter;
@@ -199,5 +214,11 @@ declare module 'lwc' {
         contextSchema?: Record<string, WireAdapterSchemaValue>;
     }
 
-    export function createContextProvider(config: WireAdapterConstructor): void;
+    type createContextProviderReturnFn = (
+        elm: EventTarget,
+        options: ContextProviderOptions
+    ) => void;
+    export function createContextProvider(
+        config: WireAdapterConstructor
+    ): createContextProviderReturnFn;
 }

--- a/packages/lwc/types.d.ts
+++ b/packages/lwc/types.d.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+
 /**
  * Lightning Web Components core module
  */
-import { WireAdapterConstructor } from '../@lwc/engine-core/src/framework/wiring';
 
 declare module 'lwc' {
     // backwards compatible type used for the old days when TS didn't support `event.composed`
@@ -180,6 +180,24 @@ declare module 'lwc' {
      * @param config configuration object for the accessor
      */
     export function wire(getType: (config?: any) => any, config?: any): PropertyDecorator;
+
+    type ConfigValue = Record<string, any>;
+    type ContextValue = Record<string, any>;
+
+    interface WireAdapter {
+        update(config: ConfigValue, context?: ContextValue): void;
+        connect(): void;
+        disconnect(): void;
+    }
+
+    type DataCallback = (value: any) => void;
+    type WireAdapterSchemaValue = 'optional' | 'required';
+
+    interface WireAdapterConstructor {
+        new (callback: DataCallback): WireAdapter;
+        configSchema?: Record<string, WireAdapterSchemaValue>;
+        contextSchema?: Record<string, WireAdapterSchemaValue>;
+    }
 
     export function createContextProvider(config: WireAdapterConstructor): void;
 }


### PR DESCRIPTION
## Details
In order to support the wire reform changes - Imports existing `WireAdapterConstructor` type, and exports type for function `createContextProvider`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-7797740
