### PR TITLE
refactor(syntheitc-shadow): remove iterable methods of HTMLCollection

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
@@ -67,7 +67,6 @@ StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
             return null;
         },
     },
-
     [Symbol.toStringTag]: {
         configurable: true,
         get() {

--- a/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/static-html-collection.ts
@@ -8,7 +8,6 @@ import {
     create,
     defineProperty,
     forEach,
-    ArrayMap,
     setPrototypeOf,
     createHiddenField,
     getHiddenField,
@@ -66,62 +65,6 @@ StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
             }
 
             return null;
-        },
-    },
-
-    // Iterable protocol
-    // TODO [#1665]: HTMLCollection should not implement the iterable protocol. The only collection
-    // interface implementing this protocol is NodeList. This code need to be removed.
-    forEach: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value(cb: (value: Element, key: number, parent: Element[]) => void, thisArg?: any) {
-            forEach.call(getHiddenField(this, Items), cb, thisArg);
-        },
-    },
-    entries: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value() {
-            return ArrayMap.call(getHiddenField(this, Items), (v, i) => [i, v]);
-        },
-    },
-    keys: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value() {
-            return ArrayMap.call(getHiddenField(this, Items), (v, i) => i);
-        },
-    },
-    values: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value() {
-            return getHiddenField(this, Items);
-        },
-    },
-    [Symbol.iterator]: {
-        writable: true,
-        configurable: true,
-        value() {
-            let nextIndex = 0;
-            return {
-                next: () => {
-                    const items = getHiddenField(this, Items)!;
-                    return nextIndex < items.length
-                        ? {
-                              value: items[nextIndex++],
-                              done: false,
-                          }
-                        : {
-                              done: true,
-                          };
-                },
-            };
         },
     },
 


### PR DESCRIPTION
## Details

This PR addresses the fact that HTMLCollection types are not expected to be iterable objects, and these extra methods should be removed.

Fixes https://github.com/salesforce/lwc/issues/1665

## Does this PR introduce breaking changes?

🚨 `Yes, it does introduce breaking changes.`

This might be a breaking change if some code relies on the `HTMLCollection` interface being iterable.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-7101579
