### PR TITLE
chore(integration-karma): Remove condition enabling assignedElement tests

### DIFF
--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -35,14 +35,8 @@ function testAssignedElements(testDescription, getContainer) {
     });
 }
 
-// Chrome is the only browser implementing HTMLSlotElement.assignedElement natively.
-// Webkit - https://bugs.webkit.org/show_bug.cgi?id=180908
-// Gecko - https://bugzilla.mozilla.org/show_bug.cgi?id=1425685
-const SUPPORT_ASSIGNED_ELEMENTS =
-    !process.env.NATIVE_SHADOW || 'assignedElements' in document.createElement('slot');
-
 // Should not be expecting native shadow behavior to work in compat mode
-if (SUPPORT_ASSIGNED_ELEMENTS && process.env.COMPAT !== true) {
+if (!process.env.COMPAT) {
     testAssignedElements(
         'assignedElements() retains native behavior in native shadow dom tree',
         () => document.body

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-properties/HTMLSlotElement-assigned.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-properties/HTMLSlotElement-assigned.spec.js
@@ -6,12 +6,6 @@ import Basic from 'x/basic';
 import SlotsInSlots from 'x/slotsInSlots';
 import Complex from 'x/complex';
 
-// Chrome is the only browser implementing HTMLSlotElement.assignedElement natively.
-// Webkit - https://bugs.webkit.org/show_bug.cgi?id=180908
-// Gecko - https://bugzilla.mozilla.org/show_bug.cgi?id=1425685
-const SUPPORT_ASSIGNED_ELEMENTS =
-    !process.env.NATIVE_SHADOW || 'assignedElements' in document.createElement('slot');
-
 describe('ignore non direct host children', () => {
     let elm;
     let nodes;
@@ -34,18 +28,16 @@ describe('ignore non direct host children', () => {
         ]);
     });
 
-    if (SUPPORT_ASSIGNED_ELEMENTS) {
-        it('assignedElements', () => {
-            expect(nodes.default1.assignedElements()).toEqual([nodes.slotted3]);
-            expect(nodes.slot1.assignedElements()).toEqual([nodes.slotted1, nodes.slotted2]);
+    it('assignedElements', () => {
+        expect(nodes.default1.assignedElements()).toEqual([nodes.slotted3]);
+        expect(nodes.slot1.assignedElements()).toEqual([nodes.slotted1, nodes.slotted2]);
 
-            expect(nodes.default1.assignedElements({ flatten: true })).toEqual([nodes.slotted3]);
-            expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([
-                nodes.slotted1,
-                nodes.slotted2,
-            ]);
-        });
-    }
+        expect(nodes.default1.assignedElements({ flatten: true })).toEqual([nodes.slotted3]);
+        expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([
+            nodes.slotted1,
+            nodes.slotted2,
+        ]);
+    });
 });
 
 describe('fallback content basic', () => {
@@ -71,15 +63,13 @@ describe('fallback content basic', () => {
         expect(nodes.slot1.assignedNodes({ flatten: true })).toEqual([]);
     });
 
-    if (SUPPORT_ASSIGNED_ELEMENTS) {
-        it('assignedElements', () => {
-            expect(nodes.default1.assignedElements()).toEqual([]);
-            expect(nodes.slot1.assignedElements()).toEqual([]);
+    it('assignedElements', () => {
+        expect(nodes.default1.assignedElements()).toEqual([]);
+        expect(nodes.slot1.assignedElements()).toEqual([]);
 
-            expect(nodes.default1.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
-            expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([]);
-        });
-    }
+        expect(nodes.default1.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
+        expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([]);
+    });
 });
 
 describe('fallback content slots in slots', () => {
@@ -101,15 +91,13 @@ describe('fallback content slots in slots', () => {
         expect(nodes.slot2.assignedNodes({ flatten: true })).toEqual([nodes.fallback1]);
     });
 
-    if (SUPPORT_ASSIGNED_ELEMENTS) {
-        it('assignedElements', () => {
-            expect(nodes.slot1.assignedElements()).toEqual([]);
-            expect(nodes.slot2.assignedElements()).toEqual([]);
+    it('assignedElements', () => {
+        expect(nodes.slot1.assignedElements()).toEqual([]);
+        expect(nodes.slot2.assignedElements()).toEqual([]);
 
-            expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
-            expect(nodes.slot2.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
-        });
-    }
+        expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
+        expect(nodes.slot2.assignedElements({ flatten: true })).toEqual([nodes.fallback1]);
+    });
 });
 
 describe('fallback content complex', () => {
@@ -145,27 +133,25 @@ describe('fallback content complex', () => {
         ]);
     });
 
-    if (SUPPORT_ASSIGNED_ELEMENTS) {
-        it('assignedElements', () => {
-            expect(nodes.slot1.assignedElements()).toEqual([nodes.slotted1]);
-            expect(nodes.slot2.assignedElements()).toEqual([]);
-            expect(nodes.slot3.assignedElements()).toEqual([nodes.slot2]);
-            expect(nodes.slot4.assignedElements()).toEqual([]);
+    it('assignedElements', () => {
+        expect(nodes.slot1.assignedElements()).toEqual([nodes.slotted1]);
+        expect(nodes.slot2.assignedElements()).toEqual([]);
+        expect(nodes.slot3.assignedElements()).toEqual([nodes.slot2]);
+        expect(nodes.slot4.assignedElements()).toEqual([]);
 
-            expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([nodes.slotted1]);
-            expect(nodes.slot2.assignedElements({ flatten: true })).toEqual([
-                nodes.slotted1,
-                nodes.fallback2,
-            ]);
-            expect(nodes.slot3.assignedElements({ flatten: true })).toEqual([
-                nodes.slotted1,
-                nodes.fallback2,
-            ]);
-            expect(nodes.slot4.assignedElements({ flatten: true })).toEqual([
-                nodes.slotted1,
-                nodes.fallback2,
-                nodes.fallback3,
-            ]);
-        });
-    }
+        expect(nodes.slot1.assignedElements({ flatten: true })).toEqual([nodes.slotted1]);
+        expect(nodes.slot2.assignedElements({ flatten: true })).toEqual([
+            nodes.slotted1,
+            nodes.fallback2,
+        ]);
+        expect(nodes.slot3.assignedElements({ flatten: true })).toEqual([
+            nodes.slotted1,
+            nodes.fallback2,
+        ]);
+        expect(nodes.slot4.assignedElements({ flatten: true })).toEqual([
+            nodes.slotted1,
+            nodes.fallback2,
+            nodes.fallback3,
+        ]);
+    });
 });


### PR DESCRIPTION
## Details

Now that Webkit and Gecko landed `HTMLSlotElement.prototype.assignedElement`, we can finally. get rid of the condition Karma tests.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅