### PR TITLE
chore(template-compiler): remove unused "secure" option

### DIFF
--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -35,7 +35,6 @@ export interface ResolvedConfig extends Required<Config> {
 }
 
 const AVAILABLE_OPTION_NAMES = new Set([
-    'secure',
     'experimentalComputedMemberExpression',
     'experimentalDynamicDirective',
 ]);


### PR DESCRIPTION
## Details

The "secure" option no longer does anything but we still have it as an available option name because removing it is a breaking change.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

## GUS work item

W-8988767