### PR TITLE
refactor(template-compiler): Remove unreachable code for inline style parsing

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -28,7 +28,6 @@
     ],
     "dependencies": {
         "@babel/generator": "~7.12.11",
-        "@babel/parser": "~7.12.11",
         "@babel/template": "~7.12.7",
         "@babel/traverse": "~7.12.12",
         "@babel/types": "~7.11.5",

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as babylon from '@babel/parser';
 import * as t from '@babel/types';
 import * as esutils from 'esutils';
 
@@ -53,47 +52,9 @@ export default class CodeGen {
     usedApis: { [name: string]: t.Identifier } = {};
     usedSlots: { [name: string]: t.Identifier } = {};
     memorizedIds: t.Identifier[] = [];
-    inlineStyleImports: t.ImportDeclaration[] = [];
-    inlineStyleBody: t.Statement[] = [];
 
     generateKey() {
         return this.currentKey++;
-    }
-
-    genInlineStyles(src: string | undefined): void {
-        if (src) {
-            // We get back a AST module which may have three pieces:
-            // 1) import statements
-            // 2) the inline function
-            // 3) default export
-            // We need to separate the imports and change the default export for a correct inlining
-            const importDeclarations: t.ImportDeclaration[] = [];
-            const styleBody: t.Statement[] = [];
-
-            // Parse the generated module code and return it's body.
-            const parsed = babylon.parse(src, { sourceType: 'module' });
-            const inlineStylesAst = parsed.program.body;
-
-            inlineStylesAst.forEach((node) => {
-                if (t.isImportDeclaration(node)) {
-                    importDeclarations.push(node);
-                } else if (t.isExportDefaultDeclaration(node)) {
-                    const stylesheetDeclaration = t.variableDeclaration('const', [
-                        t.variableDeclarator(
-                            t.identifier('stylesheets'),
-                            node.declaration as t.ArrayExpression
-                        ),
-                    ]);
-
-                    styleBody.push(stylesheetDeclaration);
-                } else {
-                    styleBody.push(node);
-                }
-            });
-
-            this.inlineStyleImports = importDeclarations;
-            this.inlineStyleBody = styleBody;
-        }
     }
 
     genElement(tagName: string, data: t.ObjectExpression, children: t.Expression) {

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -45,17 +45,13 @@ function generateSecureImports(additionalImports: string[]): t.ImportDeclaration
     );
 }
 
-function generateInlineStylesImports(state: State) {
-    return state.inlineStyle.imports;
-}
-
 export function format(templateFn: t.FunctionDeclaration, state: State): t.Program {
-    const imports = state.dependencies.map((cmpClassName) => moduleNameToImport(cmpClassName));
+    const imports = [
+        ...state.dependencies.map((cmpClassName) => moduleNameToImport(cmpClassName)),
+        generateSecureImports(state.secureDependencies),
+    ];
 
     const metadata = generateTemplateMetadata(state);
-
-    imports.push(generateSecureImports(state.secureDependencies));
-    imports.push(...generateInlineStylesImports(state));
 
     const templateBody = [
         templateFn,

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -43,10 +43,6 @@ export function isTemplate(element: IRElement) {
     return element.tag === 'template';
 }
 
-export function isStyleSheet(element: IRElement) {
-    return element.tag === 'style';
-}
-
 /** Returns true if the passed element is a slot element */
 export function isSlot(element: IRElement) {
     return element.tag === 'slot';
@@ -115,8 +111,6 @@ export function memorizeHandler(
 export function generateTemplateMetadata(state: State): t.Statement[] {
     const metadataExpressions: t.Statement[] = [];
 
-    // Generate the slots property on template function if slots are defined in the template:
-    //      tmpl.slots = ['', 'x']
     if (state.slots.length) {
         const slotsProperty = t.memberExpression(
             t.identifier(TEMPLATE_FUNCTION_NAME),
@@ -129,19 +123,10 @@ export function generateTemplateMetadata(state: State): t.Statement[] {
         metadataExpressions.push(t.expressionStatement(slotsMetadata));
     }
 
-    metadataExpressions.push(...state.inlineStyle.body);
-
-    const hasInlineStyles = state.inlineStyle.body.length;
-
-    const stylesheetsProperty = t.memberExpression(
-        t.identifier(TEMPLATE_FUNCTION_NAME),
-        t.identifier('stylesheets')
-    );
-
     const stylesheetsMetadata = t.assignmentExpression(
         '=',
-        stylesheetsProperty,
-        hasInlineStyles ? t.identifier('stylesheets') : t.arrayExpression()
+        t.memberExpression(t.identifier(TEMPLATE_FUNCTION_NAME), t.identifier('stylesheets')),
+        t.arrayExpression()
     );
     metadataExpressions.push(t.expressionStatement(stylesheetsMetadata));
 

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -50,7 +50,6 @@ const AVAILABLE_OPTION_NAMES = new Set([
     'secure',
     'experimentalComputedMemberExpression',
     'experimentalDynamicDirective',
-    'stylesheetConfig',
 ]);
 
 export function mergeConfig(config: Config): ResolvedConfig {

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -60,8 +60,6 @@ export interface IRElement {
     type: 'element';
     tag: string;
 
-    inlineStyles?: string;
-
     attrsList: parse5.AST.Default.Attribute[];
 
     parent?: IRElement;

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -7,7 +7,6 @@
 import { MarkupData } from 'parse5-with-errors';
 
 import { ResolvedConfig } from './config';
-import { Statement, ImportDeclaration } from '@babel/types';
 
 export interface IdAttributeData {
     location: MarkupData.Location;
@@ -21,14 +20,6 @@ export default class State {
     slots: string[] = [];
     dependencies: string[] = [];
     secureDependencies: string[] = []; // imports patched by locker service at runtime
-
-    inlineStyle: {
-        body: Statement[];
-        imports: ImportDeclaration[];
-    } = {
-        body: [],
-        imports: [],
-    };
 
     idAttrData: IdAttributeData[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,7 +487,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
-"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@~7.12.11":
+"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==


### PR DESCRIPTION
## Details

This is the first PR to remove Babel from the `@lwc/template-compiler` repo. This PR removes some dead code that was used to handle inline style generation. This code is unreachable since the parser block any usage of `<style>` in the template.

https://github.com/salesforce/lwc/blob/40d0f678436ce33119f73db5e6a755dcc5c81541/packages/%40lwc/template-compiler/src/parser/index.ts#L453-L458

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## Work item
W-7462545