### PR TITLE
chore: remove sauce keys from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,6 @@ ignore_forks: &ignore_forks
     # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
     ignore: /pull\/[0-9]+/
 
-env_integration_test: &env_integration_test
-  - SAUCE_USERNAME: lwc_ci
-  - SAUCE_KEY: ca71d9ad-af28-4c2b-abf7-1ddaa87fed36
-
 deploy_filters: &deploy_filters
   filters:
     branches:
@@ -167,7 +163,6 @@ jobs:
     executor: node
     environment:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id	>>_test_karma
-      <<: *env_integration_test
     steps:
       - load_workspace
       - start_sauce_connect
@@ -191,7 +186,6 @@ jobs:
     executor: node
     environment:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id	>>_test_integration
-      <<: *env_integration_test
     steps:
       - load_workspace
       - start_sauce_connect
@@ -206,7 +200,6 @@ jobs:
     executor: node
     environment:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id	>>_test_integration_compat
-      <<: *env_integration_test
     steps:
       - load_workspace
       - start_sauce_connect
@@ -257,6 +250,8 @@ workflows:
             - build
 
       - test_karma:
+          filters:
+            <<: *ignore_forks
           requires:
             - build
 
@@ -267,11 +262,15 @@ workflows:
             - build
 
       - test_integration:
+          filters:
+            <<: *ignore_forks
           requires:
             - test_unit
             - test_karma
 
       - test_integration_compat:
+          filters:
+            <<: *ignore_forks
           requires:
             - test_unit
             - test_karma


### PR DESCRIPTION
## Details
pass sauce keys as environment variables from circle ci. Forks will not be able to execute integration test suites. A LWC team member will have to help them accomplish that.

## GUS work item
W-8276416
