### PR TITLE
perf: avoid double babel transform for js files

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/index.js
+++ b/packages/@lwc/babel-plugin-component/src/index.js
@@ -8,13 +8,29 @@ const component = require('./component');
 const { decorators } = require('./decorators');
 const { exit } = require('./program');
 const dynamicImports = require('./dynamic-imports');
+
+function visitProgram(mergedVisitors, stage, path, state) {
+    if (mergedVisitors.Program) {
+        const visitors = mergedVisitors.Program[stage] || [];
+
+        for (let i = 0, n = visitors.length; i < n; i++) {
+            visitors[i](path, state);
+        }
+    }
+}
+
 /**
  * The transform is done in 2 passes:
  *    - First, apply in a single AST traversal the decorators and the component transformation.
  *    - Then, in a second path transform class properties using the official babel plugin "babel-plugin-transform-class-properties".
  */
 module.exports = function LwcClassTransform(api) {
-    const { merge: mergeVisitors } = api.traverse.visitors;
+    const mergedVisitors = api.traverse.visitors.merge([
+        decorators(api),
+        component(api),
+        dynamicImports(api),
+        exit(api),
+    ]);
 
     return {
         manipulateOptions(opts, parserOpts) {
@@ -23,6 +39,21 @@ module.exports = function LwcClassTransform(api) {
                 { decoratorsBeforeExport: true },
             ]);
         },
-        visitor: mergeVisitors([decorators(api), component(api), dynamicImports(api), exit(api)]),
+        visitor: {
+            Program(path, state) {
+                // The LWC babel plugin doesn't play well when associated along with other plugins. We first
+                // run the LWC babel plugin and then run the rest of the transformation.
+                // We ensure the ordering of the visitors by running all traversals from this Program node.
+
+                // Program.enter; it needs to run here because path.traverse wont visit Program nodes.
+                visitProgram(mergedVisitors, 'enter', path, state);
+
+                // Traverse Program
+                path.traverse(mergedVisitors, state);
+
+                // Program.exit; it needs to run here (instead of a Program.exit) to ensure other plugins don't modify the ast.
+                visitProgram(mergedVisitors, 'exit', path, state);
+            },
+        },
     };
 };

--- a/packages/@lwc/babel-plugin-component/src/index.js
+++ b/packages/@lwc/babel-plugin-component/src/index.js
@@ -48,7 +48,7 @@ module.exports = function LwcClassTransform(api) {
                 // Program.enter; it needs to run here because path.traverse wont visit Program nodes.
                 visitProgram(mergedVisitors, 'enter', path, state);
 
-                // Traverse Program
+                // Traverse Program descendant nodes.
                 path.traverse(mergedVisitors, state);
 
                 // Program.exit; it needs to run here (instead of a Program.exit) to ensure other plugins don't modify the ast.

--- a/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel-compat.js
+++ b/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel-compat.js
@@ -80,7 +80,7 @@ writable: true
 __setKey(obj, key, value);
 }
 return obj;
-}
+} // babel-plugin-check-es2015-constants
 // https://github.com/babel/babel/blob/master/packages/babel-plugin-check-es2015-constants/test/fixtures/general/program/actual.js
 var MULTIPLIER = 5;
 for (var i in __iterableKey(arr)) {

--- a/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel.js
+++ b/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel.js
@@ -2,6 +2,7 @@ import { registerDecorators } from 'lwc';
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+// babel-plugin-check-es2015-constants
 // https://github.com/babel/babel/blob/master/packages/babel-plugin-check-es2015-constants/test/fixtures/general/program/actual.js
 const MULTIPLIER = 5;
 

--- a/packages/@lwc/compiler/src/compiler/__tests__/result.spec.ts
+++ b/packages/@lwc/compiler/src/compiler/__tests__/result.spec.ts
@@ -245,7 +245,7 @@ export default class Test extends LightningElement {
 
             expect(mainDefMappedToOutputPosition).toMatchObject({
                 line: 14,
-                column: 15,
+                column: 11,
             });
 
             const stringConstantInOutputPosition = sourceMapConsumer.generatedPositionFor({
@@ -256,7 +256,7 @@ export default class Test extends LightningElement {
 
             expect(stringConstantInOutputPosition).toMatchObject({
                 line: 15,
-                column: 32,
+                column: 11,
             });
 
             const myimportDefinitionOutputPosition = sourceMapConsumer.generatedPositionFor({
@@ -267,7 +267,7 @@ export default class Test extends LightningElement {
 
             expect(myimportDefinitionOutputPosition).toMatchObject({
                 line: 19,
-                column: 16,
+                column: 8,
             });
 
             const mainInvocationInOutputPosition = sourceMapConsumer.generatedPositionFor({

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -28,21 +28,11 @@ export default function scriptTransform(
 
     let result;
     try {
-        // The LWC babel plugin doesn't play well when associated along with other plugins. We first
-        // run the LWC babel plugin and then run the rest of the transformation on the intermediary
-        // code.
-        const intermediary = babel.transformSync(code, {
-            babelrc: false,
-            configFile: false,
-            plugins: [[lwcClassTransformPlugin, { isExplicitImport, dynamicImports }]],
-            filename,
-            sourceMaps: sourcemap,
-        })!;
-
-        result = babel.transformSync(intermediary.code!, {
+        result = babel.transformSync(code, {
             babelrc: false,
             configFile: false,
             plugins: [
+                [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
                 [babelClassPropertiesPlugin, { loose: true }],
 
                 // This plugin should be removed in a future version. The object-rest-spread is
@@ -51,7 +41,6 @@ export default function scriptTransform(
             ],
             filename,
             sourceMaps: sourcemap,
-            inputSourceMap: intermediary.map ?? undefined,
         })!;
     } catch (e) {
         throw normalizeToCompilerError(TransformerErrors.JS_TRANSFORMER_ERROR, e, { filename });


### PR DESCRIPTION
# Details
This PR ensures all the visitors in `@lwc/babel-plugin-component` runs first, which allows we can join the 2 `babel.transform` in the js transform function of the compiler.

Comparison of `transformSync` function on a component js file of 1600 lines: `152 ms` (master) vs `93 ms` (this pr)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
