### PR TITLE
test(integration-karma): fix flapper related to getBoundingClientRect() precision

### DIFF
--- a/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
@@ -34,6 +34,6 @@ it('should return the host element dimensions', () => {
     document.body.appendChild(elm);
 
     const result = elm.getComponentBoundingClientRect();
-    expect(result.width).toBe(10);
-    expect(result.height).toBe(10);
+    expect(Math.abs(result.width - 10)).toBeLessThan(0.0001);
+    expect(Math.abs(result.height - 10)).toBeLessThan(0.0001);
 });

--- a/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
@@ -34,6 +34,8 @@ it('should return the host element dimensions', () => {
     document.body.appendChild(elm);
 
     const result = elm.getComponentBoundingClientRect();
-    expect(Math.abs(result.width - 10)).toBeLessThan(0.0001);
-    expect(Math.abs(result.height - 10)).toBeLessThan(0.0001);
+    // elm.getComponentBoundingClientRect returns a DOMRect
+    // Using toBeCloseTo matcher to compare a double value.
+    expect(result.width).toBeCloseTo(10, 3);
+    expect(result.height).toBeCloseTo(10, 3);
 });


### PR DESCRIPTION
## Details
This PR fixes a `LightningElement.getBoundingClientRect` karma test which is flapping in ie11 with message:

```
IE 11.0 (Windows 7) component LightningElement.getBoundingClientRect should return the host element dimensions FAILED
	Error: Expected 9.999998092651367 to be 10.
	    at <Jasmine>
	   at callKey1 (/home/circleci/lwc/node_modules/es5-proxy-compat/polyfills.js:1092:9)
	   at Anonymous function (component/LightningElement.getBoundingClientRect/test/component/LightningElement.getBoundingClientRect/index.spec.js:45:3 <- component/LightningElement.getBoundingClientRect/index.spec.js:194:5)
	    at <Jasmine>
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`