### PR TITLE
chore: normalize registry in yarn lockfile

### DIFF
--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -33,7 +33,7 @@
         "@lwc/template-compiler": "1.10.0",
         "@rollup/plugin-replace": "~2.3.4",
         "babel-preset-compat": "~0.22.1",
-        "rollup": "~2.34.0",
+        "rollup": "~2.36.0",
         "terser": "~5.5.1"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel-compat.js
+++ b/packages/@lwc/compiler/src/__tests__/fixtures/expected-babel-compat.js
@@ -44,8 +44,8 @@ var keys = Object.compatKeys(object);
 if (Object.getOwnPropertySymbols) {
 var symbols = Object.getOwnPropertySymbols(object);
 if (enumerableOnly) symbols = __callKey1(symbols, "filter", function (sym) {
-var _Object$compatGetOwnP, _enumerable;
-return _Object$compatGetOwnP = Object.compatGetOwnPropertyDescriptor(object, sym), _enumerable = _Object$compatGetOwnP._ES5ProxyType ? _Object$compatGetOwnP.get("enumerable") : _Object$compatGetOwnP.enumerable;
+var _Object$compatGetOwnP;
+return _Object$compatGetOwnP = Object.compatGetOwnPropertyDescriptor(object, sym), _Object$compatGetOwnP._ES5ProxyType ? _Object$compatGetOwnP.get("enumerable") : _Object$compatGetOwnP.enumerable;
 });
 __callKey2(keys.push, "apply", keys, symbols);
 }
@@ -179,7 +179,6 @@ _createClass(Foo, [{
 key: "foo",
 value: function () {
 var _foo = _asyncToGenerator( /*#__PURE__*/__callKey1(_regeneratorRuntime, "mark", function _callee() {
-var wat;
 return __callKey3(_regeneratorRuntime, "wrap", function _callee$(_context) {
 while (1) {
 switch (__setKey(_context, "prev", _context._ES5ProxyType ? _context.get("next") : _context.next)) {
@@ -187,7 +186,7 @@ case 0:
 __setKey(_context, "next", 2);
 return bar();
 case 2:
-wat = _context._ES5ProxyType ? _context.get("sent") : _context.sent;
+_context._ES5ProxyType ? _context.get("sent") : _context.sent;
 case 3:
 case "end":
 return __callKey0(_context, "stop");

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -139,7 +139,7 @@
       _inherits(Foo, _LightningElement);
 
       function Foo() {
-        var _getPrototypeOf2, _getPrototypeOf3, _call;
+        var _getPrototypeOf2, _getPrototypeOf3;
 
         var _this;
 
@@ -157,9 +157,9 @@
           this,
           __callKey2(
             ((_getPrototypeOf3 = _getPrototypeOf2 = _getPrototypeOf(Foo)),
-            (_call = _getPrototypeOf3._ES5ProxyType
+            _getPrototypeOf3._ES5ProxyType
               ? _getPrototypeOf3.get("call")
-              : _getPrototypeOf3.call)),
+              : _getPrototypeOf3.call),
             "apply",
             _getPrototypeOf2,
             __concat([this], args)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,6 +3898,16 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.0.3.tgz#13ae747eff125cafb230ac504b2406cf371eece2"
+  integrity sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -7462,9 +7472,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^2.1.2:
-  version "2.2.1"
-  resolved "http://npm.lwcjs.org/fsevents/-/fsevents-2.2.1/1fb02ded2036a8ac288d507a65962bd87b97628d.tgz#1fb02ded2036a8ac288d507a65962bd87b97628d"
-  integrity sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
 fsevents@~2.1.2:
   version "2.1.2"
@@ -9336,6 +9346,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -12356,6 +12371,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -12612,9 +12632,9 @@ rollup-pluginutils@~2.0.1:
     micromatch "^2.3.11"
 
 rollup@^2.35.1:
-  version "2.35.1"
-  resolved "http://npm.lwcjs.org/rollup/-/rollup-2.35.1/e6bc8d10893556a638066f89e8c97f422d03968c.tgz#e6bc8d10893556a638066f89e8c97f422d03968c"
-  integrity sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.36.0.tgz#af2cdea36f70fa3de586840c2604882dfb4d0aac"
+  integrity sha512-L38QyQK77bkJy9nPyeydnHFK6xMofqumh4scTV2d4RG4EFq6pGdxnn67dVHFUDJ9J0PSEQx8zn1FiVS5TydsKg==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -13664,11 +13684,11 @@ systeminformation@^4.31.1, systeminformation@~4.9.2:
   integrity sha512-1LynQMla38gIjzyupKBnBLIo4B0TQf3vdhs2bjKPtN02EymuSWpoAM1KX/6+gtFLVmn91MfllE3wSVGQcVTHDw==
 
 table@^6.0.4:
-  version "6.0.4"
-  resolved "http://npm.lwcjs.org/table/-/table-6.0.4/c523dd182177e926c723eb20e1b341238188aa0d.tgz#c523dd182177e926c723eb20e1b341238188aa0d"
-  integrity sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.7.tgz#e45897ffbcc1bcf9e8a87bf420f2c9e5a7a52a34"
+  integrity sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
   dependencies:
-    ajv "^6.12.4"
+    ajv "^7.0.2"
     lodash "^4.17.20"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,7 @@
 
 "@babel/code-frame@^7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/code-frame/-/code-frame-7.12.11/f4ad435aa263db935b8f10f2c552d23fb716a63f.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   dependencies:
     "@babel/highlight" "^7.10.4"
@@ -48,7 +48,7 @@
 
 "@babel/core@^7.1.0":
   version "7.12.10"
-  resolved "http://npm.lwcjs.org/@babel/core/-/core-7.12.10/b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
   integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
   dependencies:
     "@babel/code-frame" "^7.10.4"
@@ -142,7 +142,7 @@
 
 "@babel/generator@^7.12.10", "@babel/generator@^7.12.11", "@babel/generator@~7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/generator/-/generator-7.12.11/98a7df7b8c358c9a37ab07a24056853016aba3af.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
   dependencies:
     "@babel/types" "^7.12.11"
@@ -238,7 +238,7 @@
 
 "@babel/helper-function-name@^7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11/1fd7738aee5dcf53c3ecff24f1da9c511ec47b42.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
   integrity sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
   dependencies:
     "@babel/helper-get-function-arity" "^7.12.10"
@@ -254,7 +254,7 @@
 
 "@babel/helper-get-function-arity@^7.12.10":
   version "7.12.10"
-  resolved "http://npm.lwcjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10/b158817a3165b5faa2047825dfa61970ddcc16cf.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
   integrity sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
   dependencies:
     "@babel/types" "^7.12.10"
@@ -411,7 +411,7 @@
 
 "@babel/helper-split-export-declaration@^7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11/1b4cc424458643c47d37022223da33d76ea4603a.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
   integrity sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
   dependencies:
     "@babel/types" "^7.12.11"
@@ -423,7 +423,7 @@
 
 "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11/c9a1f021917dcb5ccf0d4e453e399022981fc9ed.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/helper-validator-option@^7.12.1":
@@ -489,7 +489,7 @@
 
 "@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@~7.12.11":
   version "7.12.11"
-  resolved "http://npm.lwcjs.org/@babel/parser/-/parser-7.12.11/9ce3595bcd74bc5c466905e86c535b8b25011e79.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
 "@babel/parser@^7.12.3", "@babel/parser@^7.12.5":
@@ -641,7 +641,7 @@
 
 "@babel/plugin-syntax-bigint@^7.8.3":
   version "7.8.3"
-  resolved "http://npm.lwcjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3/4c9a6f669f5d0cdf1b90a1671e9a146be5300cea.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
   integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
@@ -676,7 +676,7 @@
 
 "@babel/plugin-syntax-import-meta@^7.8.3":
   version "7.10.4"
-  resolved "http://npm.lwcjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4/ee601348c370fa334d2207be158777496521fd51.tgz#ee601348c370fa334d2207be158777496521fd51"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz#ee601348c370fa334d2207be158777496521fd51"
   integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
@@ -1336,7 +1336,7 @@
 
 "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@~7.12.7":
   version "7.12.7"
-  resolved "http://npm.lwcjs.org/@babel/template/-/template-7.12.7/c817233696018e39fbb6c491d2fb684e05ed43bc.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
   integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
   dependencies:
     "@babel/code-frame" "^7.10.4"
@@ -1375,7 +1375,7 @@
 
 "@babel/traverse@^7.12.10", "@babel/traverse@~7.12.12":
   version "7.12.12"
-  resolved "http://npm.lwcjs.org/@babel/traverse/-/traverse-7.12.12/d0cd87892704edd8da002d674bc811ce64743376.tgz#d0cd87892704edd8da002d674bc811ce64743376"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
   integrity sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
   dependencies:
     "@babel/code-frame" "^7.12.11"
@@ -1417,7 +1417,7 @@
 
 "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.3.3":
   version "7.12.12"
-  resolved "http://npm.lwcjs.org/@babel/types/-/types-7.12.12/4608a6ec313abbd87afa55004d373ad04a96c299.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
   integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
@@ -1435,7 +1435,7 @@
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
-  resolved "http://npm.lwcjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3/75a2e8b51cb758a7553d6804a5932d7aace75c39.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@best/analyzer@4.0.0-beta5":
@@ -1634,7 +1634,7 @@
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
-  resolved "http://npm.lwcjs.org/@cnakazawa/watch/-/watch-1.0.4/f864ae85004d0fcab6f50be9141c4da368d1656a.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
+  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
   integrity sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
   dependencies:
     exec-sh "^0.3.2"
@@ -1771,7 +1771,7 @@
 
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
-  resolved "http://npm.lwcjs.org/@eslint/eslintrc/-/eslintrc-0.2.2/d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
   integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
   dependencies:
     ajv "^6.12.4"
@@ -1861,7 +1861,7 @@
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
-  resolved "http://npm.lwcjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0/fd3db1d59ecf7cf121e80650bb86712f9b55eced.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
   integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
   dependencies:
     camelcase "^5.3.1"
@@ -1877,7 +1877,7 @@
 
 "@jest/console@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/console/-/console-26.6.2/4e04bc464014358b03ab4937805ee36a0aeb98f2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
   integrity sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -1889,7 +1889,7 @@
 
 "@jest/core@^26.6.3":
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/@jest/core/-/core-26.6.3/7639fcb3833d748a4656ada54bde193051e45fad.tgz#7639fcb3833d748a4656ada54bde193051e45fad"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-26.6.3.tgz#7639fcb3833d748a4656ada54bde193051e45fad"
   integrity sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   dependencies:
     "@jest/console" "^26.6.2"
@@ -1923,7 +1923,7 @@
 
 "@jest/environment@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/environment/-/environment-26.6.2/ba364cc72e221e79cc8f0a99555bf5d7577cf92c.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.6.2.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c"
   integrity sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==
   dependencies:
     "@jest/fake-timers" "^26.6.2"
@@ -1933,7 +1933,7 @@
 
 "@jest/fake-timers@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/fake-timers/-/fake-timers-26.6.2/459c329bcf70cee4af4d7e3f3e67848123535aad.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.2.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad"
   integrity sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -1945,7 +1945,7 @@
 
 "@jest/globals@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/globals/-/globals-26.6.2/5b613b78a1aa2655ae908eba638cc96a20df720a.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
   integrity sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==
   dependencies:
     "@jest/environment" "^26.6.2"
@@ -1954,7 +1954,7 @@
 
 "@jest/reporters@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/reporters/-/reporters-26.6.2/1f518b99637a5f18307bd3ecf9275f6882a667f6.tgz#1f518b99637a5f18307bd3ecf9275f6882a667f6"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-26.6.2.tgz#1f518b99637a5f18307bd3ecf9275f6882a667f6"
   integrity sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
@@ -1986,7 +1986,7 @@
 
 "@jest/source-map@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/source-map/-/source-map-26.6.2/29af5e1e2e324cafccc936f218309f54ab69d535.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
   integrity sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==
   dependencies:
     callsites "^3.0.0"
@@ -1995,7 +1995,7 @@
 
 "@jest/test-result@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/test-result/-/test-result-26.6.2/55da58b62df134576cc95476efa5f7949e3f5f18.tgz#55da58b62df134576cc95476efa5f7949e3f5f18"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.6.2.tgz#55da58b62df134576cc95476efa5f7949e3f5f18"
   integrity sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==
   dependencies:
     "@jest/console" "^26.6.2"
@@ -2005,7 +2005,7 @@
 
 "@jest/test-sequencer@^26.6.3":
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3/98e8a45100863886d074205e8ffdc5a7eb582b17.tgz#98e8a45100863886d074205e8ffdc5a7eb582b17"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz#98e8a45100863886d074205e8ffdc5a7eb582b17"
   integrity sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   dependencies:
     "@jest/test-result" "^26.6.2"
@@ -2016,7 +2016,7 @@
 
 "@jest/transform@^26.6.2":
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/@jest/transform/-/transform-26.6.2/5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b.tgz#5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.6.2.tgz#5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b"
   integrity sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==
   dependencies:
     "@babel/core" "^7.1.0"
@@ -2919,14 +2919,14 @@
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
-  resolved "http://npm.lwcjs.org/@sinonjs/commons/-/commons-1.8.1/e7df00f98a203324f6dc7cc606cad9d4a8ab2217.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
   integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
-  resolved "http://npm.lwcjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1/293674fccb3262ac782c7aadfdeca86b10c75c40.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
@@ -3011,7 +3011,7 @@
 
 "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.11.0"
-  resolved "http://npm.lwcjs.org/@types/babel__traverse/-/babel__traverse-7.11.0/b9a1efa635201ba9bc850323a8793ee2d36c04a0.tgz#b9a1efa635201ba9bc850323a8793ee2d36c04a0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.11.0.tgz#b9a1efa635201ba9bc850323a8793ee2d36c04a0"
   integrity sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==
   dependencies:
     "@babel/types" "^7.3.0"
@@ -3053,7 +3053,7 @@
 
 "@types/ejs@^3.0.5":
   version "3.0.5"
-  resolved "http://npm.lwcjs.org/@types/ejs/-/ejs-3.0.5/95a3a1c3d9603eba80fe67ff56da1ba275ef2eda.tgz#95a3a1c3d9603eba80fe67ff56da1ba275ef2eda"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.0.5.tgz#95a3a1c3d9603eba80fe67ff56da1ba275ef2eda"
   integrity sha512-k4ef69sS4sIqAPW9GoBnN+URAON2LeL1H0duQvL4RgdEBna19/WattYSA1qYqvbVEDRTSWzOw56tCLhC/m/IOw==
 
 "@types/estree@*", "@types/estree@0.0.39":
@@ -3106,7 +3106,7 @@
 
 "@types/fs-extra@^9.0.4":
   version "9.0.6"
-  resolved "http://npm.lwcjs.org/@types/fs-extra/-/fs-extra-9.0.6/488e56b77299899a608b8269719c1d133027a6ab.tgz#488e56b77299899a608b8269719c1d133027a6ab"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.6.tgz#488e56b77299899a608b8269719c1d133027a6ab"
   integrity sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==
   dependencies:
     "@types/node" "*"
@@ -3130,7 +3130,7 @@
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
-  resolved "http://npm.lwcjs.org/@types/graceful-fs/-/graceful-fs-4.1.4/4ff9f641a7c6d1a3508ff88bc3141b152772e753.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
   integrity sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==
   dependencies:
     "@types/node" "*"
@@ -3147,7 +3147,7 @@
 
 "@types/inquirer@^7.3.1":
   version "7.3.1"
-  resolved "http://npm.lwcjs.org/@types/inquirer/-/inquirer-7.3.1/1f231224e7df11ccfaf4cf9acbcc3b935fea292d.tgz#1f231224e7df11ccfaf4cf9acbcc3b935fea292d"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.1.tgz#1f231224e7df11ccfaf4cf9acbcc3b935fea292d"
   integrity sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==
   dependencies:
     "@types/through" "*"
@@ -3160,7 +3160,7 @@
 
 "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
-  resolved "http://npm.lwcjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3/4ba8ddb720221f432e443bd5f9117fd22cfd4762.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
 "@types/istanbul-lib-report@*":
@@ -3187,7 +3187,7 @@
 
 "@types/jest@^26.0.19":
   version "26.0.19"
-  resolved "http://npm.lwcjs.org/@types/jest/-/jest-26.0.19/e6fa1e3def5842ec85045bd5210e9bb8289de790.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
   integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
   dependencies:
     jest-diff "^26.0.0"
@@ -3214,7 +3214,7 @@
 
 "@types/lodash.flattendeep@^4.4.6":
   version "4.4.6"
-  resolved "http://npm.lwcjs.org/@types/lodash.flattendeep/-/lodash.flattendeep-4.4.6/2686d9161ae6c3d56d6745fa118308d88562ae53.tgz#2686d9161ae6c3d56d6745fa118308d88562ae53"
+  resolved "https://registry.yarnpkg.com/@types/lodash.flattendeep/-/lodash.flattendeep-4.4.6.tgz#2686d9161ae6c3d56d6745fa118308d88562ae53"
   integrity sha512-uLm2MaRVlqJSGsMK0RZpP5T3KqReq+9WbYDHCUhBhp98v56hMG/Yht52bsoTSui9xz2mUvQ9NfG3LrNGDL92Ng==
   dependencies:
     "@types/lodash" "*"
@@ -3235,14 +3235,14 @@
 
 "@types/lodash.pickby@^4.6.6":
   version "4.6.6"
-  resolved "http://npm.lwcjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.6/3dc39c2b38432f7a0c5e5627b0d5c0e3878b4f35.tgz#3dc39c2b38432f7a0c5e5627b0d5c0e3878b4f35"
+  resolved "https://registry.yarnpkg.com/@types/lodash.pickby/-/lodash.pickby-4.6.6.tgz#3dc39c2b38432f7a0c5e5627b0d5c0e3878b4f35"
   integrity sha512-NFa13XxlMd9eFi0UFZFWIztpMpXhozbijrx3Yb1viYZphT7jyopIFVoIRF4eYMjruWNEG1rnyrRmg/8ej9T8Iw==
   dependencies:
     "@types/lodash" "*"
 
 "@types/lodash.union@^4.6.6":
   version "4.6.6"
-  resolved "http://npm.lwcjs.org/@types/lodash.union/-/lodash.union-4.6.6/2f77f2088326ed147819e9e384182b99aae8d4b0.tgz#2f77f2088326ed147819e9e384182b99aae8d4b0"
+  resolved "https://registry.yarnpkg.com/@types/lodash.union/-/lodash.union-4.6.6.tgz#2f77f2088326ed147819e9e384182b99aae8d4b0"
   integrity sha512-Wu0ZEVNcyCz8eAn6TlUbYWZoGbH9E+iOHxAZbwUoCEXdUiy6qpcz5o44mMXViM4vlPLLCPlkAubEP1gokoSZaw==
   dependencies:
     "@types/lodash" "*"
@@ -3274,7 +3274,7 @@
 
 "@types/mocha@^8.0.0":
   version "8.2.0"
-  resolved "http://npm.lwcjs.org/@types/mocha/-/mocha-8.2.0/3eb56d13a1de1d347ecb1957c6860c911704bc44.tgz#3eb56d13a1de1d347ecb1957c6860c911704bc44"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.0.tgz#3eb56d13a1de1d347ecb1957c6860c911704bc44"
   integrity sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==
 
 "@types/morgan@^1.9.1":
@@ -3321,7 +3321,7 @@
 
 "@types/prettier@^2.0.0":
   version "2.1.6"
-  resolved "http://npm.lwcjs.org/@types/prettier/-/prettier-2.1.6/f4b1efa784e8db479cdb8b14403e2144b1e9ff03.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
   integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
 
 "@types/puppeteer-core@^2.0.0":
@@ -3362,7 +3362,7 @@
 
 "@types/recursive-readdir@^2.2.0":
   version "2.2.0"
-  resolved "http://npm.lwcjs.org/@types/recursive-readdir/-/recursive-readdir-2.2.0/b39cd5474fd58ea727fe434d5c68b7a20ba9121c.tgz#b39cd5474fd58ea727fe434d5c68b7a20ba9121c"
+  resolved "https://registry.yarnpkg.com/@types/recursive-readdir/-/recursive-readdir-2.2.0.tgz#b39cd5474fd58ea727fe434d5c68b7a20ba9121c"
   integrity sha512-HGk753KRu2N4mWduovY4BLjYq4jTOL29gV2OfGdGxHcPSWGFkC5RRIdk+VTs5XmYd7MVAD+JwKrcb5+5Y7FOCg==
   dependencies:
     "@types/node" "*"
@@ -3403,7 +3403,7 @@
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/@types/stack-utils/-/stack-utils-2.0.0/7036640b4e21cc2f259ae826ce843d277dad8cff.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
 "@types/stream-buffers@^3.0.3":
@@ -3415,7 +3415,7 @@
 
 "@types/through@*":
   version "0.0.30"
-  resolved "http://npm.lwcjs.org/@types/through/-/through-0.0.30/e0e42ce77e897bd6aead6f6ea62aeb135b8a3895.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
   integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
   dependencies:
     "@types/node" "*"
@@ -3619,7 +3619,7 @@
 
 "@wdio/logger@6.10.10":
   version "6.10.10"
-  resolved "http://npm.lwcjs.org/@wdio/logger/-/logger-6.10.10/1e07cf32a69606ddb94fa9fd4b0171cb839a5980.tgz#1e07cf32a69606ddb94fa9fd4b0171cb839a5980"
+  resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-6.10.10.tgz#1e07cf32a69606ddb94fa9fd4b0171cb839a5980"
   integrity sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==
   dependencies:
     chalk "^4.0.0"
@@ -3650,7 +3650,7 @@
 
 "@wdio/protocols@6.10.6":
   version "6.10.6"
-  resolved "http://npm.lwcjs.org/@wdio/protocols/-/protocols-6.10.6/8d1deed6651a5ca0a185ea334fc1a371dc4c700c.tgz#8d1deed6651a5ca0a185ea334fc1a371dc4c700c"
+  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-6.10.6.tgz#8d1deed6651a5ca0a185ea334fc1a371dc4c700c"
   integrity sha512-CLLVdc82S+Zij7f9djL90JC1bE5gtaOn+EF2pY4n8XdypqPUa1orQip8stQtX/wXEX0Ak45MEcSU9nCY+CzNnQ==
 
 "@wdio/protocols@6.6.0":
@@ -3726,7 +3726,7 @@
 
 "@wdio/static-server-service@^6.10.10":
   version "6.10.10"
-  resolved "http://npm.lwcjs.org/@wdio/static-server-service/-/static-server-service-6.10.10/113f36f618ad6591cf937504cb14a3daf77ce97e.tgz#113f36f618ad6591cf937504cb14a3daf77ce97e"
+  resolved "https://registry.yarnpkg.com/@wdio/static-server-service/-/static-server-service-6.10.10.tgz#113f36f618ad6591cf937504cb14a3daf77ce97e"
   integrity sha512-1AZRz6aSkwbvTGop8fLPzmTjEwentJhbswTOuMghMx0i1Zw0aB+l38gsWixn5JLt2dT6eaqGCyebStWwH8ZvUA==
   dependencies:
     "@types/express" "^4.17.8"
@@ -3770,7 +3770,7 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
 
 abab@^2.0.3:
   version "2.0.5"
-  resolved "http://npm.lwcjs.org/abab/-/abab-2.0.5/c0b678fb32d60fc1219c784d6a826fe385aeb79a.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 abbrev@1:
@@ -3788,7 +3788,7 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
 
 acorn-globals@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/acorn-globals/-/acorn-globals-6.0.0/46cdd39f0f8ff08a876619b55f5ac8a6dc770b45.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
   integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
   dependencies:
     acorn "^7.1.1"
@@ -3801,12 +3801,12 @@ acorn-jsx@^5.2.0:
 
 acorn-jsx@^5.3.1:
   version "5.3.1"
-  resolved "http://npm.lwcjs.org/acorn-jsx/-/acorn-jsx-5.3.1/fc8661e11b7ac1539c47dbfea2e72b3af34d267b.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-walk@^7.1.1:
   version "7.2.0"
-  resolved "http://npm.lwcjs.org/acorn-walk/-/acorn-walk-7.2.0/0de889a601203909b0fbe07b8938dc21d2e967bc.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
 acorn@^7.1.0:
@@ -3816,7 +3816,7 @@ acorn@^7.1.0:
 
 acorn@^7.1.1:
   version "7.4.1"
-  resolved "http://npm.lwcjs.org/acorn/-/acorn-7.4.1/feaed255973d2e77555b83dbc08851a6c63520fa.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^7.4.0:
@@ -3987,7 +3987,7 @@ any-promise@^1.0.0:
 
 anymatch@^2.0.0:
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/anymatch/-/anymatch-2.0.0/bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
   integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
   dependencies:
     micromatch "^3.1.4"
@@ -4230,7 +4230,7 @@ babel-compat@0.22.1:
 
 babel-jest@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/babel-jest/-/babel-jest-26.6.3/d87d25cb0037577a0c89f82e5755c5d293c01056.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
   integrity sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
   dependencies:
     "@jest/transform" "^26.6.2"
@@ -4251,7 +4251,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
 
 babel-plugin-istanbul@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0/e159ccdc9af95e0b570c75b4573b7c34d671d765.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
   integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -4262,7 +4262,7 @@ babel-plugin-istanbul@^6.0.0:
 
 babel-plugin-jest-hoist@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2/8185bd030348d254c6d7dd974355e6a28b21e62d.tgz#8185bd030348d254c6d7dd974355e6a28b21e62d"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz#8185bd030348d254c6d7dd974355e6a28b21e62d"
   integrity sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==
   dependencies:
     "@babel/template" "^7.3.3"
@@ -4368,7 +4368,7 @@ babel-preset-compat@0.22.1, babel-preset-compat@~0.22.1:
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
-  resolved "http://npm.lwcjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1/b4399239b89b2a011f9ddbe3e4f401fc40cff73b.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
   integrity sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
   dependencies:
     "@babel/plugin-syntax-async-generators" "^7.8.4"
@@ -4386,7 +4386,7 @@ babel-preset-current-node-syntax@^1.0.0:
 
 babel-preset-jest@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2/747872b1171df032252426586881d62d31798fee.tgz#747872b1171df032252426586881d62d31798fee"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz#747872b1171df032252426586881d62d31798fee"
   integrity sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==
   dependencies:
     babel-plugin-jest-hoist "^26.6.2"
@@ -4576,7 +4576,7 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
-  resolved "http://npm.lwcjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0/3c9b4b7d782c8121e56f10106d84c0d0ffc94626.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browser-stdout@1.3.1:
@@ -4618,7 +4618,7 @@ browserslist@^4.16.0:
 
 bser@2.1.1:
   version "2.1.1"
-  resolved "http://npm.lwcjs.org/bser/-/bser-2.1.1/e6787da20ece9d07998533cfd9de6f5c38f4bc05.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
@@ -4867,7 +4867,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
 
 camelcase@^6.0.0:
   version "6.2.0"
-  resolved "http://npm.lwcjs.org/camelcase/-/camelcase-6.2.0/924af881c9d525ac9d87f40d964e5cea982a1809.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-api@^3.0.0:
@@ -4906,7 +4906,7 @@ capital-case@^1.0.3:
 
 capture-exit@^2.0.0:
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/capture-exit/-/capture-exit-2.0.0/fb953bfaebeb781f62898239dabb426d08a509a4.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
   integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
     rsvp "^4.8.4"
@@ -4990,7 +4990,7 @@ change-case@^4.1.1:
 
 char-regex@^1.0.2:
   version "1.0.2"
-  resolved "http://npm.lwcjs.org/char-regex/-/char-regex-1.0.2/d744358226217f981ed58f479b1d6bcc29545dcf.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chardet@^0.7.0:
@@ -5067,7 +5067,7 @@ ci-info@^2.0.0:
 
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
-  resolved "http://npm.lwcjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0/4186fcca0eae175970aee870b9fe2d6cf8d5655f.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
   integrity sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
 
 clean-stack@^2.0.0:
@@ -5173,7 +5173,7 @@ clone@^1.0.2:
 
 co@^4.6.0:
   version "4.6.0"
-  resolved "http://npm.lwcjs.org/co/-/co-4.6.0/6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 coa@^2.0.2:
@@ -5192,7 +5192,7 @@ code-point-at@^1.0.0:
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
-  resolved "http://npm.lwcjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1/cc2c8e94fc18bbdffe64d6534570c8a673b27f59.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
 color-convert@^1.9.0, color-convert@^1.9.1:
@@ -5797,17 +5797,17 @@ csso@^4.0.2:
 
 cssom@^0.4.4:
   version "0.4.4"
-  resolved "http://npm.lwcjs.org/cssom/-/cssom-0.4.4/5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
 cssom@~0.3.6:
   version "0.3.8"
-  resolved "http://npm.lwcjs.org/cssom/-/cssom-0.3.8/9f1276f5b2b463f2114d3f2c75250af8c1a36f4a.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
 cssstyle@^2.2.0:
   version "2.3.0"
-  resolved "http://npm.lwcjs.org/cssstyle/-/cssstyle-2.3.0/ff665a0ddbdc31864b09647f34163443d90b0852.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
@@ -5838,7 +5838,7 @@ dashdash@^1.12.0:
 
 data-urls@^2.0.0:
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/data-urls/-/data-urls-2.0.0/156485a72963a970f5d5821aaf642bef2bf2db9b.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
   integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
   dependencies:
     abab "^2.0.3"
@@ -5927,7 +5927,7 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
 
 decimal.js@^10.2.0:
   version "10.2.1"
-  resolved "http://npm.lwcjs.org/decimal.js/-/decimal.js-10.2.1/238ae7b0f0c793d3e3cea410108b35a2c01426a3.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
   integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decode-uri-component@^0.2.0:
@@ -6085,7 +6085,7 @@ detect-libc@^1.0.2:
 
 detect-newline@^3.0.0:
   version "3.1.0"
-  resolved "http://npm.lwcjs.org/detect-newline/-/detect-newline-3.1.0/576f5dfc63ae1a192ff192d8ad3af6308991b651.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 detect-node@^2.0.4:
@@ -6207,7 +6207,7 @@ domelementtype@^2.0.1:
 
 domexception@^2.0.1:
   version "2.0.1"
-  resolved "http://npm.lwcjs.org/domexception/-/domexception-2.0.1/fb44aefba793e1574b0af6aed2801d057529f304.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
@@ -6348,7 +6348,7 @@ electron-to-chromium@^1.3.634:
 
 emittery@^0.7.1:
   version "0.7.2"
-  resolved "http://npm.lwcjs.org/emittery/-/emittery-0.7.2/25595908e13af0f5674ab419396e2fb394cdfa82.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
 emoji-regex@^7.0.1:
@@ -6635,12 +6635,12 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
 
 escape-string-regexp@^2.0.0:
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0/a30304e99daa32e23b2fd20f51babd07cffca344.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escodegen@^1.14.1:
   version "1.14.3"
-  resolved "http://npm.lwcjs.org/escodegen/-/escodegen-1.14.3/4e7b81fba61581dc97582ed78cab7f0e8d63f503.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
   dependencies:
     esprima "^4.0.1"
@@ -6760,7 +6760,7 @@ espree@^7.3.0:
 
 espree@^7.3.1:
   version "7.3.1"
-  resolved "http://npm.lwcjs.org/espree/-/espree-7.3.1/f2df330b752c6f55019f8bd89b7660039c1bbbb6.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
   integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
     acorn "^7.4.0"
@@ -6855,7 +6855,7 @@ events@1.1.1:
 
 exec-sh@^0.3.2:
   version "0.3.4"
-  resolved "http://npm.lwcjs.org/exec-sh/-/exec-sh-0.3.4/3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
 execa@^0.7.0:
@@ -6901,7 +6901,7 @@ execa@^4.0.0, execa@^4.1.0:
 
 execa@^5.0.0:
   version "5.0.0"
-  resolved "http://npm.lwcjs.org/execa/-/execa-5.0.0/4029b0007998a841fbd1032e5f4de86a3c1e3376.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
   integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
   dependencies:
     cross-spawn "^7.0.3"
@@ -6923,7 +6923,7 @@ executable@^4.1.0:
 
 exit@^0.1.2:
   version "0.1.2"
-  resolved "http://npm.lwcjs.org/exit/-/exit-0.1.2/0632638f8d877cc82107d30a0fff1a17cba1cd0c.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-tilde@~2.0.2:
@@ -6955,7 +6955,7 @@ expect@^25.2.1:
 
 expect@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/expect/-/expect-26.6.2/c6b996bf26bf3fe18b67b2d0f51fc981ba934417.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
   integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -7162,7 +7162,7 @@ fastq@^1.6.0:
 
 fb-watchman@^2.0.0:
   version "2.0.1"
-  resolved "http://npm.lwcjs.org/fb-watchman/-/fb-watchman-2.0.1/fc84fb39d2709cf3ff6d743706157bb5708a8a85.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
@@ -7202,7 +7202,7 @@ figures@^3.2.0:
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/file-entry-cache/-/file-entry-cache-6.0.0/7921a89c391c6d93efec2169ac6bf300c527ea0a.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.0.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
   integrity sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
   dependencies:
     flat-cache "^3.0.4"
@@ -7326,7 +7326,7 @@ find-versions@^3.0.0, find-versions@^3.2.0:
 
 flat-cache@^3.0.4:
   version "3.0.4"
-  resolved "http://npm.lwcjs.org/flat-cache/-/flat-cache-3.0.4/61b0338302b2fe9f957dcc32fc2a87f1c3048b11.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
   integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
     flatted "^3.1.0"
@@ -7346,7 +7346,7 @@ flatted@^2.0.1:
 
 flatted@^3.1.0:
   version "3.1.0"
-  resolved "http://npm.lwcjs.org/flatted/-/flatted-3.1.0/a5d06b4a8b01e3a63771daa5cb7a1903e2e57067.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
 flush-write-stream@^1.0.0:
@@ -7529,7 +7529,7 @@ get-own-enumerable-property-symbols@^3.0.0:
 
 get-package-type@^0.1.0:
   version "0.1.0"
-  resolved "http://npm.lwcjs.org/get-package-type/-/get-package-type-0.1.0/8de2d803cff44df3bc6c456e6668b36c3926e11a.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-pkg-repo@^1.0.0:
@@ -7594,7 +7594,7 @@ get-stream@^5.0.0, get-stream@^5.1.0:
 
 get-stream@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/get-stream/-/get-stream-6.0.0/3e0012cb6827319da2706e601a1583e8629a6718.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
   integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 getpass@^0.1.1:
@@ -7880,7 +7880,7 @@ growl@1.10.5:
 
 growly@^1.3.0:
   version "1.3.0"
-  resolved "http://npm.lwcjs.org/growly/-/growly-1.3.0/f10748cbe76af964b7c96c93c6bcc28af120c081.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.4.0:
@@ -8026,7 +8026,7 @@ html-comment-regex@^1.1.0:
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
-  resolved "http://npm.lwcjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1/42a6dc4fd33f00281176e8b23759ca4e4fa185f3.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
   integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
   dependencies:
     whatwg-encoding "^1.0.5"
@@ -8140,7 +8140,7 @@ human-signals@^1.1.1:
 
 human-signals@^2.1.0:
   version "2.1.0"
-  resolved "http://npm.lwcjs.org/human-signals/-/human-signals-2.1.0/dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 humanize-ms@^1.2.1:
@@ -8152,7 +8152,7 @@ humanize-ms@^1.2.1:
 
 husky@^4.3.6:
   version "4.3.6"
-  resolved "http://npm.lwcjs.org/husky/-/husky-4.3.6/ebd9dd8b9324aa851f1587318db4cccb7665a13c.tgz#ebd9dd8b9324aa851f1587318db4cccb7665a13c"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.6.tgz#ebd9dd8b9324aa851f1587318db4cccb7665a13c"
   integrity sha512-o6UjVI8xtlWRL5395iWq9LKDyp/9TE7XMOTvIpEVzW638UcGxTmV5cfel6fsk/jbZSTlvfGVJf2svFtybcIZag==
   dependencies:
     chalk "^4.0.0"
@@ -8243,7 +8243,7 @@ import-local@^2.0.0:
 
 import-local@^3.0.2:
   version "3.0.2"
-  resolved "http://npm.lwcjs.org/import-local/-/import-local-3.0.2/a8cfd0431d1de4a2199703d003e3e62364fa6db6.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
   integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
   dependencies:
     pkg-dir "^4.2.0"
@@ -8374,7 +8374,7 @@ invert-kv@^1.0.0:
 
 ip-regex@^2.1.0:
   version "2.1.0"
-  resolved "http://npm.lwcjs.org/ip-regex/-/ip-regex-2.1.0/fa78bf5d2e6913c911ce9f819ee5146bb6d844e9.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip@1.1.5:
@@ -8499,7 +8499,7 @@ is-fullwidth-code-point@^3.0.0:
 
 is-generator-fn@^2.0.0:
   version "2.1.0"
-  resolved "http://npm.lwcjs.org/is-generator-fn/-/is-generator-fn-2.1.0/7d140adc389aaf3011a8f2a2a4cfa6faadffb118.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^3.1.0:
@@ -8572,7 +8572,7 @@ is-plain-object@^3.0.0:
 
 is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
-  resolved "http://npm.lwcjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0/0c52e54bcca391bb2c494b21e8626d7336c6e397.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
 is-promise@^2.1.0:
@@ -8728,7 +8728,7 @@ istanbul-lib-coverage@^3.0.0:
 
 istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.3:
   version "4.0.3"
-  resolved "http://npm.lwcjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3/873c6fff897450118222774696a3f28902d77c1d.tgz#873c6fff897450118222774696a3f28902d77c1d"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
   integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
   dependencies:
     "@babel/core" "^7.7.5"
@@ -8777,7 +8777,7 @@ istanbul-reports@^3.0.0:
 
 istanbul-reports@^3.0.2:
   version "3.0.2"
-  resolved "http://npm.lwcjs.org/istanbul-reports/-/istanbul-reports-3.0.2/d593210e5000683750cb09fc0644e4b6e27fd53b.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
   integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
   dependencies:
     html-escaper "^2.0.0"
@@ -8811,7 +8811,7 @@ jasmine-core@^3.6.0:
 
 jest-changed-files@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-changed-files/-/jest-changed-files-26.6.2/f6198479e1cc66f22f9ae1e22acaa0b429c042d0.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
   integrity sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -8820,7 +8820,7 @@ jest-changed-files@^26.6.2:
 
 jest-cli@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-cli/-/jest-cli-26.6.3/43117cfef24bc4cd691a174a8796a532e135e92a.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   dependencies:
     "@jest/core" "^26.6.3"
@@ -8839,7 +8839,7 @@ jest-cli@^26.6.3:
 
 jest-config@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-config/-/jest-config-26.6.3/64f41444eef9eb03dc51d5c53b75c8c71f645349.tgz#64f41444eef9eb03dc51d5c53b75c8c71f645349"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.6.3.tgz#64f41444eef9eb03dc51d5c53b75c8c71f645349"
   integrity sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   dependencies:
     "@babel/core" "^7.1.0"
@@ -8883,14 +8883,14 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
 
 jest-docblock@^26.0.0:
   version "26.0.0"
-  resolved "http://npm.lwcjs.org/jest-docblock/-/jest-docblock-26.0.0/3e2fa20899fc928cb13bd0ff68bd3711a36889b5.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
   integrity sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
   dependencies:
     detect-newline "^3.0.0"
 
 jest-each@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-each/-/jest-each-26.6.2/02526438a77a67401c8a6382dfe5999952c167cb.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
   integrity sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -8901,7 +8901,7 @@ jest-each@^26.6.2:
 
 jest-environment-jsdom@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2/78d09fe9cf019a357009b9b7e1f101d23bd1da3e.tgz#78d09fe9cf019a357009b9b7e1f101d23bd1da3e"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz#78d09fe9cf019a357009b9b7e1f101d23bd1da3e"
   integrity sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   dependencies:
     "@jest/environment" "^26.6.2"
@@ -8914,7 +8914,7 @@ jest-environment-jsdom@^26.6.2:
 
 jest-environment-node@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-environment-node/-/jest-environment-node-26.6.2/824e4c7fb4944646356f11ac75b229b0035f2b0c.tgz#824e4c7fb4944646356f11ac75b229b0035f2b0c"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.6.2.tgz#824e4c7fb4944646356f11ac75b229b0035f2b0c"
   integrity sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==
   dependencies:
     "@jest/environment" "^26.6.2"
@@ -8936,7 +8936,7 @@ jest-get-type@^26.3.0:
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-haste-map/-/jest-haste-map-26.6.2/dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.2.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa"
   integrity sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -8957,7 +8957,7 @@ jest-haste-map@^26.6.2:
 
 jest-jasmine2@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3/adc3cf915deacb5212c93b9f3547cd12958f2edd.tgz#adc3cf915deacb5212c93b9f3547cd12958f2edd"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz#adc3cf915deacb5212c93b9f3547cd12958f2edd"
   integrity sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   dependencies:
     "@babel/traverse" "^7.1.0"
@@ -8981,7 +8981,7 @@ jest-jasmine2@^26.6.3:
 
 jest-leak-detector@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2/7717cf118b92238f2eba65054c8a0c9c653a91af.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af"
   integrity sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==
   dependencies:
     jest-get-type "^26.3.0"
@@ -8999,7 +8999,7 @@ jest-matcher-utils@^25.1.0, jest-matcher-utils@^25.5.0:
 
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2/8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
   integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
   dependencies:
     chalk "^4.0.0"
@@ -9023,7 +9023,7 @@ jest-message-util@^25.5.0:
 
 jest-message-util@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-message-util/-/jest-message-util-26.6.2/58173744ad6fc0506b5d21150b9be56ef001ca07.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
   integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -9038,7 +9038,7 @@ jest-message-util@^26.6.2:
 
 jest-mock@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-mock/-/jest-mock-26.6.2/d6cb712b041ed47fe0d9b6fc3474bc6543feb302.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
   integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -9046,7 +9046,7 @@ jest-mock@^26.6.2:
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
-  resolved "http://npm.lwcjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2/b704ac0ae028a89108a4d040b3f919dfddc8e33c.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
 jest-regex-util@^25.2.6:
@@ -9056,12 +9056,12 @@ jest-regex-util@^25.2.6:
 
 jest-regex-util@^26.0.0:
   version "26.0.0"
-  resolved "http://npm.lwcjs.org/jest-regex-util/-/jest-regex-util-26.0.0/d25e7184b36e39fd466c3bc41be0971e821fee28.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
 jest-resolve-dependencies@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3/6680859ee5d22ee5dcd961fe4871f59f4c784fb6.tgz#6680859ee5d22ee5dcd961fe4871f59f4c784fb6"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz#6680859ee5d22ee5dcd961fe4871f59f4c784fb6"
   integrity sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -9070,7 +9070,7 @@ jest-resolve-dependencies@^26.6.3:
 
 jest-resolve@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-resolve/-/jest-resolve-26.6.2/a3ab1517217f469b504f1b56603c5bb541fbb507.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.2.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507"
   integrity sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -9084,7 +9084,7 @@ jest-resolve@^26.6.2:
 
 jest-runner@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-runner/-/jest-runner-26.6.3/2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.6.3.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159"
   integrity sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   dependencies:
     "@jest/console" "^26.6.2"
@@ -9110,7 +9110,7 @@ jest-runner@^26.6.3:
 
 jest-runtime@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest-runtime/-/jest-runtime-26.6.3/4f64efbcfac398331b74b4b3c82d27d401b8fa2b.tgz#4f64efbcfac398331b74b4b3c82d27d401b8fa2b"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.6.3.tgz#4f64efbcfac398331b74b4b3c82d27d401b8fa2b"
   integrity sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   dependencies:
     "@jest/console" "^26.6.2"
@@ -9143,7 +9143,7 @@ jest-runtime@^26.6.3:
 
 jest-serializer@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-serializer/-/jest-serializer-26.6.2/d139aafd46957d3a448f3a6cdabe2919ba0742d1.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
   integrity sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
   dependencies:
     "@types/node" "*"
@@ -9151,7 +9151,7 @@ jest-serializer@^26.6.2:
 
 jest-snapshot@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-snapshot/-/jest-snapshot-26.6.2/f3b0af1acb223316850bd14e1beea9837fb39c84.tgz#f3b0af1acb223316850bd14e1beea9837fb39c84"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.6.2.tgz#f3b0af1acb223316850bd14e1beea9837fb39c84"
   integrity sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==
   dependencies:
     "@babel/types" "^7.0.0"
@@ -9173,7 +9173,7 @@ jest-snapshot@^26.6.2:
 
 jest-util@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-util/-/jest-util-26.6.2/907535dbe4d5a6cb4c47ac9b926f6af29576cbc1.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
   integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -9185,7 +9185,7 @@ jest-util@^26.6.2:
 
 jest-validate@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-validate/-/jest-validate-26.6.2/23d380971587150467342911c3d7b4ac57ab20ec.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
   integrity sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==
   dependencies:
     "@jest/types" "^26.6.2"
@@ -9197,7 +9197,7 @@ jest-validate@^26.6.2:
 
 jest-watcher@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-watcher/-/jest-watcher-26.6.2/a5b683b8f9d68dbcb1d7dae32172d2cca0592975.tgz#a5b683b8f9d68dbcb1d7dae32172d2cca0592975"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.6.2.tgz#a5b683b8f9d68dbcb1d7dae32172d2cca0592975"
   integrity sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==
   dependencies:
     "@jest/test-result" "^26.6.2"
@@ -9219,7 +9219,7 @@ jest-worker@^26.2.1:
 
 jest-worker@^26.6.2:
   version "26.6.2"
-  resolved "http://npm.lwcjs.org/jest-worker/-/jest-worker-26.6.2/7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
   dependencies:
     "@types/node" "*"
@@ -9228,7 +9228,7 @@ jest-worker@^26.6.2:
 
 jest@^26.6.3:
   version "26.6.3"
-  resolved "http://npm.lwcjs.org/jest/-/jest-26.6.3/40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   dependencies:
     "@jest/core" "^26.6.3"
@@ -9277,7 +9277,7 @@ jsbn@~0.1.0:
 
 jsdom@^16.4.0:
   version "16.4.0"
-  resolved "http://npm.lwcjs.org/jsdom/-/jsdom-16.4.0/36005bde2d136f73eee1a830c6d45e55408edddb.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.4.0.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
   integrity sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
   dependencies:
     abab "^2.0.3"
@@ -9521,7 +9521,7 @@ kind-of@^6.0.2, kind-of@^6.0.3:
 
 kleur@^3.0.3:
   version "3.0.3"
-  resolved "http://npm.lwcjs.org/kleur/-/kleur-3.0.3/a79c9ecc86ee1ce3fa6206d1216c501f147fc07e.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 lazystream@^1.0.0:
@@ -9564,7 +9564,7 @@ lerna@^3.22.1:
 
 leven@^3.1.0:
   version "3.1.0"
-  resolved "http://npm.lwcjs.org/leven/-/leven-3.1.0/77891de834064cccba82ae7842bb6b14a13ed7f2.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
 levn@^0.4.1:
@@ -9577,7 +9577,7 @@ levn@^0.4.1:
 
 levn@~0.3.0:
   version "0.3.0"
-  resolved "http://npm.lwcjs.org/levn/-/levn-0.3.0/3b09924edf9f083c0490fdd4c0bc4421e04764ee.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
@@ -9606,7 +9606,7 @@ lines-and-columns@^1.1.6:
 
 lint-staged@^10.5.3:
   version "10.5.3"
-  resolved "http://npm.lwcjs.org/lint-staged/-/lint-staged-10.5.3/c682838b3eadd4c864d1022da05daa0912fb1da5.tgz#c682838b3eadd4c864d1022da05daa0912fb1da5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.3.tgz#c682838b3eadd4c864d1022da05daa0912fb1da5"
   integrity sha512-TanwFfuqUBLufxCc3RUtFEkFraSPNR3WzWcGF39R3f2J7S9+iF9W0KTVLfSy09lYGmZS5NDCxjNvhGMSJyFCWg==
   dependencies:
     chalk "^4.1.0"
@@ -9853,7 +9853,7 @@ lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.
 
 lodash@^4.17.20:
   version "4.17.20"
-  resolved "http://npm.lwcjs.org/lodash/-/lodash-4.17.20/b44a9b6297bcb698f1c51a3545a2b3b368d59c52.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@4.0.0, log-symbols@^4.0.0:
@@ -9933,7 +9933,7 @@ lru-cache@^5.1.1:
 
 lru-cache@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/lru-cache/-/lru-cache-6.0.0/6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
@@ -9998,7 +9998,7 @@ make-fetch-happen@^5.0.0:
 
 makeerror@1.0.x:
   version "1.0.11"
-  resolved "http://npm.lwcjs.org/makeerror/-/makeerror-1.0.11/e01a5c9109f2af79660e4e8b9587790184f5a96c.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
   dependencies:
     tmpl "1.0.x"
@@ -10440,17 +10440,17 @@ node-gyp@^5.0.2:
 
 node-int64@^0.4.0:
   version "0.4.0"
-  resolved "http://npm.lwcjs.org/node-int64/-/node-int64-0.4.0/87a9065cdb355d3182d8f94ce11188b825c68a3b.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
-  resolved "http://npm.lwcjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0/8d9dbe28964a4ac5712e9131642107c71e90ec40.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-notifier@^8.0.0:
   version "8.0.1"
-  resolved "http://npm.lwcjs.org/node-notifier/-/node-notifier-8.0.1/f86e89bbc925f2b068784b31f382afdc6ca56be1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
   dependencies:
     growly "^1.3.0"
@@ -10511,7 +10511,7 @@ normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-
 
 normalize-path@^2.1.1:
   version "2.1.1"
-  resolved "http://npm.lwcjs.org/normalize-path/-/normalize-path-2.1.1/1ab28b556e198363a8c1a6f7e6fa20137fe6aed9.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
@@ -10618,7 +10618,7 @@ npm-run-path@^4.0.0:
 
 npm-run-path@^4.0.1:
   version "4.0.1"
-  resolved "http://npm.lwcjs.org/npm-run-path/-/npm-run-path-4.0.1/b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
@@ -10647,7 +10647,7 @@ number-is-nan@^1.0.0:
 
 nwsapi@^2.2.0:
   version "2.2.0"
-  resolved "http://npm.lwcjs.org/nwsapi/-/nwsapi-2.2.0/204879a9e3d068ff2a55139c2c772780681a38b7.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
 oauth-sign@~0.9.0:
@@ -10748,7 +10748,7 @@ onetime@^5.1.0:
 
 onetime@^5.1.2:
   version "5.1.2"
-  resolved "http://npm.lwcjs.org/onetime/-/onetime-5.1.2/d0e96ebb56b07476df1dd9c4806e5237985ca45e.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
@@ -10760,7 +10760,7 @@ opencollective-postinstall@^2.0.2:
 
 optionator@^0.8.1:
   version "0.8.3"
-  resolved "http://npm.lwcjs.org/optionator/-/optionator-0.8.3/84fa1d036fe9d3c7e21d99884b601167ec8fb495.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
   dependencies:
     deep-is "~0.1.3"
@@ -10836,7 +10836,7 @@ p-cancelable@^2.0.0:
 
 p-each-series@^2.1.0:
   version "2.2.0"
-  resolved "http://npm.lwcjs.org/p-each-series/-/p-each-series-2.2.0/105ab0357ce72b202a8a8b94933672657b5e2a9a.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
   integrity sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
 
 p-event@^2.1.0:
@@ -11068,7 +11068,7 @@ parse5-with-errors@~4.0.4:
 
 parse5@5.1.1:
   version "5.1.1"
-  resolved "http://npm.lwcjs.org/parse5/-/parse5-5.1.1/f68e4e5ba1852ac2cadc00f4555fff6c2abb6178.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 parseqs@0.0.5:
@@ -11280,7 +11280,7 @@ pinkie@^2.0.0:
 
 pirates@^4.0.1:
   version "4.0.1"
-  resolved "http://npm.lwcjs.org/pirates/-/pirates-4.0.1/643a92caf894566f91b2b986d2c66950a8e2fb87.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
@@ -11645,7 +11645,7 @@ prelude-ls@^1.2.1:
 
 prelude-ls@~1.1.2:
   version "1.1.2"
-  resolved "http://npm.lwcjs.org/prelude-ls/-/prelude-ls-1.1.2/21932a549f5e52ffd9a827f570e04be62a97da54.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 prepend-http@^2.0.0:
@@ -11731,7 +11731,7 @@ promise.allsettled@1.0.2:
 
 prompts@^2.0.1:
   version "2.4.0"
-  resolved "http://npm.lwcjs.org/prompts/-/prompts-2.4.0/4aa5de0723a231d1ee9121c40fdf663df73f61d7.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
   integrity sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
   dependencies:
     kleur "^3.0.3"
@@ -12280,19 +12280,19 @@ regjsparser@^0.6.4:
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
-  resolved "http://npm.lwcjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0/c24bce2a283adad5bc3f58e0d48249b92379d8ef.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 request-promise-core@1.1.4:
   version "1.1.4"
-  resolved "http://npm.lwcjs.org/request-promise-core/-/request-promise-core-1.1.4/3eedd4223208d419867b78ce815167d10593a22f.tgz#3eedd4223208d419867b78ce815167d10593a22f"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
   integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
   dependencies:
     lodash "^4.17.19"
 
 request-promise-native@^1.0.8:
   version "1.0.9"
-  resolved "http://npm.lwcjs.org/request-promise-native/-/request-promise-native-1.0.9/e407120526a5efdc9a39b28a5679bf47b9d9dc28.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
   dependencies:
     request-promise-core "1.1.4"
@@ -12385,7 +12385,7 @@ resolve-cwd@^2.0.0:
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
-  resolved "http://npm.lwcjs.org/resolve-cwd/-/resolve-cwd-3.0.0/0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
@@ -12486,7 +12486,7 @@ rgb-regex@^1.0.1:
 
 rgb2hex@0.2.3:
   version "0.2.3"
-  resolved "http://npm.lwcjs.org/rgb2hex/-/rgb2hex-0.2.3/8aa464c517b8a26c7a79d767dabaec2b49ee78ec.tgz#8aa464c517b8a26c7a79d767dabaec2b49ee78ec"
+  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.2.3.tgz#8aa464c517b8a26c7a79d767dabaec2b49ee78ec"
   integrity sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==
 
 rgb2hex@^0.2.0:
@@ -12636,7 +12636,7 @@ rollup@~2.34.0:
 
 rsvp@^4.8.4:
   version "4.8.5"
-  resolved "http://npm.lwcjs.org/rsvp/-/rsvp-4.8.5/c8f155311d167f68f21e168df71ec5b083113734.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.2.0:
@@ -12701,7 +12701,7 @@ safe-buffer@^5.1.0:
 
 sane@^4.0.3:
   version "4.1.0"
-  resolved "http://npm.lwcjs.org/sane/-/sane-4.1.0/ed881fd922733a6c461bc189dc2b6c006f3ffded.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
   integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
   dependencies:
     "@cnakazawa/watch" "^1.0.3"
@@ -12752,7 +12752,7 @@ sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
 
 saxes@^5.0.0:
   version "5.0.1"
-  resolved "http://npm.lwcjs.org/saxes/-/saxes-5.0.1/eebab953fa3b7608dbe94e5dadb15c888fa6696d.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
@@ -12826,7 +12826,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
 
 semver@^7.3.4:
   version "7.3.4"
-  resolved "http://npm.lwcjs.org/semver/-/semver-7.3.4/27aaa7d2e4ca76452f98d3add093a72c943edc97.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
   dependencies:
     lru-cache "^6.0.0"
@@ -12960,7 +12960,7 @@ shebang-regex@^3.0.0:
 
 shellwords@^0.1.1:
   version "0.1.1"
-  resolved "http://npm.lwcjs.org/shellwords/-/shellwords-0.1.1/d6b9181c1a48d397324c84871efbcfc73fc0654b.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 signal-exit@^3.0.0:
@@ -12994,7 +12994,7 @@ simple-swizzle@^0.2.2:
 
 sisteransi@^1.0.5:
   version "1.0.5"
-  resolved "http://npm.lwcjs.org/sisteransi/-/sisteransi-1.0.5/134d681297756437cc05ca01370d3a7a571075ed.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 skip-regex@^1.0.2:
@@ -13308,7 +13308,7 @@ stack-utils@^1.0.1:
 
 stack-utils@^2.0.2:
   version "2.0.3"
-  resolved "http://npm.lwcjs.org/stack-utils/-/stack-utils-2.0.3/cd5f030126ff116b78ccb3c027fe302713b61277.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
@@ -13325,7 +13325,7 @@ statuses@~1.4.0:
 
 stealthy-require@^1.1.1:
   version "1.1.1"
-  resolved "http://npm.lwcjs.org/stealthy-require/-/stealthy-require-1.1.1/35b09875b4ff49f26a777e509b3090a3226bf24b.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 stream-buffers@^3.0.2:
@@ -13367,7 +13367,7 @@ string-argv@0.3.1:
 
 string-length@^4.0.1:
   version "4.0.1"
-  resolved "http://npm.lwcjs.org/string-length/-/string-length-4.0.1/4a973bf31ef77c4edbceadd6af2611996985f8a1.tgz#4a973bf31ef77c4edbceadd6af2611996985f8a1"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.1.tgz#4a973bf31ef77c4edbceadd6af2611996985f8a1"
   integrity sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==
   dependencies:
     char-regex "^1.0.2"
@@ -13523,7 +13523,7 @@ strip-bom@^3.0.0:
 
 strip-bom@^4.0.0:
   version "4.0.0"
-  resolved "http://npm.lwcjs.org/strip-bom/-/strip-bom-4.0.0/9c3505c1db45bcedca3d9cf7a16f5c5aa3901878.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
 strip-dirs@^2.0.0:
@@ -13628,7 +13628,7 @@ supports-color@^6.1.0:
 
 supports-hyperlinks@^2.0.0:
   version "2.1.0"
-  resolved "http://npm.lwcjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0/f663df252af5f37c5d49bbd7eeefa9e0b9e59e47.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
   integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
   dependencies:
     has-flag "^4.0.0"
@@ -13655,7 +13655,7 @@ svgo@^1.0.0:
 
 symbol-tree@^3.2.4:
   version "3.2.4"
-  resolved "http://npm.lwcjs.org/symbol-tree/-/symbol-tree-3.2.4/430637d248ba77e078883951fb9aa0eed7c63fa2.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 systeminformation@^4.31.1, systeminformation@~4.9.2:
@@ -13750,7 +13750,7 @@ temp-write@^3.4.0:
 
 terminal-link@^2.0.0:
   version "2.1.1"
-  resolved "http://npm.lwcjs.org/terminal-link/-/terminal-link-2.1.1/14a64a27ab3c0df933ea546fba55f2d078edc994.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
   integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
   dependencies:
     ansi-escapes "^4.2.1"
@@ -13776,7 +13776,7 @@ terser@~5.5.1:
 
 test-exclude@^6.0.0:
   version "6.0.0"
-  resolved "http://npm.lwcjs.org/test-exclude/-/test-exclude-6.0.0/04a8698661d805ea6fa293b6cb9e63ac044ef15e.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
   integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
   dependencies:
     "@istanbuljs/schema" "^0.1.2"
@@ -13809,7 +13809,7 @@ thenify-all@^1.0.0:
 
 throat@^5.0.0:
   version "5.0.0"
-  resolved "http://npm.lwcjs.org/throat/-/throat-5.0.0/c5199235803aad18754a667d659b5e72ce16764b.tgz#c5199235803aad18754a667d659b5e72ce16764b"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
 through2@^2.0.0, through2@^2.0.2:
@@ -13858,7 +13858,7 @@ tmp@^0.0.33:
 
 tmpl@1.0.x:
   version "1.0.4"
-  resolved "http://npm.lwcjs.org/tmpl/-/tmpl-1.0.4/23640dd7b42d00433911140820e5cf440e521dd1.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
 to-array@0.1.4:
@@ -13898,7 +13898,7 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
 
 tough-cookie@^3.0.1:
   version "3.0.1"
-  resolved "http://npm.lwcjs.org/tough-cookie/-/tough-cookie-3.0.1/9df4f57e739c26930a018184887f4adb7dca73b2.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
   integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
   dependencies:
     ip-regex "^2.1.0"
@@ -13922,7 +13922,7 @@ tr46@^1.0.1:
 
 tr46@^2.0.2:
   version "2.0.2"
-  resolved "http://npm.lwcjs.org/tr46/-/tr46-2.0.2/03273586def1595ae08fedb38d7733cee91d2479.tgz#03273586def1595ae08fedb38d7733cee91d2479"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
@@ -13997,14 +13997,14 @@ type-check@^0.4.0, type-check@~0.4.0:
 
 type-check@~0.3.2:
   version "0.3.2"
-  resolved "http://npm.lwcjs.org/type-check/-/type-check-0.3.2/5884cab512cf1d355e3fb784f30804b2b520db72.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
 
 type-detect@4.0.8:
   version "4.0.8"
-  resolved "http://npm.lwcjs.org/type-detect/-/type-detect-4.0.8/7646fb5f18871cfbb7749e69bd39a6388eb7450c.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0:
@@ -14047,7 +14047,7 @@ type-is@~1.6.16, type-is@~1.6.17, type-is@~1.6.18:
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
-  resolved "http://npm.lwcjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5/a97ee7a9ff42691b9f783ff1bc5112fe3fca9080.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
@@ -14059,7 +14059,7 @@ typedarray@^0.0.6:
 
 typescript@^4.1.3:
   version "4.1.3"
-  resolved "http://npm.lwcjs.org/typescript/-/typescript-4.1.3/519d582bd94cba0cf8934c7d8e8467e473f53bb7.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 ua-parser-js@0.7.22:
@@ -14282,7 +14282,7 @@ uuid@^8.0.0:
 
 uuid@^8.3.0:
   version "8.3.2"
-  resolved "http://npm.lwcjs.org/uuid/-/uuid-8.3.2/80d5b5ced271bb9af6c445f21a1a04c606cefbe2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
@@ -14292,7 +14292,7 @@ v8-compile-cache@^2.0.3:
 
 v8-to-istanbul@^7.0.0:
   version "7.1.0"
-  resolved "http://npm.lwcjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0/5b95cef45c0f83217ec79f8fc7ee1c8b486aee07.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
   integrity sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.1"
@@ -14340,21 +14340,21 @@ void-elements@^2.0.0:
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
-  resolved "http://npm.lwcjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2/0a89cdf5cc15822df9c360543676963e0cc308cd.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
 
 w3c-xmlserializer@^2.0.0:
   version "2.0.0"
-  resolved "http://npm.lwcjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0/3e7104a05b75146cc60f564380b7f683acf1020a.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
-  resolved "http://npm.lwcjs.org/walker/-/walker-1.0.7/2f7f9b8fd10d677262b18a884e28d19618e028fb.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
@@ -14460,24 +14460,24 @@ webidl-conversions@^4.0.2:
 
 webidl-conversions@^5.0.0:
   version "5.0.0"
-  resolved "http://npm.lwcjs.org/webidl-conversions/-/webidl-conversions-5.0.0/ae59c8a00b121543a2acc65c0434f57b0fc11aff.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
   integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
 webidl-conversions@^6.1.0:
   version "6.1.0"
-  resolved "http://npm.lwcjs.org/webidl-conversions/-/webidl-conversions-6.1.0/9111b4d7ea80acd40f5270d666621afa78b69514.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"
-  resolved "http://npm.lwcjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5/5abacf777c32166a51d085d6b4f3e7d27113ddb0.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
-  resolved "http://npm.lwcjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0/3d4b1e0312d2079879f826aff18dbeeca5960fbf.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^7.0.0:
@@ -14491,7 +14491,7 @@ whatwg-url@^7.0.0:
 
 whatwg-url@^8.0.0:
   version "8.4.0"
-  resolved "http://npm.lwcjs.org/whatwg-url/-/whatwg-url-8.4.0/50fb9615b05469591d2b2bd6dfaed2942ed72837.tgz#50fb9615b05469591d2b2bd6dfaed2942ed72837"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.4.0.tgz#50fb9615b05469591d2b2bd6dfaed2942ed72837"
   integrity sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
   dependencies:
     lodash.sortby "^4.7.0"
@@ -14609,7 +14609,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
 
 write-file-atomic@^3.0.0:
   version "3.0.3"
-  resolved "http://npm.lwcjs.org/write-file-atomic/-/write-file-atomic-3.0.3/56bd5c5a5c70481cd19c571bd39ab965a5de56e8.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
   dependencies:
     imurmurhash "^0.1.4"
@@ -14675,7 +14675,7 @@ ws@~6.1.0:
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
-  resolved "http://npm.lwcjs.org/xml-name-validator/-/xml-name-validator-3.0.0/6ae73e06de4d8c6e47f9fb181f78d648ad457c6a.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
 xml2js@0.4.19:
@@ -14693,7 +14693,7 @@ xmlbuilder@~9.0.1:
 
 xmlchars@^2.2.0:
   version "2.2.0"
-  resolved "http://npm.lwcjs.org/xmlchars/-/xmlchars-2.2.0/060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xmlhttprequest-ssl@~1.5.4:
@@ -14733,7 +14733,7 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
 
 yallist@^4.0.0:
   version "4.0.0"
-  resolved "http://npm.lwcjs.org/yallist/-/yallist-4.0.0/9bb92790d9c0effec63be73519e11a35019a3a72.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12631,7 +12631,7 @@ rollup-pluginutils@~2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^2.35.1:
+rollup@^2.35.1, rollup@~2.36.0:
   version "2.36.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.36.0.tgz#af2cdea36f70fa3de586840c2604882dfb4d0aac"
   integrity sha512-L38QyQK77bkJy9nPyeydnHFK6xMofqumh4scTV2d4RG4EFq6pGdxnn67dVHFUDJ9J0PSEQx8zn1FiVS5TydsKg==
@@ -12646,13 +12646,6 @@ rollup@~1.26.0:
     "@types/estree" "*"
     "@types/node" "*"
     acorn "^7.1.0"
-
-rollup@~2.34.0:
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.0.tgz#ecc7f1d4ce2cb88bb51bec2f56b984f3c35b8271"
-  integrity sha512-dW5iLvttZzdVehjEuNJ1bWvuMEJjOWGmnuFS82WeKHTGXDkRHQeq/ExdifkSyJv9dLcR86ysKRmrIDyR6O0X8g==
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -13679,9 +13672,9 @@ symbol-tree@^3.2.4:
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 systeminformation@^4.31.1, systeminformation@~4.9.2:
-  version "4.34.2"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.34.2.tgz#2fe6c5c25478990549443a69d8300eb3010b5560"
-  integrity sha512-1LynQMla38gIjzyupKBnBLIo4B0TQf3vdhs2bjKPtN02EymuSWpoAM1KX/6+gtFLVmn91MfllE3wSVGQcVTHDw==
+  version "4.34.3"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.34.3.tgz#53e6faf07df5d3651f6537ce884c2704949e2459"
+  integrity sha512-V1iPDm6qDh+pI2je+mrFw4h+0aV2ID6CWBuL0OO1Z6WvUQLq4Jbme6nU3bpcx6pVr044KIvruE8Yj4hMiFKuaQ==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
## Details

Packages that were being installed via the `http://npm.lwcjs.org` registry were updated to use yarn's default. This incorrect registry was being used by a `.yarnrc` on my system.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8588420