### PR TITLE
feat(style-compiler): allow ::slotted

### DIFF
--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/unsupported-slotted-selector/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/unsupported-slotted-selector/actual.css
@@ -1,1 +1,0 @@
-::slotted a {}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/unsupported-slotted-selector/error.json
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/unsupported-slotted-selector/error.json
@@ -1,6 +1,0 @@
-{
-    "name": "CssSyntaxError",
-    "reason": "Invalid usage of unsupported selector \"::slotted\".",
-    "column": 1,
-    "line": 1
-}

--- a/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
@@ -7,7 +7,7 @@
 import { Root } from 'postcss-selector-parser';
 
 const DEPRECATED_SELECTORS = new Set(['/deep/', '::shadow', '>>>']);
-const UNSUPPORTED_SELECTORS = new Set(['::slotted', ':root', ':host-context']);
+const UNSUPPORTED_SELECTORS = new Set([':root', ':host-context']);
 const TEMPLATE_DIRECTIVES = [/^key$/, /^lwc:*/, /^if:*/, /^for:*/, /^iterator:*/];
 
 function validateSelectors(root: Root) {


### PR DESCRIPTION
## Details

Remove `::slotted` from the UNSUPPORTED_SELECTORS` list.

https://github.com/salesforce/lwc/pull/2213#pullrequestreview-579347311

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 