### PR TITLE
fix: removeEventListener patch handle listeners created pre-engine init

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-listener/polyfill.ts
@@ -39,7 +39,6 @@ function getEventListenerWrapper(
     if ('$$lwcEventWrapper$$' in listener) {
         return listener.$$lwcEventWrapper$$;
     }
-
     const isHandlerFunction = isFunction(listener);
     const wrapperFn = ((listener as EventListenerWrapper).$$lwcEventWrapper$$ = function (
         this: EventTarget,
@@ -84,7 +83,10 @@ function windowRemoveEventListener(
     }
 
     const wrapperFn = getEventListenerWrapper(listener);
-    nativeWindowRemoveEventListener.call(this, type, wrapperFn || listener, optionsOrCapture);
+    // Incase the listener was wrapped by the engine's addEventListener routine
+    nativeWindowRemoveEventListener.call(this, type, wrapperFn, optionsOrCapture);
+    // If the listener was added before synthetic-shadow was loaded, the listener might not be wrapped
+    nativeWindowRemoveEventListener.call(this, type, listener, optionsOrCapture);
 }
 
 function addEventListener(
@@ -112,7 +114,10 @@ function removeEventListener(
     }
 
     const wrapperFn = getEventListenerWrapper(listener);
-    nativeRemoveEventListener.call(this, type, wrapperFn || listener, optionsOrCapture);
+    // Incase the listener was wrapped by the engine's addEventListener routine
+    nativeRemoveEventListener.call(this, type, wrapperFn, optionsOrCapture);
+    // If the listener was added before synthetic-shadow was loaded, the listener might not be wrapped
+    nativeRemoveEventListener.call(this, type, listener, optionsOrCapture);
 }
 
 // TODO [#1305]: these patches should be on EventTarget.prototype instead of win and node prototypes


### PR DESCRIPTION
## Details
To account for listeners added prior to synthetic-shadow loading, remove both wrapped and raw listeners

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-8079168
