### PR TITLE
test: adds regression test introduced with #1617

### DIFF
--- a/packages/integration-karma/test/rendering/slotting/x/regressionContainer/regressionContainer.html
+++ b/packages/integration-karma/test/rendering/slotting/x/regressionContainer/regressionContainer.html
@@ -1,0 +1,17 @@
+<template>
+    <x-regression-slot>
+        <div>
+            <div if:true={outerVisible}>
+                <div class="text-result" if:true={innerVisible}>
+                    Inner visible false
+                    <button onclick={handleClick}>toggle</button>
+                </div>
+
+                <div class="text-result" if:false={innerVisible}>
+                    Inner visible true
+                    <button onclick={handleClick}>toggle</button>
+                </div>
+            </div>
+        </div>
+    </x-regression-slot>
+</template>

--- a/packages/integration-karma/test/rendering/slotting/x/regressionContainer/regressionContainer.js
+++ b/packages/integration-karma/test/rendering/slotting/x/regressionContainer/regressionContainer.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc';
+
+export default class RegressionContainer extends LightningElement {
+    outerVisible = true;
+    innerVisible = false;
+
+    handleClick(evt) {
+        this.innerVisible = !this.innerVisible;
+        evt.target.dispatchEvent(new CustomEvent('contentchange', { bubbles: true }));
+    }
+}

--- a/packages/integration-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.html
+++ b/packages/integration-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.html
@@ -1,0 +1,4 @@
+<template>
+    <slot oncontentchange={handleContentChange}></slot>
+    <p>{counter}</p>
+</template>

--- a/packages/integration-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.js
+++ b/packages/integration-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.js
@@ -1,0 +1,13 @@
+import { LightningElement } from 'lwc';
+
+export default class FocusTrap extends LightningElement {
+    counter = 1;
+
+    handleContentChange() {
+        // trigger rehydration.
+        // triggering the rehydration on the next tick throws.
+        Promise.resolve().then(() => this.counter++);
+        // triggering the rehydration on this tick is fine:
+        // this.counter++;
+    }
+}


### PR DESCRIPTION
## Details
This PR adds a tests for a behavior that was regressed in #1617 which eventually leaded to a revert in #2052.

With #1617, the added test throw error when updating slotted content (in `containerRegression`) triggers next tick re-render in component receiving the slotted content (`regressionSlot`).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
