### PR TITLE
fix(engine-core): call wire adapter connect after component connected…

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -449,9 +449,6 @@ export function runConnectedCallback(vm: VM) {
     if (connected) {
         invokeServiceHook(vm, connected);
     }
-    if (hasWireAdapters(vm)) {
-        connectWireAdapters(vm);
-    }
     const { connectedCallback } = vm.def;
     if (!isUndefined(connectedCallback)) {
         if (profilerEnabled) {
@@ -463,6 +460,10 @@ export function runConnectedCallback(vm: VM) {
         if (profilerEnabled) {
             logOperationEnd(OperationId.connectedCallback, vm);
         }
+    }
+
+    if (hasWireAdapters(vm)) {
+        connectWireAdapters(vm);
     }
 }
 

--- a/packages/integration-karma/test/wire/wiring/x/adapterConsumerWithLifecycleEvents/adapterConsumerWithLifecycleEvents.html
+++ b/packages/integration-karma/test/wire/wiring/x/adapterConsumerWithLifecycleEvents/adapterConsumerWithLifecycleEvents.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/wire/wiring/x/adapterConsumerWithLifecycleEvents/adapterConsumerWithLifecycleEvents.js
+++ b/packages/integration-karma/test/wire/wiring/x/adapterConsumerWithLifecycleEvents/adapterConsumerWithLifecycleEvents.js
@@ -1,0 +1,12 @@
+import { LightningElement, wire } from 'lwc';
+import { EchoWireAdapter } from 'x/echoAdapter';
+
+export default class AdapterConsumerWithLifecycleEvents extends LightningElement {
+    setByConnected;
+    @wire(EchoWireAdapter, { value: '$setByConnected' }) wiredValue;
+
+    connectedCallback() {
+        this.dispatchEvent(new CustomEvent('connectedcallback'));
+        this.setByConnected = true;
+    }
+}

--- a/packages/integration-karma/test/wire/wiring/x/echoAdapter/echoAdapter.js
+++ b/packages/integration-karma/test/wire/wiring/x/echoAdapter/echoAdapter.js
@@ -1,10 +1,13 @@
 let adapterSpy;
+let adapterNotifyCallback;
 
 export class EchoWireAdapter {
     callback;
+    listeners = {};
 
-    static setSpy(spy) {
+    static setSpy(spy, notifyCallback) {
         adapterSpy = spy;
+        adapterNotifyCallback = notifyCallback;
     }
 
     constructor(callback) {
@@ -29,6 +32,9 @@ export class EchoWireAdapter {
     log(method, args) {
         if (adapterSpy) {
             adapterSpy.push({ method, args });
+        }
+        if (adapterNotifyCallback) {
+            adapterNotifyCallback(method, args);
         }
     }
 }


### PR DESCRIPTION
…Callback


## Details
Followup from #2112 

This PR changes the order of execution of `adapter.connect` and a component `connectedCallback` to execute the component `connectedCallback` first, and `adapter.connect` after (and the initial `adapter.update`).

With #2112, we removed the initial `Promise.resolve()` to calculate the adapter config with dynamic parameters. This will be a breaking change for some components that:

1. Has a wire with at least 1 dynamic config parameter that is defined as getter.
2. The getter depends on a value set during the connectedCallback and is not guarding against the value not being set.

Example:

```js
export default class Foo extends LightningElement {
   connectedCallback() {
      const editorContainer = this.querySelector('.editor');
      this.editor = new FancyEditor(editorContainer);
   }

   @wire(Adapter, { p: '$val' }) model;

   get val() {
      return this.editor.fancyModel; // <- this will throw, this.editor is not defined.
   }
}
```


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
## GUS work item
@W-8537539

