### PR TITLE
fix(synthetic-shadow): fix event propagation regression

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -385,10 +385,10 @@ function shouldInvokeShadowRootListener(event: Event): boolean {
             if (isTrue(eventToShadowRootMap.has(event))) {
                 shouldInvoke = false;
             } else {
-                const rootNode = getRootNodeHost(target as Node, { composed });
-                shouldInvoke =
-                    isChildNode(rootNode as HTMLElement, currentTarget as Node) ||
-                    rootNode === currentTarget;
+                const targetHost = getRootNodeHost(target as Node, { composed }) as HTMLElement;
+                const currentTargetHost = currentTarget as HTMLElement;
+                const isCurrentTargetSlotted = isChildNode(targetHost, currentTargetHost);
+                shouldInvoke = isCurrentTargetSlotted || targetHost === currentTargetHost;
             }
         }
     }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -18,11 +18,7 @@ import {
     getHiddenField,
     setHiddenField,
 } from '@lwc/shared';
-import {
-    addShadowRootEventListener,
-    removeShadowRootEventListener,
-    setEventFromShadowRoot,
-} from './events';
+import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import { dispatchEvent } from '../env/event-target';
 import {
     shadowRootQuerySelector,
@@ -266,6 +262,8 @@ const ShadowRootDescriptors = {
     },
 };
 
+export const eventToShadowRootMap = new WeakMap<Event, SyntheticShadowRootInterface>();
+
 const NodePatchDescriptors = {
     insertBefore: {
         writable: true,
@@ -325,7 +323,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface, evt: Event): boolean {
-            setEventFromShadowRoot(evt);
+            eventToShadowRootMap.set(evt, this);
             // Typescript does not like it when you treat the `arguments` object as an array
             // @ts-ignore type-mismatch
             return dispatchEvent.apply(getHost(this), arguments);

--- a/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
@@ -7,12 +7,8 @@
 import { assert, isFalse, isFunction, isUndefined } from '@lwc/shared';
 import { eventCurrentTargetGetter } from '../env/dom';
 
-import {
-    doesEventNeedPatch,
-    eventsDispatchedDirectlyOnShadowRoot,
-    patchEvent,
-} from '../faux-shadow/events';
-import { isHostElement } from '../faux-shadow/shadow-root';
+import { doesEventNeedPatch, patchEvent } from '../faux-shadow/events';
+import { eventToShadowRootMap, isHostElement } from '../faux-shadow/shadow-root';
 
 const EventListenerMap: WeakMap<EventListenerOrEventListenerObject, EventListener> = new WeakMap();
 
@@ -36,7 +32,7 @@ export function getEventListenerWrapper(
             // TODO [#2121]: We should also be filtering out other non-composed events at this point
             // but we only do so for events dispatched via shadowRoot.dispatchEvent() to preserve
             // the current behavior.
-            if (eventsDispatchedDirectlyOnShadowRoot.has(event) && isFalse(composed)) {
+            if (eventToShadowRootMap.has(event) && isFalse(composed)) {
                 return;
             }
 

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -306,7 +306,14 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     }
 
     function extractShadowDataIds(shadowRoot) {
-        const nodes = {};
+        var nodes = {};
+
+        // Add the shadow root here even if they don't have [data-id] attributes. This reference is
+        // subsequently used to add event listeners.
+        var dataId = shadowRoot.host.getAttribute('data-id');
+        if (dataId) {
+            nodes[dataId + '.shadowRoot'] = shadowRoot;
+        }
 
         // We can't use a TreeWalker directly on the ShadowRoot since with synthetic shadow the ShadowRoot is not an
         // actual DOM nodes. So we need to iterate over the children manually and run the tree walker on each child.

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -6,16 +6,21 @@ import { extractDataIds } from 'test-utils';
 
 import Container from 'x/container';
 
-function dispatchEventWithLog(target, event) {
-    var log = [];
-    for (var node = target; node; node = node.parentNode || node.host) {
+function dispatchEventWithLog(target, nodes, event) {
+    const log = [];
+
+    // We take this appraoch instead of traversing up the DOM from the target, so that we can add
+    // listeners to targets that cannot be reached by parentNode/host traversal (e.g., shadow roots
+    // of components containing assigned slots).
+    [...Object.values(nodes), document.body, document.documentElement, document].forEach((node) => {
         node.addEventListener(
             event.type,
             function (event) {
                 log.push([this, event.target, event.composedPath()]);
             }.bind(node)
         );
-    }
+    });
+
     target.dispatchEvent(event);
     return log;
 }
@@ -36,7 +41,7 @@ describe('event propagation', () => {
 
         it('{bubbles: true, composed: true}', () => {
             const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const actualLogs = dispatchEventWithLog(nodes.button, event);
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
 
             const composedPath = [
                 nodes.button,
@@ -62,6 +67,9 @@ describe('event propagation', () => {
                 [nodes['x-button'].shadowRoot, nodes.button, composedPath],
                 [nodes['x-button'], nodes['x-button'], composedPath],
                 [nodes.container_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
                 [nodes['x-button-group'], nodes['x-button'], composedPath],
                 [nodes.container_div, nodes['x-button'], composedPath],
                 [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
@@ -76,7 +84,7 @@ describe('event propagation', () => {
 
         it('{bubbles: true, composed: false}', () => {
             const event = new CustomEvent('test', { bubbles: true, composed: false });
-            const actualLogs = dispatchEventWithLog(nodes.button, event);
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
 
             const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
 
@@ -93,6 +101,8 @@ describe('event propagation', () => {
                     [nodes.button_div, nodes.button, composedPath],
                     [nodes['x-button'].shadowRoot, nodes.button, composedPath],
                     [nodes.container_slot, null, composedPath],
+                    [nodes.button_group_slot, null, composedPath],
+                    [nodes.button_group_div, null, composedPath],
                     [nodes.container_div, null, composedPath],
                     [document.body, null, composedPath],
                     [document.documentElement, null, composedPath],
@@ -105,7 +115,7 @@ describe('event propagation', () => {
 
         it('{bubbles: false, composed: true}', () => {
             const event = new CustomEvent('test', { bubbles: false, composed: true });
-            const actualLogs = dispatchEventWithLog(nodes.button, event);
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
 
             const composedPath = [
                 nodes.button,
@@ -142,7 +152,7 @@ describe('event propagation', () => {
 
         it('{bubbles: false, composed: false}', () => {
             const event = new CustomEvent('test', { bubbles: false, composed: false });
-            const actualLogs = dispatchEventWithLog(nodes.button, event);
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
 
             const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
             const expectedLogs = [[nodes.button, nodes.button, composedPath]];
@@ -159,7 +169,7 @@ describe('event propagation', () => {
 
         it('{bubbles: true, composed: true}', () => {
             const event = new CustomEvent('test', { bubbles: true, composed: true });
-            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
 
             const composedPath = [
                 nodes['x-button'],
@@ -179,6 +189,9 @@ describe('event propagation', () => {
             const expectedLogs = [
                 [nodes['x-button'], nodes['x-button'], composedPath],
                 [nodes.container_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
                 [nodes['x-button-group'], nodes['x-button'], composedPath],
                 [nodes.container_div, nodes['x-button'], composedPath],
                 [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
@@ -193,7 +206,7 @@ describe('event propagation', () => {
 
         it('{bubbles: true, composed: false}', () => {
             const event = new CustomEvent('test', { bubbles: true, composed: false });
-            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
 
             const composedPath = [
                 nodes['x-button'],
@@ -211,6 +224,9 @@ describe('event propagation', () => {
                 expectedLogs = [
                     [nodes['x-button'], nodes['x-button'], composedPath],
                     [nodes.container_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_div, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
                     [nodes['x-button-group'], nodes['x-button'], composedPath],
                     [nodes.container_div, nodes['x-button'], composedPath],
                     [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
@@ -219,6 +235,9 @@ describe('event propagation', () => {
                 expectedLogs = [
                     [nodes['x-button'], nodes['x-button'], composedPath],
                     [nodes.container_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_div, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
                     [nodes['x-button-group'], nodes['x-button'], composedPath],
                     [nodes.container_div, nodes['x-button'], composedPath],
                     [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
@@ -233,7 +252,7 @@ describe('event propagation', () => {
 
         it('{bubbles: false, composed: true}', () => {
             const event = new CustomEvent('test', { bubbles: false, composed: true });
-            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
 
             const composedPath = [
                 nodes['x-button'],
@@ -266,7 +285,7 @@ describe('event propagation', () => {
 
         it('{bubbles: false, composed: false}', () => {
             const event = new CustomEvent('test', { bubbles: false, composed: false });
-            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
 
             const composedPath = [
                 nodes['x-button'],

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -1,0 +1,286 @@
+// Inspired from WPT:
+// https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/event-inside-shadow-tree.html
+
+import { createElement } from 'lwc';
+import { extractDataIds } from 'test-utils';
+
+import Container from 'x/container';
+
+function dispatchEventWithLog(target, event) {
+    var log = [];
+    for (var node = target; node; node = node.parentNode || node.host) {
+        node.addEventListener(
+            event.type,
+            function (event) {
+                log.push([this, event.target, event.composedPath()]);
+            }.bind(node)
+        );
+    }
+    target.dispatchEvent(event);
+    return log;
+}
+
+function createTestElement(parentNode) {
+    const elm = createElement('x-container', { is: Container });
+    elm.setAttribute('data-id', 'x-container');
+    parentNode.appendChild(elm);
+    return extractDataIds(elm);
+}
+
+describe('event propagation', () => {
+    describe('dispatched on native element', () => {
+        let nodes;
+        beforeEach(() => {
+            nodes = createTestElement(document.body);
+        });
+
+        it('{bubbles: true, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes.button, event);
+
+            const composedPath = [
+                nodes.button,
+                nodes.button_div,
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            const expectedLogs = [
+                [nodes.button, nodes.button, composedPath],
+                [nodes.button_div, nodes.button, composedPath],
+                [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.container_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-container'], nodes['x-container'], composedPath],
+                [document.body, nodes['x-container'], composedPath],
+                [document.documentElement, nodes['x-container'], composedPath],
+                [document, nodes['x-container'], composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: true, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes.button, event);
+
+            const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes.button_div, nodes.button, composedPath],
+                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                ];
+            } else {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes.button_div, nodes.button, composedPath],
+                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                    [nodes.container_slot, null, composedPath],
+                    [nodes.container_div, null, composedPath],
+                    [document.body, null, composedPath],
+                    [document.documentElement, null, composedPath],
+                    [document, null, composedPath],
+                ];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes.button, event);
+
+            const composedPath = [
+                nodes.button,
+                nodes.button_div,
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes['x-container'], nodes['x-container'], composedPath],
+                ];
+            } else {
+                expectedLogs = [[nodes.button, nodes.button, composedPath]];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes.button, event);
+
+            const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
+            const expectedLogs = [[nodes.button, nodes.button, composedPath]];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+    });
+
+    describe('dispatched on host', () => {
+        let nodes;
+        beforeEach(() => {
+            nodes = createTestElement(document.body);
+        });
+
+        it('{bubbles: true, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            const expectedLogs = [
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.container_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-container'], nodes['x-container'], composedPath],
+                [document.body, nodes['x-container'], composedPath],
+                [document.documentElement, nodes['x-container'], composedPath],
+                [document, nodes['x-container'], composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: true, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes.container_slot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'], nodes['x-button'], composedPath],
+                    [nodes.container_div, nodes['x-button'], composedPath],
+                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                ];
+            } else {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes.container_slot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'], nodes['x-button'], composedPath],
+                    [nodes.container_div, nodes['x-button'], composedPath],
+                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                    [document.body, null, composedPath],
+                    [document.documentElement, null, composedPath],
+                    [document, null, composedPath],
+                ];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes['x-container'], nodes['x-container'], composedPath],
+                ];
+            } else {
+                expectedLogs = [[nodes['x-button'], nodes['x-button'], composedPath]];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.container_slot,
+                nodes.button_group_slot,
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+            ];
+            const expectedLogs = [[nodes['x-button'], nodes['x-button'], composedPath]];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+    });
+});

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.html
@@ -1,0 +1,5 @@
+<template>
+    <div data-id="button_div">
+        <button data-id="button"></button>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
@@ -1,5 +1,7 @@
 <template>
     <div data-id="button_group_div">
-        <slot data-id="button_group_slot"></slot>
+        <x-button-group-internal data-id="x-button-group-internal">
+            <slot data-id="button_group_slot"></slot>
+        </x-button-group-internal>
     </div>
 </template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
@@ -1,0 +1,5 @@
+<template>
+    <div data-id="button_group_div">
+        <slot data-id="button_group_slot"></slot>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.html
@@ -1,0 +1,3 @@
+<template>
+    <slot data-id="button_group_internal_slot"></slot>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
@@ -1,0 +1,9 @@
+<template>
+    <div data-id="container_div">
+        <x-button-group data-id="x-button-group">
+            <slot data-id="container_slot">
+                <x-button data-id="x-button"></x-button>
+            </slot>
+        </x-button-group>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
@@ -1,9 +1,7 @@
 <template>
     <div data-id="container_div">
         <x-button-group data-id="x-button-group">
-            <slot data-id="container_slot">
-                <x-button data-id="x-button"></x-button>
-            </slot>
+            <x-button data-id="x-button"></x-button>
         </x-button-group>
     </div>
 </template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

This PR applies changes to a branch based off of v1.10.1.

Fixes an event propagation regression introduced in v1.10.0. Test coverage that would have detected this regression has been added in the form of a repro.

Added tests in `propagation.spec.js` currently overlap in coverage with `event-propagation.spec.js` and will eventually replace `event-propagation.spec.js`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8588420