### PR TITLE
fix(synthetic-shadow): composedPath() should not throw when event.target is not an instance of Node

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -64,6 +64,12 @@ function patchedComposedPathValue(this: Event): EventTarget[] {
     const originalTarget = eventTargetGetter.call(this);
     const originalCurrentTarget = eventCurrentTargetGetter.call(this);
 
+    // Account for events with targets that are not instances of Node (e.g., when a readystatechange
+    // handler is listening on an instance of XMLHttpRequest).
+    if (!(originalTarget instanceof Node)) {
+        return [];
+    }
+
     // If the event has completed propagation, the composedPath should be an empty array.
     if (isNull(originalCurrentTarget)) {
         return [];

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
@@ -1,0 +1,34 @@
+import { createElement } from 'lwc';
+
+import Container from 'x/container';
+
+describe('Event.composedPath', () => {
+    it('should return an empty array when asynchronously invoked', function (done) {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
+
+        container.addEventListener('test', (event) => {
+            expect(event.composedPath()).toHaveSize(7);
+            setTimeout(() => {
+                expect(event.composedPath()).toHaveSize(0);
+                done();
+            });
+        });
+        const div = container.shadowRoot.querySelector('div');
+        div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+    });
+
+    it('should not throw when invoked on an event with a target that is not an instance of Node', function (done) {
+        const req = new XMLHttpRequest();
+        req.addEventListener('readystatechange', (event) => {
+            // Chrome and Safari return an empty array but Firefox returns an array containing a
+            // single instance of XMLHttpRequest.
+            expect(() => {
+                event.composedPath();
+            }).not.toThrowError();
+            done();
+        });
+        req.open('GET', 'http://localhost');
+        req.send();
+    });
+});


### PR DESCRIPTION
## Details

The `composedPath()` polyfill should account for events whose `target` is not an instance of `Node`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 

## GUS work item

W-8735932

