### PR TITLE
docs(synthetic-shadow): Update README content

### DIFF
--- a/packages/@lwc/synthetic-shadow/README.md
+++ b/packages/@lwc/synthetic-shadow/README.md
@@ -7,10 +7,5 @@ This is a polyfill for ShadowRoot that was tailor-made for LWC in order to meet 
 ## Compromises
 
 -   Default content for `<slot>` elements is always empty.
--   `slotchange` is only available directly on the slot (it doesn't bubble as in the case of the native implementation)
--   Dispatching events directly on the `ShadowRoot` instance isn't allowed because the events will always leak into the host, and we have no way to contain them.
+-   `slotchange` is only available directly on the `<slot>` (it doesn't bubble as in the case of the native implementation). This restriction is in place because implementing `slotchange` requires using `MutationObserver` which is expensive at runtime. By only supporting `slotchange` event applied directly on the `<slot>` element, the LWC engine receives a clear signal that the component author is interested in listening to this event. This avoids spending unnecessary CPU time when the `slotchange` event is never consumed.
 -   If you use `MutationObserver` to watch changes in a DOM tree, disconnect it or you will cause a memory leak. Note that a component can observe mutations only in its own template. It can't observe mutations within the shadow tree of other custom elements.
-
-## Missing features
-
-TBD


### PR DESCRIPTION
## Details

- Remove comment about restricting dispatching events on `ShadowRoot`. This landed with #2117.
- Add more context around the `slotchange` event restriction.


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 