### PR TITLE
chore(lwc): Expose engine-server ESM artifact

### DIFF
--- a/packages/lwc/index.js
+++ b/packages/lwc/index.js
@@ -17,7 +17,7 @@ function getVersion() {
     return pkg.version;
 }
 
-const MODULES = new Set(['engine', 'synthetic-shadow', 'wire-service']);
+const MODULES = new Set(['engine', 'engine-server', 'synthetic-shadow', 'wire-service']);
 const FORMATS = new Set(['iife', 'umd', 'esm']);
 const TARGETS = new Set(['es5', 'es2017']);
 const MODES = new Set(['dev', 'prod', 'prod_debug']);
@@ -29,25 +29,24 @@ const DEFAULT_MODE = 'dev';
 function validateArgs(name, format, target, mode) {
     if (!MODULES.has(name)) {
         throw new Error(
-            `Invalid module name "${name}"` +
-                `Available module names: ${Array.from(MODULES.keys())}`
+            `Invalid module name "${name}". Available module names: ${Array.from(MODULES.keys())}`
         );
     }
 
     if (!FORMATS.has(format)) {
         throw new Error(
-            `Invalid format "${name}"` + `Available formats: ${Array.from(FORMATS.keys())}`
+            `Invalid format "${name}". Available formats: ${Array.from(FORMATS.keys())}`
         );
     }
 
     if (!TARGETS.has(target)) {
         throw new Error(
-            `Invalid target "${target}"` + `Available targets: ${Array.from(TARGETS.keys())}`
+            `Invalid target "${target}". Available targets: ${Array.from(TARGETS.keys())}`
         );
     }
 
     if (!MODES.has(mode)) {
-        throw new Error(`Invalid mode "${mode}"` + `Available modes: ${Array.from(MODES.keys())}`);
+        throw new Error(`Invalid mode "${mode}". Available modes: ${Array.from(MODES.keys())}`);
     }
 }
 

--- a/packages/lwc/scripts/build.js
+++ b/packages/lwc/scripts/build.js
@@ -82,6 +82,7 @@ function buildWireService(targets) {
         ...buildSyntheticShadow(COMMON_TARGETS),
         ...buildWireService(COMMON_TARGETS),
         ...buildEngineServerTargets([
+            { target: 'es2017', format: 'esm', prod: false },
             { target: 'es2017', format: 'commonjs', prod: false },
             { target: 'es2017', format: 'commonjs', prod: true },
         ]),


### PR DESCRIPTION
## Details

This PR makes the `@lwc/engine-server` ESM artifact available throw the `lwc` package. Currently, the only artifact available is the commonjs one.   

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-8094084
