### PR TITLE
fix(engine): fixes diffing algo when if has dynamic child

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
@@ -174,7 +174,7 @@ export function updateStaticChildren(parentElm: Node, oldCh: VNodes, newCh: VNod
         return;
     }
     if (newChLength === 0) {
-        // the new list is empty and there's some old nodes, we can directly remove anything old.
+        // the old list is nonempty and the new list is empty so we can directly remove all old nodes
         // this may be the case in which the children are dynamic, and are inside an if.
         removeVnodes(parentElm, oldCh, 0, oldChLength);
         return;

--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
@@ -175,7 +175,7 @@ export function updateStaticChildren(parentElm: Node, oldCh: VNodes, newCh: VNod
     }
     if (newChLength === 0) {
         // the old list is nonempty and the new list is empty so we can directly remove all old nodes
-        // this may be the case in which the children are dynamic, and are inside an if.
+        // this is the case in which the dynamic children of an if-directive should be removed
         removeVnodes(parentElm, oldCh, 0, oldChLength);
         return;
     }

--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
@@ -165,22 +165,24 @@ export function updateDynamicChildren(parentElm: Node, oldCh: VNodes, newCh: VNo
 }
 
 export function updateStaticChildren(parentElm: Node, oldCh: VNodes, newCh: VNodes) {
-    const { length } = newCh;
-    if (oldCh.length === 0) {
+    const oldChLength = oldCh.length;
+    const newChLength = newCh.length;
+
+    if (oldChLength === 0) {
         // the old list is empty, we can directly insert anything new
-        addVnodes(parentElm, null, newCh, 0, length);
+        addVnodes(parentElm, null, newCh, 0, newChLength);
         return;
     }
-    if (length === 0) {
+    if (newChLength === 0) {
         // the new list is empty and there's some old nodes, we can directly remove anything old.
         // this may be the case in which the children are dynamic, and are inside an if.
-        removeVnodes(parentElm, oldCh, 0, oldCh.length);
+        removeVnodes(parentElm, oldCh, 0, oldChLength);
         return;
     }
     // if the old list is not empty, the new list MUST have the same
     // amount of nodes, that's why we call this static children
     let referenceElm: Node | null = null;
-    for (let i = length - 1; i >= 0; i -= 1) {
+    for (let i = newChLength - 1; i >= 0; i -= 1) {
         const vnode = newCh[i];
         const oldVNode = oldCh[i];
         if (vnode !== oldVNode) {

--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts
@@ -171,6 +171,12 @@ export function updateStaticChildren(parentElm: Node, oldCh: VNodes, newCh: VNod
         addVnodes(parentElm, null, newCh, 0, length);
         return;
     }
+    if (length === 0) {
+        // the new list is empty and there's some old nodes, we can directly remove anything old.
+        // this may be the case in which the children are dynamic, and are inside an if.
+        removeVnodes(parentElm, oldCh, 0, oldCh.length);
+        return;
+    }
     // if the old list is not empty, the new list MUST have the same
     // amount of nodes, that's why we call this static children
     let referenceElm: Node | null = null;

--- a/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
+++ b/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
@@ -1,0 +1,49 @@
+import { createElement } from 'lwc';
+import ForEachCmp from 'x/forEachCmp';
+import LwcDynamic from 'x/lwcDynamic';
+
+describe('for:each', () => {
+    it('should remove/add elements when if is toggled', function () {
+        const elm = createElement('x-container', { is: ForEachCmp });
+        document.body.appendChild(elm);
+        const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
+
+        elm.shadowRoot.querySelector('button').click();
+
+        return Promise.resolve()
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
+            });
+    });
+});
+
+describe('lwc:dynamic', () => {
+    it('should remove/add elements when if is toggled', function () {
+        const elm = createElement('x-container', { is: LwcDynamic });
+        document.body.appendChild(elm);
+
+        const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
+        elm.shadowRoot.querySelector('button').click();
+
+        return Promise.resolve()
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+            });
+    });
+});

--- a/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/forEachCmp/forEachCmp.html
+++ b/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/forEachCmp/forEachCmp.html
@@ -1,0 +1,11 @@
+<template>
+    <button onclick={toggleSection}>toggle section</button>
+
+    <div>
+        <template if:true={sectionOpen}>
+            <template for:each={items} for:item="item">
+                <div key={item.id}>{item.name}</div>
+            </template>
+        </template>
+    </div>
+</template>

--- a/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/forEachCmp/forEachCmp.js
+++ b/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/forEachCmp/forEachCmp.js
@@ -1,0 +1,13 @@
+import { LightningElement } from 'lwc';
+
+export default class ForEachCmp extends LightningElement {
+    items = [
+        { id: 1, name: 'item 1' },
+        { id: 2, name: 'item 2' },
+    ];
+    sectionOpen = false;
+
+    toggleSection() {
+        this.sectionOpen = !this.sectionOpen;
+    }
+}

--- a/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/lwcDynamic/lwcDynamic.html
+++ b/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/lwcDynamic/lwcDynamic.html
@@ -1,0 +1,10 @@
+<template>
+    <button onclick={toggleSection}>toggle section</button>
+
+    <div>
+        <template if:true={sectionOpen}>
+            <p>item</p>
+            <x-dynamic-cmp lwc:dynamic={ctor}></x-dynamic-cmp>
+        </template>
+    </div>
+</template>

--- a/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/lwcDynamic/lwcDynamic.js
+++ b/packages/integration-karma/test/rendering/dynamic-childrens-inside-if/x/lwcDynamic/lwcDynamic.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class LwcDynamic extends LightningElement {
+    sectionOpen = false;
+
+    toggleSection() {
+        this.sectionOpen = !this.sectionOpen;
+    }
+}


### PR DESCRIPTION
## Details
This PR fixes an issue in the diffing algo that causes re-render issues when the `if` directive has dynamic children. 

Ex: In a component with the template like:
```html
<template>
    <template if:true={sectionOpen}>
            <template for:each={items} for:item="item">
                <div key={item.id}>{item.name}</div>
            </template>
    </template>
</template>
```
the content of the iteration is not cleared out when the if block is unrendered (setting `sectionOpen` to `false`)

### Problem
The compiled code for the `if` directive depends on whether it contains direct dynamic children or not. In the case of dynamic children, the code looks like `$cmp.sectionOpen ? api_iterator(.../*returns childrens*/) : []`, the problem is that the `children` from `api_iterator` are dynamic, therefore, it will go through the `updateDynamicChildren` (slow path) when `sectionOpen = true`, but when the if is toggled (`sectionOpen = false`), `[]` is not marked as dynamic children, and therefore it will go via the `updateStaticChildren` (fast path) while having old children, and this algo is expecting that:
1. oldChild is empty (adding new children) or
2. `oldChildren.length === newChildren.length` (do a direct patch).

### Solutions
i took into account 3 possible solutions:
1. when deciding which algo to use, take into account if the old vnode children are dynamic. With this, we will add an extra check for all of the patching mechanism (`updateChildrenHook`) and the diffing to remove such nodes will be `updateDynamicChildren` (slow path)
2. updating the static child diffing algo to account for this. With this, add an extra check in the `updateStaticChildren`, and if is true, remove the old children vnodes.
3. change the compiled code of the `if` directive (in theory). This one will avoid the extra condition, but will go through the `updateDynamicChildren` (slow path)

This PR implements option **2**.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
## GUS work item
W-8047884
