### PR TITLE
fix(synthetic-shadow): fix invoking context for shadow root and custom element listeners

### DIFF
--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -117,4 +117,44 @@ describe('EventTarget.addEventListener', () => {
             });
         });
     }
+
+    describe('should always invoke listener with actual current target context', () => {
+        it('for host element', () => {
+            let id;
+            function handleTest() {
+                id = this.id;
+            }
+
+            const firstContainer = createElement('x-container', { is: Container });
+            firstContainer.setAttribute('id', 'first-container');
+            const secondContainer = createElement('x-container', { is: Container });
+            secondContainer.setAttribute('id', 'second-container');
+
+            firstContainer.addEventListener('test', handleTest);
+            secondContainer.addEventListener('test', handleTest);
+            firstContainer.dispatchEvent(new CustomEvent('test'));
+            secondContainer.dispatchEvent(new CustomEvent('test'));
+            expect(id).toEqual('second-container');
+        });
+
+        it('for shadow root', () => {
+            let id;
+            function handleTest() {
+                id = this.host.id;
+            }
+
+            const firstContainer = createElement('x-container', { is: Container });
+            firstContainer.setAttribute('id', 'first-container');
+            const firstContainerShadowRoot = firstContainer.shadowRoot;
+            const secondContainer = createElement('x-container', { is: Container });
+            secondContainer.setAttribute('id', 'second-container');
+            const secondContainerShadowRoot = secondContainer.shadowRoot;
+
+            firstContainerShadowRoot.addEventListener('test', handleTest);
+            secondContainerShadowRoot.addEventListener('test', handleTest);
+            firstContainerShadowRoot.dispatchEvent(new CustomEvent('test'));
+            secondContainerShadowRoot.dispatchEvent(new CustomEvent('test'));
+            expect(id).toEqual('second-container');
+        });
+    });
 });

--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -118,7 +118,7 @@ describe('EventTarget.addEventListener', () => {
         });
     }
 
-    describe('should always invoke listener with actual current target context', () => {
+    describe('should invoke listener with correct current target', () => {
         it('for host element', () => {
             let id;
             function handleTest() {
@@ -133,6 +133,7 @@ describe('EventTarget.addEventListener', () => {
             firstContainer.addEventListener('test', handleTest);
             secondContainer.addEventListener('test', handleTest);
             firstContainer.dispatchEvent(new CustomEvent('test'));
+            expect(id).toEqual('first-container');
             secondContainer.dispatchEvent(new CustomEvent('test'));
             expect(id).toEqual('second-container');
         });
@@ -153,6 +154,7 @@ describe('EventTarget.addEventListener', () => {
             firstContainerShadowRoot.addEventListener('test', handleTest);
             secondContainerShadowRoot.addEventListener('test', handleTest);
             firstContainerShadowRoot.dispatchEvent(new CustomEvent('test'));
+            expect(id).toEqual('first-container');
             secondContainerShadowRoot.dispatchEvent(new CustomEvent('test'));
             expect(id).toEqual('second-container');
         });


### PR DESCRIPTION
Currently we have wrong `this` value for shadow root and custom element listeners. With this PR listeners invoking context will be set properly.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced?  ✅ 

## GUS work item
W-8883676
