### PR TITLE
test: Move all component create in test

### DIFF
--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -2,7 +2,13 @@ import { createElement } from 'lwc';
 import LWCParent from 'x/lwcParent';
 import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 
-function testAssignedElements(testDescription, container) {
+function testAssignedElements(testDescription, getContainer) {
+    let container;
+
+    beforeAll(() => {
+        container = getContainer();
+    });
+
     describe(testDescription, () => {
         let nativeSlottedBasic;
         beforeEach((done) => {
@@ -39,13 +45,16 @@ const SUPPORT_ASSIGNED_ELEMENTS =
 if (SUPPORT_ASSIGNED_ELEMENTS && process.env.COMPAT !== true) {
     testAssignedElements(
         'assignedElements() retains native behavior in native shadow dom tree',
-        document.body
+        () => document.body
     );
-    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
-    document.body.appendChild(lwcParent);
-    const domManual = lwcParent.shadowRoot.querySelector('div');
+
     testAssignedElements(
         'assignedElements() retains behavior in native shadow tree nested in lwc parent',
-        domManual
+        () => {
+            const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+            document.body.appendChild(lwcParent);
+
+            return lwcParent.shadowRoot.querySelector('div');
+        }
     );
 }

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
@@ -2,7 +2,13 @@ import { createElement } from 'lwc';
 import LWCParent from 'x/lwcParent';
 import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 
-function testAssignedNodes(testDescription, container) {
+function testAssignedNodes(testDescription, getContainer) {
+    let container;
+
+    beforeAll(() => {
+        container = getContainer();
+    });
+
     describe(testDescription, () => {
         let nativeSlottedBasic;
         beforeEach((done) => {
@@ -33,13 +39,16 @@ function testAssignedNodes(testDescription, container) {
 if (process.env.COMPAT !== true) {
     testAssignedNodes(
         'assignedNodes() retains native behavior in native shadow dom tree',
-        document.body
+        () => document.body
     );
-    const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
-    document.body.appendChild(lwcParent);
-    const domManual = lwcParent.shadowRoot.querySelector('div');
+
     testAssignedNodes(
         'assignedNodes() retains behavior in native shadow tree nested in lwc parent',
-        domManual
+        () => {
+            const lwcParent = createElement('x-lwc-parent', { is: LWCParent });
+            document.body.appendChild(lwcParent);
+
+            return lwcParent.shadowRoot.querySelector('div');
+        }
     );
 }

--- a/packages/integration-karma/test/template/attribute-boolean-global/index.spec.js
+++ b/packages/integration-karma/test/template/attribute-boolean-global/index.spec.js
@@ -3,31 +3,28 @@ import { createElement } from 'lwc';
 import Test from 'x/test';
 import Computed from 'x/computed';
 
-function generateTestCases(testElement) {
-    const itTitle = testElement.textContent;
+function assertPropAndAttribute(testElement) {
     const expectedPropertyValue = testElement.hasAttribute('data-expected');
     const expectedAttributeValue = testElement.getAttribute('data-expected');
 
-    it(itTitle, () => {
-        expect(testElement.hidden).toBe(expectedPropertyValue);
-        expect(testElement.getAttribute('hidden')).toBe(expectedAttributeValue);
-    });
+    expect(testElement.hidden).toBe(expectedPropertyValue);
+    expect(testElement.getAttribute('hidden')).toBe(expectedAttributeValue);
 }
 
 describe('boolean attribute', () => {
-    const elm = createElement('x-test', { is: Test });
-    document.body.appendChild(elm);
+    it('should set the right property and attribute value', () => {
+        const host = createElement('x-test', { is: Test });
+        document.body.appendChild(host);
 
-    describe('used in html element', () => {
-        const tests = elm.shadowRoot.querySelectorAll('.test-case');
+        const elms = host.shadowRoot.querySelectorAll('.test-case');
+        for (const elm of elms) {
+            assertPropAndAttribute(elm);
+        }
 
-        tests.forEach(generateTestCases);
-    });
-
-    describe('used in custom element', () => {
-        const tests = elm.shadowRoot.querySelectorAll('.ce-test-case');
-
-        tests.forEach(generateTestCases);
+        const customElms = host.shadowRoot.querySelectorAll('.ce-test-case');
+        for (const customElm of customElms) {
+            assertPropAndAttribute(customElm);
+        }
     });
 
     it('should be added/removed when used with computed value in html element', () => {


### PR DESCRIPTION
## Details

It's currently hard to tedious the component creation code in Karma test. Some tests file are creating LWC components outside `it` or `before*` block. Because of this even if a single test in the entire test suite is focussed, components are created before this test runs, which forces us to skip breakpoints until reaching the interesting test.

This PR fixes this by moving all the component creation in either a `before*` block or a `it` block. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7971595
