### PR TITLE
chore(lwc): Add missing depenency on @lwc/engine-server

### DIFF
--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -43,6 +43,7 @@
     "dependencies": {
         "@lwc/compiler": "1.8.4",
         "@lwc/engine": "1.8.4",
+        "@lwc/engine-server": "1.8.4",
         "@lwc/features": "1.8.4",
         "@lwc/synthetic-shadow": "1.8.4",
         "@lwc/wire-service": "1.8.4"


### PR DESCRIPTION
## Details

This API is a follow up to https://github.com/salesforce/lwc/pull/2039. There is [a case in the `lwc/index.js`](https://github.com/salesforce/lwc/blob/master/packages/lwc/index.js#L67-L68) where it attempts to resolve NPM instead of the `dist/` folder. However the `@lwc/engine-server` is not pulled in as a dependency and due to this, the resolution fails.  

Adding the NPM package to `dependency` fixes the issue.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`


## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-8094084
