### PR TITLE
fix(synthetic-shadow): innerText of elements with non-selectable text

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
@@ -111,7 +111,11 @@ function getTextNodeInnerText(textNode: Text): string {
     selection.removeAllRanges();
     selection.addRange(range);
 
-    return selection.toString();
+    const selectionText = selection.toString();
+
+    // The textNode is visible, but it may not be selectable. When the text is not selectable,
+    // textContext is the nearest approximation to innerText.
+    return selectionText ? selectionText : textNode.textContent || '';
 }
 
 const nodeIsElement = (node: Node): node is Element => node.nodeType === ELEMENT_NODE;

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/inner-text.ts
@@ -114,7 +114,7 @@ function getTextNodeInnerText(textNode: Text): string {
     const selectionText = selection.toString();
 
     // The textNode is visible, but it may not be selectable. When the text is not selectable,
-    // textContext is the nearest approximation to innerText.
+    // textContent is the nearest approximation to innerText.
     return selectionText ? selectionText : textNode.textContent || '';
 }
 

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -23,6 +23,12 @@ if (!process.env.NATIVE_SHADOW) {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
+        it('should return textContent when text within element is not selectable', () => {
+            const testCase = elm.shadowRoot.querySelector('.non-selectable-text');
+
+            expect(testCase.innerText).toBe('non selectable text');
+        });
+
         it('should remove consecutive LF in between from partial results', () => {
             const testCase = elm.shadowRoot.querySelector('.consecutive-LF');
 

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.css
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.css
@@ -28,3 +28,10 @@
     z-index: 1;
     background-color: red;
 }
+
+.non-selectable-text {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.html
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/x/container/container.html
@@ -1,4 +1,7 @@
 <template>
+    <div class="non-selectable-text">
+        <span>non selectable text</span>
+    </div>
     <div class="consecutive-LF">
         <span>initial</span>
         <p>first case text</p>


### PR DESCRIPTION
## Details
This PR fixes an issue with the innerText polyfill on elements that has no selectable text.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`