### PR TITLE
refactor: simplify types

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -175,7 +175,7 @@ export interface LightningElement extends HTMLElementTheGoodParts, AccessibleEle
  * This class is the base class for any LWC element.
  * Some elements directly extends this class, others implement it via inheritance.
  **/
-function BaseLightningElementConstructor(this: LightningElement): LightningElement {
+function LightningElementConstructor(this: LightningElement): LightningElement {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
         throw new ReferenceError('Illegal constructor');
@@ -236,8 +236,8 @@ function BaseLightningElementConstructor(this: LightningElement): LightningEleme
     return this;
 }
 
-BaseLightningElementConstructor.prototype = {
-    constructor: BaseLightningElementConstructor,
+LightningElementConstructor.prototype = {
+    constructor: LightningElementConstructor,
 
     dispatchEvent(event: Event): boolean {
         const {
@@ -537,9 +537,9 @@ for (const propName in HTMLElementOriginalDescriptors) {
     );
 }
 
-defineProperties(BaseLightningElementConstructor.prototype, lightningBasedDescriptors);
+defineProperties(LightningElementConstructor.prototype, lightningBasedDescriptors);
 
-defineProperty(BaseLightningElementConstructor, 'CustomElementConstructor', {
+defineProperty(LightningElementConstructor, 'CustomElementConstructor', {
     get() {
         // If required, a runtime-specific implementation must be defined.
         throw new ReferenceError('The current runtime does not support CustomElementConstructor.');
@@ -548,8 +548,8 @@ defineProperty(BaseLightningElementConstructor, 'CustomElementConstructor', {
 });
 
 if (process.env.NODE_ENV !== 'production') {
-    patchLightningElementPrototypeWithRestrictions(BaseLightningElementConstructor.prototype);
+    patchLightningElementPrototypeWithRestrictions(LightningElementConstructor.prototype);
 }
 
 // @ts-ignore
-export const BaseLightningElement: LightningElementConstructor = BaseLightningElementConstructor as unknown;
+export const BaseLightningElement: LightningElementConstructor = LightningElementConstructor as unknown;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -550,4 +550,4 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // @ts-ignore
-export const LightningElement: LightningElementConstructor = LightningElementConstructor as unknown;
+export const LightningElement: LightningElementConstructor = LightningElementConstructor;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -128,8 +128,6 @@ export interface LightningElementConstructor {
     delegatesFocus?: boolean;
 }
 
-export declare let LightningElement: LightningElementConstructor;
-
 type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
     Pick<
         HTMLElement,
@@ -552,4 +550,4 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // @ts-ignore
-export const BaseLightningElement: LightningElementConstructor = LightningElementConstructor as unknown;
+export const LightningElement: LightningElementConstructor = LightningElementConstructor as unknown;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -173,7 +173,10 @@ export interface LightningElement extends HTMLElementTheGoodParts, AccessibleEle
  * This class is the base class for any LWC element.
  * Some elements directly extends this class, others implement it via inheritance.
  **/
-function LightningElementConstructor(this: LightningElement): LightningElement {
+// @ts-ignore
+export const LightningElement: LightningElementConstructor = function (
+    this: LightningElement
+): LightningElement {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
         throw new ReferenceError('Illegal constructor');
@@ -232,10 +235,11 @@ function LightningElementConstructor(this: LightningElement): LightningElement {
     }
 
     return this;
-}
+};
 
-LightningElementConstructor.prototype = {
-    constructor: LightningElementConstructor,
+// @ts-ignore
+LightningElement.prototype = {
+    constructor: LightningElement,
 
     dispatchEvent(event: Event): boolean {
         const {
@@ -535,9 +539,9 @@ for (const propName in HTMLElementOriginalDescriptors) {
     );
 }
 
-defineProperties(LightningElementConstructor.prototype, lightningBasedDescriptors);
+defineProperties(LightningElement.prototype, lightningBasedDescriptors);
 
-defineProperty(LightningElementConstructor, 'CustomElementConstructor', {
+defineProperty(LightningElement, 'CustomElementConstructor', {
     get() {
         // If required, a runtime-specific implementation must be defined.
         throw new ReferenceError('The current runtime does not support CustomElementConstructor.');
@@ -546,8 +550,5 @@ defineProperty(LightningElementConstructor, 'CustomElementConstructor', {
 });
 
 if (process.env.NODE_ENV !== 'production') {
-    patchLightningElementPrototypeWithRestrictions(LightningElementConstructor.prototype);
+    patchLightningElementPrototypeWithRestrictions(LightningElement.prototype);
 }
-
-// @ts-ignore
-export const LightningElement: LightningElementConstructor = LightningElementConstructor;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -30,7 +30,7 @@ import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
 import { Template } from './template';
 import { LightningElement, LightningElementConstructor } from './base-lightning-element';
-import { BaseLightningElement, lightningBasedDescriptors } from './base-lightning-element';
+import { lightningBasedDescriptors } from './base-lightning-element';
 import { PropType, getDecoratorsMeta } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
 
@@ -84,7 +84,7 @@ function getCtorProto(Ctor: LightningElementConstructor): LightningElementConstr
         // of our Base class without having to leak it to user-land. If the circular function returns
         // itself, that's the signal that we have hit the end of the proto chain, which must always
         // be base.
-        proto = p === proto ? BaseLightningElement : p;
+        proto = p === proto ? LightningElement : p;
     }
     return proto!;
 }
@@ -120,9 +120,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
     } = proto;
     const superProto = getCtorProto(Ctor);
     const superDef =
-        superProto !== BaseLightningElement
-            ? getComponentInternalDef(superProto)
-            : lightingElementDef;
+        superProto !== LightningElement ? getComponentInternalDef(superProto) : lightingElementDef;
     const bridge = HTMLBridgeElementFactory(superDef.bridge, keys(apiFields), keys(apiMethods));
     const props: PropertyDescriptorMap = assign(create(null), superDef.props, apiFields);
     const propsConfig = assign(create(null), superDef.propsConfig, apiFieldsConfig);
@@ -177,7 +175,7 @@ export function isComponentConstructor(ctor: unknown): ctor is LightningElementC
     }
 
     // Fast path: LightningElement is part of the prototype chain of the constructor.
-    if (ctor.prototype instanceof BaseLightningElement) {
+    if (ctor.prototype instanceof LightningElement) {
         return true;
     }
 
@@ -198,7 +196,7 @@ export function isComponentConstructor(ctor: unknown): ctor is LightningElementC
             current = circularResolved;
         }
 
-        if (current === BaseLightningElement) {
+        if (current === LightningElement) {
             return true;
         }
     } while (!isNull(current) && (current = getPrototypeOf(current)));
@@ -237,15 +235,15 @@ export function getComponentInternalDef(Ctor: unknown): ComponentDef {
 }
 
 const lightingElementDef: ComponentDef = {
-    ctor: BaseLightningElement,
-    name: BaseLightningElement.name,
+    ctor: LightningElement,
+    name: LightningElement.name,
     props: lightningBasedDescriptors,
     propsConfig: EmptyObject,
     methods: EmptyObject,
     wire: EmptyObject,
     bridge: BaseBridgeElement,
     template: defaultEmptyTemplate,
-    render: BaseLightningElement.prototype.render,
+    render: LightningElement.prototype.render,
 };
 
 enum PropDefType {

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -7,7 +7,7 @@
 
 // Public APIs -------------------------------------------------------------------------------------
 export { createContextProvider } from './context-provider';
-export { BaseLightningElement as LightningElement } from './base-lightning-element';
+export { LightningElement } from './base-lightning-element';
 export { register } from './services';
 
 export { default as api } from './decorators/api';

--- a/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
@@ -11,6 +11,6 @@ it('should rely on the constructor name', () => {
 if (process.env.COMPAT !== true) {
     it('should fallback to BaseLightningElementConstructor if constructor has no name', () => {
         const elm = createElement('x-anonymous', { is: Anonymous });
-        expect(elm.getToString()).toBe('[object BaseLightningElementConstructor]');
+        expect(elm.getToString()).toBe('[object LightningElementConstructor]');
     });
 }

--- a/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
@@ -9,8 +9,8 @@ it('should rely on the constructor name', () => {
 });
 
 if (process.env.COMPAT !== true) {
-    it('should fallback to LightningElementConstructor if constructor has no name', () => {
+    it('should fallback to LightningElement if constructor has no name', () => {
         const elm = createElement('x-anonymous', { is: Anonymous });
-        expect(elm.getToString()).toBe('[object LightningElementConstructor]');
+        expect(elm.getToString()).toBe('[object LightningElement]');
     });
 }

--- a/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.toString/index.spec.js
@@ -9,7 +9,7 @@ it('should rely on the constructor name', () => {
 });
 
 if (process.env.COMPAT !== true) {
-    it('should fallback to BaseLightningElementConstructor if constructor has no name', () => {
+    it('should fallback to LightningElementConstructor if constructor has no name', () => {
         const elm = createElement('x-anonymous', { is: Anonymous });
         expect(elm.getToString()).toBe('[object LightningElementConstructor]');
     });


### PR DESCRIPTION
## Details
Removes `BaseLightningElement` and uses `LightningElement` throughout. In preparation for creating a new `BaseLightningElement` that will be superclass of both `LightningElement` and `MacroElement` (light DOM).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
W-8844567
