### PR TITLE
refactor(synthetic-shadow): relatedTarget prototype patching for MouseEvent

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -25,6 +25,7 @@ import './polyfills/custom-event-composed/main';
 import './polyfills/clipboard-event-composed/main';
 import './polyfills/iframe-content-window/main';
 import './polyfills/mutation-observer/main';
+import './polyfills/mouse-event/main';
 
 // Internal Patches
 import './faux-shadow/node';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/main.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/main.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import './polyfill';

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.html
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.html
@@ -1,3 +1,3 @@
 <template>
-    <input type="text" />
+    <input class="shadow-element">
 </template>

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.js
@@ -1,3 +1,3 @@
 import { LightningElement } from 'lwc';
 
-export default class Child extends LightningElement {}
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.html
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.html
@@ -1,6 +1,7 @@
 <template>
-    <span class="related-target-tabname">{relatedTargetTagName}</span>
-    <input type="text" onfocusin={handleFocusIn} />
-    <br />
-    <integration-child></integration-child>
+    <div onmouseover={handleMouseOver}>
+        <integration-child class="first"></integration-child>
+        <integration-child class="second"></integration-child>
+    </div>
+    <span class="related-target-class-name">{relatedTargetClassNames}</span>
 </template>

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
@@ -1,8 +1,14 @@
 import { LightningElement, track } from 'lwc';
 
-export default class RetargetRelatedTarget extends LightningElement {
-    @track relatedTargetTagName;
-    handleFocusIn(evt) {
-        this.relatedTargetTagName = evt.relatedTarget.tagName.toLowerCase();
+export default class extends LightningElement {
+    @track
+    _relatedTargetClassNames = [];
+
+    get relatedTargetClassNames() {
+        return this._relatedTargetClassNames.map((className) => className || 'undefined');
+    }
+
+    handleMouseOver(event) {
+        this._relatedTargetClassNames.push(event.relatedTarget && event.relatedTarget.className);
     }
 }

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
@@ -5,7 +5,9 @@ export default class extends LightningElement {
     _relatedTargetClassNames = [];
 
     get relatedTargetClassNames() {
-        return this._relatedTargetClassNames.map((className) => className || 'undefined');
+        return this._relatedTargetClassNames
+            .map((className) => className || 'undefined')
+            .join(', ');
     }
 
     handleMouseOver(event) {

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -6,27 +6,35 @@
  */
 const assert = require('assert');
 
-describe('Retarget relatedTarget', () => {
-    const URL = '/retarget-related-target';
+const URL = '/retarget-related-target';
 
+describe('Retarget relatedTarget', () => {
     before(() => {
         browser.url(URL);
     });
 
-    it('should retarget relatedTarget from a foreign shadow', () => {
-        browser.execute(function () {
-            document
-                .querySelector('integration-retarget-related-target')
-                .shadowRoot.querySelector('integration-child')
-                .shadowRoot.querySelector('input')
-                .focus();
-        });
-        browser.keys(['Shift', 'Tab', 'Shift']);
-        const indicator = browser.$(function () {
+    it('should retarget relatedTarget for MouseEvent', () => {
+        var first = browser.$(function () {
             return document
                 .querySelector('integration-retarget-related-target')
-                .shadowRoot.querySelector('.related-target-tabname');
+                .shadowRoot.querySelector('integration-child.first')
+                .shadowRoot.querySelector('input');
         });
-        assert.equal(indicator.getText(), 'integration-child');
+        var second = browser.$(function () {
+            return document
+                .querySelector('integration-retarget-related-target')
+                .shadowRoot.querySelector('integration-child.second')
+                .shadowRoot.querySelector('input');
+        });
+        var indicator = browser.$(function () {
+            return document
+                .querySelector('integration-retarget-related-target')
+                .shadowRoot.querySelector('.related-target-class-name');
+        });
+
+        first.moveTo();
+        second.moveTo();
+
+        assert.strictEqual(indicator.getText(), 'undefined, first');
     });
 });


### PR DESCRIPTION
## Details

Moves `relatedTarget` instance patching to `MouseEvent.prototype`.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

Locker already prevents access to the original `relatedTarget`. Environments without Locker will potentially lose access to the original `relatedTarget` if the event was not handled in LWC.

## The PR fulfills these requirements:

* Have tests for the proposed changes been added? ✅ 

## GUS work item

W-8384245