### PR TITLE
fix(synthetic-shadow): correct currentTarget in shadow root listeners

### DIFF
--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -17,4 +17,30 @@ describe('Event.currentTarget', () => {
         const div = container.shadowRoot.querySelector('div');
         div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
     });
+
+    it('should reference the host element', (done) => {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
+
+        container.addEventListener('test', (event) => {
+            expect(event.currentTarget).toEqual(container);
+            done();
+        });
+
+        const child = container.shadowRoot.querySelector('x-child');
+        child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+    });
+
+    it('should reference the shadow root', (done) => {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
+
+        container.shadowRoot.addEventListener('test', (event) => {
+            expect(event.currentTarget).toEqual(container.shadowRoot);
+            done();
+        });
+
+        const child = container.shadowRoot.querySelector('x-child');
+        child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+    });
 });


### PR DESCRIPTION
## Details

Listeners on shadow roots currently receive events whose `event.currentTarget` references the shadow root's host.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 

## GUS work item

W-9066543