### PR TITLE
refactor(engine-core): replaces vm.context wire connecting/disconnecting

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -41,7 +41,12 @@ import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } f
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from './mutation-tracker';
 import { LightningElement } from './base-lightning-element';
-import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
+import {
+    connectWireAdapters,
+    disconnectWireAdapters,
+    installWireAdapters,
+    WireAdapter,
+} from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
 import { Renderer, HostNode, HostElement } from './renderer';
 import { removeActiveVM } from './hot-swaps';
@@ -66,11 +71,6 @@ export enum VMState {
     disconnected,
 }
 
-export interface WireConnector {
-    connect: () => void;
-    disconnect: () => void;
-}
-
 export interface Context {
     /** The attribute name used on the host element to scope the style. */
     hostAttribute: string | undefined;
@@ -82,7 +82,7 @@ export interface Context {
      *  different render cycle of the same template. */
     tplCache: TemplateCache;
     /** List of wire connectors attached to this component. */
-    wiredConnectors: WireConnector[];
+    wiredConnectors: WireAdapter[];
 }
 
 export interface VM<N = HostNode, E = HostElement> {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -66,6 +66,11 @@ export enum VMState {
     disconnected,
 }
 
+export interface WireConnector {
+    connect: () => void;
+    disconnect: () => void;
+}
+
 export interface Context {
     /** The attribute name used on the host element to scope the style. */
     hostAttribute: string | undefined;
@@ -76,10 +81,8 @@ export interface Context {
     /** Object used by the template function to store information that can be reused between
      *  different render cycle of the same template. */
     tplCache: TemplateCache;
-    /** List of wire hooks that are invoked when the component gets connected. */
-    wiredConnecting: Array<() => void>;
-    /** List of wire hooks that are invoked when the component gets disconnected. */
-    wiredDisconnecting: Array<() => void>;
+    /** List of wire connectors attached to this component. */
+    wiredConnectors: WireConnector[];
 }
 
 export interface VM<N = HostNode, E = HostElement> {
@@ -275,8 +278,7 @@ export function createVM<HostNode, HostElement>(
             shadowAttribute: undefined,
             styleVNode: null,
             tplCache: EmptyObject,
-            wiredConnecting: EmptyArray,
-            wiredDisconnecting: EmptyArray,
+            wiredConnectors: EmptyArray,
         },
 
         tro: null!, // Set synchronously after the VM creation.

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -80,11 +80,11 @@ function createMethodDataCallback(vm: VM, method: (data: any) => any) {
     };
 }
 
-interface InternalWireAdapter extends WireAdapter {
+interface WireAdapterDecorator extends WireAdapter {
     computeConfig: () => ConfigValue;
 }
 
-class BaseWireAdapter implements InternalWireAdapter {
+class BaseWireAdapter implements WireAdapterDecorator {
     private readonly vm;
     private readonly connector;
     private readonly configCallback;
@@ -141,7 +141,7 @@ class BaseWireAdapter implements InternalWireAdapter {
     }
 }
 
-class ContextAwareWireAdapter implements InternalWireAdapter {
+class ContextAwareWireAdapter implements WireAdapterDecorator {
     private readonly decoratedWireAdapter;
     private readonly vm;
     private readonly adapterContextToken;
@@ -172,7 +172,7 @@ class ContextAwareWireAdapter implements InternalWireAdapter {
     };
 
     constructor(
-        decoratedWireAdapter: InternalWireAdapter,
+        decoratedWireAdapter: WireAdapterDecorator,
         vm: VM,
         adapter: WireAdapterConstructor
     ) {
@@ -228,8 +228,8 @@ class ContextAwareWireAdapter implements InternalWireAdapter {
     }
 }
 
-class ConfigAwareWireAdapter implements InternalWireAdapter {
-    private readonly decoratedWireAdapter: InternalWireAdapter;
+class ConfigAwareWireAdapter implements WireAdapterDecorator {
+    private readonly decoratedWireAdapter: WireAdapterDecorator;
     private readonly hasDynamicConfigParams: boolean;
     private readonly ro: ReactiveObserver;
     private hasPendingConfig = false;
@@ -259,7 +259,7 @@ class ConfigAwareWireAdapter implements InternalWireAdapter {
     };
 
     constructor(
-        decoratedWireAdapter: InternalWireAdapter,
+        decoratedWireAdapter: WireAdapterDecorator,
         vm: VM,
         hasDynamicConfigParams: boolean
     ) {
@@ -320,7 +320,7 @@ function createConnector(vm: VM, name: string, wireDef: WireDef): WireConnector 
         noop
     );
 
-    let wireConnector: InternalWireAdapter = new BaseWireAdapter(
+    let wireConnector: WireAdapterDecorator = new BaseWireAdapter(
         connector!,
         vm,
         wireDef.configCallback

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -435,7 +435,7 @@ export function installWireAdapters(vm: VM) {
         if (!isUndefined(wireDef)) {
             const connector = createConnector(vm, fieldNameOrMethod, wireDef);
 
-            wiredConnectors.push(connector);
+            ArrayPush.call(wiredConnectors, connector);
         }
     }
 }


### PR DESCRIPTION
## Details
This PR attempts to simplify the logic of how the wiring is done by encapsulating the connect/disconnect logic into the `WireConnector` and all context related logic into the `ContextWatcher` abstractions.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`