### PR TITLE
fix(synthetic-shadow): conservatively disable focus navigation routine upon focus

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -253,6 +253,9 @@ export function disableKeyboardFocusNavigationRoutines(): void {
 export function enableKeyboardFocusNavigationRoutines(): void {
     letBrowserHandleFocus = false;
 }
+export function isKeyboardFocusNavigationRoutineEnabled(): boolean {
+    return !letBrowserHandleFocus;
+}
 
 function skipHostHandler(event: FocusEvent) {
     if (letBrowserHandleFocus) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -116,11 +116,11 @@ function blurPatched(this: HTMLElement) {
 }
 
 function focusPatched(this: HTMLElement) {
-    // Capture enabled state at function start
-    const isEnabled = isKeyboardFocusNavigationRoutineEnabled();
+    // Save enabled state
+    const originallyEnabled = isKeyboardFocusNavigationRoutineEnabled();
 
-    // Disable if originally enabled (change state)
-    if (isEnabled) {
+    // Change state by disabling if originally enabled
+    if (originallyEnabled) {
         disableKeyboardFocusNavigationRoutines();
     }
 
@@ -133,8 +133,8 @@ function focusPatched(this: HTMLElement) {
     // @ts-ignore type-mismatch
     focus.apply(this, arguments);
 
-    // Enable if originally enabled (restore state)
-    if (isEnabled) {
+    // Restore state by enabling if originally enabled
+    if (originallyEnabled) {
         enableKeyboardFocusNavigationRoutines();
     }
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -16,6 +16,7 @@ import {
     hostElementFocus,
     ignoreFocus,
     ignoreFocusIn,
+    isKeyboardFocusNavigationRoutineEnabled,
 } from './focus';
 
 const { blur, focus } = HTMLElement.prototype;
@@ -115,7 +116,13 @@ function blurPatched(this: HTMLElement) {
 }
 
 function focusPatched(this: HTMLElement) {
-    disableKeyboardFocusNavigationRoutines();
+    // Capture enabled state at function start
+    const isEnabled = isKeyboardFocusNavigationRoutineEnabled();
+
+    // Disable if originally enabled (change state)
+    if (isEnabled) {
+        disableKeyboardFocusNavigationRoutines();
+    }
 
     if (isHostElement(this) && isDelegatingFocus(this)) {
         hostElementFocus.call(this);
@@ -126,7 +133,10 @@ function focusPatched(this: HTMLElement) {
     // @ts-ignore type-mismatch
     focus.apply(this, arguments);
 
-    enableKeyboardFocusNavigationRoutines();
+    // Enable if originally enabled (restore state)
+    if (isEnabled) {
+        enableKeyboardFocusNavigationRoutines();
+    }
 }
 
 // Non-deep-traversing patches: this descriptor map includes all descriptors that

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/child/child.html
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <button onfocus={handleFocus}>click me</button>
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/child/child.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/child/child.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static delegatesFocus = true;
+
+    handleFocus(event) {
+        event.target.focus();
+    }
+}

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/invoke-focus-on-click/invoke-focus-on-click.html
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/invoke-focus-on-click/invoke-focus-on-click.html
@@ -1,0 +1,5 @@
+<template>
+    <input class="before">
+    <integration-child tabindex="-1"></integration-child>
+    <input class="after">
+</template>

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/invoke-focus-on-click/invoke-focus-on-click.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/integration/invoke-focus-on-click/invoke-focus-on-click.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 
 const URL = '/invoke-focus-on-click';
 
-describe('focus() method invocation inside a focus handler caused by a click', () => {
+describe('focus() method invocation inside a focus handler triggered by a click', () => {
     before(() => {
         browser.url(URL);
     });

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
@@ -8,12 +8,29 @@ const assert = require('assert');
 
 const URL = '/invoke-focus-on-click';
 
-describe('focus() method invocation inside a focus handler triggered by a click', () => {
+/*
+This regression test reproduces a very specific scenario where an element's focus() method is
+invoked immediately after the mousedown event listener on the global document:
+
+1) mousedown (disable)
+2) patched focus method
+  - (disable)
+  - invoke original focus method
+  - (enable)
+3) focusin (programmatic focus management) <-- expectation is to be disabled here
+4) mouseup (enable)
+
+The mousedown and mouseup events are used as hooks to disable/enable keyboard focus navigation
+for focus delegation, and the unexpected invocation of the focus() method was breaking that by
+enabling keyboard focus navigation before the subsequent focusin event listener which is used to
+implement shadow semantics for keyboard focus navigation.
+*/
+describe('[W-8350504] focus() method invocation, inside a focus handler, triggered by a click', () => {
     before(() => {
         browser.url(URL);
     });
 
-    it('should focus the clicked element', function () {
+    it('should not interfere with focusing the clicked element', function () {
         browser.keys(['Tab']); // input.before
         const button = browser.$(function () {
             return document
@@ -21,7 +38,7 @@ describe('focus() method invocation inside a focus handler triggered by a click'
                 .shadowRoot.querySelector('integration-child')
                 .shadowRoot.querySelector('button');
         });
-        button.click(); // click into input
+        button.click(); // click into button
         const active = browser.$(function () {
             return document
                 .querySelector('integration-invoke-focus-on-click')

--- a/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-click/test-invoke-focus-on-click/invoke-focus-on-click.spec.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+
+const URL = '/invoke-focus-on-click';
+
+describe('focus() method invocation inside a focus handler caused by a click', () => {
+    before(() => {
+        browser.url(URL);
+    });
+
+    it('should focus the clicked element', function () {
+        browser.keys(['Tab']); // input.before
+        const button = browser.$(function () {
+            return document
+                .querySelector('integration-invoke-focus-on-click')
+                .shadowRoot.querySelector('integration-child')
+                .shadowRoot.querySelector('button');
+        });
+        button.click(); // click into input
+        const active = browser.$(function () {
+            return document
+                .querySelector('integration-invoke-focus-on-click')
+                .shadowRoot.querySelector('integration-child').shadowRoot.activeElement;
+        });
+        assert.strictEqual(active.getTagName(), 'button');
+    });
+});


### PR DESCRIPTION
## Details

In a nutshell, this is how we disable keyboard focus navigation when the user clicks on an element:

`mousedown`: `letBrowserHandleFocus` is set to `true`
`focusin`: short circuit the keyboard focus navigation routine if `letBrowserHandleFocus` is set to `true`
`mouseup`: `letBrowserHandleFocus` is set to `false`

The problem here is that, during a `click`,  all `focus` events are processed before `focusin` events, so if there is a focus handler that runs between the `mousedown` and `focusin` events above, and it invokes the `focus()` method on an element (which is a very strange behavior), the `letBrowserHandleFocus` flag is incorrectly set to `false` before our `focusin` handler runs, causing the "next" element to be incorrectly focused.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

N/A yet