### PR TITLE
feat(engine): Add simple client rehydration for SSR markup

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -78,6 +78,12 @@ if (isCustomElementRegistryAvailable()) {
     HTMLElementConstructor.prototype = HTMLElement.prototype;
 }
 
+function removeAllChildNodes(parent: Node) :void {
+    while (parent.firstChild) {
+        parent.removeChild(parent.firstChild);
+    }
+}
+
 // TODO [#0]: Evaluate how we can extract the `$shadowToken$` property name in a shared package
 // to avoid having to synchronize it between the different modules.
 export const useSyntheticShadow = hasOwnProperty.call(Element.prototype, '$shadowToken$');
@@ -109,6 +115,13 @@ export const renderer: Renderer<Node, Element> = {
     },
 
     attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
+        if(element.shadowRoot) {
+            removeAllChildNodes(element.shadowRoot);
+            return element.shadowRoot;
+        }
+        if(useSyntheticShadow) {
+            removeAllChildNodes(element);
+        }
         return element.attachShadow(options);
     },
 


### PR DESCRIPTION

## Details
This PR introduces a simple client side rehydration mechanism for the markup generated on the server (SSR). This is not a real rehydration as it does not link the components to the existing markup, but it fully replaces this markup by the new one, generated by the components. Actually, when a component should create its shadow root, it checks if it already exists. If so, it empties its content before continuing the rendering.
It works surprisingly well when the components are rendered in the same frame (no async calls). It is very fast and it doesn't generate a flash in the browser.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`


## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
Not sure where to add tests for this, but happy to have some guidance
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
<!--Work ID in text, no links -->
