### PR TITLE
fix(engine-core): delay initial wire config computation until next tick

### DIFF
--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -330,9 +330,14 @@ export function installWireAdapters(vm: VM) {
                 fieldNameOrMethod,
                 wireDef
             );
+            const hasDynamicParams = wireDef.dynamic.length > 0;
             ArrayPush.call(wiredConnecting, () => {
                 connector.connect();
-                computeConfigAndUpdate();
+                if (hasDynamicParams) {
+                    Promise.resolve().then(computeConfigAndUpdate);
+                } else {
+                    computeConfigAndUpdate();
+                }
             });
             ArrayPush.call(wiredDisconnecting, () => {
                 connector.disconnect();

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -78,6 +78,9 @@ describe('wiring', () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
+            expect(spy).toHaveSize(1);
+            expect(spy[0].method).toBe('connect');
+
             return Promise.resolve().then(() => {
                 expect(spy).toHaveSize(2);
                 expect(spy[0].method).toBe('connect');


### PR DESCRIPTION
## Details
Follow up to #2112 

[In #2112](https://github.com/salesforce/lwc/pull/2112/files#diff-357ab2b7c6c4aa2aaece1c46d4f45152bd32f1ea4c25ed4792497e528fa4a14fL197-L207), we removed the initial `Promise.resolve()` when calculating the first config (with dynamic parameters) for a wire adapter instance. There is some wire-adapters/components on platform that does not handle well when the value of the dynamic parameter is changed during the connected or rendered callback.

This PR re-introduces the `Promise.resolve()` to compute the first config (that has dynamic parameters) for a wire adapter instance.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-8537539
