### PR TITLE
refactor(synthetic-shadow): account for event targets that are neither Window nor Node in path-composer

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -20,10 +20,6 @@ import { getOwnerDocument } from '../../shared/utils';
 import { isInstanceOfNativeShadowRoot } from '../../env/shadow-root';
 import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 
-interface Slotable extends Node {
-    assignedSlot: HTMLSlotElement;
-}
-
 export function pathComposer(startNode: EventTarget, composed: boolean): EventTarget[] {
     const composedPath: EventTarget[] = [];
 
@@ -40,14 +36,14 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
     while (!isNull(current)) {
         composedPath.push(current);
 
-        const _slotable: unknown = current;
-        if ((_slotable as Slotable).assignedSlot) {
-            const slotable = _slotable as Slotable;
-            const assignedSlot: HTMLSlotElement | null = slotable.assignedSlot;
+        if ((current as Element | Text).assignedSlot) {
+            // Element and Text include the Slottable mixin
+            const slottable = current as Element | Text;
+            const assignedSlot: HTMLSlotElement | null = slottable.assignedSlot;
             if (!isNull(assignedSlot)) {
                 current = assignedSlot;
             } else {
-                current = slotable.parentNode;
+                current = slottable.parentNode;
             }
         } else if (
             (current instanceof SyntheticShadowRoot || isInstanceOfNativeShadowRoot(current)) &&

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -36,14 +36,12 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
     while (!isNull(current)) {
         composedPath.push(current);
 
-        if ((current as Element | Text).assignedSlot) {
-            // Element and Text include the Slottable mixin
-            const slottable = current as Element | Text;
-            const assignedSlot: HTMLSlotElement | null = slottable.assignedSlot;
+        if (current instanceof Element || current instanceof Text) {
+            const assignedSlot: HTMLSlotElement | null = current.assignedSlot;
             if (!isNull(assignedSlot)) {
                 current = assignedSlot;
             } else {
-                current = slottable.parentNode;
+                current = current.parentNode;
             }
         } else if (
             (current instanceof SyntheticShadowRoot || isInstanceOfNativeShadowRoot(current)) &&
@@ -57,12 +55,14 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
             current = null;
         }
     }
+
     let doc: Document;
     if (startNode instanceof Window) {
         doc = startNode.document;
     } else {
         doc = getOwnerDocument(startNode as Node);
     }
+
     // event composedPath includes window when startNode's ownerRoot is document
     if ((composedPath[composedPath.length - 1] as any) === doc) {
         composedPath.push(window);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -89,10 +89,7 @@ function getWrappedShadowRootListener(
                 listener.call(sr, event);
             }
         } as WrappedListener;
-        shadowRootWrappedListener!.placement = EventListenerContext.SHADOW_ROOT_LISTENER;
-        if (process.env.NODE_ENV !== 'production') {
-            shadowRootWrappedListener!.original = listener; // for logging purposes
-        }
+        shadowRootWrappedListener.placement = EventListenerContext.SHADOW_ROOT_LISTENER;
         shadowRootEventListenerMap.set(listener, shadowRootWrappedListener);
     }
     return shadowRootWrappedListener;
@@ -112,10 +109,7 @@ function getWrappedCustomElementListener(elm: Element, listener: EventListener):
                 listener.call(elm, event);
             }
         } as WrappedListener;
-        customElementWrappedListener!.placement = EventListenerContext.CUSTOM_ELEMENT_LISTENER;
-        if (process.env.NODE_ENV !== 'production') {
-            customElementWrappedListener!.original = listener; // for logging purposes
-        }
+        customElementWrappedListener.placement = EventListenerContext.CUSTOM_ELEMENT_LISTENER;
         customElementEventListenerMap.set(listener, customElementWrappedListener);
     }
     return customElementWrappedListener;
@@ -196,7 +190,7 @@ function detachDOMListener(elm: Element, type: string, wrappedListener: WrappedL
     ) {
         ArraySplice.call(listeners, p, 1);
         // only remove from DOM if there is no other listener on the same placement
-        if (listeners!.length === 0) {
+        if (listeners.length === 0) {
             removeEventListener.call(elm, type, domListener);
         }
     }

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
@@ -30,27 +30,31 @@ describe('Event.composedPath', () => {
         req.dispatchEvent(new CustomEvent('test'));
     });
 
-    it('should return expected composed path when the target is a text node', (done) => {
-        const container = createElement('x-container', { is: Container });
-        document.body.appendChild(container);
+    // Excluding IE11 from this test involving text nodes since our IE11 shadow root polyfill
+    // injects comments outside of production for debugging purposes.
+    if (!process.env.COMPAT) {
+        it('should return expected composed path when the target is a text node', (done) => {
+            const container = createElement('x-container', { is: Container });
+            document.body.appendChild(container);
 
-        const div = container.shadowRoot.querySelector('div');
-        const child = container.shadowRoot.querySelector('x-child');
-        const textNode = child.childNodes[0];
-        const slot = textNode.assignedSlot;
+            const div = container.shadowRoot.querySelector('div');
+            const child = container.shadowRoot.querySelector('x-child');
+            const textNode = child.childNodes[0];
+            const slot = textNode.assignedSlot;
 
-        textNode.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                textNode,
-                slot,
-                child.shadowRoot,
-                child,
-                div,
-                container.shadowRoot,
-            ]);
-            done();
+            textNode.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual([
+                    textNode,
+                    slot,
+                    child.shadowRoot,
+                    child,
+                    div,
+                    container.shadowRoot,
+                ]);
+                done();
+            });
+
+            textNode.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: false }));
         });
-
-        textNode.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: false }));
-    });
+    }
 });

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
@@ -29,4 +29,28 @@ describe('Event.composedPath', () => {
         });
         req.dispatchEvent(new CustomEvent('test'));
     });
+
+    it('should return expected composed path when the target is a text node', (done) => {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
+
+        const div = container.shadowRoot.querySelector('div');
+        const child = container.shadowRoot.querySelector('x-child');
+        const textNode = child.childNodes[0];
+        const slot = textNode.assignedSlot;
+
+        textNode.addEventListener('test', (event) => {
+            expect(event.composedPath()).toEqual([
+                textNode,
+                slot,
+                child.shadowRoot,
+                child,
+                div,
+                container.shadowRoot,
+            ]);
+            done();
+        });
+
+        textNode.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: false }));
+    });
 });

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.composedPath.spec.js
@@ -3,32 +3,30 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event.composedPath', () => {
-    it('should return an empty array when asynchronously invoked', function (done) {
+    it('should return an empty array when asynchronously invoked', () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
+        let _event;
         container.addEventListener('test', (event) => {
-            expect(event.composedPath()).toHaveSize(7);
-            setTimeout(() => {
-                expect(event.composedPath()).toHaveSize(0);
-                done();
-            });
+            _event = event;
         });
+
         const div = container.shadowRoot.querySelector('div');
         div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+
+        expect(_event.composedPath()).toHaveSize(0);
     });
 
-    it('should not throw when invoked on an event with a target that is not an instance of Node', function (done) {
+    it('should not throw when invoked on an event with a target that is not an instance of Node', (done) => {
         const req = new XMLHttpRequest();
-        req.addEventListener('readystatechange', (event) => {
-            // Chrome and Safari return an empty array but Firefox returns an array containing a
-            // single instance of XMLHttpRequest.
+        req.addEventListener('test', (event) => {
+            // Not looking at return value because browsers have different implementations.
             expect(() => {
                 event.composedPath();
             }).not.toThrowError();
             done();
         });
-        req.open('GET', 'http://localhost');
-        req.send();
+        req.dispatchEvent(new CustomEvent('test'));
     });
 });

--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/child/child.html
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/child/child.html
@@ -1,4 +1,5 @@
 <template>
     <div></div>
     <div class="container-for-manually-added-span"></div>
+    <slot></slot>
 </template>

--- a/packages/integration-karma/test/shadow-dom/Event-properties/x/container/container.html
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/x/container/container.html
@@ -1,5 +1,5 @@
 <template>
     <div>
-        <x-child></x-child>
+        <x-child>text</x-child>
     </div>
 </template>


### PR DESCRIPTION
## Details

Account for instances of `EventTarget` that are neither instances of `Window` nor `Node`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8588420