### PR TITLE
chore: set dependency resolution to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "resolutions": {
     "micromatch": "^4.0.2",
     "meow": "^7.1.1",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "systeminformation": "^4.31.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13794,10 +13794,10 @@ symbol-tree@^3.2.4:
   resolved "http://npm.lwcjs.org/symbol-tree/-/symbol-tree-3.2.4/430637d248ba77e078883951fb9aa0eed7c63fa2.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-systeminformation@~4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.9.2.tgz#df6e534d660ee438f61dc9cc08f6f826fb599406"
-  integrity sha512-J3a2Rsdtk+JhJ5cL2ByMLtW5/EZnsZ5gzE573U/Jlu7Ss+cjme9qOVeND5cDKvGcouW3b+hMBtZl5ivNb7HDFw==
+systeminformation@^4.31.1, systeminformation@~4.9.2:
+  version "4.33.1"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.33.1.tgz#25e1491303cfdba897c4b836d2a1d0164a3cf734"
+  integrity sha512-ZSAluWiZWNfyJMKXk+cBGVSh+dwa3dYEfJHKUVAUdJmtJAXms2Hurxk/TufM0ZUHthyimj85xAuXKnRMMAbgmQ==
 
 table@^6.0.4:
   version "6.0.4"


### PR DESCRIPTION
## Details
Fix resolution of systeminformation dependency. This resolved vulnerability GHSA-m57p-p67h-mq74

The usage of "systeminformation" package is as follows
perf-benchmarks > @best/cli > @best/utils > systeminformation
Issue filed for best repo https://github.com/salesforce/best/issues/263

### When can the manual resolution be reverted?
Once @best/utils updates its version of systeminformation, the manual resolution in lwc can be reverted.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

