### PR TITLE
fix(engine-core): leaking reactive observers for wire config

### DIFF
--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -330,9 +330,14 @@ export function installWireAdapters(vm: VM) {
                 fieldNameOrMethod,
                 wireDef
             );
+            const hasDynamicParams = wireDef.dynamic.length > 0;
             ArrayPush.call(wiredConnecting, () => {
                 connector.connect();
-                computeConfigAndUpdate();
+                if (hasDynamicParams) {
+                    Promise.resolve().then(computeConfigAndUpdate);
+                } else {
+                    computeConfigAndUpdate();
+                }
             });
             ArrayPush.call(wiredDisconnecting, () => {
                 connector.disconnect();

--- a/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -9,6 +9,8 @@ describe('legacy wire adapters (register call)', () => {
     describe('with static config', () => {
         it('should call config when config is empty (@wire(foo)...)', () => {
             const elm = createElement('x-simple-wire', { is: StaticWiredProps });
+            document.body.appendChild(elm);
+
             const calls = elm.emptyConfigCalls;
             expect(calls.length).toBe(1);
             expect(calls[0]).toEqual({});
@@ -16,6 +18,8 @@ describe('legacy wire adapters (register call)', () => {
 
         it('should call config when config is empty object', () => {
             const elm = createElement('x-simple-wire', { is: StaticWiredProps });
+            document.body.appendChild(elm);
+
             const calls = elm.emptyObjectConfigCalls;
             expect(calls.length).toBe(1);
             expect(calls[0]).toEqual({});
@@ -23,12 +27,16 @@ describe('legacy wire adapters (register call)', () => {
 
         it('should call config when all props of config are undefined', () => {
             const elm = createElement('x-simple-wire', { is: StaticWiredProps });
+            document.body.appendChild(elm);
+
             const calls = elm.allUndefinedPropsInConfigCalls;
             expect(calls.length).toBe(1);
         });
 
         it('should call config when at least one prop in config is defined', () => {
             const elm = createElement('x-simple-wire', { is: StaticWiredProps });
+            document.body.appendChild(elm);
+
             const calls = elm.someUndefinedPropsInConfigCalls;
             expect(calls.length).toBe(1);
             expect(calls[0]).toEqual({ p1: 'test', p2: undefined });
@@ -38,6 +46,7 @@ describe('legacy wire adapters (register call)', () => {
     describe('with dynamic config', () => {
         it('should not call config when all initially all props of config are undefined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const calls = elm.allUndefinedConfigCalls;
@@ -48,6 +57,7 @@ describe('legacy wire adapters (register call)', () => {
 
         it('should call config when at least one prop in config is defined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const calls = elm.someDefinedConfigCalls;
@@ -60,6 +70,7 @@ describe('legacy wire adapters (register call)', () => {
 
         it('should call config when all props become undefined after initialization', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const calls = elm.someDefinedConfigCalls;
@@ -79,6 +90,7 @@ describe('legacy wire adapters (register call)', () => {
 
         it('should call config when initially all props of config are undefined and some change', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const calls = elm.allUndefinedConfigCalls;
@@ -99,6 +111,7 @@ describe('legacy wire adapters (register call)', () => {
     describe('with dynamic and static config', () => {
         it('should not call config when initially all props from params in config are undefined', (done) => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const calls = elm.mixedAllParamsUndefinedCalls;
@@ -124,6 +137,7 @@ describe('legacy wire adapters (register call)', () => {
             const elm = createElement('x-same-config', { is: SameConfigCase });
             elm.a = 3;
             elm.b = 2;
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const firstResult = elm.resultMultipleDependenciesForConfig;
@@ -147,6 +161,7 @@ describe('legacy wire adapters (register call)', () => {
         it('should not call config when the generated config is the same as the last one (case 2)', (done) => {
             const elm = createElement('x-same-config', { is: SameConfigCase });
             elm.a = 3;
+            document.body.appendChild(elm);
 
             setTimeout(() => {
                 const firstResult = elm.resultApiValueDependency;
@@ -171,6 +186,7 @@ describe('legacy wire adapters (register call)', () => {
             const elm = createElement('x-same-adapter-different-config', {
                 is: SameAdapterDifferentConfig,
             });
+            document.body.appendChild(elm);
 
             const resultFoo = elm.wireFooData;
             expect(resultFoo.prop).toBe('foo');

--- a/packages/integration-karma/test/wire/property-trap/index.spec.js
+++ b/packages/integration-karma/test/wire/property-trap/index.spec.js
@@ -31,17 +31,17 @@ describe('wire adapter update', () => {
         const wireKey = { b: { c: { d: 'a.b.c.d value' } } };
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
 
-        document.body.appendChild(elm);
         elm.setWireKeyParameter(wireKey);
+        document.body.appendChild(elm);
 
         return Promise.resolve().then(() => {
             const actualWiredValues = elm.getWiredProp();
-            expect(spy.length).toBe(1);
+            expect(spy).toHaveSize(1);
             expect(actualWiredValues.data.recordId).toBe('default value');
             elm.setWireKeyParameter(wireKey);
 
             return Promise.resolve().then(() => {
-                expect(spy.length).toBe(1);
+                expect(spy).toHaveSize(1);
             });
         });
     });
@@ -68,7 +68,6 @@ describe('wire adapter update', () => {
         });
     });
 
-    // all currently failing
     describe('reactivity when vm.isDirty === true', () => {
         it('should call update with value set before connected (using observed fields)', () => {
             const wireKey = { b: { c: { d: 'expected' } } };

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -78,6 +78,9 @@ describe('wiring', () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
+            expect(spy).toHaveSize(1);
+            expect(spy[0].method).toBe('connect');
+
             return Promise.resolve().then(() => {
                 expect(spy).toHaveSize(2);
                 expect(spy[0].method).toBe('connect');

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -60,12 +60,14 @@ describe('wiring', () => {
             AdapterId.setSpy(spy);
             expect(spy.length).toBe(0);
 
-            createElement('x-echo-adapter-consumer', { is: InheritedMethods });
+            const elm = createElement('x-echo-adapter-consumer', { is: InheritedMethods });
+            document.body.appendChild(elm);
 
-            expect(spy.length).toBe(3);
-            expect(spy[0].method).toBe('update'); // parentMethod
-            expect(spy[1].method).toBe('update'); // childMethod
-            expect(spy[2].method).toBe('update'); // overriddenInChild
+            const updateCalls = filterCalls(spy, 'update');
+            expect(updateCalls).toHaveSize(3);
+            expect(updateCalls[0].method).toBe('update'); // parentMethod
+            expect(updateCalls[1].method).toBe('update'); // childMethod
+            expect(updateCalls[2].method).toBe('update'); // overriddenInChild
         });
 
         it('should be called next tick when component with wire that has dynamic params is created', () => {
@@ -73,11 +75,13 @@ describe('wiring', () => {
             AdapterId.setSpy(spy);
             expect(spy.length).toBe(0);
 
-            createElement('x-echo-adapter-consumer', { is: ComponentClass });
+            const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
+            document.body.appendChild(elm);
 
             return Promise.resolve().then(() => {
-                expect(spy.length).toBe(1);
-                expect(spy[0].method).toBe('update');
+                expect(spy).toHaveSize(2);
+                expect(spy[0].method).toBe('connect');
+                expect(spy[1].method).toBe('update');
             });
         });
 
@@ -94,7 +98,7 @@ describe('wiring', () => {
                 // in the old wire protocol, there is only one call because
                 // on the same tick the config was modified
                 const updateCalls = filterCalls(spy, 'update');
-                expect(updateCalls.length).toBe(1);
+                expect(updateCalls).toHaveSize(1);
             });
         });
 
@@ -106,13 +110,13 @@ describe('wiring', () => {
 
             return Promise.resolve()
                 .then(() => {
-                    expect(filterCalls(spy, 'update').length).toBe(1);
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
                     elm.forceRerender();
 
                     return Promise.resolve();
                 })
                 .then(() => {
-                    expect(filterCalls(spy, 'update').length).toBe(1);
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
                 });
         });
 
@@ -124,13 +128,13 @@ describe('wiring', () => {
 
             return Promise.resolve()
                 .then(() => {
-                    expect(filterCalls(spy, 'update').length).toBe(1);
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
                     elm.setDynamicParamSource('simpleParam modified');
 
                     return Promise.resolve();
                 })
                 .then(() => {
-                    expect(filterCalls(spy, 'update').length).toBe(2);
+                    expect(filterCalls(spy, 'update')).toHaveSize(2);
                     const wireResult = elm.getWiredProp();
 
                     expect(wireResult.simpleParam).toBe('simpleParam modified');
@@ -144,11 +148,11 @@ describe('wiring', () => {
             document.body.appendChild(elm);
 
             return Promise.resolve().then(() => {
-                expect(filterCalls(spy, 'update').length).toBe(2);
+                expect(filterCalls(spy, 'update')).toHaveSize(2);
                 elm.setCommonParameter('modified');
 
                 return Promise.resolve().then(() => {
-                    expect(filterCalls(spy, 'update').length).toBe(4);
+                    expect(filterCalls(spy, 'update')).toHaveSize(4);
                     const wireResult1 = elm.getEchoWiredProp1();
                     const wireResult2 = elm.getEchoWiredProp2();
 
@@ -209,6 +213,50 @@ describe('wiring', () => {
 
                         done();
                     }, 5);
+                });
+        });
+
+        it('should not call update when component is disconnected.', () => {
+            const spy = [];
+            AdapterId.setSpy(spy);
+            const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
+            document.body.appendChild(elm);
+
+            return Promise.resolve()
+                .then(() => {
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
+                    document.body.removeChild(elm);
+                    elm.setDynamicParamSource('simpleParam modified');
+                })
+                .then(() => {
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
+                });
+        });
+
+        it('should call update when component is re-connected.', () => {
+            const spy = [];
+            AdapterId.setSpy(spy);
+            const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
+            document.body.appendChild(elm);
+
+            return Promise.resolve()
+                .then(() => {
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
+                    document.body.removeChild(elm);
+                    elm.setDynamicParamSource('simpleParam modified');
+                })
+                .then(() => {
+                    expect(filterCalls(spy, 'update')).toHaveSize(1);
+                    const wireResult = elm.getWiredProp();
+
+                    expect(wireResult.simpleParam).not.toBeDefined();
+                    document.body.appendChild(elm);
+                })
+                .then(() => {
+                    expect(filterCalls(spy, 'update')).toHaveSize(2);
+                    const wireResult = elm.getWiredProp();
+
+                    expect(wireResult.simpleParam).toBe('simpleParam modified');
                 });
         });
     });


### PR DESCRIPTION
## Details
Cherrypicks 506da13099b1d91fadcf34242a38b5cdfd04286f (#2112 ) and 3042241c6c51ef8a2c1513c7ec435fdb736cdb49 (#2120 ) into spring21 release branch.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
@W-8554610
