### PR TITLE
fix(synthetic-shadow): duplicate event listeners on template and host are not discarded

### DIFF
--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -161,51 +161,74 @@ describe('EventTarget.addEventListener', () => {
     });
     // TODO [#2253]: Enable in all modes once bug is fixed
     if (process.env.NATIVE_SHADOW) {
-        describe('should discard multiple identical listeners on same target', () => {
-            it('listeners on shadow root, non-composed event', () => {
-                const logs = [];
-                const listener = function (event) {
-                    logs.push([this, event.currentTarget]);
-                };
-                const listenerTargets = [
-                    nodes.button,
-                    nodes['container_div'],
-                    nodes['x-container'].shadowRoot,
-                ];
-                listenerTargets.forEach((target) => {
-                    target.addEventListener('dedupe', listener);
-                    target.addEventListener('dedupe', listener); // duplicate listener
+        describe('identical listeners', () => {
+            describe('should discard multiple identical listeners on same target', () => {
+                function testDiscardingIdenticalListeners(
+                    target,
+                    listenerTargets,
+                    expected,
+                    composed = false
+                ) {
+                    const logs = [];
+                    const listener = function (event) {
+                        logs.push([this, event.currentTarget]);
+                    };
+                    listenerTargets.forEach((target) => {
+                        target.addEventListener('dedupe', listener);
+                        target.addEventListener('dedupe', listener); // identical listener
+                    });
+                    target.dispatchEvent(new CustomEvent('dedupe', { bubbles: true, composed }));
+                    expect(logs).toEqual(expected);
+                }
+                it('listeners on shadow root, non-composed event', () => {
+                    testDiscardingIdenticalListeners(
+                        nodes.button,
+                        [nodes.button, nodes['container_div'], nodes['x-container'].shadowRoot],
+                        [
+                            [nodes.button, nodes.button],
+                            [nodes['container_div'], nodes['container_div']],
+                            [nodes['x-container'].shadowRoot, nodes['x-container'].shadowRoot],
+                        ]
+                    );
                 });
-                nodes.button.dispatchEvent(new CustomEvent('dedupe', { bubbles: true }));
-                expect(logs).toEqual([
-                    [nodes.button, nodes.button],
-                    [nodes['container_div'], nodes['container_div']],
-                    [nodes['x-container'].shadowRoot, nodes['x-container'].shadowRoot],
-                ]);
-            });
 
-            it('listeners on host, composed event', () => {
-                const logs = [];
-                const listener = function (event) {
-                    logs.push([this, event.currentTarget]);
-                };
-                const listenerTargets = [
-                    nodes.button,
-                    nodes['container_div'],
-                    nodes['x-container'],
-                ];
-                listenerTargets.forEach((target) => {
-                    target.addEventListener('dedupe', listener);
-                    target.addEventListener('dedupe', listener); // duplicate listener
+                it('listeners on host, composed event', () => {
+                    testDiscardingIdenticalListeners(
+                        nodes.button,
+                        [nodes.button, nodes['container_div'], nodes['x-container']],
+                        [
+                            [nodes.button, nodes.button],
+                            [nodes['container_div'], nodes['container_div']],
+                            [nodes['x-container'], nodes['x-container']],
+                        ],
+                        true
+                    );
                 });
-                nodes.button.dispatchEvent(
-                    new CustomEvent('dedupe', { bubbles: true, composed: true })
-                );
-                expect(logs).toEqual([
-                    [nodes.button, nodes.button],
-                    [nodes['container_div'], nodes['container_div']],
-                    [nodes['x-container'], nodes['x-container']],
-                ]);
+            });
+            describe('should invoke identical listeners on same target with different options', () => {
+                // Note: addEventListener() with options are restricted for shadow root and host elements
+                function testIdenticalListeners(target, listenerTargets, expected) {
+                    const logs = [];
+                    const listener = function (event) {
+                        logs.push([this, event.currentTarget]);
+                    };
+                    listenerTargets.forEach((target) => {
+                        target.addEventListener('identical', listener);
+                        target.addEventListener('identical', listener, { passive: true }); // identical listener with different option
+                    });
+                    target.dispatchEvent(new CustomEvent('identical', { bubbles: true }));
+                    expect(logs).toEqual(expected);
+                }
+                it('listeners on standard html elements', () => {
+                    testIdenticalListeners(
+                        nodes.button,
+                        [nodes.button, nodes['container_div']],
+                        [
+                            [nodes.button, nodes.button],
+                            [nodes['container_div'], nodes['container_div']],
+                        ]
+                    );
+                });
             });
         });
     }

--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -159,77 +159,90 @@ describe('EventTarget.addEventListener', () => {
             expect(id).toEqual('second-container');
         });
     });
-    // TODO [#2253]: Enable in all modes once bug is fixed
-    if (process.env.NATIVE_SHADOW) {
-        describe('identical listeners', () => {
-            describe('should discard multiple identical listeners on same target', () => {
-                function testDiscardingIdenticalListeners(
-                    target,
-                    listenerTargets,
-                    expected,
-                    composed = false
-                ) {
-                    const logs = [];
-                    const listener = function (event) {
-                        logs.push([this, event.currentTarget]);
-                    };
-                    listenerTargets.forEach((target) => {
-                        target.addEventListener('dedupe', listener);
-                        target.addEventListener('dedupe', listener); // identical listener
-                    });
-                    target.dispatchEvent(new CustomEvent('dedupe', { bubbles: true, composed }));
-                    expect(logs).toEqual(expected);
-                }
-                it('listeners on shadow root, non-composed event', () => {
-                    testDiscardingIdenticalListeners(
-                        nodes.button,
-                        [nodes.button, nodes['container_div'], nodes['x-container'].shadowRoot],
-                        [
-                            [nodes.button, nodes.button],
-                            [nodes['container_div'], nodes['container_div']],
-                            [nodes['x-container'].shadowRoot, nodes['x-container'].shadowRoot],
-                        ]
-                    );
-                });
 
-                it('listeners on host, composed event', () => {
-                    testDiscardingIdenticalListeners(
-                        nodes.button,
-                        [nodes.button, nodes['container_div'], nodes['x-container']],
-                        [
-                            [nodes.button, nodes.button],
-                            [nodes['container_div'], nodes['container_div']],
-                            [nodes['x-container'], nodes['x-container']],
-                        ],
-                        true
-                    );
+    describe('identical listeners', () => {
+        describe('should discard multiple identical listeners on same target', () => {
+            function testDiscardingIdenticalListeners(
+                target,
+                listenerTargets,
+                expected,
+                composed = false
+            ) {
+                const logs = [];
+                const listener = function (event) {
+                    logs.push([this, event.currentTarget]);
+                };
+                listenerTargets.forEach((target) => {
+                    target.addEventListener('dedupe', listener);
+                    target.addEventListener('dedupe', listener); // identical listener
                 });
-            });
-            describe('should invoke identical listeners on same target with different options', () => {
-                // Note: addEventListener() with options are restricted for shadow root and host elements
-                function testIdenticalListeners(target, listenerTargets, expected) {
-                    const logs = [];
-                    const listener = function (event) {
-                        logs.push([this, event.currentTarget]);
-                    };
-                    listenerTargets.forEach((target) => {
-                        target.addEventListener('identical', listener);
-                        target.addEventListener('identical', listener, { passive: true }); // identical listener with different option
-                    });
-                    target.dispatchEvent(new CustomEvent('identical', { bubbles: true }));
-                    expect(logs).toEqual(expected);
+                target.dispatchEvent(new CustomEvent('dedupe', { bubbles: true, composed }));
+                expect(logs).toEqual(expected);
+            }
+            it('listeners on shadow root, non-composed event', () => {
+                const expected = [
+                    [nodes.button, nodes.button],
+                    [nodes['container_div'], nodes['container_div']],
+                ];
+
+                if (process.env.NATIVE_SHADOW) {
+                    expected.push([
+                        nodes['x-container'].shadowRoot,
+                        nodes['x-container'].shadowRoot,
+                    ]);
+                } else {
+                    expected.push([nodes['x-container'].shadowRoot, nodes['x-container']]);
                 }
-                it('listeners on standard html elements', () => {
-                    testIdenticalListeners(
-                        nodes.button,
-                        [nodes.button, nodes['container_div']],
-                        [
-                            [nodes.button, nodes.button],
-                            [nodes['container_div'], nodes['container_div']],
-                        ]
-                    );
-                });
+
+                testDiscardingIdenticalListeners(
+                    nodes.button,
+                    [nodes.button, nodes['container_div'], nodes['x-container'].shadowRoot],
+                    expected
+                );
+                testDiscardingIdenticalListeners(
+                    nodes.button,
+                    [nodes.button, nodes['container_div'], nodes['x-container'].shadowRoot],
+                    expected
+                );
+            });
+
+            it('listeners on host, composed event', () => {
+                testDiscardingIdenticalListeners(
+                    nodes.button,
+                    [nodes.button, nodes['container_div'], nodes['x-container']],
+                    [
+                        [nodes.button, nodes.button],
+                        [nodes['container_div'], nodes['container_div']],
+                        [nodes['x-container'], nodes['x-container']],
+                    ],
+                    true
+                );
             });
         });
-    }
+        describe('should invoke identical listeners on same target with different options', () => {
+            // Note: addEventListener() with options are restricted for shadow root and host elements
+            function testIdenticalListeners(target, listenerTargets, expected) {
+                const logs = [];
+                const listener = function (event) {
+                    logs.push([this, event.currentTarget]);
+                };
+                listenerTargets.forEach((target) => {
+                    target.addEventListener('identical', listener);
+                    target.addEventListener('identical', listener, { passive: true }); // identical listener with different option
+                });
+                target.dispatchEvent(new CustomEvent('identical', { bubbles: true }));
+                expect(logs).toEqual(expected);
+            }
+            it('listeners on standard html elements', () => {
+                testIdenticalListeners(
+                    nodes.button,
+                    [nodes.button, nodes['container_div']],
+                    [
+                        [nodes.button, nodes.button],
+                        [nodes['container_div'], nodes['container_div']],
+                    ]
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
Duplicate event listeners on template and host are not discarded.

## GUS work item
W-8928394
