### PR TITLE
refactor(template-compiler): Remove unused id from internal state

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -22,7 +22,7 @@ const EXPECTED_LOCATION = expect.objectContaining({
 
 function parseTemplate(src: string): any {
     const config = mergeConfig({});
-    const state = new State(src, config);
+    const state = new State(config);
 
     const res = parse(src, state);
     return {
@@ -659,24 +659,6 @@ describe('props and attributes', () => {
 });
 
 describe('metadata', () => {
-    it('usedIds simple', () => {
-        const { state } = parseTemplate(
-            `<template><h1 if:true={visible} class={titleClass}>{text}</h1></template>`
-        );
-        expect(Array.from(state.ids)).toEqual(['visible', 'titleClass', 'text']);
-    });
-
-    it('usedIds with expression', () => {
-        const { state } = parseTemplate(`<template>
-            <div for:each={state.items} for:item="item">
-                <template if:true={item.visible}>
-                    {componentProp} - {item.value}
-                </template>
-            </div>
-        </template>`);
-        expect(Array.from(state.ids)).toEqual(['state', 'componentProp']);
-    });
-
     it('slots', () => {
         const { state } = parseTemplate(`<template>
             <slot></slot>

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -100,7 +100,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
                 let { value } = textNode;
 
                 if (typeof value !== 'string') {
-                    value = bindExpression(value, textNode).expression as t.MemberExpression;
+                    value = bindExpression(value, textNode) as t.MemberExpression;
                 }
 
                 (stack.peek() as t.ArrayExpression).elements.push(codeGen.genText(value));
@@ -139,7 +139,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
 
         // Check wether it has the special directive lwc:dynamic
         if (element.lwc && element.lwc.dynamic) {
-            const { expression } = bindExpression(element.lwc.dynamic, element);
+            const expression = bindExpression(element.lwc.dynamic, element);
             babelElement = codeGen.genDynamicElement(element.tag, expression, databag, children);
         } else if (isCustomElement(element)) {
             // Make sure to register the component
@@ -194,7 +194,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
         }
 
         if (!testExpression) {
-            testExpression = bindExpression(element.if!, element).expression;
+            testExpression = bindExpression(element.if!, element);
         }
 
         let leftExpression: t.Expression;
@@ -225,7 +225,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
             params.push(index);
         }
 
-        const { expression: iterable } = bindExpression(expression, element);
+        const iterable = bindExpression(expression, element);
         const iterationFunction = t.functionExpression(
             undefined,
             params,
@@ -257,6 +257,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
             )
         );
 
+        const iterable = bindExpression(expression, element);
         const iterationFunction = t.functionExpression(
             undefined,
             iteratorArgs,
@@ -268,7 +269,6 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
             ])
         );
 
-        const { expression: iterable } = bindExpression(expression, element);
         return codeGen.genIterator(iterable, iterationFunction);
     }
 
@@ -297,7 +297,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
 
         if (t.isArrayExpression(fragmentNodes)) {
             // Bind the expression once for all the template children
-            const { expression: testExpression } = bindExpression(element.if!, element);
+            const testExpression = bindExpression(element.if!, element);
 
             return t.arrayExpression(
                 fragmentNodes.elements.map((child) =>
@@ -333,7 +333,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
 
         switch (attr.type) {
             case IRAttributeType.Expression: {
-                const { expression } = bindExpression(attr.value, element);
+                const expression = bindExpression(attr.value, element);
 
                 // TODO [#2012]: Normalize global boolean attrs values passed to custom elements as props
                 if (isUsedAsAttribute && isBooleanAttribute(attr.name, tagName)) {
@@ -416,7 +416,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
 
         // Class attibute defined via string
         if (className) {
-            const { expression: classExpression } = bindExpression(className, element);
+            const classExpression = bindExpression(className, element);
             data.push(t.objectProperty(t.identifier('className'), classExpression));
         }
 
@@ -439,7 +439,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
 
         // Style attribute defined via string
         if (style) {
-            const { expression: styleExpression } = bindExpression(style, element);
+            const styleExpression = bindExpression(style, element);
             data.push(t.objectProperty(t.identifier('style'), styleExpression));
         }
 
@@ -466,7 +466,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
         // Key property on VNode
         if (forKey) {
             // If element has user-supplied `key` or is in iterator, call `api.k`
-            const { expression: forKeyExpression } = bindExpression(forKey, element);
+            const forKeyExpression = bindExpression(forKey, element);
             const generatedKey = codeGen.genKey(
                 t.numericLiteral(codeGen.generateKey()),
                 forKeyExpression
@@ -483,7 +483,7 @@ function transform(root: IRNode, codeGen: CodeGen, state: State): t.Expression {
         // Event handler
         if (on) {
             const onObj = objectToAST(on, (key) => {
-                const { expression: componentHandler } = bindExpression(on[key], element);
+                const componentHandler = bindExpression(on[key], element);
                 let handler: t.Expression = codeGen.genBind(componentHandler);
 
                 handler = memorizeHandler(codeGen, element, componentHandler, handler);

--- a/packages/@lwc/template-compiler/src/codegen/scope.ts
+++ b/packages/@lwc/template-compiler/src/codegen/scope.ts
@@ -7,9 +7,9 @@
 import * as types from '@babel/types';
 import traverse from '@babel/traverse';
 
-import { TEMPLATE_PARAMS } from './constants';
-import { isComponentProp } from './ir';
-import { IRNode, TemplateExpression } from './types';
+import { TEMPLATE_PARAMS } from '../shared/constants';
+import { isComponentProp } from '../shared/ir';
+import { IRNode, TemplateExpression } from '../shared/types';
 
 /**
  * Bind the passed expression to the component instance. It applies the following transformation to the expression:

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -28,13 +28,13 @@ export { Config } from './config';
 
 export function parse(source: string, config?: Config): TemplateParseResult {
     const options = mergeConfig(config || {});
-    const state = new State(source, options);
+    const state = new State(options);
     return parseTemplate(source, state);
 }
 
 export default function compile(source: string, config: Config): TemplateCompileResult {
     const options = mergeConfig(config);
-    const state = new State(source, options);
+    const state = new State(options);
 
     let code = '';
     const warnings: CompilerDiagnostic[] = [];
@@ -65,7 +65,7 @@ export function compileToFunction(source: string): Function {
     const options = mergeConfig({});
     options.format = 'function';
 
-    const state = new State(source, options);
+    const state = new State(options);
 
     const parsingResults = parseTemplate(source, state);
 

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -32,11 +32,11 @@ import {
 
 import {
     isExpression,
-    parseExpression,
     parseIdentifier,
     isIteratorElement,
     getForOfParent,
     getForEachParent,
+    parseExpression,
 } from './expression';
 
 import { parseStyleText, parseClassNames } from './style';
@@ -44,7 +44,6 @@ import { parseStyleText, parseClassNames } from './style';
 import { createElement, isCustomElement, createText } from '../shared/ir';
 
 import {
-    IRNode,
     IRElement,
     IRAttribute,
     IRAttributeType,
@@ -57,8 +56,6 @@ import {
     LWCDirectiveDomMode,
     LWCDirectives,
 } from '../shared/types';
-
-import { bindExpression } from '../shared/scope';
 
 import State from '../state';
 
@@ -216,7 +213,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                     let value;
                     if (isExpression(token)) {
                         try {
-                            value = parseTemplateExpression(parent, token);
+                            value = parseExpression(token, state);
                         } catch (error) {
                             addDiagnostic(
                                 normalizeToDiagnostic(
@@ -905,19 +902,6 @@ export default function parse(source: string, state: State): TemplateParseResult
         }
     }
 
-    function parseTemplateExpression(node: IRNode, sourceExpression: string) {
-        const expression = parseExpression(sourceExpression, state);
-        const { bounded } = bindExpression(expression, node, false);
-
-        for (const boundedIdentifier of bounded) {
-            if (!state.ids.includes(boundedIdentifier)) {
-                state.ids.push(boundedIdentifier);
-            }
-        }
-
-        return expression;
-    }
-
     function getTemplateAttribute(
         el: IRElement,
         pattern: string | RegExp
@@ -960,7 +944,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                     name,
                     location,
                     type: IRAttributeType.Expression,
-                    value: parseTemplateExpression(el, value),
+                    value: parseExpression(value, state),
                 };
             } else if (isBooleanAttribute) {
                 return {

--- a/packages/@lwc/template-compiler/src/shared/scope.ts
+++ b/packages/@lwc/template-compiler/src/shared/scope.ts
@@ -11,11 +11,6 @@ import { TEMPLATE_PARAMS } from './constants';
 import { isComponentProp } from './ir';
 import { IRNode, TemplateExpression } from './types';
 
-export interface BindingResult {
-    expression: types.Expression;
-    bounded: string[];
-}
-
 /**
  * Bind the passed expression to the component instance. It applies the following transformation to the expression:
  * - {value} --> {$cmp.value}
@@ -25,14 +20,13 @@ export function bindExpression(
     expression: TemplateExpression,
     node: IRNode,
     applyBinding: boolean = true
-): BindingResult {
+): TemplateExpression {
     const wrappedExpression = types.expressionStatement(expression);
-    const boundIdentifiers: Set<string> = new Set();
 
     traverse(wrappedExpression, {
         noScope: true,
         Identifier(path) {
-            const identifierNode = path.node as types.Identifier;
+            const identifierNode = path.node;
             let shouldBind = false;
 
             if (types.isMemberExpression(path.parent)) {
@@ -58,15 +52,9 @@ export function bindExpression(
                     );
                     path.replaceWith(boundedExpression);
                 }
-
-                // Save the bounded identifier
-                boundIdentifiers.add(identifierNode.name);
             }
         },
     });
 
-    return {
-        expression: wrappedExpression.expression,
-        bounded: Array.from(boundIdentifiers),
-    };
+    return wrappedExpression.expression as TemplateExpression;
 }

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -12,15 +12,13 @@ export interface IdAttributeData {
     location: MarkupData.Location;
     value: string;
 }
+
 export default class State {
-    code: string;
     config: ResolvedConfig;
 
-    ids: string[] = [];
     slots: string[] = [];
     dependencies: string[] = [];
-    secureDependencies: string[] = []; // imports patched by locker service at runtime
-
+    secureDependencies: string[] = [];
     idAttrData: IdAttributeData[] = [];
 
     /**
@@ -32,8 +30,7 @@ export default class State {
      */
     shouldScopeFragmentId: boolean = false;
 
-    constructor(code: string, config: ResolvedConfig) {
-        this.code = code;
+    constructor(config: ResolvedConfig) {
         this.config = config;
     }
 }


### PR DESCRIPTION
## Details

This PR simplifies the `@lwc/template-compiler` by removing the `ids` gathered on `State`. This property is never used. As a side effect, this PR also improves the compiler performance by removing an AST traversal for each parsed expression.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 