### PR TITLE
docs(engine-core): Improve decorator validation message

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -12,7 +12,6 @@ import {
     forEach,
     defineProperty,
     getOwnPropertyDescriptor,
-    toString,
     isFalse,
 } from '@lwc/shared';
 import { ComponentConstructor } from '../component';
@@ -58,15 +57,26 @@ interface RegisterDecoratorMeta {
     readonly fields?: string[];
 }
 
+function getClassDescriptorType(descriptor: PropertyDescriptor): string {
+    if (isFunction(descriptor.value)) {
+        return 'method';
+    } else if (isFunction(descriptor.set) || isFunction(descriptor.get)) {
+        return 'accessor';
+    } else {
+        return 'field';
+    }
+}
+
 function validateObservedField(
     Ctor: ComponentConstructor,
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isUndefined(descriptor)) {
-            assert.fail(`Compiler Error: Invalid field ${fieldName} declaration.`);
-        }
+    if (!isUndefined(descriptor)) {
+        const type = getClassDescriptorType(descriptor);
+        assert.fail(
+            `Invalid observed ${fieldName} field. Found a duplicate ${type} with the same name.`
+        );
     }
 }
 
@@ -75,10 +85,11 @@ function validateFieldDecoratedWithTrack(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isUndefined(descriptor)) {
-            assert.fail(`Compiler Error: Invalid @track ${fieldName} declaration.`);
-        }
+    if (!isUndefined(descriptor)) {
+        const type = getClassDescriptorType(descriptor);
+        assert.fail(
+            `Invalid @track ${fieldName} field. Found a duplicate ${type} with the same name.`
+        );
     }
 }
 
@@ -87,10 +98,11 @@ function validateFieldDecoratedWithWire(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isUndefined(descriptor)) {
-            assert.fail(`Compiler Error: Invalid @wire(...) ${fieldName} field declaration.`);
-        }
+    if (!isUndefined(descriptor)) {
+        const type = getClassDescriptorType(descriptor);
+        assert.fail(
+            `Invalid @wire ${fieldName} field. Found a duplicate ${type} with the same name.`
+        );
     }
 }
 
@@ -99,14 +111,8 @@ function validateMethodDecoratedWithWire(
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (
-            isUndefined(descriptor) ||
-            !isFunction(descriptor.value) ||
-            isFalse(descriptor.writable)
-        ) {
-            assert.fail(`Compiler Error: Invalid @wire(...) ${methodName} method declaration.`);
-        }
+    if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
+        assert.fail(`Invalid @wire ${methodName} method.`);
     }
 }
 
@@ -115,10 +121,11 @@ function validateFieldDecoratedWithApi(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isUndefined(descriptor)) {
-            assert.fail(`Compiler Error: Invalid @api ${fieldName} field declaration.`);
-        }
+    if (!isUndefined(descriptor)) {
+        const type = getClassDescriptorType(descriptor);
+        assert.fail(
+            `Invalid @api ${fieldName} field. Found a duplicate ${type} with the same name.`
+        );
     }
 }
 
@@ -127,19 +134,15 @@ function validateAccessorDecoratedWithApi(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (isUndefined(descriptor)) {
-            assert.fail(`Compiler Error: Invalid @api get ${fieldName} accessor declaration.`);
-        } else if (isFunction(descriptor.set)) {
-            assert.isTrue(
-                isFunction(descriptor.get),
-                `Compiler Error: Missing getter for property ${toString(
-                    fieldName
-                )} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
-            );
-        } else if (!isFunction(descriptor.get)) {
-            assert.fail(`Compiler Error: Missing @api get ${fieldName} accessor declaration.`);
-        }
+    if (isUndefined(descriptor)) {
+        assert.fail(`Invalid @api get ${fieldName} accessor.`);
+    } else if (isFunction(descriptor.set)) {
+        assert.isTrue(
+            isFunction(descriptor.get),
+            `Missing getter for property ${fieldName} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
+        );
+    } else if (!isFunction(descriptor.get)) {
+        assert.fail(`Missing @api get ${fieldName} accessor.`);
     }
 }
 
@@ -148,14 +151,8 @@ function validateMethodDecoratedWithApi(
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (
-            isUndefined(descriptor) ||
-            !isFunction(descriptor.value) ||
-            isFalse(descriptor.writable)
-        ) {
-            assert.fail(`Compiler Error: Invalid @api ${methodName} method declaration.`);
-        }
+    if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
+        assert.fail(`Invalid @api ${methodName} method.`);
     }
 }
 

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, LightningElement, api } from 'lwc';
 
 import Properties from 'x/properties';
 import Mutate from 'x/mutate';
@@ -110,4 +110,18 @@ it('should not log an error when initializing api value to null', () => {
     const elm = createElement('x-foo-init-api', { is: NullInitialValue });
 
     expect(() => document.body.appendChild(elm)).not.toLogErrorDev();
+});
+
+describe('restrictions', () => {
+    it('throws a property error when a public field conflicts with a method', () => {
+        expect(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            class Invalid extends LightningElement {
+                @api showFeatures;
+                showFeatures() {}
+            }
+        }).toThrowError(
+            'Invalid @api showFeatures field. Found a duplicate method with the same name.'
+        );
+    });
 });

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -115,7 +115,7 @@ it('should not log an error when initializing api value to null', () => {
 describe('restrictions', () => {
     it('throws a property error when a public field conflicts with a method', () => {
         expect(() => {
-            // The following class is wrapper by the compiler with registerDecorators. We check
+            // The following class is wrapped by the compiler with registerDecorators. We check
             // here if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -115,6 +115,8 @@ it('should not log an error when initializing api value to null', () => {
 describe('restrictions', () => {
     it('throws a property error when a public field conflicts with a method', () => {
         expect(() => {
+            // The following class is wrapper by the compiler with registerDecorators. We check
+            // here if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {
                 @api showFeatures;

--- a/packages/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/track/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { LightningElement, track, createElement } from 'lwc';
 
 import Properties from 'x/properties';
 import SideEffect from 'x/sideEffect';
@@ -38,6 +38,33 @@ describe('restrictions', () => {
         }).toThrowErrorDev(
             Error,
             /Invariant Violation: \[.+\]\.render\(\) method has side effects on the state of \[.+\]\.prop/
+        );
+    });
+
+    it('throws a property error when a track field conflicts with a method', () => {
+        expect(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            class Invalid extends LightningElement {
+                @track showFeatures;
+                showFeatures() {}
+            }
+        }).toThrowError(
+            'Invalid @track showFeatures field. Found a duplicate method with the same name.'
+        );
+    });
+
+    it('throws a property error when a track field conflicts with an accessor', () => {
+        expect(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            class Invalid extends LightningElement {
+                @track showFeatures;
+                get showFeatures() {
+                    return 1;
+                }
+                set showFeatures(v) {}
+            }
+        }).toThrowError(
+            'Invalid @track showFeatures field. Found a duplicate accessor with the same name.'
         );
     });
 });

--- a/packages/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/track/index.spec.js
@@ -43,7 +43,7 @@ describe('restrictions', () => {
 
     it('throws a property error when a track field conflicts with a method', () => {
         expect(() => {
-            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {
@@ -57,7 +57,7 @@ describe('restrictions', () => {
 
     it('throws a property error when a track field conflicts with an accessor', () => {
         expect(() => {
-            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {

--- a/packages/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/track/index.spec.js
@@ -43,6 +43,8 @@ describe('restrictions', () => {
 
     it('throws a property error when a track field conflicts with a method', () => {
         expect(() => {
+            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {
                 @track showFeatures;
@@ -55,6 +57,8 @@ describe('restrictions', () => {
 
     it('throws a property error when a track field conflicts with an accessor', () => {
         expect(() => {
+            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {
                 @track showFeatures;

--- a/packages/integration-karma/test/component/decorators/wire/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/wire/index.spec.js
@@ -1,0 +1,17 @@
+import { LightningElement, wire } from 'lwc';
+
+import { adapter } from 'x/adapter';
+
+describe('restrictions', () => {
+    it('throws a property error when a wired field conflicts with a method', () => {
+        expect(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            class Invalid extends LightningElement {
+                @wire(adapter) showFeatures;
+                showFeatures() {}
+            }
+        }).toThrowError(
+            'Invalid @wire showFeatures field. Found a duplicate method with the same name.'
+        );
+    });
+});

--- a/packages/integration-karma/test/component/decorators/wire/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/wire/index.spec.js
@@ -5,7 +5,7 @@ import { adapter } from 'x/adapter';
 describe('restrictions', () => {
     it('throws a property error when a wired field conflicts with a method', () => {
         expect(() => {
-            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {

--- a/packages/integration-karma/test/component/decorators/wire/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/wire/index.spec.js
@@ -5,6 +5,8 @@ import { adapter } from 'x/adapter';
 describe('restrictions', () => {
     it('throws a property error when a wired field conflicts with a method', () => {
         expect(() => {
+            // The following class is wrapper by the compiler with registerDecorators. We check here
+            // if the fields are validated properly.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class Invalid extends LightningElement {
                 @wire(adapter) showFeatures;

--- a/packages/integration-karma/test/component/decorators/wire/x/adapter/adapter.js
+++ b/packages/integration-karma/test/component/decorators/wire/x/adapter/adapter.js
@@ -1,0 +1,1 @@
+export function adapter() {}

--- a/packages/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/integration-karma/test/component/observed-fields/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, LightningElement } from 'lwc';
 
 import Simple from 'x/simple';
 import SideEffect from './x/fieldWithSideEffect/fieldWithSideEffect';
@@ -127,6 +127,20 @@ describe('observed-fields', () => {
         return Promise.resolve().then(() => {
             expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
                 'static value modified'
+            );
+        });
+    });
+
+    describe('restrictions', () => {
+        it('throws a property error when a reactive field conflicts with a method', () => {
+            expect(() => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                class Invalid extends LightningElement {
+                    showFeatures;
+                    showFeatures() {}
+                }
+            }).toThrowError(
+                'Invalid observed showFeatures field. Found a duplicate method with the same name.'
             );
         });
     });

--- a/packages/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/integration-karma/test/component/observed-fields/index.spec.js
@@ -134,6 +134,8 @@ describe('observed-fields', () => {
     describe('restrictions', () => {
         it('throws a property error when a reactive field conflicts with a method', () => {
             expect(() => {
+                // The following class is wrapper by the compiler with registerDecorators. We check
+                // here if the fields are validated properly.
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 class Invalid extends LightningElement {
                     showFeatures;

--- a/packages/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/integration-karma/test/component/observed-fields/index.spec.js
@@ -134,7 +134,7 @@ describe('observed-fields', () => {
     describe('restrictions', () => {
         it('throws a property error when a reactive field conflicts with a method', () => {
             expect(() => {
-                // The following class is wrapper by the compiler with registerDecorators. We check
+                // The following class is wrapped by the compiler with registerDecorators. We check
                 // here if the fields are validated properly.
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 class Invalid extends LightningElement {


### PR DESCRIPTION
## Details

This PR improves the error message for decorator validation.
- Indicate that the decorated field is conflicting with another class member (method, accessor)
- Remove unnecessary process.env.NODE_ENV check. Invocation is already wrapped in env check
- Add tests

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-8651291
