### PR TITLE
refactor(engine): removing another public api isAttributeLocked

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -20,7 +20,7 @@ import {
     seal,
     setPrototypeOf,
     keys,
-    htmlPropertyToAttribute
+    htmlPropertyToAttribute,
 } from '@lwc/shared';
 
 import { getAssociatedVM } from './vm';

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -19,7 +19,6 @@ export { setFeatureFlag, setFeatureFlagForTest } from '@lwc/features';
 
 // Internal APIs used by renderers -----------------------------------------------------------------
 export { getComponentInternalDef } from './def';
-export { isAttributeLocked } from './attributes';
 export {
     createVM,
     connectRootElement,

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -5,13 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { create, isUndefined, keys, htmlPropertyToAttribute } from '@lwc/shared';
 import {
     createVM,
     connectRootElement,
     disconnectRootElement,
     getComponentInternalDef,
-    isAttributeLocked,
     LightningElement,
 } from '@lwc/engine-core';
 
@@ -52,13 +50,6 @@ export function deprecatedBuildCustomElementConstructor(
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {
     const def = getComponentInternalDef(Ctor);
 
-    // generating the hash table for attributes to avoid duplicate fields and facilitate validation
-    // and false positives in case of inheritance.
-    const attributeToPropMap: Record<string, string> = create(null);
-    for (const propName in def.props) {
-        attributeToPropMap[htmlPropertyToAttribute(propName)] = propName;
-    }
-
     return class extends def.bridge {
         constructor() {
             super();
@@ -75,29 +66,5 @@ export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLE
         disconnectedCallback() {
             disconnectRootElement(this);
         }
-        attributeChangedCallback(attrName: string, oldValue: string, newValue: string) {
-            if (oldValue === newValue) {
-                // Ignore same values.
-                return;
-            }
-            const propName = attributeToPropMap[attrName];
-            if (isUndefined(propName)) {
-                // Ignore unknown attributes.
-                return;
-            }
-            if (!isAttributeLocked(this, attrName)) {
-                // Ignore changes triggered by the engine itself during:
-                // * diffing when public props are attempting to reflect to the DOM
-                // * component via `this.setAttribute()`, should never update the prop
-                // Both cases, the setAttribute call is always wrapped by the unlocking of the
-                // attribute to be changed
-                return;
-            }
-            // Reflect attribute change to the corresponding property when changed from outside.
-            (this as any)[propName] = newValue;
-        }
-        // Specify attributes for which we want to reflect changes back to their corresponding
-        // properties via attributeChangedCallback.
-        static observedAttributes = keys(attributeToPropMap);
     };
 }


### PR DESCRIPTION
## Details

* continue with the trend of removing unnecessary public api used by dom from core pkg
* this also makes it more generic in case we eventually go with vanilla web components
* it relies on the same principle used by public fields and accessors using the proto chain of the bridge to provide the observability of attributes when producing a custom element constructor

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.
