### PR TITLE
chore: remove push option from version script

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -5,12 +5,7 @@
 This script is used to generate a release commit that updates the version of all packages in this
 monorepo. The version number should be specified through the interactive prompt.
 
-The release commit is generated locally, along with a git tag. Pass the `--push` flag to
-immediately push both the release commit and tag.
-
-```sh
-yarn release:version --push
-```
+The release commit is generated locally, along with a git tag.
 
 ## `yarn release:publish:ci`
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -7,6 +7,10 @@ monorepo. The version number should be specified through the interactive prompt.
 
 The release commit is generated locally, along with a git tag.
 
+:rotating_light: Please avoid pushing prerelease git tags such as `alpha`. These tags usually
+point to commits that are not guaranteed to exist at a later time due to squashed merges or
+deleted branches.
+
 ## `yarn release:publish:ci`
 
 This script publishes packages to NPM. It restricts usage to a CI context to ensure that all

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -16,12 +16,8 @@ const ARGS = [
     '--exact',
     // Update version number even if there were no changes in the package
     '--force-publish',
+    '--no-push',
 ];
-
-if (!process.argv.includes('--push')) {
-    // Don't push release commit and tag
-    ARGS.push('--no-push');
-}
 
 const { stderr, stdin, stdout } = process;
 


### PR DESCRIPTION
## Details

Removing this option to minimize the possibility of pushing alpha tags.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7971595