### PR TITLE
test: Rename modules to avoid jest conflict

### DIFF
--- a/packages/@lwc/module-resolver/src/__tests__/fixtures/custom-resolution/package.json
+++ b/packages/@lwc/module-resolver/src/__tests__/fixtures/custom-resolution/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "test-fixtures",
+    "name": "custom-resolution",
     "private": true
 }

--- a/packages/@lwc/module-resolver/src/__tests__/fixtures/from-npm/package.json
+++ b/packages/@lwc/module-resolver/src/__tests__/fixtures/from-npm/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "test-fixtures",
+    "name": "from-npm",
     "private": true
 }

--- a/packages/@lwc/module-resolver/src/__tests__/fixtures/module-entries/package.json
+++ b/packages/@lwc/module-resolver/src/__tests__/fixtures/module-entries/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "test-fixtures",
+    "name": "modules-entries",
     "private": true
 }

--- a/packages/@lwc/module-resolver/src/__tests__/fixtures/no-config/package.json
+++ b/packages/@lwc/module-resolver/src/__tests__/fixtures/no-config/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "test-fixtures",
+    "name": "no-config",
     "private": true
 }


### PR DESCRIPTION
## Details

This PR avoids jest conflicting module names by removing duplicate module names.

![Screen Shot 2021-01-06 at 11 28 40 AM](https://user-images.githubusercontent.com/2567083/103761018-44e08700-5016-11eb-8a98-9402b253935f.png)
 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
