### PR TITLE
fix(synthetic-shadow): properly filter non-composed events

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/event-target.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isFalse, isFunction, isNull, isObject, isUndefined } from '@lwc/shared';
-import { eventCurrentTargetGetter } from '../env/dom';
-import { eventToShadowRootMap, isHostElement } from '../faux-shadow/shadow-root';
+import { eventCurrentTargetGetter, eventTargetGetter } from '../env/dom';
+import { isHostElement } from '../faux-shadow/shadow-root';
 
 const EventListenerMap: WeakMap<EventListenerOrEventListenerObject, EventListener> = new WeakMap();
 
@@ -37,12 +37,11 @@ export function getEventListenerWrapper(fnOrObj: unknown) {
                 );
             }
 
-            const { composed } = event;
+            const composedPath = event.composedPath();
+            const currentTarget = eventCurrentTargetGetter.call(event) as EventTarget;
+            const target = eventTargetGetter.call(event);
 
-            // TODO [#2121]: We should also be filtering out other non-composed events at this point
-            // but we only do so for events dispatched via shadowRoot.dispatchEvent() to preserve
-            // the current behavior.
-            if (eventToShadowRootMap.has(event) && isFalse(composed)) {
+            if (currentTarget !== target && !composedPath.includes(currentTarget)) {
                 return;
             }
 

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-propagation.spec.js
@@ -223,14 +223,7 @@ describe('non-composed and bubbling event propagation in nested shadow tree', ()
                 [nodes['div-manual'], nodes['span-manual'], composedPath],
                 [nodes['x-shadow-tree'].shadowRoot, nodes['span-manual'], composedPath],
             ];
-            if (!process.env.NATIVE_SHADOW) {
-                // TODO [#1569]: Listeners on the following targets should not be invoked when the event is non-composed.
-                expectedLogs.push(
-                    [document.body, null, composedPath],
-                    [document.documentElement, null, composedPath],
-                    [document, null, composedPath]
-                );
-            }
+
             expect(logs).toEqual(expectedLogs);
         });
     });

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -89,28 +89,11 @@ describe('event propagation', () => {
 
             const composedPath = [nodes.button, nodes.button_div, nodes['x-button'].shadowRoot];
 
-            let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
-                expectedLogs = [
-                    [nodes.button, nodes.button, composedPath],
-                    [nodes.button_div, nodes.button, composedPath],
-                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
-                ];
-            } else {
-                expectedLogs = [
-                    [nodes.button, nodes.button, composedPath],
-                    [nodes.button_div, nodes.button, composedPath],
-                    [nodes['x-button'].shadowRoot, nodes.button, composedPath],
-                    [nodes.button_group_slot, null, composedPath],
-                    [nodes.button_group_internal_slot, null, composedPath],
-                    [nodes.button_group_div, null, composedPath],
-                    [nodes.container_div, null, composedPath],
-                    [document.body, null, composedPath],
-                    [document.documentElement, null, composedPath],
-                    [document, null, composedPath],
-                    [window, null, composedPath],
-                ];
-            }
+            const expectedLogs = [
+                [nodes.button, nodes.button, composedPath],
+                [nodes.button_div, nodes.button, composedPath],
+                [nodes['x-button'].shadowRoot, nodes.button, composedPath],
+            ];
 
             expect(actualLogs).toEqual(expectedLogs);
         });
@@ -230,38 +213,18 @@ describe('event propagation', () => {
                 nodes['x-container'].shadowRoot,
             ];
 
-            let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
-                expectedLogs = [
-                    [nodes['x-button'], nodes['x-button'], composedPath],
-                    [nodes.button_group_slot, nodes['x-button'], composedPath],
-                    [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
-                    [nodes.button_group_div, nodes['x-button'], composedPath],
-                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group'], nodes['x-button'], composedPath],
-                    [nodes.container_div, nodes['x-button'], composedPath],
-                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
-                ];
-            } else {
-                expectedLogs = [
-                    [nodes['x-button'], nodes['x-button'], composedPath],
-                    [nodes.button_group_slot, nodes['x-button'], composedPath],
-                    [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
-                    [nodes.button_group_div, nodes['x-button'], composedPath],
-                    [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
-                    [nodes['x-button-group'], nodes['x-button'], composedPath],
-                    [nodes.container_div, nodes['x-button'], composedPath],
-                    [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
-                    [document.body, null, composedPath],
-                    [document.documentElement, null, composedPath],
-                    [document, null, composedPath],
-                    [window, null, composedPath],
-                ];
-            }
+            const expectedLogs = [
+                [nodes['x-button'], nodes['x-button'], composedPath],
+                [nodes.button_group_slot, nodes['x-button'], composedPath],
+                [nodes.button_group_internal_slot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group-internal'], nodes['x-button'], composedPath],
+                [nodes.button_group_div, nodes['x-button'], composedPath],
+                [nodes['x-button-group'].shadowRoot, nodes['x-button'], composedPath],
+                [nodes['x-button-group'], nodes['x-button'], composedPath],
+                [nodes.container_div, nodes['x-button'], composedPath],
+                [nodes['x-container'].shadowRoot, nodes['x-button'], composedPath],
+            ];
 
             expect(actualLogs).toEqual(expectedLogs);
         });


### PR DESCRIPTION
## Details

Todo:

- [ ] Introduce similar logic to event listener wrappers for custom elements
- [ ] Introduce similar logic to event listener wrappers for shadow roots
- [ ] Implement in a feature-flaggable way

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

## GUS work item

W-8538508