### PR TITLE
refactor(template-compiler): Use single traversal for scoped id generation

### DIFF
--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -772,7 +772,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             }
         });
 
-        if ((!state.shouldScopeFragmentId && element.props?.id) || element.attrs?.id) {
+        if (!state.shouldScopeFragmentId && (element.props?.id || element.attrs?.id)) {
             state.shouldScopeFragmentId = true;
         }
     }

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -771,6 +771,10 @@ export default function parse(source: string, state: State): TemplateParseResult
                 removeAttribute(element, name);
             }
         });
+
+        if ((!state.shouldScopeFragmentId && element.props?.id) || element.attrs?.id) {
+            state.shouldScopeFragmentId = true;
+        }
     }
 
     function validateElement(element: IRElement) {

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -23,6 +23,15 @@ export default class State {
 
     idAttrData: IdAttributeData[] = [];
 
+    /**
+     * This flag indicates if a the generated code should scope the template fragment id. It is set
+     * to true if the template also contains ids.
+     *
+     * TODO [#1150]: Remove this code once we can figure out how to do this in a deterministic
+     * fashion.
+     */
+    shouldScopeFragmentId: boolean = false;
+
     constructor(code: string, config: ResolvedConfig) {
         this.code = code;
         this.config = config;


### PR DESCRIPTION
## Details

Before doing the actual code gen, the compiler does a full AST traversal to detect if some nodes are using the `id` attribute or prop. In order to avoid this extra AST traversal, this information is gathered while parsing the AST.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 