### PR TITLE
refactor(babel-plugin-component): move component registration transform out of post-process

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/observed-fields.spec.js
@@ -264,8 +264,8 @@ describe('observed fields', () => {
         {
             output: {
                 code: `
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
                 import _tmpl from "./test.html";
-                import { registerComponent as _registerComponent, registerDecorators as _registerDecorators, createElement } from "lwc";
                 
                 const Test = _registerDecorators(
                   class {

--- a/packages/@lwc/babel-plugin-component/src/component.js
+++ b/packages/@lwc/babel-plugin-component/src/component.js
@@ -4,11 +4,61 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const { generateError, getEngineImportSpecifiers } = require('./utils');
-const { LWC_PACKAGE_EXPORTS, LWC_SUPPORTED_APIS } = require('./constants');
+const { basename, extname } = require('path');
+
+const moduleImports = require('@babel/helper-module-imports');
 const { LWCClassErrors } = require('@lwc/errors');
 
-module.exports = function () {
+const { generateError, getEngineImportSpecifiers } = require('./utils');
+const { LWC_PACKAGE_EXPORTS, LWC_SUPPORTED_APIS, REGISTER_COMPONENT_ID } = require('./constants');
+
+module.exports = function ({ types: t }) {
+    function getBaseName({ file }) {
+        const classPath = file.opts.filename;
+        const ext = extname(classPath);
+        return basename(classPath, ext);
+    }
+
+    function importDefaultTemplate(path, state) {
+        const componentName = getBaseName(state);
+        return moduleImports.addDefault(path, `./${componentName}.html`, {
+            nameHint: 'tmpl',
+        });
+    }
+
+    function createRegisterComponent(declarationPath, state) {
+        const id = moduleImports.addNamed(declarationPath, REGISTER_COMPONENT_ID, 'lwc');
+        const templateIdentifier = importDefaultTemplate(declarationPath, state);
+        const statementPath = declarationPath.getStatementParent();
+        let node = declarationPath.node;
+
+        if (declarationPath.isClassDeclaration()) {
+            const hasIdentifier = t.isIdentifier(node.id);
+            if (hasIdentifier) {
+                statementPath.insertBefore(node);
+                node = node.id;
+            } else {
+                // if it does not have an id, we can treat it as a ClassExpression
+                node.type = 'ClassExpression';
+            }
+        }
+
+        return t.callExpression(id, [
+            node,
+            t.objectExpression([t.objectProperty(t.identifier('tmpl'), templateIdentifier)]),
+        ]);
+    }
+
+    function needsComponentRegistration(path) {
+        return (
+            (path.isIdentifier() && path.node.name !== 'undefined' && path.node.name !== 'null') ||
+            // path.isMemberExpression() || // this will probably yield more false positives than anything else
+            path.isCallExpression() ||
+            path.isClassDeclaration() ||
+            path.isConditionalExpression()
+        );
+    }
+
     return {
         Program(path, state) {
             const engineImportSpecifiers = getEngineImportSpecifiers(path);
@@ -27,6 +77,16 @@ module.exports = function () {
             state.componentBaseClassImports = engineImportSpecifiers
                 .filter(({ name }) => name === LWC_PACKAGE_EXPORTS.BASE_COMPONENT)
                 .map(({ path }) => path.get('local'));
+        },
+
+        ExportDefaultDeclaration(path, state) {
+            const implicitResolution = !state.opts.isExplicitImport;
+            if (implicitResolution) {
+                const declaration = path.get('declaration');
+                if (needsComponentRegistration(declaration)) {
+                    declaration.replaceWith(createRegisterComponent(declaration, state));
+                }
+            }
         },
     };
 };

--- a/packages/@lwc/babel-plugin-component/src/component.js
+++ b/packages/@lwc/babel-plugin-component/src/component.js
@@ -20,9 +20,7 @@ function getBaseName(classPath) {
 }
 
 function importDefaultTemplate(path, state) {
-    const { file } = state;
-    const { opts } = file;
-    const { filename } = opts;
+    const { filename } = state.file.opts;
     const componentName = getBaseName(filename);
     return moduleImports.addDefault(path, `./${componentName}.html`, {
         nameHint: TEMPLATE_KEY,
@@ -41,7 +39,7 @@ function needsComponentRegistration(path) {
 
 module.exports = function ({ types: t }) {
     function createRegisterComponent(declarationPath, state) {
-        const id = moduleImports.addNamed(
+        const registerComponentId = moduleImports.addNamed(
             declarationPath,
             REGISTER_COMPONENT_ID,
             LWC_PACKAGE_ALIAS
@@ -57,11 +55,11 @@ module.exports = function ({ types: t }) {
                 node = node.id;
             } else {
                 // if it does not have an id, we can treat it as a ClassExpression
-                node.type = 'ClassExpression';
+                t.toExpression(node);
             }
         }
 
-        return t.callExpression(id, [
+        return t.callExpression(registerComponentId, [
             node,
             t.objectExpression([t.objectProperty(t.identifier(TEMPLATE_KEY), templateIdentifier)]),
         ]);

--- a/packages/@lwc/babel-plugin-component/src/component.js
+++ b/packages/@lwc/babel-plugin-component/src/component.js
@@ -9,8 +9,8 @@ const { basename, extname } = require('path');
 const moduleImports = require('@babel/helper-module-imports');
 const { LWCClassErrors } = require('@lwc/errors');
 
+const { LWC_SUPPORTED_APIS, REGISTER_COMPONENT_ID } = require('./constants');
 const { generateError, getEngineImportSpecifiers } = require('./utils');
-const { LWC_PACKAGE_EXPORTS, LWC_SUPPORTED_APIS, REGISTER_COMPONENT_ID } = require('./constants');
 
 module.exports = function ({ types: t }) {
     function getBaseName({ file }) {
@@ -60,7 +60,7 @@ module.exports = function ({ types: t }) {
     }
 
     return {
-        Program(path, state) {
+        Program(path) {
             const engineImportSpecifiers = getEngineImportSpecifiers(path);
 
             // validate internal api imports
@@ -72,11 +72,6 @@ module.exports = function ({ types: t }) {
                     });
                 }
             });
-
-            // Store on state local identifiers referencing engine base component
-            state.componentBaseClassImports = engineImportSpecifiers
-                .filter(({ name }) => name === LWC_PACKAGE_EXPORTS.BASE_COMPONENT)
-                .map(({ path }) => path.get('local'));
         },
 
         ExportDefaultDeclaration(path, state) {

--- a/packages/@lwc/babel-plugin-component/src/constants.js
+++ b/packages/@lwc/babel-plugin-component/src/constants.js
@@ -70,6 +70,9 @@ const DECORATOR_TYPES = {
     METHOD: 'method',
 };
 
+const REGISTER_COMPONENT_ID = 'registerComponent';
+const REGISTER_DECORATORS_ID = 'registerDecorators';
+
 module.exports = {
     AMBIGUOUS_PROP_SET,
     DISALLOWED_PROP_SET,
@@ -78,4 +81,6 @@ module.exports = {
     LWC_SUPPORTED_APIS,
     LWC_COMPONENT_PROPERTIES,
     DECORATOR_TYPES,
+    REGISTER_COMPONENT_ID,
+    REGISTER_DECORATORS_ID,
 };

--- a/packages/@lwc/babel-plugin-component/src/post-process/transform.js
+++ b/packages/@lwc/babel-plugin-component/src/post-process/transform.js
@@ -10,13 +10,10 @@
  * of all transformed decorators.
  */
 
-const { basename, extname } = require('path');
 const moduleImports = require('@babel/helper-module-imports');
+const { REGISTER_DECORATORS_ID } = require('../constants');
 const { isLWCNode } = require('../utils');
 const LWC_POST_PROCCESED = Symbol();
-
-const REGISTER_DECORATORS_ID = 'registerDecorators';
-const REGISTER_COMPONENT_ID = 'registerComponent';
 
 module.exports = function postProcess({ types: t }) {
     function collectDecoratedProperties(body) {
@@ -84,63 +81,7 @@ module.exports = function postProcess({ types: t }) {
         return t.callExpression(id, [klass, t.objectExpression(props)]);
     }
 
-    function getBaseName({ file }) {
-        const classPath = file.opts.filename;
-        const ext = extname(classPath);
-        return basename(classPath, ext);
-    }
-
-    function importDefaultTemplate(path, state) {
-        const componentName = getBaseName(state);
-        return moduleImports.addDefault(path, `./${componentName}.html`, {
-            nameHint: 'tmpl',
-        });
-    }
-
-    function createRegisterComponent(declarationPath, state) {
-        const id = moduleImports.addNamed(declarationPath, REGISTER_COMPONENT_ID, 'lwc');
-        const templateIdentifier = importDefaultTemplate(declarationPath, state);
-        const statementPath = declarationPath.getStatementParent();
-        let node = declarationPath.node;
-
-        if (declarationPath.isClassDeclaration()) {
-            const hasIdentifier = t.isIdentifier(node.id);
-            if (hasIdentifier) {
-                statementPath.insertBefore(node);
-                node = node.id;
-            } else {
-                // if it does not have an id, we can treat it as a ClassExpression
-                node.type = 'ClassExpression';
-            }
-        }
-
-        return t.callExpression(id, [
-            node,
-            t.objectExpression([t.objectProperty(t.identifier('tmpl'), templateIdentifier)]),
-        ]);
-    }
-
-    function needsComponentRegistration(path) {
-        return (
-            (path.isIdentifier() && path.node.name !== 'undefined' && path.node.name !== 'null') ||
-            // path.isMemberExpression() || // this will probably yield more false positives than anything else
-            path.isCallExpression() ||
-            path.isClassDeclaration() ||
-            path.isConditionalExpression()
-        );
-    }
-
     return {
-        // Register component
-        ExportDefaultDeclaration(path, state) {
-            const implicitResolution = !state.opts.isExplicitImport;
-            if (implicitResolution) {
-                const declaration = path.get('declaration');
-                if (needsComponentRegistration(declaration)) {
-                    declaration.replaceWith(createRegisterComponent(declaration, state));
-                }
-            }
-        },
         // Decorator collector for class expressions
         ClassExpression(path) {
             const { node } = path;


### PR DESCRIPTION
## Details

Move component registration transform out of post-process.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8630713