### PR TITLE
chore: Remove force-publish usage

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,4 @@
 {
-  "command": {
-    "publish": {
-      "forcePublish": "*"
-    }
-  },
   "exact": true,
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -14,8 +14,6 @@ const ARGS = [
     'version',
     // Use exact version number without using semver notation (i.e., ~ and ^)
     '--exact',
-    // Update version number even if there were no changes in the package
-    '--force-publish',
     '--no-push',
 ];
 


### PR DESCRIPTION
## Details

This PR removes the `lerna --force-publish` option. This option has long been deprecated and removed.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
* 
## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

