### PR TITLE
chore: Add back lerna --force-publish flag

### DIFF
--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -14,7 +14,7 @@ const ARGS = [
     'version',
     // Use exact version number without using semver notation (i.e., ~ and ^)
     '--exact',
-    // Skip lerna change detection and force all the package to be re-published
+    // Skip lerna change detection and force version number updates across all packages
     '--force-publish',
     // Skip git commit and tag push
     '--no-push',

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -14,6 +14,9 @@ const ARGS = [
     'version',
     // Use exact version number without using semver notation (i.e., ~ and ^)
     '--exact',
+    // Skip lerna change detection and force all the package to be re-published
+    '--force-publish',
+    // Skip git commit and tag push
     '--no-push',
 ];
 


### PR DESCRIPTION
## Details

This reverts the changes introduced in #2223. By default, lerna publish only a subset of all the packages that have been changed since the previous release. 

While the standard behavior is the right approach, because of the way LWC is released on Salesforce, downstream consumers expect ALL the package to have the same version. We can change this behavior in the future however it would require more work on the automation pipeline.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 