### PR TITLE
refactor(synthetic-shadow): relatedTarget prototype patching for FocusEvent and MouseEvent

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -27,6 +27,8 @@ import './polyfills/mutation-observer/main';
 import './polyfills/event-target/main';
 import './polyfills/window-event-target/main';
 import './polyfills/event/main';
+import './polyfills/focus-event/main';
+import './polyfills/mouse-event/main';
 
 // Internal Patches
 import './faux-shadow/node';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/README.md
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/README.md
@@ -1,0 +1,4 @@
+# FocusEvent.prototype.relatedTarget
+
+This polyfill enables retargeting of the secondary target for instances of FocusEvent which have
+a secondary target.

--- a/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/main.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/main.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import './polyfill';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/focus-event/polyfill.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { retargetRelatedTarget } from '../../shared/retarget-related-target';
+
+retargetRelatedTarget(FocusEvent);

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/README.md
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/README.md
@@ -1,0 +1,4 @@
+# MouseEvent.prototype.relatedTarget
+
+This polyfill enables retargeting of the secondary target for instances of MouseEvent which have
+a secondary target.

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/main.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/main.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import './polyfill';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mouse-event/polyfill.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { retargetRelatedTarget } from '../../shared/retarget-related-target';
+
+retargetRelatedTarget(MouseEvent);

--- a/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
@@ -6,8 +6,6 @@
  */
 import { assert, isFalse, isFunction, isNull, isObject, isUndefined } from '@lwc/shared';
 import { eventCurrentTargetGetter } from '../env/dom';
-
-import { doesEventNeedPatch, patchEvent } from '../faux-shadow/events';
 import { eventToShadowRootMap, isHostElement } from '../faux-shadow/shadow-root';
 
 const EventListenerMap: WeakMap<EventListenerOrEventListenerObject, EventListener> = new WeakMap();
@@ -46,10 +44,6 @@ export function getEventListenerWrapper(fnOrObj: unknown) {
             // the current behavior.
             if (eventToShadowRootMap.has(event) && isFalse(composed)) {
                 return;
-            }
-
-            if (doesEventNeedPatch(event)) {
-                patchEvent(event);
             }
 
             return isFunction(fnOrObj)

--- a/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
@@ -9,7 +9,7 @@ import { defineProperty, getOwnPropertyDescriptor, isNull } from '@lwc/shared';
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { retarget } from '../3rdparty/polymer/retarget';
 import { eventCurrentTargetGetter } from '../env/dom';
-import { isNodeShadowed } from '../faux-shadow/node';
+import { isNodeShadowed } from '../shared/node-ownership';
 import { getOwnerDocument } from '../shared/utils';
 
 export function retargetRelatedTarget(Ctor: typeof FocusEvent | typeof MouseEvent) {

--- a/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { defineProperty, getOwnPropertyDescriptor, isNull } from '@lwc/shared';
+
+import { pathComposer } from '../3rdparty/polymer/path-composer';
+import { retarget } from '../3rdparty/polymer/retarget';
+import { eventCurrentTargetGetter } from '../env/dom';
+import { isNodeShadowed } from '../faux-shadow/node';
+import { getOwnerDocument } from '../shared/utils';
+
+export function retargetRelatedTarget(Ctor: typeof FocusEvent | typeof MouseEvent) {
+    const relatedTargetGetter = getOwnPropertyDescriptor(Ctor.prototype, 'relatedTarget')!
+        .get as () => typeof Ctor.prototype.relatedTarget;
+
+    defineProperty(Ctor.prototype, 'relatedTarget', {
+        get(this: Event) {
+            const relatedTarget = relatedTargetGetter.call(this);
+            if (isNull(relatedTarget)) {
+                return null;
+            }
+            if (!(relatedTarget instanceof Node) || !isNodeShadowed(relatedTarget as Node)) {
+                return relatedTarget;
+            }
+            let pointOfReference = eventCurrentTargetGetter.call(this);
+            if (isNull(pointOfReference)) {
+                pointOfReference = getOwnerDocument(relatedTarget as Node);
+            }
+            return retarget(pointOfReference, pathComposer(relatedTarget, true));
+        },
+        enumerable: true,
+        configurable: true,
+    });
+}

--- a/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
@@ -22,12 +22,12 @@ export function retargetRelatedTarget(Ctor: typeof FocusEvent | typeof MouseEven
             if (isNull(relatedTarget)) {
                 return null;
             }
-            if (!(relatedTarget instanceof Node) || !isNodeShadowed(relatedTarget as Node)) {
+            if (!(relatedTarget instanceof Node) || !isNodeShadowed(relatedTarget)) {
                 return relatedTarget;
             }
             let pointOfReference = eventCurrentTargetGetter.call(this);
             if (isNull(pointOfReference)) {
-                pointOfReference = getOwnerDocument(relatedTarget as Node);
+                pointOfReference = getOwnerDocument(relatedTarget);
             }
             return retarget(pointOfReference, pathComposer(relatedTarget, true));
         },

--- a/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
@@ -1,0 +1,12 @@
+import { createElement } from 'lwc';
+import Container from 'x/container';
+
+it('should retarget relatedTarget', function () {
+    const elm = createElement('x-container', { is: Container });
+    document.body.appendChild(elm);
+
+    elm.focusFirstInput();
+    elm.focusSecondInput();
+
+    expect(elm.relatedTargetClassName).toBe('first');
+});

--- a/packages/integration-karma/test/events/focus-event-related-target/x/container/container.html
+++ b/packages/integration-karma/test/events/focus-event-related-target/x/container/container.html
@@ -1,0 +1,6 @@
+<template>
+    <div onfocusin={handleFocusIn}>
+        <x-input class="first"></x-input>
+        <x-input class="second"></x-input>
+    </div>
+</template>

--- a/packages/integration-karma/test/events/focus-event-related-target/x/container/container.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/x/container/container.js
@@ -1,0 +1,22 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    focusFirstInput() {
+        this.template.querySelector(`.first`).focus();
+    }
+
+    @api
+    focusSecondInput() {
+        this.template.querySelector(`.second`).focus();
+    }
+
+    @api
+    get relatedTargetClassName() {
+        return this._className;
+    }
+
+    handleFocusIn(event) {
+        this._className = event.relatedTarget && event.relatedTarget.className;
+    }
+}

--- a/packages/integration-karma/test/events/focus-event-related-target/x/input/input.html
+++ b/packages/integration-karma/test/events/focus-event-related-target/x/input/input.html
@@ -1,0 +1,3 @@
+<template>
+    <input class="internal">
+</template>

--- a/packages/integration-karma/test/events/focus-event-related-target/x/input/input.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/x/input/input.js
@@ -1,0 +1,8 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    focus() {
+        this.template.querySelector('input').focus();
+    }
+}

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.html
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.html
@@ -1,3 +1,3 @@
 <template>
-    <input type="text" />
+    <input class="shadow-element">
 </template>

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/child/child.js
@@ -1,3 +1,3 @@
 import { LightningElement } from 'lwc';
 
-export default class Child extends LightningElement {}
+export default class extends LightningElement {}

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.html
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.html
@@ -1,6 +1,7 @@
 <template>
-    <span class="related-target-tabname">{relatedTargetTagName}</span>
-    <input type="text" onfocusin={handleFocusIn} />
-    <br />
-    <integration-child></integration-child>
+    <div onmouseover={handleMouseOver}>
+        <integration-child class="first"></integration-child>
+        <integration-child class="second"></integration-child>
+    </div>
+    <span class="related-target-class-name">{relatedTargetClassNames}</span>
 </template>

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/integration/retarget-related-target/retarget-related-target.js
@@ -1,8 +1,16 @@
 import { LightningElement, track } from 'lwc';
 
-export default class RetargetRelatedTarget extends LightningElement {
-    @track relatedTargetTagName;
-    handleFocusIn(evt) {
-        this.relatedTargetTagName = evt.relatedTarget.tagName.toLowerCase();
+export default class extends LightningElement {
+    @track
+    _relatedTargetClassNames = [];
+
+    get relatedTargetClassNames() {
+        return this._relatedTargetClassNames
+            .map((className) => className || 'undefined')
+            .join(', ');
+    }
+
+    handleMouseOver(event) {
+        this._relatedTargetClassNames.push(event.relatedTarget && event.relatedTarget.className);
     }
 }

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -6,26 +6,32 @@
  */
 const assert = require('assert');
 
-describe('Retarget relatedTarget', () => {
-    const URL = '/retarget-related-target';
+const URL = '/retarget-related-target';
 
+describe('Retarget relatedTarget', () => {
     before(async () => {
         await browser.url(URL);
     });
 
-    it('should retarget relatedTarget from a foreign shadow', async () => {
-        const target = await browser.shadowDeep$(
+    it('should retarget relatedTarget for MouseEvent', () => {
+        const first = await browser.shadowDeep$(
             'integration-retarget-related-target',
-            'integration-child',
+            'integration-child.first',
             'input'
         );
-        await target.focus();
-        await browser.keys(['Shift', 'Tab', 'Shift']);
-
-        const indicator = await browser.shadowDeep$(
+        const second = await browser.shadowDeep$(
             'integration-retarget-related-target',
-            '.related-target-tabname'
+            'integration-child.second',
+            'input'
         );
-        assert.strictEqual(await indicator.getText(), 'integration-child');
+        const indicator = browser.shadowDeep$(
+            'integration-retarget-related-target',
+            '.related-target-class-name'
+        );
+
+        await first.moveTo();
+        await second.moveTo();
+
+        assert.strictEqual(await indicator.getText(), 'undefined, first');
     });
 });

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -13,7 +13,7 @@ describe('Retarget relatedTarget', () => {
         await browser.url(URL);
     });
 
-    it('should retarget relatedTarget for MouseEvent', () => {
+    it('should retarget relatedTarget for MouseEvent', async () => {
         const first = await browser.shadowDeep$(
             'integration-retarget-related-target',
             'integration-child.first',
@@ -24,7 +24,7 @@ describe('Retarget relatedTarget', () => {
             'integration-child.second',
             'input'
         );
-        const indicator = browser.shadowDeep$(
+        const indicator = await browser.shadowDeep$(
             'integration-retarget-related-target',
             '.related-target-class-name'
         );

--- a/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
+++ b/packages/integration-tests/src/components/events/test-retarget-related-target/retarget-related-target.spec.js
@@ -8,30 +8,33 @@ const assert = require('assert');
 
 const URL = '/retarget-related-target';
 
-describe('Retarget relatedTarget', () => {
-    before(async () => {
-        await browser.url(URL);
+if (process.env.COMPAT === 'false') {
+    describe('Retarget relatedTarget', () => {
+        before(async () => {
+            await browser.url(URL);
+        });
+
+        it('should retarget relatedTarget for MouseEvent', async () => {
+            const first = await browser.shadowDeep$(
+                'integration-retarget-related-target',
+                'integration-child.first',
+                'input'
+            );
+            const second = await browser.shadowDeep$(
+                'integration-retarget-related-target',
+                'integration-child.second',
+                'input'
+            );
+            const indicator = await browser.shadowDeep$(
+                'integration-retarget-related-target',
+                '.related-target-class-name'
+            );
+
+            await first.moveTo();
+            await second.moveTo();
+            await first.moveTo();
+
+            assert.strictEqual(await indicator.getText(), 'undefined, first, second');
+        });
     });
-
-    it('should retarget relatedTarget for MouseEvent', async () => {
-        const first = await browser.shadowDeep$(
-            'integration-retarget-related-target',
-            'integration-child.first',
-            'input'
-        );
-        const second = await browser.shadowDeep$(
-            'integration-retarget-related-target',
-            'integration-child.second',
-            'input'
-        );
-        const indicator = await browser.shadowDeep$(
-            'integration-retarget-related-target',
-            '.related-target-class-name'
-        );
-
-        await first.moveTo();
-        await second.moveTo();
-
-        assert.strictEqual(await indicator.getText(), 'undefined, first');
-    });
-});
+}


### PR DESCRIPTION
## Details

Add shadow semantics to the relatedTarget property of `FocusEvent` and `MouseEvent`.

These changes have already been reviewed in #2087 and this PR will be labeled with "nomerge" until it's decided that we're ready to move forward.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

Minimal to no impact in environments where Locker is available due to the relatedTarget reference changing from the generic `document` to actual relevant event retargeting.

In environments without Locker, relatedTarget will change from the original relatedTarget to a retargeted one, as defined in the spec.

## The PR fulfills these requirements:

* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item

W-8384244