### PR TITLE
fix: unblock shadow methods

### DIFF
--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -162,12 +162,7 @@ export function patchElementWithRestrictions(elm: Element, options: { isPortal: 
     defineProperties(elm, descriptors);
 }
 
-const BLOCKED_SHADOW_ROOT_METHODS = [
-    'cloneNode',
-    'getElementById',
-    'getSelection',
-    'elementsFromPoint',
-];
+const BLOCKED_SHADOW_ROOT_METHODS = ['cloneNode', 'getElementById'];
 
 function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -229,7 +229,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface, _left: number, _top: number): Element[] {
-            throw new Error('Disallowed method "elementsFromPoint" in ShadowRoot.');
+            throw new Error('Disallowed method "elementsFromPoint" on ShadowRoot.');
         },
     },
     getSelection: {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -237,7 +237,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface): Selection | null {
-            throw new Error('Disallowed method "getSelection" in ShadowRoot.');
+            throw new Error('Disallowed method "getSelection" on ShadowRoot.');
         },
     },
     host: {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -229,7 +229,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface, _left: number, _top: number): Element[] {
-            throw new Error(`Disallowed method "elementsFromPoint" in ShadowRoot.`);
+            throw new Error('Disallowed method "elementsFromPoint" in ShadowRoot.');
         },
     },
     getSelection: {
@@ -237,7 +237,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface): Selection | null {
-            throw new Error(`Disallowed method "getSelection" in ShadowRoot.`);
+            throw new Error('Disallowed method "getSelection" in ShadowRoot.');
         },
     },
     host: {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -229,7 +229,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface, _left: number, _top: number): Element[] {
-            throw new Error();
+            throw new Error(`Disallowed method "elementsFromPoint" in ShadowRoot.`);
         },
     },
     getSelection: {
@@ -237,7 +237,7 @@ const ShadowRootDescriptors = {
         enumerable: true,
         configurable: true,
         value(this: SyntheticShadowRootInterface): Selection | null {
-            throw new Error();
+            throw new Error(`Disallowed method "getSelection" in ShadowRoot.`);
         },
     },
     host: {

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -94,7 +94,7 @@ if (!process.env.NATIVE_SHADOW) {
         });
 
         it(`should throw when invoking ShadowRoot.elementsFromPoint`, () => {
-            expect(() => elm.shadowRoot.elementsFromPoint(0, 0)).toThrowErrorDev(
+            expect(() => elm.shadowRoot.elementsFromPoint(0, 0)).toThrow(
                 Error,
                 `Disallowed method "elementsFromPoint" in ShadowRoot.`
             );

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -94,16 +94,14 @@ if (!process.env.NATIVE_SHADOW) {
         });
 
         it(`should throw when invoking ShadowRoot.elementsFromPoint`, () => {
-            expect(() => elm.shadowRoot.elementsFromPoint(0, 0)).toThrow(
-                Error,
-                `Disallowed method "elementsFromPoint" in ShadowRoot.`
+            expect(() => elm.shadowRoot.elementsFromPoint(0, 0)).toThrowError(
+                `Disallowed method "elementsFromPoint" on ShadowRoot.`
             );
         });
 
         it(`should throw when invoking ShadowRoot.getSelection`, () => {
-            expect(() => elm.shadowRoot.getSelection()).toThrowErrorDev(
-                Error,
-                `Disallowed method "getSelection" in ShadowRoot.`
+            expect(() => elm.shadowRoot.getSelection()).toThrowError(
+                `Disallowed method "getSelection" on ShadowRoot.`
             );
         });
     });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -66,7 +66,7 @@ describe('Properties overrides', () => {
     });
 });
 
-const SHADOW_ROOT_RESTRICTED = ['cloneNode', 'getElementById', 'getSelection', 'elementsFromPoint'];
+const SHADOW_ROOT_RESTRICTED = ['cloneNode', 'getElementById'];
 
 describe('restrictions', () => {
     let elm;
@@ -84,3 +84,27 @@ describe('restrictions', () => {
         });
     }
 });
+
+if (!process.env.NATIVE_SHADOW) {
+    describe('synthetic-shadow restrictions', () => {
+        let elm;
+
+        beforeAll(() => {
+            elm = createElement('x-test', { is: Test });
+        });
+
+        it(`should throw when invoking ShadowRoot.elementsFromPoint`, () => {
+            expect(() => elm.shadowRoot.elementsFromPoint(0, 0)).toThrowErrorDev(
+                Error,
+                `Disallowed method "elementsFromPoint" in ShadowRoot.`
+            );
+        });
+
+        it(`should throw when invoking ShadowRoot.getSelection`, () => {
+            expect(() => elm.shadowRoot.getSelection()).toThrowErrorDev(
+                Error,
+                `Disallowed method "getSelection" in ShadowRoot.`
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Details

These two methods should not be blocked in OSS as they are stable and non-experimental.