### PR TITLE
fix(integration-tests): make browser loading synchronous for delegates-focus-tab-navigation test

### DIFF
--- a/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
+++ b/packages/integration-tests/src/components/delegates-focus-tab-navigation/test-tabindex-zero-internal-tabindex-negative/test-tabindex-zero-internal-tabindex-negative.spec.js
@@ -8,8 +8,8 @@ const assert = require('assert');
 const URL = '/tabindex-zero-internal-tabindex-negative';
 
 describe('Tab navigation when tabindex 0', () => {
-    beforeEach(() => {
-        browser.url(URL);
+    beforeEach(async () => {
+        await browser.url(URL);
     });
 
     it('should skip internal elements contained by a negative tabindex subtree when delegating focus (forward)', async () => {


### PR DESCRIPTION
## Details

Makes browser loading synchronous. This one was missed from #2116.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8330504