### PR TITLE
fix(synthetic-shadow): native shadow root support for pathComposer()

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,6 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
+import { isInstanceOfNativeShadowRoot } from '../../env/shadow-root';
+import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 
 export function pathComposer(startNode: EventTarget, composed: boolean): EventTarget[] {
     const composedPath: EventTarget[] = [];
@@ -35,8 +37,11 @@ export function pathComposer(startNode: EventTarget, composed: boolean): EventTa
             } else {
                 current = current.parentNode;
             }
-        } else if (current instanceof ShadowRoot && (composed || current !== startRoot)) {
-            current = current.host;
+        } else if (
+            (current instanceof SyntheticShadowRoot || isInstanceOfNativeShadowRoot(current)) &&
+            (composed || current !== startRoot)
+        ) {
+            current = (current as ShadowRoot).host;
         } else if (current instanceof Node) {
             current = current.parentNode;
         } else {

--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isNull, isUndefined } from '@lwc/shared';
+
+let NativeShadowRoot: any = null;
+if (!isUndefined(typeof ShadowRoot)) {
+    NativeShadowRoot = ShadowRoot;
+}
+
+export function isInstanceOfNativeShadowRoot(node: any): boolean {
+    if (isNull(NativeShadowRoot)) {
+        return false;
+    }
+    return node instanceof NativeShadowRoot;
+}

--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -11,9 +11,6 @@ if (typeof ShadowRoot !== 'undefined') {
     NativeShadowRoot = ShadowRoot;
 }
 
-export function isInstanceOfNativeShadowRoot(node: any): boolean {
-    if (isNull(NativeShadowRoot)) {
-        return false;
-    }
-    return node instanceof NativeShadowRoot;
-}
+export const isInstanceOfNativeShadowRoot: (node: any) => boolean = isNull(NativeShadowRoot)
+    ? () => false
+    : (node) => node instanceof NativeShadowRoot;

--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isNull, isUndefined } from '@lwc/shared';
+import { isNull } from '@lwc/shared';
 
 let NativeShadowRoot: any = null;
-if (!isUndefined(typeof ShadowRoot)) {
+if (typeof ShadowRoot !== 'undefined') {
     NativeShadowRoot = ShadowRoot;
 }
 

--- a/packages/@lwc/synthetic-shadow/src/index.ts
+++ b/packages/@lwc/synthetic-shadow/src/index.ts
@@ -13,6 +13,7 @@ import './env/dom';
 import './env/document';
 import './env/window';
 import './env/mutation-observer';
+import './env/shadow-root';
 
 // Initialization Routines
 import './polyfills/HTMLSlotElement/main';

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,0 +1,24 @@
+if (process.env.COMPAT !== true) {
+    describe('Event.composedPath() method', () => {
+        it('should return expected value', () => {
+            const native = document.createElement('x-native');
+            native.attachShadow({ mode: 'open' });
+            document.body.appendChild(native);
+
+            native.shadowRoot.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual([
+                    native.shadowRoot,
+                    native,
+                    document.body,
+                    document.documentElement,
+                    document,
+                    window,
+                ]);
+            });
+
+            native.shadowRoot.dispatchEvent(
+                new CustomEvent('test', { bubbles: true, composed: true })
+            );
+        });
+    });
+}

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,24 +1,51 @@
 if (process.env.COMPAT !== true) {
     describe('Event.composedPath() method', () => {
-        it('should return expected value', () => {
-            const native = document.createElement('x-native');
-            native.attachShadow({ mode: 'open' });
-            document.body.appendChild(native);
+        describe('dispatched on shadow root', () => {
+            it('{bubbles: true, composed: true}', (done) => {
+                const native = document.createElement('x-native');
+                native.attachShadow({ mode: 'open' });
+                document.body.appendChild(native);
 
-            native.shadowRoot.addEventListener('test', (event) => {
-                expect(event.composedPath()).toEqual([
-                    native.shadowRoot,
-                    native,
-                    document.body,
-                    document.documentElement,
-                    document,
-                    window,
-                ]);
+                native.shadowRoot.addEventListener('test', (event) => {
+                    expect(event.composedPath()).toEqual([
+                        native.shadowRoot,
+                        native,
+                        document.body,
+                        document.documentElement,
+                        document,
+                        window,
+                    ]);
+                    done();
+                });
+
+                native.shadowRoot.dispatchEvent(
+                    new CustomEvent('test', { bubbles: true, composed: true })
+                );
             });
+        });
+        describe('dispatched on shadowed element', () => {
+            it('{bubbles: true, composed: true}', (done) => {
+                const native = document.createElement('x-native');
+                const span = document.createElement('span');
+                const sr = native.attachShadow({ mode: 'open' });
+                sr.appendChild(span);
+                document.body.appendChild(native);
 
-            native.shadowRoot.dispatchEvent(
-                new CustomEvent('test', { bubbles: true, composed: true })
-            );
+                native.shadowRoot.addEventListener('test', (event) => {
+                    expect(event.composedPath()).toEqual([
+                        span,
+                        native.shadowRoot,
+                        native,
+                        document.body,
+                        document.documentElement,
+                        document,
+                        window,
+                    ]);
+                    done();
+                });
+
+                span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            });
         });
     });
 }


### PR DESCRIPTION
## Details

`event.composedPath()` is returning incorrect values for native shadow roots due to `ShadowRoot` being defined/replaced with our `SyntheticShadowRoot` by our [ShadowRoot polyfill](https://github.com/salesforce/lwc/blob/ff6c28bc001b55cdee2a6f9442ce5e95a4f0e96a/packages/%40lwc/synthetic-shadow/src/polyfills/shadow-root/polyfill.ts).

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

Impact should be minimal since this bugfix only affects native web components inside LWC.

## GUS work item

W-8538508