### PR TITLE
fix(synthetic-shadow): attachShadow mode required

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -117,6 +117,13 @@ export function isHostElement(elm: Element | Node): boolean {
 
 let uid = 0;
 
+type ShadowRootMode = 'closed' | 'open';
+
+interface ShadowRootInit {
+    delegatesFocus?: boolean;
+    mode: ShadowRootMode;
+}
+
 export function attachShadow(elm: Element, options: ShadowRootInit): SyntheticShadowRootInterface {
     if (!isUndefined(getHiddenField(elm, InternalSlot))) {
         throw new Error(


### PR DESCRIPTION
## Details
Issue: using our attachShadow implementation, the options parameter is expecting there to be a required property of `mode` which can be 'closed' or 'open'. Currently no type error is given when omitting this param, or using an incorrect value. Strangely the type definition seems ok, but when the function is imported the params are of type `any`, and not what's defined. By duplicating the definitions for those param types from the `lib.dom.d.ts` into `shadow-root.ts` the parameter type checking is behaving as expected. Attached screenshots show that duplicating the types into this file fixes the issue, but does this indicate that there's something more problematic going on, as shouldn't those param types properly resolve to what's defined in `lib.dom.d.ts`?

Notice in the SS how the first element param is of type `any` even though it's defined as an `Element` in `shadow-root.ts`. Could there be something up with the imports?

Before:
<img width="599" alt="Screen Shot 2020-09-04 at 9 09 33 AM" src="https://user-images.githubusercontent.com/66496087/92261512-6413b000-ee8e-11ea-911d-8b1b8fc4d240.png">
<img width="641" alt="Screen Shot 2020-09-04 at 9 09 23 AM" src="https://user-images.githubusercontent.com/66496087/92261515-6544dd00-ee8e-11ea-8c1b-94055f600874.png">


After:
<img width="1031" alt="Screen Shot 2020-09-04 at 9 06 41 AM" src="https://user-images.githubusercontent.com/66496087/92261401-375f9880-ee8e-11ea-9f2c-79f802e66ef0.png">
<img width="998" alt="Screen Shot 2020-09-04 at 9 06 56 AM" src="https://user-images.githubusercontent.com/66496087/92261412-39c1f280-ee8e-11ea-9850-5bfc3e9e6106.png">


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-7797743
