### PR TITLE
refactor(engine-core): Remove duplicate Component type definition

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -35,17 +35,6 @@ import {
     rerenderVM,
     appendVM,
 } from './vm';
-import { ComponentConstructor } from './component';
-import {
-    VNode,
-    VNodeData,
-    VNodes,
-    VElement,
-    VText,
-    Hooks,
-    Key,
-    VCustomElement,
-} from '../3rdparty/snabbdom/types';
 import {
     createViewModelHook,
     fallbackElmHook,
@@ -65,6 +54,18 @@ import {
 import { isComponentConstructor } from './def';
 import { getUpgradableConstructor } from './upgradable-element';
 
+import type {
+    VNode,
+    VNodeData,
+    VNodes,
+    VElement,
+    VText,
+    Hooks,
+    Key,
+    VCustomElement,
+} from '../3rdparty/snabbdom/types';
+import { LightningElementConstructor } from './base-lightning-element';
+
 export interface ElementCompilerData extends VNodeData {
     key: Key;
 }
@@ -78,7 +79,7 @@ export interface RenderAPI {
     h(tagName: string, data: ElementCompilerData, children: VNodes): VNode;
     c(
         tagName: string,
-        Ctor: ComponentConstructor,
+        Ctor: LightningElementConstructor,
         data: CustomElementCompilerData,
         children?: VNodes
     ): VNode;
@@ -369,7 +370,7 @@ export function s(
 // [c]ustom element node
 export function c(
     sel: string,
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     data: CustomElementCompilerData,
     children: VNodes = EmptyArray
 ): VCustomElement {
@@ -645,7 +646,7 @@ export function fid(url: string | undefined | null): string | null | undefined {
  * by dc() api. This allows us to generate a unique unique per template per dynamic
  * component reference to avoid diffing algo mismatches.
  */
-const DynamicImportedComponentMap: Map<ComponentConstructor, number> = new Map();
+const DynamicImportedComponentMap: Map<LightningElementConstructor, number> = new Map();
 let dynamicImportedComponentCounter = 0;
 
 /**
@@ -653,7 +654,7 @@ let dynamicImportedComponentCounter = 0;
  */
 export function dc(
     sel: string,
-    Ctor: ComponentConstructor | null | undefined,
+    Ctor: LightningElementConstructor | null | undefined,
     data: CustomElementCompilerData,
     children?: VNodes
 ): VCustomElement | null {

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -36,6 +36,17 @@ import {
     appendVM,
 } from './vm';
 import {
+    VNode,
+    VNodeData,
+    VNodes,
+    VElement,
+    VText,
+    Hooks,
+    Key,
+    VCustomElement,
+} from '../3rdparty/snabbdom/types';
+import { LightningElementConstructor } from './base-lightning-element';
+import {
     createViewModelHook,
     fallbackElmHook,
     removeElmHook,
@@ -53,18 +64,6 @@ import {
 } from './hooks';
 import { isComponentConstructor } from './def';
 import { getUpgradableConstructor } from './upgradable-element';
-
-import type {
-    VNode,
-    VNodeData,
-    VNodes,
-    VElement,
-    VText,
-    Hooks,
-    Key,
-    VCustomElement,
-} from '../3rdparty/snabbdom/types';
-import { LightningElementConstructor } from './base-lightning-element';
 
 export interface ElementCompilerData extends VNodeData {
     key: Key;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -24,7 +24,7 @@ import {
     setPrototypeOf,
 } from '@lwc/shared';
 import { HTMLElementOriginalDescriptors } from './html-properties';
-import { ComponentInterface, getWrappedComponentsListener } from './component';
+import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
 import { associateVM, getAssociatedVM } from './vm';
 import { componentValueMutated, componentValueObserved } from './mutation-tracker';
@@ -72,7 +72,7 @@ function createBridgeToElementDescriptor(
     return {
         enumerable,
         configurable,
-        get(this: ComponentInterface) {
+        get(this: LightningElement) {
             const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
@@ -86,7 +86,7 @@ function createBridgeToElementDescriptor(
             componentValueObserved(vm, propName);
             return get.call(vm.elm);
         },
-        set(this: ComponentInterface, newValue: any) {
+        set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -124,6 +124,8 @@ export interface LightningElementConstructor {
     new (): LightningElement;
     readonly prototype: LightningElement;
     readonly CustomElementConstructor: HTMLElementConstructor;
+
+    delegatesFocus?: boolean;
 }
 
 export declare let LightningElement: LightningElementConstructor;

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -18,10 +18,6 @@ import { LightningElementConstructor } from './base-lightning-element';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 
 export type ErrorCallback = (error: any, stack: string) => void;
-export interface ComponentInterface {
-    // TODO [#1291]: complete the entire interface used by the engine
-    setAttribute(attrName: string, value: any): void;
-}
 
 export interface ComponentConstructor extends LightningElementConstructor {
     readonly name: string;

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -14,9 +14,8 @@ import {
 import { VM, scheduleRehydration } from './vm';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { ReactiveObserver } from '../libs/mutation-tracker';
+import { LightningElementConstructor } from './base-lightning-element';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
-
-import type { LightningElementConstructor } from './base-lightning-element';
 
 const signedTemplateMap: Map<LightningElementConstructor, Template> = new Map();
 

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -14,38 +14,33 @@ import {
 import { VM, scheduleRehydration } from './vm';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { ReactiveObserver } from '../libs/mutation-tracker';
-import { LightningElementConstructor } from './base-lightning-element';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 
-export type ErrorCallback = (error: any, stack: string) => void;
+import type { LightningElementConstructor } from './base-lightning-element';
 
-export interface ComponentConstructor extends LightningElementConstructor {
-    readonly name: string;
-    readonly labels?: string[];
-    readonly delegatesFocus?: boolean;
-}
-
-const signedTemplateMap: Map<ComponentConstructor, Template> = new Map();
+const signedTemplateMap: Map<LightningElementConstructor, Template> = new Map();
 
 /**
  * INTERNAL: This function can only be invoked by compiled code. The compiler
  * will prevent this function from being imported by userland code.
  */
 export function registerComponent(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     { tmpl }: { tmpl: Template }
-): ComponentConstructor {
+): LightningElementConstructor {
     signedTemplateMap.set(Ctor, tmpl);
     // chaining this method as a way to wrap existing assignment of component constructor easily,
     // without too much transformation
     return Ctor;
 }
 
-export function getComponentRegisteredTemplate(Ctor: ComponentConstructor): Template | undefined {
+export function getComponentRegisteredTemplate(
+    Ctor: LightningElementConstructor
+): Template | undefined {
     return signedTemplateMap.get(Ctor);
 }
 
-export function createComponent(vm: VM, Ctor: ComponentConstructor) {
+export function createComponent(vm: VM, Ctor: LightningElementConstructor) {
     // create the component instance
     invokeComponentConstructor(vm, Ctor);
 

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -25,11 +25,6 @@ export interface ComponentConstructor extends LightningElementConstructor {
     readonly delegatesFocus?: boolean;
 }
 
-export interface ComponentMeta {
-    readonly name: string;
-    readonly template?: Template;
-}
-
 const signedTemplateMap: Map<ComponentConstructor, Template> = new Map();
 
 /**

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -13,10 +13,11 @@ import {
     componentValueMutated,
     ReactiveObserver,
 } from '../mutation-tracker';
-import { ComponentInterface } from '../component';
 import { getAssociatedVM, rerenderVM, VM } from '../vm';
 import { addCallbackToNextTick } from '../utils';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
+
+import type { LightningElement } from '../base-lightning-element';
 
 /**
  * @api decorator to mark public fields and public methods in
@@ -33,7 +34,7 @@ export default function api() {
 
 export function createPublicPropertyDescriptor(key: string): PropertyDescriptor {
     return {
-        get(this: ComponentInterface): any {
+        get(this: LightningElement): any {
             const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
@@ -49,7 +50,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             componentValueObserved(vm, key);
             return vm.cmpProps[key];
         },
-        set(this: ComponentInterface, newValue: any) {
+        set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
@@ -126,14 +127,14 @@ export function createPublicAccessorDescriptor(
         throw new Error();
     }
     return {
-        get(this: ComponentInterface): any {
+        get(this: LightningElement): any {
             if (process.env.NODE_ENV !== 'production') {
                 // Assert that the this value is an actual Component with an associated VM.
                 getAssociatedVM(this);
             }
             return get.call(this);
         },
-        set(this: ComponentInterface, newValue: any) {
+        set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -13,11 +13,10 @@ import {
     componentValueMutated,
     ReactiveObserver,
 } from '../mutation-tracker';
+import { LightningElement } from '../base-lightning-element';
 import { getAssociatedVM, rerenderVM, VM } from '../vm';
 import { addCallbackToNextTick } from '../utils';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
-
-import type { LightningElement } from '../base-lightning-element';
 
 /**
  * @api decorator to mark public fields and public methods in

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -15,6 +15,7 @@ import {
     toString,
     isFalse,
 } from '@lwc/shared';
+import { LightningElementConstructor } from '../base-lightning-element';
 import { internalWireFieldDecorator } from './wire';
 import { internalTrackDecorator } from './track';
 import { createPublicPropertyDescriptor, createPublicAccessorDescriptor } from './api';
@@ -26,8 +27,6 @@ import {
 } from '../wiring';
 import { EmptyObject } from '../utils';
 import { createObservedFieldPropertyDescriptor } from '../observed-fields';
-
-import type { LightningElementConstructor } from '../base-lightning-element';
 
 // data produced by compiler
 type WireCompilerMeta = Record<string, WireCompilerDef>;

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -15,7 +15,6 @@ import {
     toString,
     isFalse,
 } from '@lwc/shared';
-import { ComponentConstructor } from '../component';
 import { internalWireFieldDecorator } from './wire';
 import { internalTrackDecorator } from './track';
 import { createPublicPropertyDescriptor, createPublicAccessorDescriptor } from './api';
@@ -27,6 +26,8 @@ import {
 } from '../wiring';
 import { EmptyObject } from '../utils';
 import { createObservedFieldPropertyDescriptor } from '../observed-fields';
+
+import type { LightningElementConstructor } from '../base-lightning-element';
 
 // data produced by compiler
 type WireCompilerMeta = Record<string, WireCompilerDef>;
@@ -59,7 +60,7 @@ interface RegisterDecoratorMeta {
 }
 
 function validateObservedField(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -71,7 +72,7 @@ function validateObservedField(
 }
 
 function validateFieldDecoratedWithTrack(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -83,7 +84,7 @@ function validateFieldDecoratedWithTrack(
 }
 
 function validateFieldDecoratedWithWire(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -95,7 +96,7 @@ function validateFieldDecoratedWithWire(
 }
 
 function validateMethodDecoratedWithWire(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -111,7 +112,7 @@ function validateMethodDecoratedWithWire(
 }
 
 function validateFieldDecoratedWithApi(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -123,7 +124,7 @@ function validateFieldDecoratedWithApi(
 }
 
 function validateAccessorDecoratedWithApi(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -144,7 +145,7 @@ function validateAccessorDecoratedWithApi(
 }
 
 function validateMethodDecoratedWithApi(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
@@ -164,9 +165,9 @@ function validateMethodDecoratedWithApi(
  * will prevent this function from being imported by user-land code.
  */
 export function registerDecorators(
-    Ctor: ComponentConstructor,
+    Ctor: LightningElementConstructor,
     meta: RegisterDecoratorMeta
-): ComponentConstructor {
+): LightningElementConstructor {
     const proto = Ctor.prototype;
     const { publicProps, publicMethods, wire, track, fields } = meta;
     const apiMethods: PropertyDescriptorMap = create(null);
@@ -280,7 +281,7 @@ export function registerDecorators(
     return Ctor;
 }
 
-const signedDecoratorToMetaMap: Map<ComponentConstructor, DecoratorMeta> = new Map();
+const signedDecoratorToMetaMap: Map<LightningElementConstructor, DecoratorMeta> = new Map();
 
 interface DecoratorMeta {
     readonly apiMethods: PropertyDescriptorMap;
@@ -291,7 +292,7 @@ interface DecoratorMeta {
     readonly observedFields: PropertyDescriptorMap;
 }
 
-function setDecoratorsMeta(Ctor: ComponentConstructor, meta: DecoratorMeta) {
+function setDecoratorsMeta(Ctor: LightningElementConstructor, meta: DecoratorMeta) {
     signedDecoratorToMetaMap.set(Ctor, meta);
 }
 
@@ -304,7 +305,7 @@ const defaultMeta: DecoratorMeta = {
     observedFields: EmptyObject,
 };
 
-export function getDecoratorsMeta(Ctor: ComponentConstructor): DecoratorMeta {
+export function getDecoratorsMeta(Ctor: LightningElementConstructor): DecoratorMeta {
     const meta = signedDecoratorToMetaMap.get(Ctor);
     return isUndefined(meta) ? defaultMeta : meta;
 }

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -9,8 +9,9 @@ import { componentValueObserved, componentValueMutated } from '../mutation-track
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
-import { ComponentInterface } from '../component';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
+
+import type { LightningElement } from '../base-lightning-element';
 
 /**
  * @track decorator function to mark field value as reactive in
@@ -36,12 +37,12 @@ export default function track(target: any): any {
 
 export function internalTrackDecorator(key: string): PropertyDescriptor {
     return {
-        get(this: ComponentInterface): any {
+        get(this: LightningElement): any {
             const vm = getAssociatedVM(this);
             componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
-        set(this: ComponentInterface, newValue: any) {
+        set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -9,9 +9,8 @@ import { componentValueObserved, componentValueMutated } from '../mutation-track
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
+import { LightningElement } from '../base-lightning-element';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
-
-import type { LightningElement } from '../base-lightning-element';
 
 /**
  * @track decorator function to mark field value as reactive in

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -5,10 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert } from '@lwc/shared';
-import { ComponentInterface } from '../component';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
 import { WireAdapterConstructor } from '../wiring';
+
+import { LightningElement } from '../base-lightning-element';
 
 /**
  * @wire decorator to wire fields and methods to a wire adapter in
@@ -27,12 +28,12 @@ export default function wire(
 
 export function internalWireFieldDecorator(key: string): PropertyDescriptor {
     return {
-        get(this: ComponentInterface): any {
+        get(this: LightningElement): any {
             const vm = getAssociatedVM(this);
             componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
-        set(this: ComponentInterface, value: any) {
+        set(this: LightningElement, value: any) {
             const vm = getAssociatedVM(this);
             /**
              * Reactivity for wired fields is provided in wiring.

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -5,11 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert } from '@lwc/shared';
+import { LightningElement } from '../base-lightning-element';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
 import { WireAdapterConstructor } from '../wiring';
-
-import { LightningElement } from '../base-lightning-element';
 
 /**
  * @wire decorator to wire fields and methods to a wire adapter in

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -28,6 +28,8 @@ import {
 } from '@lwc/shared';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
+import { Template } from './template';
+import { LightningElement, LightningElementConstructor } from './base-lightning-element';
 import { BaseLightningElement, lightningBasedDescriptors } from './base-lightning-element';
 import { PropType, getDecoratorsMeta } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
@@ -42,9 +44,6 @@ import {
     resolveCircularModuleDependency,
 } from '../shared/circular-module-dependencies';
 import { getComponentOrSwappedComponent } from './hot-swaps';
-
-import type { Template } from './template';
-import type { LightningElement, LightningElementConstructor } from './base-lightning-element';
 
 export interface ComponentDef {
     name: string;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -27,8 +27,7 @@ import {
     htmlPropertyToAttribute,
 } from '@lwc/shared';
 import { EmptyObject } from './utils';
-import { ComponentConstructor, ErrorCallback, getComponentRegisteredTemplate } from './component';
-import { Template } from './template';
+import { getComponentRegisteredTemplate } from './component';
 import { BaseLightningElement, lightningBasedDescriptors } from './base-lightning-element';
 import { PropType, getDecoratorsMeta } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
@@ -44,6 +43,9 @@ import {
 } from '../shared/circular-module-dependencies';
 import { getComponentOrSwappedComponent } from './hot-swaps';
 
+import type { Template } from './template';
+import type { LightningElement, LightningElementConstructor } from './base-lightning-element';
+
 export interface ComponentDef {
     name: string;
     wire: PropertyDescriptorMap | undefined;
@@ -51,19 +53,19 @@ export interface ComponentDef {
     propsConfig: Record<string, PropType>;
     methods: PropertyDescriptorMap;
     template: Template;
-    ctor: ComponentConstructor;
+    ctor: LightningElementConstructor;
     bridge: HTMLElementConstructor;
-    connectedCallback?: () => void;
-    disconnectedCallback?: () => void;
-    renderedCallback?: () => void;
-    errorCallback?: ErrorCallback;
-    render: () => Template;
+    connectedCallback?: LightningElement['connectedCallback'];
+    disconnectedCallback?: LightningElement['disconnectedCallback'];
+    renderedCallback?: LightningElement['renderedCallback'];
+    errorCallback?: LightningElement['errorCallback'];
+    render: LightningElement['render'];
 }
 
 const CtorToDefMap: WeakMap<any, ComponentDef> = new WeakMap();
 
-function getCtorProto(Ctor: ComponentConstructor): ComponentConstructor {
-    let proto: ComponentConstructor | null = getPrototypeOf(Ctor);
+function getCtorProto(Ctor: LightningElementConstructor): LightningElementConstructor {
+    let proto: LightningElementConstructor | null = getPrototypeOf(Ctor);
     if (isNull(proto)) {
         throw new ReferenceError(
             `Invalid prototype chain for ${Ctor.name}, you must extend LightningElement.`
@@ -88,7 +90,7 @@ function getCtorProto(Ctor: ComponentConstructor): ComponentConstructor {
     return proto!;
 }
 
-function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
+function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
     if (process.env.NODE_ENV !== 'production') {
         const ctorName = Ctor.name;
         // Removing the following assert until https://bugs.webkit.org/show_bug.cgi?id=190140 is fixed.
@@ -170,7 +172,7 @@ function createComponentDef(Ctor: ComponentConstructor): ComponentDef {
  * EXPERIMENTAL: This function allows for the identification of LWC constructors. This API is
  * subject to change or being removed.
  */
-export function isComponentConstructor(ctor: unknown): ctor is ComponentConstructor {
+export function isComponentConstructor(ctor: unknown): ctor is LightningElementConstructor {
     if (!isFunction(ctor)) {
         return false;
     }
@@ -208,7 +210,7 @@ export function isComponentConstructor(ctor: unknown): ctor is ComponentConstruc
 
 export function getComponentInternalDef(Ctor: unknown): ComponentDef {
     if (process.env.NODE_ENV !== 'production') {
-        Ctor = getComponentOrSwappedComponent(Ctor as ComponentConstructor);
+        Ctor = getComponentOrSwappedComponent(Ctor as LightningElementConstructor);
     }
     let def = CtorToDefMap.get(Ctor);
 
@@ -261,7 +263,7 @@ interface PublicComponentDef {
     name: string;
     props: Record<string, PropDef>;
     methods: Record<string, PublicMethod>;
-    ctor: ComponentConstructor;
+    ctor: LightningElementConstructor;
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/hot-swaps.ts
+++ b/packages/@lwc/engine-core/src/framework/hot-swaps.ts
@@ -8,12 +8,11 @@ import { isFalse, isUndefined, isNull } from '@lwc/shared';
 import featureFlags from '@lwc/features';
 import { VM, scheduleRehydration, forceRehydration } from './vm';
 import { isComponentConstructor } from './def';
+import { LightningElementConstructor } from './base-lightning-element';
+import { Template } from './template';
 import { markComponentAsDirty } from './component';
 import { isTemplateRegistered } from './secure-template';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
-
-import type { Template } from './template';
-import type { LightningElementConstructor } from './base-lightning-element';
 
 const swappedTemplateMap = new WeakMap<Template, Template>();
 const swappedComponentMap = new WeakMap<LightningElementConstructor, LightningElementConstructor>();

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -8,11 +8,13 @@ import { assert, isFunction, isUndefined } from '@lwc/shared';
 
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
 import { VM, runWithBoundaryProtection } from './vm';
-import { ComponentConstructor, ComponentInterface } from './component';
+import { ComponentConstructor } from './component';
 import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 
-import { VNodes } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
+
+import type { VNodes } from '../3rdparty/snabbdom/types';
+import type { LightningElement } from './base-lightning-element';
 
 export let isInvokingRender: boolean = false;
 
@@ -160,7 +162,7 @@ export function invokeComponentRenderedCallback(vm: VM): void {
 export function invokeEventListener(
     vm: VM,
     fn: EventListener,
-    thisValue: undefined | ComponentInterface,
+    thisValue: LightningElement | undefined,
     event: Event
 ) {
     const { callHook, owner } = vm;

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -8,12 +8,11 @@ import { assert, isFunction, isUndefined } from '@lwc/shared';
 
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
 import { VM, runWithBoundaryProtection } from './vm';
+import { LightningElement, LightningElementConstructor } from './base-lightning-element';
 import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 
+import { VNodes } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
-
-import type { VNodes } from '../3rdparty/snabbdom/types';
-import type { LightningElement, LightningElementConstructor } from './base-lightning-element';
 
 export let isInvokingRender: boolean = false;
 

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -8,13 +8,12 @@ import { assert, isFunction, isUndefined } from '@lwc/shared';
 
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
 import { VM, runWithBoundaryProtection } from './vm';
-import { ComponentConstructor } from './component';
 import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 
 import { addErrorComponentStack } from '../shared/error';
 
 import type { VNodes } from '../3rdparty/snabbdom/types';
-import type { LightningElement } from './base-lightning-element';
+import type { LightningElement, LightningElementConstructor } from './base-lightning-element';
 
 export let isInvokingRender: boolean = false;
 
@@ -49,7 +48,7 @@ export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, arg
     return result;
 }
 
-export function invokeComponentConstructor(vm: VM, Ctor: ComponentConstructor) {
+export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstructor) {
     const vmBeingConstructedInception = vmBeingConstructed;
     let error;
     if (profilerEnabled) {

--- a/packages/@lwc/engine-core/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine-core/src/framework/observed-fields.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { LightningElement } from './base-lightning-element';
 import { getAssociatedVM } from './vm';
 import { componentValueMutated, componentValueObserved } from './mutation-tracker';
-
-import type { LightningElement } from './base-lightning-element';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {

--- a/packages/@lwc/engine-core/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine-core/src/framework/observed-fields.ts
@@ -4,18 +4,19 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ComponentInterface } from './component';
 import { getAssociatedVM } from './vm';
 import { componentValueMutated, componentValueObserved } from './mutation-tracker';
 
+import type { LightningElement } from './base-lightning-element';
+
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {
-        get(this: ComponentInterface): any {
+        get(this: LightningElement): any {
             const vm = getAssociatedVM(this);
             componentValueObserved(vm, key);
             return vm.cmpFields[key];
         },
-        set(this: ComponentInterface, newValue: any) {
+        set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
 
             if (newValue !== vm.cmpFields[key]) {

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -22,7 +22,6 @@ import {
 } from '@lwc/shared';
 
 import { LightningElement } from './base-lightning-element';
-import { ComponentInterface } from './component';
 import { globalHTMLProperties } from './attributes';
 import { getAssociatedVM, getAssociatedVMIfPresent } from './vm';
 import { logError } from '../shared/logger';
@@ -302,7 +301,7 @@ function getComponentRestrictionsDescriptors(): PropertyDescriptorMap {
     }
     return {
         tagName: generateAccessorDescriptor({
-            get(this: ComponentInterface) {
+            get(this: LightningElement) {
                 throw new Error(
                     `Usage of property \`tagName\` is disallowed because the component itself does` +
                         ` not know which tagName will be used to create the element, therefore writing` +
@@ -357,7 +356,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(
             return; // no need to redefine something that we are already exposing
         }
         descriptors[propName] = generateAccessorDescriptor({
-            get(this: ComponentInterface) {
+            get(this: LightningElement) {
                 const { error, attribute } = globalHTMLProperties[propName];
                 const msg: string[] = [];
                 msg.push(`Accessing the global HTML property "${propName}" is disabled.`);
@@ -368,7 +367,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(
                 }
                 logError(msg.join('\n'), getAssociatedVM(this));
             },
-            set(this: ComponentInterface) {
+            set(this: LightningElement) {
                 const { readOnly } = globalHTMLProperties[propName];
                 if (readOnly) {
                     logError(
@@ -395,7 +394,7 @@ export function patchCustomElementWithRestrictions(elm: HTMLElement) {
     setPrototypeOf(elm, create(elmProto, restrictionsDescriptors));
 }
 
-export function patchComponentWithRestrictions(cmp: ComponentInterface) {
+export function patchComponentWithRestrictions(cmp: LightningElement) {
     defineProperties(cmp, getComponentRestrictionsDescriptors());
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -35,20 +35,20 @@ import { invokeComponentCallback, invokeComponentRenderedCallback } from './invo
 
 import { Template } from './template';
 import { ComponentDef } from './def';
-import { ComponentInterface } from './component';
 import { startGlobalMeasure, endGlobalMeasure, GlobalMeasurementPhase } from './performance-timing';
 import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from './mutation-tracker';
-import { LightningElement } from './base-lightning-element';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
-import { Renderer, HostNode, HostElement } from './renderer';
 import { removeActiveVM } from './hot-swaps';
 
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
-import { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
+
+import type { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
+import type { LightningElement } from './base-lightning-element';
+import type { Renderer, HostNode, HostElement } from './renderer';
 
 type ShadowRootMode = 'open' | 'closed';
 
@@ -123,7 +123,7 @@ export interface VM<N = HostNode, E = HostElement> {
     /** The template method returning the VDOM tree. */
     cmpTemplate: Template | null;
     /** The component instance. */
-    component: ComponentInterface;
+    component: LightningElement;
     /** The custom element shadow root. */
     cmpRoot: ShadowRoot;
     /** The template reactive observer. */
@@ -133,23 +133,19 @@ export interface VM<N = HostNode, E = HostElement> {
     oar: { [name: string]: AccessorReactiveObserver };
     /** Hook invoked whenever a property is accessed on the host element. This hook is used by
      *  Locker only. */
-    setHook: (cmp: ComponentInterface, prop: PropertyKey, newValue: any) => void;
+    setHook: (cmp: LightningElement, prop: PropertyKey, newValue: any) => void;
     /** Hook invoked whenever a property is set on the host element. This hook is used by Locker
      *  only. */
-    getHook: (cmp: ComponentInterface, prop: PropertyKey) => any;
+    getHook: (cmp: LightningElement, prop: PropertyKey) => any;
     /** Hook invoked whenever a method is called on the component (life-cycle hooks, public
      *  properties and event handlers). This hook is used by Locker. */
-    callHook: (
-        cmp: ComponentInterface | undefined,
-        fn: (...args: any[]) => any,
-        args?: any[]
-    ) => any;
+    callHook: (cmp: LightningElement | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
 }
 
 let profilerEnabled = false;
 trackProfilerState((t) => (profilerEnabled = t));
 
-type VMAssociable = HostNode | LightningElement | ComponentInterface;
+type VMAssociable = HostNode | LightningElement;
 
 let idx: number = 0;
 
@@ -157,18 +153,18 @@ let idx: number = 0;
 const ViewModelReflection = createHiddenField<VM>('ViewModel', 'engine');
 
 function callHook(
-    cmp: ComponentInterface | undefined,
+    cmp: LightningElement | undefined,
     fn: (...args: any[]) => any,
     args: any[] = []
 ): any {
     return fn.apply(cmp, args);
 }
 
-function setHook(cmp: ComponentInterface, prop: PropertyKey, newValue: any) {
+function setHook(cmp: LightningElement, prop: PropertyKey, newValue: any) {
     (cmp as any)[prop] = newValue;
 }
 
-function getHook(cmp: ComponentInterface, prop: PropertyKey): any {
+function getHook(cmp: LightningElement, prop: PropertyKey): any {
     return (cmp as any)[prop];
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -35,20 +35,19 @@ import { invokeComponentCallback, invokeComponentRenderedCallback } from './invo
 
 import { Template } from './template';
 import { ComponentDef } from './def';
+import { LightningElement } from './base-lightning-element';
 import { startGlobalMeasure, endGlobalMeasure, GlobalMeasurementPhase } from './performance-timing';
 import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
+import { Renderer, HostNode, HostElement } from './renderer';
 import { removeActiveVM } from './hot-swaps';
 
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
+import { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
-
-import type { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
-import type { LightningElement } from './base-lightning-element';
-import type { Renderer, HostNode, HostElement } from './renderer';
 
 type ShadowRootMode = 'open' | 'closed';
 

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -5,9 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isUndefined, ArrayPush, defineProperty, defineProperties } from '@lwc/shared';
-import { ComponentInterface } from './component';
 import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
-import { VM, runWithBoundaryProtection, VMState } from './vm';
+import { runWithBoundaryProtection, VMState } from './vm';
+
+import type { LightningElement } from './base-lightning-element';
+import type { VM } from './vm';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
@@ -74,7 +76,7 @@ function createMethodDataCallback(vm: VM, method: (data: any) => any) {
 }
 
 function createConfigWatcher(
-    component: ComponentInterface,
+    component: LightningElement,
     configCallback: ConfigCallback,
     callbackWhenConfigIsReady: (newConfig: ConfigValue) => void
 ): { computeConfigAndUpdate: () => void; ro: ReactiveObserver } {
@@ -263,7 +265,7 @@ export function setAdapterToken(adapter: WireAdapterConstructor, token: string) 
 }
 
 export type ContextValue = Record<string, any>;
-export type ConfigCallback = (component: ComponentInterface) => ConfigValue;
+export type ConfigCallback = (component: LightningElement) => ConfigValue;
 
 export interface WireAdapterConstructor {
     new (callback: DataCallback): WireAdapter;

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -5,11 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isUndefined, ArrayPush, defineProperty, defineProperties } from '@lwc/shared';
+import { LightningElement } from './base-lightning-element';
 import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
-import { runWithBoundaryProtection, VMState } from './vm';
-
-import type { LightningElement } from './base-lightning-element';
-import type { VM } from './vm';
+import { runWithBoundaryProtection, VMState, VM } from './vm';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';


### PR DESCRIPTION
## Details

While investigating the `MacroElement` proposal I realized that the `@lwc/engine` contains competing type definition for the `LightningElement` class: `LightElement` interface and `Component` interface. This PR removes `Component` interface definition. It also fixes #1291. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 