### PR TITLE
fix(synthetic-shadow): fix event propagation regression

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -260,7 +260,7 @@ function shouldInvokeCustomElementListener(event: Event): boolean {
     }
 
     // If this {composed: false} event was dispatched on any root.
-    if (eventToShadowRootMap.get(event)) {
+    if (eventToShadowRootMap.has(event)) {
         return false;
     }
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -20,7 +20,12 @@ import {
     isUndefined,
     toString,
 } from '@lwc/shared';
-import { getHost, SyntheticShadowRootInterface, getShadowRoot } from './shadow-root';
+import {
+    eventToShadowRootMap,
+    getHost,
+    getShadowRoot,
+    SyntheticShadowRootInterface,
+} from './shadow-root';
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { retarget } from '../3rdparty/polymer/retarget';
 import { eventCurrentTargetGetter, eventTargetGetter } from '../env/dom';
@@ -114,12 +119,6 @@ function getEventMap(elm: EventTarget): ListenerMap {
         customElementToWrappedListeners.set(elm, listenerInfo);
     }
     return listenerInfo;
-}
-
-export const eventsDispatchedDirectlyOnShadowRoot: WeakSet<Event> = new WeakSet();
-
-export function setEventFromShadowRoot(event: Event) {
-    eventsDispatchedDirectlyOnShadowRoot.add(event);
 }
 
 const shadowRootEventListenerMap: WeakMap<EventListener, WrappedListener> = new WeakMap();
@@ -263,7 +262,7 @@ function shouldInvokeCustomEventListener(event: Event): boolean {
         shouldInvoke = true;
     } else if (target === currentTarget) {
         // Address the possibility that `target` is a shadow root
-        shouldInvoke = !eventsDispatchedDirectlyOnShadowRoot.has(event);
+        shouldInvoke = !eventToShadowRootMap.has(event);
     } else {
         // it is coming from a slotted element
         shouldInvoke = isChildNode(
@@ -280,27 +279,32 @@ function shouldInvokeCustomEventListener(event: Event): boolean {
 
 function shouldInvokeShadowRootListener(event: Event): boolean {
     const { composed } = event;
+    const target = eventTargetGetter.call(event);
+    const currentTarget = eventCurrentTargetGetter.call(event);
 
     let shouldInvoke = false;
 
-    if (isTrue(composed)) {
-        shouldInvoke = true;
+    // If the listener is bound to a host and the event was dispatched on either said host or its
+    // associated root.
+    if (target === currentTarget) {
+        // If the event was dispatched directly on the associated root of said host.
+        if (eventToShadowRootMap.get(event) === getShadowRoot(target as Element)) {
+            shouldInvoke = true;
+        }
     } else {
-        const target = eventTargetGetter.call(event);
-        const currentTarget = eventCurrentTargetGetter.call(event);
-
-        if (eventsDispatchedDirectlyOnShadowRoot.has(event)) {
-            // If this event was directly dispatched on a root, then we should only handle
-            // it if it was dispatched on the current root because {composed: false} here.
-            shouldInvoke = target === currentTarget;
+        // The event has bubbled up to this root from a shadow-including descendant node.
+        if (isTrue(composed)) {
+            shouldInvoke = true;
         } else {
-            // The event was not dispatched directly on the current root so it must be bubbles:true.
-            // { bubbles: true, composed: false }
-
-            // Only invoke the listener if the target element is in the current root.
-            const currentRoot = getShadowRoot(currentTarget as HTMLElement);
-            const targetRoot = (target as HTMLElement).getRootNode();
-            shouldInvoke = currentRoot === targetRoot;
+            // If this non-composed event was dispatched on a descendant shadow root.
+            if (isTrue(eventToShadowRootMap.has(event))) {
+                shouldInvoke = false;
+            } else {
+                const targetHost = getRootNodeHost(target as Node, { composed }) as HTMLElement;
+                const currentTargetHost = currentTarget as HTMLElement;
+                const isCurrentTargetSlotted = isChildNode(targetHost, currentTargetHost);
+                shouldInvoke = isCurrentTargetSlotted || targetHost === currentTargetHost;
+            }
         }
     }
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -18,11 +18,7 @@ import {
     getHiddenField,
     setHiddenField,
 } from '@lwc/shared';
-import {
-    addShadowRootEventListener,
-    removeShadowRootEventListener,
-    setEventFromShadowRoot,
-} from './events';
+import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import { dispatchEvent } from '../env/event-target';
 import {
     shadowRootQuerySelector,
@@ -266,6 +262,8 @@ const ShadowRootDescriptors = {
     },
 };
 
+export const eventToShadowRootMap = new WeakMap<Event, SyntheticShadowRootInterface>();
+
 const NodePatchDescriptors = {
     insertBefore: {
         writable: true,
@@ -325,7 +323,7 @@ const NodePatchDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface, evt: Event): boolean {
-            setEventFromShadowRoot(evt);
+            eventToShadowRootMap.set(evt, this);
             // Typescript does not like it when you treat the `arguments` object as an array
             // @ts-ignore type-mismatch
             return dispatchEvent.apply(getHost(this), arguments);

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -8,8 +8,7 @@ import { defineProperties, isNull, isUndefined } from '@lwc/shared';
 import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { retarget } from '../../3rdparty/polymer/retarget';
 import { eventTargetGetter, eventCurrentTargetGetter } from '../../env/dom';
-import { eventsDispatchedDirectlyOnShadowRoot } from '../../faux-shadow/events';
-import { getShadowRoot, isHostElement } from '../../faux-shadow/shadow-root';
+import { eventToShadowRootMap, getShadowRoot, isHostElement } from '../../faux-shadow/shadow-root';
 import { EventListenerContext, eventToContextMap } from '../../faux-shadow/events';
 import { getNodeOwnerKey } from '../../shared/node-ownership';
 import { getOwnerDocument } from '../../shared/utils';
@@ -54,7 +53,7 @@ function patchedTargetGetter(this: Event): EventTarget | null {
     }
 
     // Address the possibility that `target` is a shadow root
-    if (isHostElement(originalTarget) && eventsDispatchedDirectlyOnShadowRoot.has(this)) {
+    if (isHostElement(originalTarget) && eventToShadowRootMap.has(this)) {
         actualPath = pathComposer(getShadowRoot(originalTarget), this.composed);
     }
 
@@ -72,7 +71,7 @@ function patchedComposedPathValue(this: Event): EventTarget[] {
 
     // Address the possibility that `target` is a shadow root
     let actualTarget = originalTarget;
-    if (isHostElement(originalTarget) && eventsDispatchedDirectlyOnShadowRoot.has(this)) {
+    if (isHostElement(originalTarget) && eventToShadowRootMap.has(this)) {
         actualTarget = getShadowRoot(originalTarget);
     }
 

--- a/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
@@ -7,12 +7,8 @@
 import { assert, isFalse, isFunction, isUndefined } from '@lwc/shared';
 import { eventCurrentTargetGetter } from '../env/dom';
 
-import {
-    doesEventNeedPatch,
-    eventsDispatchedDirectlyOnShadowRoot,
-    patchEvent,
-} from '../faux-shadow/events';
-import { isHostElement } from '../faux-shadow/shadow-root';
+import { doesEventNeedPatch, patchEvent } from '../faux-shadow/events';
+import { eventToShadowRootMap, isHostElement } from '../faux-shadow/shadow-root';
 
 const EventListenerMap: WeakMap<EventListenerOrEventListenerObject, EventListener> = new WeakMap();
 
@@ -36,7 +32,7 @@ export function getEventListenerWrapper(
             // TODO [#2121]: We should also be filtering out other non-composed events at this point
             // but we only do so for events dispatched via shadowRoot.dispatchEvent() to preserve
             // the current behavior.
-            if (eventsDispatchedDirectlyOnShadowRoot.has(event) && isFalse(composed)) {
+            if (eventToShadowRootMap.has(event) && isFalse(composed)) {
                 return;
             }
 

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -306,7 +306,14 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     }
 
     function extractShadowDataIds(shadowRoot) {
-        const nodes = {};
+        var nodes = {};
+
+        // Add the shadow root here even if they don't have [data-id] attributes. This reference is
+        // subsequently used to add event listeners.
+        var dataId = shadowRoot.host.getAttribute('data-id');
+        if (dataId) {
+            nodes[dataId + '.shadowRoot'] = shadowRoot;
+        }
 
         // We can't use a TreeWalker directly on the ShadowRoot since with synthetic shadow the ShadowRoot is not an
         // actual DOM nodes. So we need to iterate over the children manually and run the tree walker on each child.

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -38,33 +38,6 @@ describe('event propagation in simple shadow tree', () => {
         nodes = createShadowTree(document.body);
     });
 
-    it('propagate event from a child element', () => {
-        const logs = dispatchEventWithLog(
-            nodes.span,
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
-
-        const composedPath = [
-            nodes.span,
-            nodes.div,
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes.span, nodes.span, composedPath],
-            [nodes.div, nodes.span, composedPath],
-            [nodes['x-shadow-tree'].shadowRoot, nodes.span, composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [document.body, nodes['x-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-shadow-tree'], composedPath],
-            [document, nodes['x-shadow-tree'], composedPath],
-        ]);
-    });
-
     it('propagate event from a child element added via lwc:dom="manual"', () => {
         // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
         return new Promise((resolve) => {
@@ -95,27 +68,6 @@ describe('event propagation in simple shadow tree', () => {
                 [document, nodes['x-shadow-tree'], composedPath],
             ]);
         });
-    });
-
-    it('propagate event from a host element', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'],
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
-
-        const composedPath = [
-            nodes['x-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [document.body, nodes['x-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-shadow-tree'], composedPath],
-            [document, nodes['x-shadow-tree'], composedPath],
-        ]);
     });
 
     describe('parent with declarative handlers', () => {
@@ -208,37 +160,6 @@ describe('composed and bubbling event propagation in nested shadow tree', () => 
         nodes = createNestedShadowTree(document.body);
     });
 
-    it('propagate event from a child element', () => {
-        const logs = dispatchEventWithLog(
-            nodes.span,
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
-
-        const composedPath = [
-            nodes.span,
-            nodes.div,
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            nodes['x-nested-shadow-tree'].shadowRoot,
-            nodes['x-nested-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes.span, nodes.span, composedPath],
-            [nodes.div, nodes.span, composedPath],
-            [nodes['x-shadow-tree'].shadowRoot, nodes.span, composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'], nodes['x-nested-shadow-tree'], composedPath],
-            [document.body, nodes['x-nested-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-nested-shadow-tree'], composedPath],
-            [document, nodes['x-nested-shadow-tree'], composedPath],
-        ]);
-    });
-
     it('propagate event from a child element added via lwc:dom="manual"', () => {
         // Fire the event in next macrotask to allow time for the MO to key the manually inserted nodes
         return new Promise((resolve) => {
@@ -274,60 +195,12 @@ describe('composed and bubbling event propagation in nested shadow tree', () => 
             ]);
         });
     });
-
-    it('propagate event from an inner host', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'],
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
-
-        const composedPath = [
-            nodes['x-shadow-tree'],
-            nodes['x-nested-shadow-tree'].shadowRoot,
-            nodes['x-nested-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'], nodes['x-nested-shadow-tree'], composedPath],
-            [document.body, nodes['x-nested-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-nested-shadow-tree'], composedPath],
-            [document, nodes['x-nested-shadow-tree'], composedPath],
-        ]);
-    });
 });
 
 describe('non-composed and bubbling event propagation in nested shadow tree', () => {
     let nodes;
     beforeEach(() => {
         nodes = createNestedShadowTree(document.body);
-    });
-
-    it('propagate event from a child element', () => {
-        const logs = dispatchEventWithLog(
-            nodes.span,
-            new CustomEvent('test', { composed: false, bubbles: true })
-        );
-
-        const composedPath = [nodes.span, nodes.div, nodes['x-shadow-tree'].shadowRoot];
-        const expectedLogs = [
-            [nodes.span, nodes.span, composedPath],
-            [nodes.div, nodes.span, composedPath],
-            [nodes['x-shadow-tree'].shadowRoot, nodes.span, composedPath],
-        ];
-        if (!process.env.NATIVE_SHADOW) {
-            // TODO [#1569]: Listeners on the following targets should not be invoked when the event is non-composed.
-            expectedLogs.push(
-                [document.body, null, composedPath],
-                [document.documentElement, null, composedPath],
-                [document, null, composedPath]
-            );
-        }
-        expect(logs).toEqual(expectedLogs);
     });
 
     it('propagate event from a child element added via lwc:dom="manual"', () => {
@@ -360,28 +233,6 @@ describe('non-composed and bubbling event propagation in nested shadow tree', ()
             }
             expect(logs).toEqual(expectedLogs);
         });
-    });
-
-    it('propagate event from an inner host', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'],
-            new CustomEvent('test', { composed: false, bubbles: true })
-        );
-
-        const composedPath = [nodes['x-shadow-tree'], nodes['x-nested-shadow-tree'].shadowRoot];
-        const expectedLogs = [
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
-        ];
-        if (!process.env.NATIVE_SHADOW) {
-            // TODO [#1569]: Listeners on the following targets should not be invoked when the event is non-composed.
-            expectedLogs.push(
-                [document.body, null, composedPath],
-                [document.documentElement, null, composedPath],
-                [document, null, composedPath]
-            );
-        }
-        expect(logs).toEqual(expectedLogs);
     });
 });
 
@@ -447,101 +298,6 @@ describe('Event.stopImmediatePropagation', () => {
                     window,
                 ],
             ],
-        ]);
-    });
-});
-
-describe('when dispatched on shadowRoot', () => {
-    let nodes;
-
-    beforeEach(() => {
-        nodes = createNestedShadowTree(document.body);
-    });
-
-    it('{ bubbles: true, composed: true }', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'].shadowRoot,
-            new CustomEvent('test', { bubbles: true, composed: true })
-        );
-
-        const composedPath = [
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            nodes['x-nested-shadow-tree'].shadowRoot,
-            nodes['x-nested-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(logs).toEqual([
-            [nodes['x-shadow-tree'].shadowRoot, nodes['x-shadow-tree'].shadowRoot, composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'].shadowRoot, nodes['x-shadow-tree'], composedPath],
-            [nodes['x-nested-shadow-tree'], nodes['x-nested-shadow-tree'], composedPath],
-            [document.body, nodes['x-nested-shadow-tree'], composedPath],
-            [document.documentElement, nodes['x-nested-shadow-tree'], composedPath],
-            [document, nodes['x-nested-shadow-tree'], composedPath],
-        ]);
-    });
-
-    it('{ bubbles: false, composed: true }', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'].shadowRoot,
-            new CustomEvent('test', { bubbles: false, composed: true })
-        );
-
-        const composedPath = [
-            nodes['x-shadow-tree'].shadowRoot,
-            nodes['x-shadow-tree'],
-            nodes['x-nested-shadow-tree'].shadowRoot,
-            nodes['x-nested-shadow-tree'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-
-        const expectedLogs = [
-            [nodes['x-shadow-tree'].shadowRoot, nodes['x-shadow-tree'].shadowRoot, composedPath],
-            [nodes['x-shadow-tree'], nodes['x-shadow-tree'], composedPath],
-        ];
-
-        // TODO [#1138]: Composed and non-bubbling events should invoke all ancestor host listeners
-        if (process.env.NATIVE_SHADOW) {
-            expectedLogs.push([
-                nodes['x-nested-shadow-tree'],
-                nodes['x-nested-shadow-tree'],
-                composedPath,
-            ]);
-        }
-
-        expect(logs).toEqual(expectedLogs);
-    });
-
-    it('{ bubbles: true, composed: false }', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'].shadowRoot,
-            new CustomEvent('test', { bubbles: true, composed: false })
-        );
-
-        const composedPath = [nodes['x-shadow-tree'].shadowRoot];
-
-        expect(logs).toEqual([
-            [nodes['x-shadow-tree'].shadowRoot, nodes['x-shadow-tree'].shadowRoot, composedPath],
-        ]);
-    });
-
-    it('{ bubbles: false, composed: false }', () => {
-        const logs = dispatchEventWithLog(
-            nodes['x-shadow-tree'].shadowRoot,
-            new CustomEvent('test', { bubbles: false, composed: false })
-        );
-
-        const composedPath = [nodes['x-shadow-tree'].shadowRoot];
-
-        expect(logs).toEqual([
-            [nodes['x-shadow-tree'].shadowRoot, nodes['x-shadow-tree'].shadowRoot, composedPath],
         ]);
     });
 });

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -165,7 +165,7 @@ describe('event propagation', () => {
         });
     });
 
-    describe('dispatched on host', () => {
+    describe('dispatched on host element', () => {
         let nodes;
         beforeEach(() => {
             nodes = createTestElement();
@@ -318,6 +318,121 @@ describe('event propagation', () => {
                 nodes['x-container'].shadowRoot,
             ];
             const expectedLogs = [[nodes['x-button'], nodes['x-button'], composedPath]];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+    });
+
+    describe('dispatched on shadow root', () => {
+        let nodes;
+        beforeEach(() => {
+            nodes = createTestElement();
+        });
+
+        it('{bubbles: true, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'].shadowRoot, nodes, event);
+
+            const composedPath = [
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            const expectedLogs = [
+                [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-container'], nodes['x-container'], composedPath],
+                [document.body, nodes['x-container'], composedPath],
+                [document.documentElement, nodes['x-container'], composedPath],
+                [document, nodes['x-container'], composedPath],
+                [window, nodes['x-container'], composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: true, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'].shadowRoot, nodes, event);
+
+            const composedPath = [nodes['x-button'].shadowRoot];
+            const expectedLogs = [
+                [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'].shadowRoot, nodes, event);
+
+            const composedPath = [
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes['x-container'], nodes['x-container'], composedPath],
+                ];
+            } else {
+                expectedLogs = [
+                    [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                ];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'].shadowRoot, nodes, event);
+
+            const composedPath = [nodes['x-button'].shadowRoot];
+            const expectedLogs = [
+                [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
+            ];
 
             expect(actualLogs).toEqual(expectedLogs);
         });

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -1,0 +1,328 @@
+// Inspired from WPT:
+// https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/event-inside-shadow-tree.html
+
+import { createElement } from 'lwc';
+import { extractDataIds } from 'test-utils';
+
+import Container from 'x/container';
+
+function dispatchEventWithLog(target, nodes, event) {
+    const log = [];
+
+    [...Object.values(nodes), document.body, document.documentElement, document, window].forEach(
+        (node) => {
+            node.addEventListener(
+                event.type,
+                function (event) {
+                    log.push([this, event.target, event.composedPath()]);
+                }.bind(node)
+            );
+        }
+    );
+
+    target.dispatchEvent(event);
+    return log;
+}
+
+function createTestElement() {
+    const elm = createElement('x-container', { is: Container });
+    elm.setAttribute('data-id', 'x-container');
+    document.body.appendChild(elm);
+    return extractDataIds(elm);
+}
+
+describe('event propagation', () => {
+    describe('dispatched on native element', () => {
+        let nodes;
+        beforeEach(() => {
+            nodes = createTestElement();
+        });
+
+        it('{bubbles: true, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
+
+            const composedPath = [
+                nodes.button,
+                nodes.button_div,
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            const expectedLogs = [
+                [nodes.button, nodes.button, composedPath],
+                [nodes.button_div, nodes.button, composedPath],
+                [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-container'], nodes['x-container'], composedPath],
+                [document.body, nodes['x-container'], composedPath],
+                [document.documentElement, nodes['x-container'], composedPath],
+                [document, nodes['x-container'], composedPath],
+                [window, nodes['x-container'], composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: true, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
+
+            const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes.button_div, nodes.button, composedPath],
+                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                ];
+            } else {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes.button_div, nodes.button, composedPath],
+                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+                    [nodes.button_group_slot, null, composedPath],
+                    [nodes.button_group_internal_slot, null, composedPath],
+                    [nodes.button_group_div, null, composedPath],
+                    [nodes.container_div, null, composedPath],
+                    [document.body, null, composedPath],
+                    [document.documentElement, null, composedPath],
+                    [document, null, composedPath],
+                    [window, null, composedPath],
+                ];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
+
+            const composedPath = [
+                nodes.button,
+                nodes.button_div,
+                nodes['x-button'].shadowRoot,
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes.button, nodes.button, composedPath],
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes['x-container'], nodes['x-container'], composedPath],
+                ];
+            } else {
+                expectedLogs = [[nodes.button, nodes.button, composedPath]];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);
+
+            const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
+            const expectedLogs = [[nodes.button, nodes.button, composedPath]];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+    });
+
+    describe('dispatched on host', () => {
+        let nodes;
+        beforeEach(() => {
+            nodes = createTestElement();
+        });
+
+        it('{bubbles: true, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            const expectedLogs = [
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-container'], nodes['x-container'], composedPath],
+                [document.body, nodes['x-container'], composedPath],
+                [document.documentElement, nodes['x-container'], composedPath],
+                [document, nodes['x-container'], composedPath],
+                [window, nodes['x-container'], composedPath],
+            ];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: true, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes.button_group_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                    [nodes.button_group_div, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'], nodes['x-button'], composedPath],
+                    [nodes.container_div, nodes['x-button'], composedPath],
+                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                ];
+            } else {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes.button_group_slot, nodes['x-button'], composedPath],
+                    [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                    [nodes.button_group_div, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                    [nodes['x-button-group'], nodes['x-button'], composedPath],
+                    [nodes.container_div, nodes['x-button'], composedPath],
+                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+                    [document.body, null, composedPath],
+                    [document.documentElement, null, composedPath],
+                    [document, null, composedPath],
+                    [window, null, composedPath],
+                ];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: true}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: true });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+                nodes['x-container'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+
+            let expectedLogs;
+            if (process.env.NATIVE_SHADOW) {
+                expectedLogs = [
+                    [nodes['x-button'], nodes['x-button'], composedPath],
+                    [nodes['x-container'], nodes['x-container'], composedPath],
+                ];
+            } else {
+                expectedLogs = [[nodes['x-button'], nodes['x-button'], composedPath]];
+            }
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+
+        it('{bubbles: false, composed: false}', () => {
+            const event = new CustomEvent('test', { bubbles: false, composed: false });
+            const actualLogs = dispatchEventWithLog(nodes['x-button'], nodes, event);
+
+            const composedPath = [
+                nodes['x-button'],
+                nodes.button_group_slot,
+                nodes.button_group_internal_slot,
+                nodes['x-button-group-internal'].shadowRoot,
+                nodes['x-button-group-internal'],
+                nodes.button_group_div,
+                nodes['x-button-group'].shadowRoot,
+                nodes['x-button-group'],
+                nodes.container_div,
+                nodes['x-container'].shadowRoot,
+            ];
+            const expectedLogs = [[nodes['x-button'], nodes['x-button'], composedPath]];
+
+            expect(actualLogs).toEqual(expectedLogs);
+        });
+    });
+});

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -11,12 +11,9 @@ function dispatchEventWithLog(target, nodes, event) {
 
     [...Object.values(nodes), document.body, document.documentElement, document, window].forEach(
         (node) => {
-            node.addEventListener(
-                event.type,
-                function (event) {
-                    log.push([this, event.target, event.composedPath()]);
-                }.bind(node)
-            );
+            node.addEventListener(event.type, (event) => {
+                log.push([node, event.target, event.composedPath()]);
+            });
         }
     );
 

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.html
@@ -1,0 +1,5 @@
+<template>
+    <div data-id="button_div">
+        <button data-id="button"></button>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/button/button.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.html
@@ -1,0 +1,7 @@
+<template>
+    <div data-id="button_group_div">
+        <x-button-group-internal data-id="x-button-group-internal">
+            <slot data-id="button_group_slot"></slot>
+        </x-button-group-internal>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroup/buttonGroup.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.html
@@ -1,0 +1,3 @@
+<template>
+    <slot data-id="button_group_internal_slot"></slot>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/buttonGroupInternal/buttonGroupInternal.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.html
@@ -1,0 +1,7 @@
+<template>
+    <div data-id="container_div">
+        <x-button-group data-id="x-button-group">
+            <x-button data-id="x-button"></x-button>
+        </x-button-group>
+    </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/x/container/container.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

- Fixes an event propagation regression introduced in v1.10.0.
- Added test coverage that would have detected this regression.
- Move tests that dispatch an event on the shadow root.
- Refactor `shouldInvokeShadowRootListener()` to use multiple return statements instead of a single one at the end for improved readability.
- Fixes a minor bug for events dispatched on shadow roots so that ancestor host elements don't handle these.
- Will move the remaining propagation tests in a subsequent pull request.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8588420