### PR TITLE
feat(synthetic-shadow): innerText and outerText polyfills

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -10,6 +10,9 @@ export type FeatureFlagLookup = { [name: string]: FeatureFlagValue };
 const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
     ENABLE_HMR: null,
+    // Flag to toggle on/off the enforcement of innerText/outerText shadow dom semantic in elements when using synthetic shadow.
+    // Note: Once active, elements outside the lwc boundary are controlled by the ENABLE_ELEMENT_PATCH flag.
+    ENABLE_INNER_OUTER_TEXT_PATCH: null,
     // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_NODE_LIST_PATCH: null,

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
@@ -91,7 +91,6 @@ function restoreSelectionState(state: SelectionState | null): void {
  *
  * NOTE: For performance reasons, since this function will be called multiple times while calculating the innerText of
  *       an element, it does not restore the current selection.
- * @param textNode
  */
 function getTextNodeInnerText(textNode: Text): string {
     const selection = getWindowSelection(textNode);
@@ -122,7 +121,6 @@ const nodeIsText = (node: Node): node is Text => node.nodeType === TEXT_NODE;
 /**
  * Spec: https://html.spec.whatwg.org/multipage/dom.html#inner-text-collection-steps
  * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1132
- * @param node
  */
 function innerTextCollectionSteps(node: Node): InnerTextItem[] {
     const items: InnerTextItem[] = [];

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { ArrayPush } from '@lwc/shared';
+import { innerTextGetter } from '../env/element';
+import { ELEMENT_NODE, TEXT_NODE } from '../env/node';
+import { windowGetComputedStyle, windowGetSelection } from '../env/window';
+import { childNodesGetterPatched } from '../faux-shadow/node';
+import { getOwnerWindow } from '../shared/utils';
+import { getTextContent } from './polymer/text-content';
+
+type InnerTextItem = string | number;
+
+interface SelectionState {
+    element: Element;
+    onselect: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+    onselectionchange: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+    onselectstart: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+    ranges: Range[];
+}
+
+function getElementComputedStyle(element: Element): CSSStyleDeclaration {
+    const win = getOwnerWindow(element);
+
+    return windowGetComputedStyle.call(win, element);
+}
+
+function getWindowSelection(node: Node): Selection | null {
+    const win = getOwnerWindow(node);
+
+    return windowGetSelection.call(win);
+}
+
+function nodeIsBeingRendered(nodeComputedStyle: CSSStyleDeclaration): boolean {
+    return nodeComputedStyle.visibility === 'visible' && nodeComputedStyle.display !== 'none';
+}
+
+function getSelectionState(element: Element): SelectionState | null {
+    const win = getOwnerWindow(element);
+    const selection = getWindowSelection(element);
+
+    if (selection === null) {
+        return null;
+    }
+
+    const ranges: Range[] = [];
+    for (let i = 0; i < selection.rangeCount; i++) {
+        ranges.push(selection.getRangeAt(i));
+    }
+
+    const state: SelectionState = {
+        element,
+        onselect: win.onselect,
+        onselectstart: win.onselectstart,
+        onselectionchange: win.onselectionchange,
+        ranges,
+    };
+
+    win.onselect = null;
+    win.onselectstart = null;
+    win.onselectionchange = null;
+
+    return state;
+}
+
+function restoreSelectionState(state: SelectionState | null): void {
+    if (state === null) {
+        return;
+    }
+
+    const { element, onselect, onselectstart, onselectionchange, ranges } = state;
+
+    const win = getOwnerWindow(element);
+    const selection = getWindowSelection(element)!;
+
+    selection.removeAllRanges();
+    for (let i = 0; i < ranges.length; i++) {
+        selection.addRange(ranges[i]);
+    }
+
+    win.onselect = onselect;
+    win.onselectstart = onselectstart;
+    win.onselectionchange = onselectionchange;
+}
+
+/**
+ * Gets the "innerText" of a text node using the Selection API
+ *
+ * NOTE: For performance reasons, since this function will be called multiple times while calculating the innerText of
+ *       an element, it does not restore the current selection.
+ * @param textNode
+ */
+function getTextNodeInnerText(textNode: Text): string {
+    const selection = getWindowSelection(textNode);
+
+    if (selection === null) {
+        return textNode.textContent || '';
+    }
+
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    const domRect = range.getBoundingClientRect();
+
+    if (domRect.height <= 0 || domRect.width <= 0) {
+        // the text node is not rendered
+        return '';
+    }
+
+    // Needed to remove non rendered characters from the text node.
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    return selection.toString();
+}
+
+const nodeIsElement = (node: Node): node is Element => node.nodeType === ELEMENT_NODE;
+const nodeIsText = (node: Node): node is Text => node.nodeType === TEXT_NODE;
+
+/**
+ * Spec: https://html.spec.whatwg.org/multipage/dom.html#inner-text-collection-steps
+ * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1132
+ * @param node
+ */
+function innerTextCollectionSteps(node: Node): InnerTextItem[] {
+    const items: InnerTextItem[] = [];
+
+    if (nodeIsElement(node)) {
+        const { tagName } = node;
+        const computedStyle = getElementComputedStyle(node);
+
+        if (tagName === 'OPTION') {
+            // For options, is hard to get the "rendered" text, let's use the original getter.
+            return [1, innerTextGetter!.call(node), 1];
+        } else if (tagName === 'TEXTAREA') {
+            return [];
+        } else {
+            const childNodes = childNodesGetterPatched.call(node);
+            for (let i = 0, n = childNodes.length; i < n; i++) {
+                ArrayPush.apply(items, innerTextCollectionSteps(childNodes[i]));
+            }
+        }
+
+        if (!nodeIsBeingRendered(computedStyle)) {
+            if (tagName === 'SELECT' || tagName === 'DATALIST') {
+                // the select is either: .visibility != 'visible' or .display === hidden, therefore this select should
+                // not display any value.
+                return [];
+            }
+
+            return items;
+        }
+
+        if (tagName === 'BR') {
+            items.push('\u{000A}' /* line feed */);
+        }
+
+        const { display } = computedStyle;
+
+        if (display === 'table-cell') {
+            // omitting case: and node's CSS box is not the last 'table-cell' box of its enclosing 'table-row' box
+            items.push('\u{0009}' /* tab */);
+        }
+
+        if (display === 'table-row') {
+            // omitting case: and node's CSS box is not the last 'table-row' box of the nearest ancestor 'table' box
+            items.push('\u{000A}' /* line feed */);
+        }
+
+        if (tagName === 'P') {
+            items.unshift(2);
+            items.push(2);
+        }
+
+        if (
+            display === 'block' ||
+            display === 'table-caption' ||
+            display === 'flex' ||
+            display === 'table'
+        ) {
+            items.unshift(1);
+            items.push(1);
+        }
+    } else if (nodeIsText(node)) {
+        items.push(getTextNodeInnerText(node));
+    }
+
+    return items;
+}
+
+/**
+ * InnerText getter spec: https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute
+ *
+ * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1087
+ */
+export function getInnerText(element: Element): string {
+    const thisComputedStyle = getElementComputedStyle(element);
+
+    if (!nodeIsBeingRendered(thisComputedStyle)) {
+        return getTextContent(element) || '';
+    }
+
+    const selectionState = getSelectionState(element);
+    const results: InnerTextItem[] = [];
+    const childNodes = childNodesGetterPatched.call(element);
+
+    for (let i = 0, n = childNodes.length; i < n; i++) {
+        ArrayPush.apply(results, innerTextCollectionSteps(childNodes[i]));
+    }
+
+    restoreSelectionState(selectionState);
+
+    let elementInnerText = '';
+    let maxReqLineBreakCount = 0;
+    for (let i = 0, n = results.length; i < n; i++) {
+        const item = results[i];
+
+        if (typeof item === 'string') {
+            if (maxReqLineBreakCount > 0) {
+                for (let j = 0; j < maxReqLineBreakCount; j++) {
+                    elementInnerText += '\u{000A}';
+                }
+
+                maxReqLineBreakCount = 0;
+            }
+
+            if (item.length > 0) {
+                elementInnerText += item;
+            }
+        } else {
+            if (elementInnerText.length == 0) {
+                // Remove required line break count at the start.
+                continue;
+            }
+            // Store the count if it's the max of this run,
+            // but it may be ignored if no text item is found afterwards,
+            // which means that these are consecutive line breaks at the end.
+            if (item > maxReqLineBreakCount) {
+                maxReqLineBreakCount = item;
+            }
+        }
+    }
+
+    return elementInnerText;
+}

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
@@ -8,7 +8,6 @@ import { ArrayPush } from '@lwc/shared';
 import { innerTextGetter } from '../env/element';
 import { ELEMENT_NODE, TEXT_NODE } from '../env/node';
 import { windowGetComputedStyle, windowGetSelection } from '../env/window';
-import { childNodesGetterPatched } from '../faux-shadow/node';
 import { getOwnerWindow } from '../shared/utils';
 import { getTextContent } from './polymer/text-content';
 
@@ -135,7 +134,7 @@ function innerTextCollectionSteps(node: Node): InnerTextItem[] {
         } else if (tagName === 'TEXTAREA') {
             return [];
         } else {
-            const childNodes = childNodesGetterPatched.call(node);
+            const childNodes = node.childNodes;
             for (let i = 0, n = childNodes.length; i < n; i++) {
                 ArrayPush.apply(items, innerTextCollectionSteps(childNodes[i]));
             }
@@ -202,7 +201,7 @@ export function getInnerText(element: Element): string {
 
     const selectionState = getSelectionState(element);
     const results: InnerTextItem[] = [];
-    const childNodes = childNodesGetterPatched.call(element);
+    const childNodes = element.childNodes;
 
     for (let i = 0, n = childNodes.length; i < n; i++) {
         ArrayPush.apply(results, innerTextCollectionSteps(childNodes[i]));

--- a/packages/@lwc/synthetic-shadow/src/env/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/element.ts
@@ -43,6 +43,25 @@ const lastElementChildGetter: (this: ParentNode) => Element | null = getOwnPrope
     'lastElementChild'
 )!.get!;
 
+const innerTextDescriptor = getOwnPropertyDescriptor(HTMLElement.prototype, 'innerText');
+
+const innerTextGetter: ((this: Element) => string) | null = innerTextDescriptor
+    ? innerTextDescriptor.get!
+    : null;
+const innerTextSetter: ((this: Element, s: string) => void) | null = innerTextDescriptor
+    ? innerTextDescriptor.set!
+    : null;
+
+// Note: Firefox does not have outerText, https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText
+const outerTextDescriptor = getOwnPropertyDescriptor(HTMLElement.prototype, 'outerText');
+
+const outerTextGetter: ((this: Element) => string) | null = outerTextDescriptor
+    ? outerTextDescriptor.get!
+    : null;
+const outerTextSetter: ((this: Element, s: string) => void) | null = outerTextDescriptor
+    ? outerTextDescriptor.set!
+    : null;
+
 const innerHTMLDescriptor = hasOwnProperty.call(Element.prototype, 'innerHTML')
     ? getOwnPropertyDescriptor(Element.prototype, 'innerHTML')
     : getOwnPropertyDescriptor(HTMLElement.prototype, 'innerHTML'); // IE11
@@ -104,10 +123,14 @@ export {
     hasAttribute,
     innerHTMLGetter,
     innerHTMLSetter,
+    innerTextGetter,
+    innerTextSetter,
     lastElementChildGetter,
     matches,
     outerHTMLGetter,
     outerHTMLSetter,
+    outerTextGetter,
+    outerTextSetter,
     querySelector,
     querySelectorAll,
     removeAttribute,

--- a/packages/@lwc/synthetic-shadow/src/env/window.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/window.ts
@@ -7,6 +7,13 @@
 const {
     addEventListener: windowAddEventListener,
     removeEventListener: windowRemoveEventListener,
+    getComputedStyle: windowGetComputedStyle,
+    getSelection: windowGetSelection,
 } = window;
 
-export { windowAddEventListener, windowRemoveEventListener };
+export {
+    windowAddEventListener,
+    windowGetComputedStyle,
+    windowGetSelection,
+    windowRemoveEventListener,
+};

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -31,22 +31,20 @@ import {
     childrenGetter,
     childElementCountGetter,
     firstElementChildGetter,
+    getElementsByClassName as elementGetElementsByClassName,
+    getElementsByTagName as elementGetElementsByTagName,
+    getElementsByTagNameNS as elementGetElementsByTagNameNS,
     innerHTMLGetter,
+    innerHTMLSetter,
     lastElementChildGetter,
     outerHTMLSetter,
     outerHTMLGetter,
+    querySelectorAll as elementQuerySelectorAll,
     shadowRootGetter as originalShadowRootGetter,
 } from '../env/element';
 import { createStaticNodeList } from '../shared/static-node-list';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getInternalChildNodes, hasMountedChildren } from './node';
-import {
-    innerHTMLSetter,
-    getElementsByClassName as elementGetElementsByClassName,
-    getElementsByTagName as elementGetElementsByTagName,
-    getElementsByTagNameNS as elementGetElementsByTagNameNS,
-    querySelectorAll as elementQuerySelectorAll,
-} from '../env/element';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import {
     getNodeKey,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -249,6 +249,9 @@ if (outerTextGetter !== null && outerTextSetter !== null) {
             return getInnerText(this);
         },
         set(this: HTMLElement, v: string) {
+            // Invoking the `outerText` setter on a host element should trigger its disconnection, but until we merge node reactions, it will not work.
+            // We could reimplement the outerText setter in JavaScript ([blink implementation](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/html/html_element.cc;l=841-879;drc=6e8b402a6231405b753919029c9027404325ea00;bpv=0;bpt=1))
+            // but the benefits don't worth the efforts.
             outerTextSetter!.call(this, v);
         },
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -164,7 +164,7 @@ function cloneNodePatched(this: Node, deep?: boolean): Node {
 /**
  * This method only applies to elements with a shadow or slots
  */
-function childNodesGetterPatched(this: Node): NodeListOf<Node> {
+export function childNodesGetterPatched(this: Node): NodeListOf<Node> {
     if (isHostElement(this)) {
         const owner = getNodeOwner(this);
         const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -164,7 +164,7 @@ function cloneNodePatched(this: Node, deep?: boolean): Node {
 /**
  * This method only applies to elements with a shadow or slots
  */
-export function childNodesGetterPatched(this: Node): NodeListOf<Node> {
+function childNodesGetterPatched(this: Node): NodeListOf<Node> {
     if (isHostElement(this)) {
         const owner = getNodeOwner(this);
         const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -118,6 +118,24 @@ Cat`);
 
             expect(testElement.innerText).toBe('first text\n\nslotted element\n\nsecond text');
         });
+
+        describe('slot element', () => {
+            it('should return default slot content when no content is passed into the slot', () => {
+                const testElement = elm.shadowRoot
+                    .querySelector('.without-slotted-content x-slotable')
+                    .shadowRoot.querySelector('slot');
+
+                expect(testElement.innerText).toBe('default slot content');
+            });
+
+            it('should be empty when default slot content is overwritten', () => {
+                const testElement = elm.shadowRoot
+                    .querySelector('.with-slotted-content x-slotable')
+                    .shadowRoot.querySelector('slot');
+
+                expect(testElement.innerText).toBe('');
+            });
+        });
     });
 
     const outerTextDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'outerText');

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -1,0 +1,150 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import Container from 'x/container';
+
+if (!process.env.NATIVE_SHADOW) {
+    beforeAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', true);
+    });
+
+    afterAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', false);
+    });
+
+    describe('innerText', () => {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+
+        it('should remove consecutive LF in between from partial results', () => {
+            const testCase = elm.shadowRoot.querySelector('.consecutive-LF');
+
+            expect(testCase.innerText).toBe(`initial
+
+first case text
+
+second case text
+
+end`);
+        });
+
+        it('should remove hidden text + removes empty text between LF counts', () => {
+            const testCase = elm.shadowRoot.querySelector('.hidden-text-in-between');
+
+            expect(testCase.innerText).toBe(`initialend`);
+        });
+
+        it('should remove hidden text with css', () => {
+            const testCase = elm.shadowRoot.querySelector('.hidden-text-with-css');
+
+            expect(testCase.innerText).toBe(`initialend`);
+        });
+
+        it('should display textContent if element is hidden', () => {
+            const testCase = elm.shadowRoot.querySelector('.element-hidden-shows-text-content');
+
+            expect(testCase.innerText).toBe(`initialfirst case textsecond case textend`);
+        });
+
+        it('should return empty when childNodes are hidden', () => {
+            const testCase = elm.shadowRoot.querySelector('.empty-inner-text-due-hidden-children');
+
+            expect(testCase.innerText).toBe(``);
+        });
+
+        it('should collect text from multiple levels', () => {
+            const testCase = elm.shadowRoot.querySelector('.collect-text-multiple-levels');
+
+            expect(testCase.innerText)
+                .toBe(`This is, a text that should be displayed, in one line. It includes links.
+
+Also paragraphs
+
+and then another text`);
+        });
+
+        it('should collect text from tables (table-cell and table-row)', () => {
+            const testCase = elm.shadowRoot.querySelector('.table-testcase');
+
+            // Notice that:
+            // 1. the last \t on each row is incorrect, it's a relaxation from the spec.
+            // 2. the last \n is incorrect, it's also a relaxation from the spec.
+            expect(testCase.innerText).toBe(`1,1\t1,2\t
+2,1\t2,2\t
+`);
+        });
+
+        it('should collect text from select', () => {
+            const testCase = elm.shadowRoot.querySelector('.select-testcase');
+
+            expect(testCase.innerText).toBe(`Chose a pet:
+Dog
+Cat`);
+        });
+
+        it('should not collect text from hidden select', () => {
+            const testCase = elm.shadowRoot.querySelector('.select-hidden-testcase');
+
+            expect(testCase.innerText).toBe(`Chose a pet:`);
+        });
+
+        it('should not collect text from textarea', () => {
+            const testCase = elm.shadowRoot.querySelector('.textarea-testcase');
+
+            expect(testCase.innerText).toBe(`Tell us your story:`);
+        });
+
+        // datalist is supported on safari >= 12
+        if (!process.env.COMPAT) {
+            it('should not collect text from datalist', () => {
+                const testCase = elm.shadowRoot.querySelector('.datalist-case');
+
+                expect(testCase.innerText).toBe(`Choose a flavor:`);
+            });
+        }
+
+        it('should not go inside custom element shadow', () => {
+            const testElement = elm.shadowRoot.querySelector('.without-slotted-content');
+
+            expect(testElement.innerText).toBe('first text\nsecond text');
+        });
+
+        it('should process custom elements light dom', () => {
+            const testElement = elm.shadowRoot.querySelector('.with-slotted-content');
+
+            expect(testElement.innerText).toBe('first text\n\nslotted element\n\nsecond text');
+        });
+
+        it('should process custom elements light dom across multiple shadows', () => {
+            const testElement = elm.shadowRoot.querySelector('.with-slotted-content-2-levels');
+
+            expect(testElement.innerText).toBe('first text\n\nslotted element\n\nsecond text');
+        });
+    });
+
+    const outerTextDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'outerText');
+
+    // Firefox does not have outerText.
+    if (outerTextDescriptor) {
+        describe('outerText', () => {
+            const elm = createElement('x-container', { is: Container });
+            document.body.appendChild(elm);
+
+            it('should not go inside custom element shadow', () => {
+                const testElement = elm.shadowRoot.querySelector('.without-slotted-content');
+
+                expect(testElement.outerText).toBe('first text\nsecond text');
+            });
+
+            it('should process custom elements light dom', () => {
+                const testElement = elm.shadowRoot.querySelector('.with-slotted-content');
+
+                expect(testElement.outerText).toBe('first text\n\nslotted element\n\nsecond text');
+            });
+
+            it('should process custom elements light dom across multiple shadows', () => {
+                const testElement = elm.shadowRoot.querySelector('.with-slotted-content-2-levels');
+
+                expect(testElement.outerText).toBe('first text\n\nslotted element\n\nsecond text');
+            });
+        });
+    }
+}

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.css
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.css
@@ -1,0 +1,30 @@
+.table {
+    display: table;
+}
+
+.table-cell {
+    display: table-cell;
+}
+
+.table-row {
+    display: table-row;
+}
+
+.multiple-layers .container {
+    position: relative;
+}
+
+.multiple-layers .container div {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+}
+
+.multiple-layers .in-bg {
+    z-index: 0;
+}
+
+.multiple-layers .in-front {
+    z-index: 1;
+    background-color: red;
+}

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.html
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.html
@@ -1,0 +1,125 @@
+<template>
+    <div class="consecutive-LF">
+        <span>initial</span>
+        <p>first case text</p>
+        <p>second case text</p>
+        <span>end</span>
+    </div>
+
+    <div class="hidden-text-in-between" data-desc="removes hidden text + removes empty text between LF counts">
+        <span>initial</span>
+        <p hidden>first case text</p>
+        <p hidden>second case text</p>
+        <span>end</span>
+    </div>
+
+    <div class="hidden-text-with-css" data-desc="removes hidden text with css">
+        <span>initial</span>
+        <p style="display: none">first case text</p>
+        <p style="display: none">second case text</p>
+        <span>end</span>
+    </div>
+
+    <div style="display: none" class="element-hidden-shows-text-content" data-desc="displays textContent if element is hidden">
+        <span>initial</span>
+        <p style="display: none">first case text</p>
+        <p style="display: none">second case text</p>
+        <span>end</span>
+    </div>
+
+    <div class="empty-inner-text-due-hidden-children" data-desc="innerText is empty when childNodes are hidden">
+        <p style="display: none">first case text</p>
+        <p style="display: none">second case text</p>
+    </div>
+
+    <div class="collect-text-multiple-levels" data-desc="collect text from multiple levels">
+        <div>
+            This is,
+            a text that should be displayed,
+            in one line. It includes <a href="#">links</a>.
+            <p>Also
+            paragraphs
+            </p>
+        </div>
+        <span>and then another text</span>
+    </div>
+
+    <div class="table-testcase" data-desc="collect text from table cell / row">
+        <div class="table">
+            <div class="table-row">
+                <div class="table-cell">1,1</div>
+                <div class="table-cell">1,2</div>
+            </div>
+            <div class="table-row">
+                <div class="table-cell">2,1</div>
+                <div class="table-cell">2,2</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="select-testcase">
+        <label for="pets">Chose a pet:</label>
+        <select id="pets" name="pets">
+            <option value="dog">Dog</option>
+            <option value="cat">Cat</option>
+        </select>
+    </div>
+
+    <div class="select-hidden-testcase">
+        <label for="pets1">Chose a pet:</label>
+        <select id="pets1" name="pets" style="display: none">
+            <option value="dog">Dog</option>
+            <option value="cat">Cat</option>
+        </select>
+    </div>
+
+    <div class="textarea-testcase">
+        <label for="story">Tell us your story:</label>
+
+        <textarea id="story" name="story" rows="5" cols="33">It was a dark and stormy night...</textarea>
+    </div>
+
+    <div class="datalist-case">
+        <label for="ice-cream-choice">Choose a flavor:</label>
+        <input list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />
+
+        <datalist id="ice-cream-flavors">
+            <option value="Chocolate">Chocolate</option>
+            <option value="Coconut">Coconut</option>
+        </datalist>
+    </div>
+
+    <div class="test-case multiple-layers" data-desc="collect text from multiple layers">
+        <!-- hack is to go around the issue that the polyfill does not treat correctly the last table-cell/table-row properly. -->
+        <div class="container">
+            <div class="in-bg">hidden text, but part of innerText</div>
+            <div class="in-front">visible text</div>
+        </div>
+    </div>
+
+    <!-- These tests check that innerText polyfill uses patched traversals for a web component -->
+    <div class="without-slotted-content">
+        <span>first text</span>
+        <br>
+        <x-slotable></x-slotable>
+        <span>second text</span>
+    </div>
+
+    <div class="with-slotted-content">
+        <span>first text</span>
+        <x-slotable>
+            <p>slotted element</p>
+        </x-slotable>
+        <span>second text</span>
+    </div>
+
+    <div class="with-slotted-content-2-levels">
+        <span>first text</span>
+        <x-slotable>
+            <x-grand-child>
+                <p>slotted element</p>
+            </x-grand-child>
+        </x-slotable>
+        <span>second text</span>
+    </div>
+</template>

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {}

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/grandChild/grandChild.html
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/grandChild/grandChild.html
@@ -1,0 +1,3 @@
+<template>
+    <slot></slot>
+</template>

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/grandChild/grandChild.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/grandChild/grandChild.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class GrandChild extends LightningElement {}

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.html
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.html
@@ -1,0 +1,5 @@
+<template>
+    <p>shadow start text</p>
+    <slot></slot>
+    <p>shadow end text</p>
+</template>

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.html
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.html
@@ -1,5 +1,5 @@
 <template>
     <p>shadow start text</p>
-    <slot></slot>
+    <slot>default slot content</slot>
     <p>shadow end text</p>
 </template>

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/slotable/slotable.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Slotable extends LightningElement {}


### PR DESCRIPTION
## Details
This PR provides an `innerText` and `outerText` polyfill for synthetic-shadow, _behind a feature flag_.

The polyfill is based on the [innerText spec](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute), though it has some known drawbacks (so far):

- for the last `table-cell` within a `table-row`, an extra `\t` will be added.
- for the last `table-row` within a `table`, an extra `\n` will be added.
- the inner text value varies from browser to browser, ex: https://codepen.io/jodarove/pen/vYGmrXj is different in chrome and safari.

Pending: innerText setter implementation.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`