### PR TITLE
refactor(engine): setElementProto can be moved to the base constructor

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -21,6 +21,7 @@ import {
     defineProperty,
     isObject,
     AccessibleElementProperties,
+    setPrototypeOf,
 } from '@lwc/shared';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { ComponentInterface, getWrappedComponentsListener } from './component';
@@ -183,7 +184,7 @@ function BaseLightningElementConstructor(this: LightningElement): LightningEleme
         elm,
         mode,
         renderer,
-        def: { ctor },
+        def: { ctor, bridge },
     } = vm;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -194,6 +195,7 @@ function BaseLightningElementConstructor(this: LightningElement): LightningEleme
     }
 
     const component = this;
+    setPrototypeOf(elm, bridge.prototype);
     const cmpRoot = renderer.attachShadow(elm, {
         mode,
         delegatesFocus: !!ctor.delegatesFocus,

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -23,7 +23,6 @@ import {
     isFunction,
     isNull,
     isUndefined,
-    setPrototypeOf,
     keys,
 } from '@lwc/shared';
 import { getAttrNameFromPropName } from './attributes';
@@ -43,7 +42,6 @@ import {
     isCircularModuleDependency,
     resolveCircularModuleDependency,
 } from '../shared/circular-module-dependencies';
-import { HostElement } from './renderer';
 
 export interface ComponentDef {
     name: string;
@@ -231,11 +229,6 @@ export function getComponentInternalDef(Ctor: unknown): ComponentDef {
     }
 
     return def;
-}
-
-/** Set prototype for public methods and properties on the element. No DOM Patching occurs here. */
-export function setElementProto(elm: HostElement, def: ComponentDef): void {
-    setPrototypeOf(elm, def.bridge.prototype);
 }
 
 const lightingElementDef: ComponentDef = {

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -23,7 +23,7 @@ import modStaticClassName from './modules/static-class-attr';
 import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
-import { getComponentInternalDef, setElementProto } from './def';
+import { getComponentInternalDef } from './def';
 
 const noop = () => void 0;
 
@@ -183,7 +183,6 @@ export function createViewModelHook(elm: HTMLElement, vnode: VCustomElement) {
     }
     const { sel, mode, ctor, owner } = vnode;
     const def = getComponentInternalDef(ctor);
-    setElementProto(elm, def);
     if (isTrue(owner.renderer.syntheticShadow)) {
         const { shadowAttribute } = owner.context;
         // when running in synthetic shadow mode, we need to set the shadowToken value

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -18,7 +18,7 @@ export { readonly } from './readonly';
 export { setFeatureFlag, setFeatureFlagForTest } from '@lwc/features';
 
 // Internal APIs used by renderers -----------------------------------------------------------------
-export { getComponentInternalDef, setElementProto } from './def';
+export { getComponentInternalDef } from './def';
 export { getAttrNameFromPropName, isAttributeLocked } from './attributes';
 export {
     createVM,

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -19,7 +19,6 @@ import {
 } from '@lwc/shared';
 import {
     getComponentInternalDef,
-    setElementProto,
     createVM,
     connectRootElement,
     disconnectRootElement,
@@ -116,8 +115,6 @@ export function createElement(
      */
     const element = new UpgradableConstructor((elm: HTMLElement) => {
         const def = getComponentInternalDef(Ctor);
-        setElementProto(elm, def);
-
         createVM(elm, def, {
             tagName: sel,
             mode: options.mode !== 'closed' ? 'open' : 'closed',

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -8,7 +8,6 @@ import {
     createVM,
     connectRootElement,
     getComponentInternalDef,
-    setElementProto,
     LightningElement,
 } from '@lwc/engine-core';
 import { isString, isFunction, isObject, isNull } from '@lwc/shared';
@@ -54,7 +53,6 @@ export function renderComponent(
     const element = renderer.createElement(tagName);
 
     const def = getComponentInternalDef(Ctor);
-    setElementProto(element, def);
 
     createVM(element, def, {
         mode: 'open',


### PR DESCRIPTION
## Details

Clean up of core public APIs that are truly not needed anymore to be exposed.

In this case, before `createVM`, we were adjusting the `__proto__` of the element to be upgraded in ever place where we call `createVM`, instead, we can do that as part of the construction process for the component, as the first step before handling the control back to the user.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
