### PR TITLE
refactor(template-compiler): Replace @babel/traverse by estree-walker

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -29,11 +29,11 @@
     "dependencies": {
         "@babel/generator": "~7.12.11",
         "@babel/template": "~7.12.7",
-        "@babel/traverse": "~7.12.12",
         "@babel/types": "~7.11.5",
         "@lwc/errors": "1.17.4",
         "@lwc/shared": "1.17.4",
         "acorn": "~8.0.5",
+        "estree-walker": "~2.0.2",
         "esutils": "~2.0.3",
         "he": "~1.2.0",
         "parse5-with-errors": "~4.0.4"

--- a/packages/@lwc/template-compiler/src/codegen/scope.ts
+++ b/packages/@lwc/template-compiler/src/codegen/scope.ts
@@ -20,7 +20,7 @@ import {
 /**
  * Bind the passed expression to the component instance. It applies the following transformation to the expression:
  * - {value} --> {$cmp.value}
- * - {value[state.index]} --> {$cmp.value[$cmp.index]}
+ * - {value[index]} --> {$cmp.value[$cmp.index]}
  */
 export function bindExpression(expression: TemplateExpression, irNode: IRNode): TemplateExpression {
     const root: estree.BaseNode = expression as any;

--- a/packages/@lwc/template-compiler/src/shared/estree.ts
+++ b/packages/@lwc/template-compiler/src/shared/estree.ts
@@ -6,10 +6,7 @@
  */
 import { BaseNode, Identifier, MemberExpression, Expression } from 'estree';
 
-export function createIdentifier(
-    name: string,
-    config?: Partial<Omit<Identifier, 'type' | 'name'>>
-): Identifier {
+export function createIdentifier(name: string, config?: Partial<Identifier>): Identifier {
     return {
         type: 'Identifier',
         name,
@@ -24,7 +21,7 @@ export function isIdentifier(node: BaseNode): node is Identifier {
 export function createMemberExpression(
     object: Expression,
     property: Expression,
-    config?: Partial<Omit<MemberExpression, 'type' | 'object' | 'property'>>
+    config?: Partial<MemberExpression>
 ): MemberExpression {
     return {
         type: 'MemberExpression',

--- a/packages/@lwc/template-compiler/src/shared/estree.ts
+++ b/packages/@lwc/template-compiler/src/shared/estree.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { BaseNode, Identifier, MemberExpression, Expression } from 'estree';
+
+export function createIdentifier(
+    name: string,
+    config?: Partial<Omit<Identifier, 'type' | 'name'>>
+): Identifier {
+    return {
+        type: 'Identifier',
+        name,
+        ...config,
+    };
+}
+
+export function isIdentifier(node: BaseNode): node is Identifier {
+    return node.type === 'Identifier';
+}
+
+export function createMemberExpression(
+    object: Expression,
+    property: Expression,
+    config?: Partial<Omit<MemberExpression, 'type' | 'object' | 'property'>>
+): MemberExpression {
+    return {
+        type: 'MemberExpression',
+        object,
+        property,
+        computed: false,
+        optional: false,
+        ...config,
+    };
+}
+
+export function isMemberExpression(node: BaseNode): node is MemberExpression {
+    return node.type === 'MemberExpression';
+}

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -46,7 +46,7 @@ export function isComponentProp(identifier: TemplateIdentifier, root: IRNode): b
     let current: IRNode | undefined = root;
 
     // Walking up the AST and checking for each node to find if the identifer name is identical to
-    //  an iteration variable.
+    // an iteration variable.
     while (current !== undefined) {
         if (isElement(current)) {
             const { forEach, forOf } = current;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,7 +1373,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/traverse@^7.12.10", "@babel/traverse@~7.12.12":
+"@babel/traverse@^7.12.10":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
   integrity sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
@@ -6817,12 +6817,7 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -6842,10 +6837,10 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
-estree-walker@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
-  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
+estree-walker@^2.0.1, estree-walker@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2, esutils@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
## Details

This PR removes the dependency on `@babel/traverse` in favor of `estree-walker`. This package is lighter and faster compared to `@babel/traverse`. The `isComponentProp` has also been optimized by replacing the recursive invocation with a simple while loop.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 