### PR TITLE
fix: hmr memory leak + feature flag

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hot-swaps.ts
+++ b/packages/@lwc/engine-core/src/framework/hot-swaps.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isFalse, isUndefined, isNull } from '@lwc/shared';
+import featureFlags from '@lwc/features';
 import { VM, scheduleRehydration, forceRehydration } from './vm';
 import { isComponentConstructor } from './def';
 import { markComponentAsDirty, ComponentConstructor } from './component';
@@ -99,11 +100,15 @@ export function getTemplateOrSwappedTemplate(tpl: Template): Template {
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    const visited: Set<Template> = new Set();
-    while (swappedTemplateMap.has(tpl) && !visited.has(tpl)) {
-        visited.add(tpl);
-        tpl = swappedTemplateMap.get(tpl)!;
+
+    if (featureFlags.ENABLE_HMR) {
+        const visited: Set<Template> = new Set();
+        while (swappedTemplateMap.has(tpl) && !visited.has(tpl)) {
+            visited.add(tpl);
+            tpl = swappedTemplateMap.get(tpl)!;
+        }
     }
+
     return tpl;
 }
 
@@ -112,11 +117,15 @@ export function getComponentOrSwappedComponent(Ctor: ComponentConstructor): Comp
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    const visited: Set<ComponentConstructor> = new Set();
-    while (swappedComponentMap.has(Ctor) && !visited.has(Ctor)) {
-        visited.add(Ctor);
-        Ctor = swappedComponentMap.get(Ctor)!;
+
+    if (featureFlags.ENABLE_HMR) {
+        const visited: Set<ComponentConstructor> = new Set();
+        while (swappedComponentMap.has(Ctor) && !visited.has(Ctor)) {
+            visited.add(Ctor);
+            Ctor = swappedComponentMap.get(Ctor)!;
+        }
     }
+
     return Ctor;
 }
 
@@ -125,11 +134,15 @@ export function getStyleOrSwappedStyle(style: StylesheetFactory): StylesheetFact
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    const visited: Set<StylesheetFactory> = new Set();
-    while (swappedStyleMap.has(style) && !visited.has(style)) {
-        visited.add(style);
-        style = swappedStyleMap.get(style)!;
+
+    if (featureFlags.ENABLE_HMR) {
+        const visited: Set<StylesheetFactory> = new Set();
+        while (swappedStyleMap.has(style) && !visited.has(style)) {
+            visited.add(style);
+            style = swappedStyleMap.get(style)!;
+        }
     }
+
     return style;
 }
 
@@ -138,46 +151,49 @@ export function setActiveVM(vm: VM) {
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    // tracking active component
-    const Ctor = vm.def.ctor;
-    let componentVMs = activeComponents.get(Ctor);
-    if (isUndefined(componentVMs)) {
-        componentVMs = new Set();
-        activeComponents.set(Ctor, componentVMs);
-    }
-    // this will allow us to keep track of the hot components
-    componentVMs.add(vm);
 
-    // tracking active template
-    const tpl = vm.cmpTemplate;
-    if (tpl) {
-        let templateVMs = activeTemplates.get(tpl);
-        if (isUndefined(templateVMs)) {
-            templateVMs = new Set();
-            activeTemplates.set(tpl, templateVMs);
+    if (featureFlags.ENABLE_HMR) {
+        // tracking active component
+        const Ctor = vm.def.ctor;
+        let componentVMs = activeComponents.get(Ctor);
+        if (isUndefined(componentVMs)) {
+            componentVMs = new Set();
+            activeComponents.set(Ctor, componentVMs);
         }
-        // this will allow us to keep track of the templates that are
-        // being used by a hot component
-        templateVMs.add(vm);
+        // this will allow us to keep track of the hot components
+        componentVMs.add(vm);
 
-        // tracking active styles associated to template
-        const stylesheets = tpl.stylesheets;
-        if (!isUndefined(stylesheets)) {
-            flattenStylesheets(stylesheets).forEach((stylesheet) => {
-                // this is necessary because we don't hold the list of styles
-                // in the vm, we only hold the selected (already swapped template)
-                // but the styles attached to the template might not be the actual
-                // active ones, but the swapped versions of those.
-                stylesheet = getStyleOrSwappedStyle(stylesheet);
-                let stylesheetVMs = activeStyles.get(stylesheet);
-                if (isUndefined(stylesheetVMs)) {
-                    stylesheetVMs = new Set();
-                    activeStyles.set(stylesheet, stylesheetVMs);
-                }
-                // this will allow us to keep track of the stylesheet that are
-                // being used by a hot component
-                stylesheetVMs.add(vm);
-            });
+        // tracking active template
+        const tpl = vm.cmpTemplate;
+        if (tpl) {
+            let templateVMs = activeTemplates.get(tpl);
+            if (isUndefined(templateVMs)) {
+                templateVMs = new Set();
+                activeTemplates.set(tpl, templateVMs);
+            }
+            // this will allow us to keep track of the templates that are
+            // being used by a hot component
+            templateVMs.add(vm);
+
+            // tracking active styles associated to template
+            const stylesheets = tpl.stylesheets;
+            if (!isUndefined(stylesheets)) {
+                flattenStylesheets(stylesheets).forEach((stylesheet) => {
+                    // this is necessary because we don't hold the list of styles
+                    // in the vm, we only hold the selected (already swapped template)
+                    // but the styles attached to the template might not be the actual
+                    // active ones, but the swapped versions of those.
+                    stylesheet = getStyleOrSwappedStyle(stylesheet);
+                    let stylesheetVMs = activeStyles.get(stylesheet);
+                    if (isUndefined(stylesheetVMs)) {
+                        stylesheetVMs = new Set();
+                        activeStyles.set(stylesheet, stylesheetVMs);
+                    }
+                    // this will allow us to keep track of the stylesheet that are
+                    // being used by a hot component
+                    stylesheetVMs.add(vm);
+                });
+            }
         }
     }
 }
@@ -187,31 +203,34 @@ export function removeActiveVM(vm: VM) {
         // this method should never leak to prod
         throw new ReferenceError();
     }
-    // tracking inactive component
-    const Ctor = vm.def.ctor;
-    let list = activeComponents.get(Ctor);
-    if (!isUndefined(list)) {
-        // deleting the vm from the set to avoid leaking memory
-        list.delete(vm);
-    }
-    // removing inactive template
-    const tpl = vm.cmpTemplate;
-    if (tpl) {
-        list = activeTemplates.get(tpl);
+
+    if (featureFlags.ENABLE_HMR) {
+        // tracking inactive component
+        const Ctor = vm.def.ctor;
+        let list = activeComponents.get(Ctor);
         if (!isUndefined(list)) {
             // deleting the vm from the set to avoid leaking memory
             list.delete(vm);
         }
-        // removing active styles associated to template
-        const styles = tpl.stylesheets;
-        if (!isUndefined(styles)) {
-            flattenStylesheets(styles).forEach((style) => {
-                list = activeStyles.get(style);
-                if (!isUndefined(list)) {
-                    // deleting the vm from the set to avoid leaking memory
-                    list.delete(vm);
-                }
-            });
+        // removing inactive template
+        const tpl = vm.cmpTemplate;
+        if (tpl) {
+            list = activeTemplates.get(tpl);
+            if (!isUndefined(list)) {
+                // deleting the vm from the set to avoid leaking memory
+                list.delete(vm);
+            }
+            // removing active styles associated to template
+            const styles = tpl.stylesheets;
+            if (!isUndefined(styles)) {
+                flattenStylesheets(styles).forEach((style) => {
+                    list = activeStyles.get(style);
+                    if (!isUndefined(list)) {
+                        // deleting the vm from the set to avoid leaking memory
+                        list.delete(vm);
+                    }
+                });
+            }
         }
     }
 }
@@ -225,6 +244,11 @@ export function swapTemplate(oldTpl: Template, newTpl: Template): boolean {
             throw new TypeError(`Invalid Template`);
         }
     }
+
+    if (!featureFlags.ENABLE_HMR) {
+        throw new Error('HMR is not enabled');
+    }
+
     return false;
 }
 
@@ -240,6 +264,11 @@ export function swapComponent(
             throw new TypeError(`Invalid Component`);
         }
     }
+
+    if (!featureFlags.ENABLE_HMR) {
+        throw new Error('HMR is not enabled');
+    }
+
     return false;
 }
 
@@ -250,5 +279,10 @@ export function swapStyle(oldStyle: StylesheetFactory, newStyle: StylesheetFacto
         swappedStyleMap.set(oldStyle, newStyle);
         return rehydrateHotStyle(oldStyle);
     }
+
+    if (!featureFlags.ENABLE_HMR) {
+        throw new Error('HMR is not enabled');
+    }
+
     return false;
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -206,6 +206,7 @@ export function appendVM(vm: VM) {
 // while preventing any attempt to rehydration until after reinsertion.
 function resetComponentStateWhenRemoved(vm: VM) {
     const { state } = vm;
+
     if (state !== VMState.disconnected) {
         const { oar, tro } = vm;
         // Making sure that any observing record will not trigger the rehydrated on this vm
@@ -219,13 +220,16 @@ function resetComponentStateWhenRemoved(vm: VM) {
         runShadowChildNodesDisconnectedCallback(vm);
         runLightChildNodesDisconnectedCallback(vm);
     }
+
+    if (process.env.NODE_ENV !== 'production') {
+        removeActiveVM(vm);
+    }
 }
 
 // this method is triggered by the diffing algo only when a vnode from the
 // old vnode.children is removed from the DOM.
 export function removeVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        removeActiveVM(vm);
         assert.isTrue(
             vm.state === VMState.connected || vm.state === VMState.disconnected,
             `${vm} must have been connected.`

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -9,7 +9,7 @@ export type FeatureFlagLookup = { [name: string]: FeatureFlagValue };
 
 const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
-
+    ENABLE_HMR: null,
     // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_NODE_LIST_PATCH: null,

--- a/packages/integration-karma/test/swapping/components/index.spec.js
+++ b/packages/integration-karma/test/swapping/components/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 
 // TODO [#1869]: getting the global API from global LWC in tests until it is allowed in compiler
 const { swapComponent } = LWC;
@@ -11,6 +11,7 @@ import D from 'base/d';
 import E from 'base/e';
 
 describe('component swapping', () => {
+    setFeatureFlagForTest('ENABLE_HMR', true);
     it('should work before and after instantiation', () => {
         expect(swapComponent(A, B)).toBe(true);
         const elm = createElement('x-container', { is: Container });


### PR DESCRIPTION
## Details

The call for `removeActiveVMs` was in the wrong place which was causing memory leaks for non-diffed disconnected events.
To explicitly about the non-trivial memory consumption I have made a HMR_FLAG to have it disabled by default.

Note: The diff looks like a lot of changes, but I just moved things around, [this view is better](https://github.com/salesforce/lwc/pull/2103/files?w=1)