### PR TITLE
refactor(shared): Make @lwc/shared treeshakable

### DIFF
--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -17,6 +17,7 @@
     "license": "MIT",
     "scripts": {
         "build": "tsc --emitDeclarationOnly && rollup --config ./scripts/rollup/rollup.config.js",
+        "postbuild": "node ../../../scripts/tasks/verify-treeshakable.js ./dist/index.js",
         "clean": "rm -rf dist/ types/"
     },
     "files": [

--- a/packages/@lwc/shared/src/aria.ts
+++ b/packages/@lwc/shared/src/aria.ts
@@ -64,76 +64,30 @@ const AriaPropertyNames = [
     'ariaValueNow',
     'ariaValueText',
     'role',
-];
+] as const;
 
-export interface AccessibleElementProperties {
-    ariaActiveDescendant: string | null;
-    ariaAtomic: string | null;
-    ariaAutoComplete: string | null;
-    ariaBusy: string | null;
-    ariaChecked: string | null;
-    ariaColCount: string | null;
-    ariaColIndex: string | null;
-    ariaColSpan: string | null;
-    ariaControls: string | null;
-    ariaCurrent: string | null;
-    ariaDescribedBy: string | null;
-    ariaDetails: string | null;
-    ariaDisabled: string | null;
-    ariaErrorMessage: string | null;
-    ariaExpanded: string | null;
-    ariaFlowTo: string | null;
-    ariaHasPopup: string | null;
-    ariaHidden: string | null;
-    ariaInvalid: string | null;
-    ariaKeyShortcuts: string | null;
-    ariaLabel: string | null;
-    ariaLabelledBy: string | null;
-    ariaLevel: string | null;
-    ariaLive: string | null;
-    ariaModal: string | null;
-    ariaMultiLine: string | null;
-    ariaMultiSelectable: string | null;
-    ariaOrientation: string | null;
-    ariaOwns: string | null;
-    ariaPlaceholder: string | null;
-    ariaPosInSet: string | null;
-    ariaPressed: string | null;
-    ariaReadOnly: string | null;
-    ariaRelevant: string | null;
-    ariaRequired: string | null;
-    ariaRoleDescription: string | null;
-    ariaRowCount: string | null;
-    ariaRowIndex: string | null;
-    ariaRowSpan: string | null;
-    ariaSelected: string | null;
-    ariaSetSize: string | null;
-    ariaSort: string | null;
-    ariaValueMax: string | null;
-    ariaValueMin: string | null;
-    ariaValueNow: string | null;
-    ariaValueText: string | null;
-    role: string | null;
-}
-
-const AttrNameToPropNameMap: Record<string, string> = create(null);
-const PropNameToAttrNameMap: Record<string, string> = create(null);
-
-// Synthetic creation of all AOM property descriptors for Custom Elements
-forEach.call(AriaPropertyNames, (propName) => {
-    // Typescript infers the wrong function type for this particular overloaded method:
-    // https://github.com/Microsoft/TypeScript/issues/27972
-    // @ts-ignore type-mismatch
-    const attrName = StringToLowerCase.call(StringReplace.call(propName, /^aria/, 'aria-'));
-    AttrNameToPropNameMap[attrName] = propName;
-    PropNameToAttrNameMap[propName] = attrName;
-});
-
-export {
-    AttrNameToPropNameMap as AriaAttrNameToPropNameMap,
-    PropNameToAttrNameMap as AriaPropNameToAttrNameMap,
+export type AccessibleElementProperties = {
+    [prop in typeof AriaPropertyNames[number]]: string | null;
 };
 
+const { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap } = /*@__PURE__*/ (() => {
+    const AriaAttrNameToPropNameMap: Record<string, string> = create(null);
+    const AriaPropNameToAttrNameMap: Record<string, string> = create(null);
+
+    // Synthetic creation of all AOM property descriptors for Custom Elements
+    forEach.call(AriaPropertyNames, (propName) => {
+        const attrName = StringToLowerCase.call(
+            StringReplace.call(propName, /^aria/, () => 'aria-')
+        );
+        AriaAttrNameToPropNameMap[attrName] = propName;
+        AriaPropNameToAttrNameMap[propName] = attrName;
+    });
+
+    return { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap };
+})();
+
 export function isAriaAttribute(attrName: string): boolean {
-    return attrName in AttrNameToPropNameMap;
+    return attrName in AriaAttrNameToPropNameMap;
 }
+
+export { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap };

--- a/packages/@lwc/shared/src/global-this.ts
+++ b/packages/@lwc/shared/src/global-this.ts
@@ -6,7 +6,7 @@
  */
 
 // Inspired from: https://mathiasbynens.be/notes/globalthis
-const _globalThis = (function (): any {
+const _globalThis = /*@__PURE__*/ (function (): any {
     // On recent browsers, `globalThis` is already defined. In this case return it directly.
     if (typeof globalThis === 'object') {
         return globalThis;

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -124,7 +124,7 @@ export function toString(obj: any): string {
     } else if (typeof obj === 'object') {
         return OtS.call(obj);
     } else {
-        return obj + emptyString;
+        return obj + '';
     }
 }
 
@@ -137,5 +137,3 @@ export function getPropertyDescriptor(o: any, p: PropertyKey): PropertyDescripto
         o = getPrototypeOf(o);
     } while (o !== null);
 }
-
-export const emptyString = '';

--- a/packages/@lwc/shared/src/symbol.ts
+++ b/packages/@lwc/shared/src/symbol.ts
@@ -7,4 +7,5 @@
 
 // We use this to detect symbol support in order to avoid the expensive symbol polyfill. Note that
 // we can't use typeof since it will fail when transpiling.
-export const hasNativeSymbolSupport = Symbol('x').toString() === 'Symbol(x)';
+export const hasNativeSymbolSupport = /*@__PURE__*/ (() =>
+    Symbol('x').toString() === 'Symbol(x)')();

--- a/scripts/tasks/verify-treeshakable.js
+++ b/scripts/tasks/verify-treeshakable.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// Inspired from: https://github.com/Rich-Harris/agadoo
+
+const path = require('path');
+const { rollup } = require('rollup');
+
+async function check(input) {
+    const resolved = path.resolve(input);
+
+    const bundle = await rollup({
+        input: '__root__',
+        plugins: [
+            {
+                resolveId(id) {
+                    if (id === '__root__') return id;
+                },
+                load(id) {
+                    if (id === '__root__') return `import "${resolved}"`;
+                },
+            },
+        ],
+        onwarn: (warning, handle) => {
+            if (warning.code !== 'EMPTY_BUNDLE') handle(warning);
+        },
+    });
+
+    const res = await bundle.generate({
+        format: 'esm',
+    });
+
+    const [chunk] = res.output;
+
+    return {
+        code: chunk.code,
+        isTreeShakable: chunk.code.trim().length === 0,
+    };
+}
+
+const input = process.argv[2];
+check(input)
+    .then((res) => {
+        if (res.isTreeShakable === false) {
+            console.error(
+                `Failed to fully treeshake ${input}. Remaining code after treeshaking:\n\n${res.code}`
+            );
+        }
+
+        process.exit(res.isTreeShakable ? 0 : 1);
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Details

This PR ensures that `@lwc/shared` is fully treeshakable. It's a first step in the direction of fixing #2024. While it doesn't solve the fact that `@lwc/shared` is imported multiple times by `@lwc/engine`, it adds [`/*@__PURE__*/`](https://rollupjs.org/guide/en/#treeshake) annotation to indicate to rollup that some of the code can be tree shaken safely.

A new script has been added as a `postbuild` step to the `@lwc/shared` to prevent future regression. The postbuild script check if importing the `@lwc/shared` library without consuming any import produces an empty chunk.

Fixes #2104

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
