### PR TITLE
perf: use constructable stylesheets in native shadow

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
@@ -31,7 +31,7 @@ it('should apply transformation for stylesheet file', async () => {
     `;
     const { code } = await transform(actual, 'foo.css', TRANSFORMATION_OPTIONS);
 
-    expect(code).toContain('function stylesheet');
+    expect(code).toContain('var stylesheet');
 });
 
 describe('custom properties', () => {

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
@@ -31,7 +31,7 @@ it('should apply transformation for stylesheet file', async () => {
     `;
     const { code } = await transform(actual, 'foo.css', TRANSFORMATION_OPTIONS);
 
-    expect(code).toContain('var stylesheet');
+    expect(code).toContain('const stylesheet');
 });
 
 describe('custom properties', () => {

--- a/packages/@lwc/engine-core/src/framework/hot-swaps.ts
+++ b/packages/@lwc/engine-core/src/framework/hot-swaps.ts
@@ -12,7 +12,8 @@ import { LightningElementConstructor } from './base-lightning-element';
 import { Template } from './template';
 import { markComponentAsDirty } from './component';
 import { isTemplateRegistered } from './secure-template';
-import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
+import { TemplateStylesheetFactories } from './stylesheet';
+import { StylesheetFactory } from '../shared/stylesheet-factory';
 
 const swappedTemplateMap = new WeakMap<Template, Template>();
 const swappedComponentMap = new WeakMap<LightningElementConstructor, LightningElementConstructor>();

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -30,6 +30,7 @@ export {
 export { registerComponent } from './component';
 export { registerTemplate } from './secure-template';
 export { registerDecorators } from './decorators/register';
+export { createCachingCssGenerator } from '../shared/create-caching-css-generator';
 
 // Mics. internal APIs -----------------------------------------------------------------------------
 export { unwrap } from './membrane';

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -11,23 +11,10 @@ import { VNode } from '../3rdparty/snabbdom/types';
 import { VM } from './vm';
 import { Template } from './template';
 import { getStyleOrSwappedStyle } from './hot-swaps';
+import { StylesheetFactory, StylesheetFactoryResult } from '../shared/stylesheet-factory';
 
 const hasAdoptedStyleSheets =
     typeof ShadowRoot !== 'undefined' && 'adoptedStyleSheets' in ShadowRoot.prototype;
-
-type StylesheetFactoryResult = string | CSSStyleSheet;
-
-/**
- * Function producing style based on a host and a shadow selector. This function is invoked by
- * the engine with different values depending on the mode that the component is running on.
- * If adopted style sheets are supported, then a CSSStyleSheet is returned. Otherwise, a string.
- */
-export type StylesheetFactory = (
-    hostSelector: string,
-    shadowSelector: string,
-    nativeShadow: boolean,
-    hasAdoptedStyleSheets: boolean
-) => StylesheetFactoryResult;
 
 /**
  * The list of stylesheets associated with a template. Each entry is either a StylesheetFactory or a
@@ -112,7 +99,12 @@ function evaluateStylesheetsContent(
             }
             ArrayPush.call(
                 content,
-                stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets)
+                (stylesheet as StylesheetFactory)(
+                    hostSelector,
+                    shadowSelector,
+                    nativeShadow,
+                    hasAdoptedStyleSheets
+                )
             );
         }
     }

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -12,9 +12,7 @@ import { VM } from './vm';
 import { Template } from './template';
 import { getStyleOrSwappedStyle } from './hot-swaps';
 import { StylesheetFactory, StylesheetFactoryResult } from '../shared/stylesheet-factory';
-
-const hasAdoptedStyleSheets =
-    typeof ShadowRoot !== 'undefined' && 'adoptedStyleSheets' in ShadowRoot.prototype;
+import { hasAdoptedStyleSheets } from '../shared/has-adopted-stylesheets';
 
 /**
  * The list of stylesheets associated with a template. Each entry is either a StylesheetFactory or a
@@ -71,8 +69,7 @@ function evaluateStylesheetsContent(
     stylesheets: TemplateStylesheetFactories,
     hostSelector: string,
     shadowSelector: string,
-    nativeShadow: boolean,
-    hasAdoptedStyleSheets: boolean
+    nativeShadow: boolean
 ): StylesheetFactoryResult[] {
     const content: StylesheetFactoryResult[] = [];
 
@@ -82,13 +79,7 @@ function evaluateStylesheetsContent(
         if (isArray(stylesheet)) {
             ArrayPush.apply(
                 content,
-                evaluateStylesheetsContent(
-                    stylesheet,
-                    hostSelector,
-                    shadowSelector,
-                    nativeShadow,
-                    hasAdoptedStyleSheets
-                )
+                evaluateStylesheetsContent(stylesheet, hostSelector, shadowSelector, nativeShadow)
             );
         } else {
             if (process.env.NODE_ENV !== 'production') {
@@ -99,12 +90,7 @@ function evaluateStylesheetsContent(
             }
             ArrayPush.call(
                 content,
-                stylesheet(
-                    hostSelector,
-                    shadowSelector,
-                    nativeShadow,
-                    hasAdoptedStyleSheets
-                )
+                stylesheet(hostSelector, shadowSelector, nativeShadow)
             );
         }
     }
@@ -126,8 +112,7 @@ export function getStylesheetsContent(vm: VM, template: Template): StylesheetFac
             stylesheets,
             hostSelector,
             shadowSelector,
-            !syntheticShadow,
-            hasAdoptedStyleSheets
+            !syntheticShadow
         );
     }
 

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -139,7 +139,7 @@ export function createStylesheet(vm: VM, stylesheets: StylesheetFactoryResult[])
 
     if (renderer.syntheticShadow) {
         for (let i = 0; i < stylesheets.length; i++) {
-            renderer.insertGlobalStylesheet(stylesheets[i] as 'string'); // always string if not hasAdoptedStyleSheets
+            renderer.insertGlobalStylesheet(stylesheets[i] as string); // always string if not hasAdoptedStyleSheets
         }
 
         return null;

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -99,7 +99,7 @@ function evaluateStylesheetsContent(
             }
             ArrayPush.call(
                 content,
-                (stylesheet as StylesheetFactory)(
+                stylesheet(
                     hostSelector,
                     shadowSelector,
                     nativeShadow,

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -88,10 +88,7 @@ function evaluateStylesheetsContent(
                 // the stylesheet, while internally, we have a replacement for it.
                 stylesheet = getStyleOrSwappedStyle(stylesheet);
             }
-            ArrayPush.call(
-                content,
-                stylesheet(hostSelector, shadowSelector, nativeShadow)
-            );
+            ArrayPush.call(content, stylesheet(hostSelector, shadowSelector, nativeShadow));
         }
     }
 

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -20,7 +20,7 @@ import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory
  * @param generateCss
  */
 export function createCachingCssGenerator(generateCss: StylesheetFactory): StylesheetFactory {
-    let cachedStylesheet: CSSStyleSheet;
+    let cachedStylesheet: CSSStyleSheet | undefined;
 
     return function generateCssWithCaching(
         hostSelector: string,

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -29,7 +29,7 @@ export function createCachingCssGenerator(generateCss: StylesheetFactory): Style
         hasAdoptedStyleSheets: boolean
     ): StylesheetFactoryResult {
         if (nativeShadow && hasAdoptedStyleSheets) {
-            if (!cachedStylesheet) {
+            if (!isUndefined(cachedStylesheet)) {
                 cachedStylesheet = new CSSStyleSheet();
                 // adoptedStyleSheets not in TypeScript yet: https://github.com/microsoft/TypeScript/issues/30022
                 // @ts-ignore

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -13,10 +13,10 @@ import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory
  * shadow DOM.
  *
  * The reason we do this here is because the input `generateCss` function is generated,
- * and will vary from component to component. But we want to define the CSSStyleSheet in
- * exactly one place, and the best place to do that is in the component itself (to avoid
- * having to keep a Map of strings to CSSStyleSheets). But to avoid duplicating this code
- * over and over into every component, we extract it into this own shared function.
+ * and will vary from component to component. But we want to define the CSSStyleSheet only
+ * once per component, and the best place to do that is in the component itself (to avoid
+ * needing to keep a Map of strings to CSSStyleSheets). But to avoid duplicating this code
+ * over and over in every component, we extract it into its own shared function.
  * @param generateCss
  */
 export function createCachingCssGenerator(generateCss: StylesheetFactory): StylesheetFactory {

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -6,6 +6,7 @@
  */
 
 import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory';
+import { hasAdoptedStyleSheets } from './has-adopted-stylesheets';
 
 /**
  * Given a StylesheetFactory, return another StylesheetFactory that properly caches the
@@ -25,8 +26,7 @@ export function createCachingCssGenerator(generateCss: StylesheetFactory): Style
     return function generateCssWithCaching(
         hostSelector: string,
         shadowSelector: string,
-        nativeShadow: boolean,
-        hasAdoptedStyleSheets: boolean
+        nativeShadow: boolean
     ): StylesheetFactoryResult {
         if (nativeShadow && hasAdoptedStyleSheets) {
             if (!isUndefined(cachedStylesheet)) {
@@ -34,11 +34,11 @@ export function createCachingCssGenerator(generateCss: StylesheetFactory): Style
                 // adoptedStyleSheets not in TypeScript yet: https://github.com/microsoft/TypeScript/issues/30022
                 // @ts-ignore
                 cachedStylesheet.replaceSync(
-                    generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets)
+                    generateCss(hostSelector, shadowSelector, nativeShadow)
                 );
             }
             return cachedStylesheet; // fast path
         }
-        return generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets);
+        return generateCss(hostSelector, shadowSelector, nativeShadow);
     };
 }

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory';
+
+/**
+ * Given a StylesheetFactory, return another StylesheetFactory that properly caches the
+ * CSSStyleSheet object if the browser supports adopted style sheets and we're in native
+ * shadow DOM.
+ *
+ * The reason we do this here is because the input `generateCss` function is generated,
+ * and will vary from component to component. But we want to define the CSSStyleSheet in
+ * exactly one place, and the best place to do that is in the component itself (to avoid
+ * having to keep a Map of strings to CSSStyleSheets). But to avoid duplicating this code
+ * over and over into every component, we extract it into this own shared function.
+ * @param generateCss
+ */
+export function createCachingCssGenerator(generateCss: StylesheetFactory): StylesheetFactory {
+    let cachedStylesheet: CSSStyleSheet;
+
+    return function generateCssWithCaching(
+        hostSelector: string,
+        shadowSelector: string,
+        nativeShadow: boolean,
+        hasAdoptedStyleSheets: boolean
+    ): StylesheetFactoryResult {
+        if (nativeShadow && hasAdoptedStyleSheets) {
+            if (!cachedStylesheet) {
+                cachedStylesheet = new CSSStyleSheet();
+                // adoptedStyleSheets not in TypeScript yet: https://github.com/microsoft/TypeScript/issues/30022
+                // @ts-ignore
+                cachedStylesheet.replaceSync(
+                    generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets)
+                );
+            }
+            return cachedStylesheet; // fast path
+        }
+        return generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets);
+    };
+}

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -5,9 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { isUndefined } from '@lwc/shared';
 import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory';
 import { hasAdoptedStyleSheets } from './has-adopted-stylesheets';
-import { isUndefined } from '@lwc/shared';
 
 /**
  * Given a StylesheetFactory, return another StylesheetFactory that properly caches the

--- a/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
+++ b/packages/@lwc/engine-core/src/shared/create-caching-css-generator.ts
@@ -7,6 +7,7 @@
 
 import { StylesheetFactory, StylesheetFactoryResult } from './stylesheet-factory';
 import { hasAdoptedStyleSheets } from './has-adopted-stylesheets';
+import { isUndefined } from '@lwc/shared';
 
 /**
  * Given a StylesheetFactory, return another StylesheetFactory that properly caches the
@@ -29,7 +30,7 @@ export function createCachingCssGenerator(generateCss: StylesheetFactory): Style
         nativeShadow: boolean
     ): StylesheetFactoryResult {
         if (nativeShadow && hasAdoptedStyleSheets) {
-            if (!isUndefined(cachedStylesheet)) {
+            if (isUndefined(cachedStylesheet)) {
                 cachedStylesheet = new CSSStyleSheet();
                 // adoptedStyleSheets not in TypeScript yet: https://github.com/microsoft/TypeScript/issues/30022
                 // @ts-ignore
@@ -37,7 +38,7 @@ export function createCachingCssGenerator(generateCss: StylesheetFactory): Style
                     generateCss(hostSelector, shadowSelector, nativeShadow)
                 );
             }
-            return cachedStylesheet; // fast path
+            return cachedStylesheet as CSSStyleSheet; // fast path
         }
         return generateCss(hostSelector, shadowSelector, nativeShadow);
     };

--- a/packages/@lwc/engine-core/src/shared/has-adopted-stylesheets.ts
+++ b/packages/@lwc/engine-core/src/shared/has-adopted-stylesheets.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export const hasAdoptedStyleSheets =
+    typeof ShadowRoot !== 'undefined' && 'adoptedStyleSheets' in ShadowRoot.prototype;

--- a/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
+++ b/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
@@ -1,0 +1,13 @@
+export type StylesheetFactoryResult = string | CSSStyleSheet;
+
+/**
+ * Function producing style based on a host and a shadow selector. This function is invoked by
+ * the engine with different values depending on the mode that the component is running on.
+ * If adopted style sheets are supported, then a CSSStyleSheet is returned. Otherwise, a string.
+ */
+export type StylesheetFactory = (
+    hostSelector: string,
+    shadowSelector: string,
+    nativeShadow: boolean,
+    hasAdoptedStyleSheets: boolean
+) => StylesheetFactoryResult;

--- a/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
+++ b/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
@@ -14,6 +14,5 @@ export type StylesheetFactoryResult = string | CSSStyleSheet;
 export type StylesheetFactory = (
     hostSelector: string,
     shadowSelector: string,
-    nativeShadow: boolean,
-    hasAdoptedStyleSheets: boolean
+    nativeShadow: boolean
 ) => StylesheetFactoryResult;

--- a/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
+++ b/packages/@lwc/engine-core/src/shared/stylesheet-factory.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 export type StylesheetFactoryResult = string | CSSStyleSheet;
 
 /**

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -29,6 +29,7 @@ export {
     swapComponent,
     swapStyle,
     swapTemplate,
+    createCachingCssGenerator,
     __unstable__ProfilerControl,
 } from '@lwc/engine-core';
 

--- a/packages/@lwc/engine-server/src/index.ts
+++ b/packages/@lwc/engine-server/src/index.ts
@@ -24,6 +24,7 @@ export {
     sanitizeAttribute,
     getComponentDef,
     isComponentConstructor,
+    createCachingCssGenerator,
 } from '@lwc/engine-core';
 
 // Engine-server public APIs -----------------------------------------------------------------------

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -85,7 +85,9 @@
 
   var __concat = Proxy.concat;
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+  var cachedStylesheet;
+
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : __callKey1(
@@ -93,6 +95,29 @@
           "join",
           ""
         );
+  }
+
+  function stylesheet(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
+    if (nativeShadow && hasAdoptedStyleSheets) {
+      if (!cachedStylesheet) {
+        cachedStylesheet = new CSSStyleSheet();
+
+        __callKey1(
+          cachedStylesheet,
+          "replaceSync",
+          generateCss(hostSelector, shadowSelector, nativeShadow)
+        );
+      }
+
+      return cachedStylesheet; // fast path
+    }
+
+    return generateCss(hostSelector, shadowSelector, nativeShadow);
   }
 
   var _implicitStylesheets = [stylesheet];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -85,9 +85,12 @@
 
   var __concat = Proxy.concat;
 
-  var cachedStylesheet;
-
-  function generateCss(hostSelector, shadowSelector, nativeShadow) {
+  function generateCss(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : __callKey1(
@@ -97,29 +100,7 @@
         );
   }
 
-  function stylesheet(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
-    if (nativeShadow && hasAdoptedStyleSheets) {
-      if (!cachedStylesheet) {
-        cachedStylesheet = new CSSStyleSheet();
-
-        __callKey1(
-          cachedStylesheet,
-          "replaceSync",
-          generateCss(hostSelector, shadowSelector, nativeShadow)
-        );
-      }
-
-      return cachedStylesheet; // fast path
-    }
-
-    return generateCss(hostSelector, shadowSelector, nativeShadow);
-  }
-
+  var stylesheet = lwc.createCachingCssGenerator(generateCss);
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -85,12 +85,7 @@
 
   var __concat = Proxy.concat;
 
-  function generateCss(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : __callKey1(

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -1,18 +1,13 @@
 (function (lwc) {
   "use strict";
 
-  function generateCss(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
   }
 
-  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+  const stylesheet = lwc.createCachingCssGenerator(generateCss);
 
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -1,10 +1,30 @@
 (function (lwc) {
   "use strict";
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+  var cachedStylesheet;
+
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
+  }
+
+  function stylesheet(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
+    if (nativeShadow && hasAdoptedStyleSheets) {
+      if (!cachedStylesheet) {
+        cachedStylesheet = new CSSStyleSheet();
+        cachedStylesheet.replaceSync(
+          generateCss(hostSelector, shadowSelector, nativeShadow)
+        );
+      }
+      return cachedStylesheet; // fast path
+    }
+    return generateCss(hostSelector, shadowSelector, nativeShadow);
   }
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -1,31 +1,19 @@
 (function (lwc) {
   "use strict";
 
-  var cachedStylesheet;
-
-  function generateCss(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
-  }
-
-  function stylesheet(
+  function generateCss(
     hostSelector,
     shadowSelector,
     nativeShadow,
     hasAdoptedStyleSheets
   ) {
-    if (nativeShadow && hasAdoptedStyleSheets) {
-      if (!cachedStylesheet) {
-        cachedStylesheet = new CSSStyleSheet();
-        cachedStylesheet.replaceSync(
-          generateCss(hostSelector, shadowSelector, nativeShadow)
-        );
-      }
-      return cachedStylesheet; // fast path
-    }
-    return generateCss(hostSelector, shadowSelector, nativeShadow);
+    return nativeShadow
+      ? ":host {color: var(--lwc-my-color);}"
+      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
   }
+
+  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -7,7 +7,9 @@
 
   var varResolver__default = /*#__PURE__*/ _interopDefaultLegacy(varResolver);
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+  var cachedStylesheet;
+
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? [
           ":host {color: ",
@@ -20,6 +22,24 @@
           varResolver__default["default"]("--lwc-my-color"),
           ";}",
         ].join("");
+  }
+
+  function stylesheet(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
+    if (nativeShadow && hasAdoptedStyleSheets) {
+      if (!cachedStylesheet) {
+        cachedStylesheet = new CSSStyleSheet();
+        cachedStylesheet.replaceSync(
+          generateCss(hostSelector, shadowSelector, nativeShadow)
+        );
+      }
+      return cachedStylesheet; // fast path
+    }
+    return generateCss(hostSelector, shadowSelector, nativeShadow);
   }
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -7,9 +7,12 @@
 
   var varResolver__default = /*#__PURE__*/ _interopDefaultLegacy(varResolver);
 
-  var cachedStylesheet;
-
-  function generateCss(hostSelector, shadowSelector, nativeShadow) {
+  function generateCss(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
     return nativeShadow
       ? [
           ":host {color: ",
@@ -24,23 +27,8 @@
         ].join("");
   }
 
-  function stylesheet(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
-    if (nativeShadow && hasAdoptedStyleSheets) {
-      if (!cachedStylesheet) {
-        cachedStylesheet = new CSSStyleSheet();
-        cachedStylesheet.replaceSync(
-          generateCss(hostSelector, shadowSelector, nativeShadow)
-        );
-      }
-      return cachedStylesheet; // fast path
-    }
-    return generateCss(hostSelector, shadowSelector, nativeShadow);
-  }
+  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -7,12 +7,7 @@
 
   var varResolver__default = /*#__PURE__*/ _interopDefaultLegacy(varResolver);
 
-  function generateCss(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? [
           ":host {color: ",
@@ -27,7 +22,7 @@
         ].join("");
   }
 
-  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+  const stylesheet = lwc.createCachingCssGenerator(generateCss);
 
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -1,18 +1,13 @@
 (function (lwc) {
   "use strict";
 
-  function generateCss(
-    hostSelector,
-    shadowSelector,
-    nativeShadow,
-    hasAdoptedStyleSheets
-  ) {
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
   }
 
-  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+  const stylesheet = lwc.createCachingCssGenerator(generateCss);
 
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -1,10 +1,30 @@
 (function (lwc) {
   "use strict";
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+  var cachedStylesheet;
+
+  function generateCss(hostSelector, shadowSelector, nativeShadow) {
     return nativeShadow
       ? ":host {color: var(--lwc-my-color);}"
       : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
+  }
+
+  function stylesheet(
+    hostSelector,
+    shadowSelector,
+    nativeShadow,
+    hasAdoptedStyleSheets
+  ) {
+    if (nativeShadow && hasAdoptedStyleSheets) {
+      if (!cachedStylesheet) {
+        cachedStylesheet = new CSSStyleSheet();
+        cachedStylesheet.replaceSync(
+          generateCss(hostSelector, shadowSelector, nativeShadow)
+        );
+      }
+      return cachedStylesheet; // fast path
+    }
+    return generateCss(hostSelector, shadowSelector, nativeShadow);
   }
   var _implicitStylesheets = [stylesheet];
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -1,31 +1,19 @@
 (function (lwc) {
   "use strict";
 
-  var cachedStylesheet;
-
-  function generateCss(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
-  }
-
-  function stylesheet(
+  function generateCss(
     hostSelector,
     shadowSelector,
     nativeShadow,
     hasAdoptedStyleSheets
   ) {
-    if (nativeShadow && hasAdoptedStyleSheets) {
-      if (!cachedStylesheet) {
-        cachedStylesheet = new CSSStyleSheet();
-        cachedStylesheet.replaceSync(
-          generateCss(hostSelector, shadowSelector, nativeShadow)
-        );
-      }
-      return cachedStylesheet; // fast path
-    }
-    return generateCss(hostSelector, shadowSelector, nativeShadow);
+    return nativeShadow
+      ? ":host {color: var(--lwc-my-color);}"
+      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
   }
+
+  var stylesheet = lwc.createCachingCssGenerator(generateCss);
+
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[aria-labelledby]", shadowSelector, " {}[aria-labelledby=\"bar\"]", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[aria-labelledby]", shadowSelector, " {}[aria-labelledby=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/aria-attributes/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[aria-labelledby]", shadowSelector, " {}[aria-labelledby=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@charset \"utf-8\";@namespace url(http://www.w3.org/1999/xhtml);@keyframes slidein {from {margin-left: 100%;}to {margin-left: 0%;}}@media screen and (min-width: 900px) {article", shadowSelector, " {padding: 1rem 3rem;}}@supports (display: grid) {div", shadowSelector, " {display: grid;}}@document url('https://www.example.com/') {h1", shadowSelector, " {color: green;}}@font-face {font-family: 'Open Sans';src: url('/fonts/OpenSans-Regular-webfont.woff2') format('woff2'),\n        url('/fonts/OpenSans-Regular-webfont.woff') format('woff');}@viewport {width: device-width;}@counter-style thumbs {system: cyclic;symbols: '\\1F44D';suffix: ' ';}@font-feature-values Font One {@styleset {nice-style: 12;}}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@charset \"utf-8\";@namespace url(http://www.w3.org/1999/xhtml);@keyframes slidein {from {margin-left: 100%;}to {margin-left: 0%;}}@media screen and (min-width: 900px) {article", shadowSelector, " {padding: 1rem 3rem;}}@supports (display: grid) {div", shadowSelector, " {display: grid;}}@document url('https://www.example.com/') {h1", shadowSelector, " {color: green;}}@font-face {font-family: 'Open Sans';src: url('/fonts/OpenSans-Regular-webfont.woff2') format('woff2'),\n        url('/fonts/OpenSans-Regular-webfont.woff') format('woff');}@viewport {width: device-width;}@counter-style thumbs {system: cyclic;symbols: '\\1F44D';suffix: ' ';}@font-feature-values Font One {@styleset {nice-style: 12;}}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/at-rules/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["@charset \"utf-8\";@namespace url(http://www.w3.org/1999/xhtml);@keyframes slidein {from {margin-left: 100%;}to {margin-left: 0%;}}@media screen and (min-width: 900px) {article", shadowSelector, " {padding: 1rem 3rem;}}@supports (display: grid) {div", shadowSelector, " {display: grid;}}@document url('https://www.example.com/') {h1", shadowSelector, " {color: green;}}@font-face {font-family: 'Open Sans';src: url('/fonts/OpenSans-Regular-webfont.woff2') format('woff2'),\n        url('/fonts/OpenSans-Regular-webfont.woff') format('woff');}@viewport {width: device-width;}@counter-style thumbs {system: cyclic;symbols: '\\1F44D';suffix: ' ';}@font-feature-values Font One {@styleset {nice-style: 12;}}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [".foo", shadowSelector, " {content: \"\\\\\";}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [".foo", shadowSelector, " {content: \"\\\\\";}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/back-slash/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [".foo", shadowSelector, " {content: \"\\\\\";}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["h1", shadowSelector, " > a", shadowSelector, " {}h1", shadowSelector, " + a", shadowSelector, " {}div.active", shadowSelector, " > p", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, " > a", shadowSelector, " {}h1", shadowSelector, " + a", shadowSelector, " {}div.active", shadowSelector, " > p", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/complex-selectors/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, " > a", shadowSelector, " {}h1", shadowSelector, " + a", shadowSelector, " {}div.active", shadowSelector, " > p", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/data-attributes/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[dir=\"rtl\"]", shadowSelector, " test", shadowSelector, " {order: 0;}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[dir=\"rtl\"]", shadowSelector, " test", shadowSelector, " {order: 0;}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-attribute/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[dir=\"rtl\"]", shadowSelector, " test", shadowSelector, " {order: 0;}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[dir=\"ltr\"] {order: 0;}[dir=\"ltr\"] test", shadowSelector, " {order: 1;}[dir=\"ltr\"] test", shadowSelector, " {order: 2;}[dir=\"ltr\"] test", shadowSelector, " {order: 3;}[dir=\"ltr\"] test", shadowSelector, " test", shadowSelector, " {order: 4;}[dir=\"rtl\"] {order: 5;}[dir=\"rtl\"] test", shadowSelector, " {order: 6;}[dir=\"rtl\"] test", shadowSelector, " {order: 7;}[dir=\"rtl\"] test", shadowSelector, " {order: 8;}[dir=\"rtl\"] test", shadowSelector, " test", shadowSelector, " {order: 9;}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[dir=\"ltr\"] {order: 0;}[dir=\"ltr\"] test", shadowSelector, " {order: 1;}[dir=\"ltr\"] test", shadowSelector, " {order: 2;}[dir=\"ltr\"] test", shadowSelector, " {order: 3;}[dir=\"ltr\"] test", shadowSelector, " test", shadowSelector, " {order: 4;}[dir=\"rtl\"] {order: 5;}[dir=\"rtl\"] test", shadowSelector, " {order: 6;}[dir=\"rtl\"] test", shadowSelector, " {order: 7;}[dir=\"rtl\"] test", shadowSelector, " {order: 8;}[dir=\"rtl\"] test", shadowSelector, " test", shadowSelector, " {order: 9;}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/dir-pseudo-class/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[dir=\"ltr\"] {order: 0;}[dir=\"ltr\"] test", shadowSelector, " {order: 1;}[dir=\"ltr\"] test", shadowSelector, " {order: 2;}[dir=\"ltr\"] test", shadowSelector, " {order: 3;}[dir=\"ltr\"] test", shadowSelector, " test", shadowSelector, " {order: 4;}[dir=\"rtl\"] {order: 5;}[dir=\"rtl\"] test", shadowSelector, " {order: 6;}[dir=\"rtl\"] test", shadowSelector, " {order: 7;}[dir=\"rtl\"] test", shadowSelector, " {order: 8;}[dir=\"rtl\"] test", shadowSelector, " test", shadowSelector, " {order: 9;}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["h1", shadowSelector, ":before {content: '$test\"escaping quote(\\')'}h1", shadowSelector, ":after {content: \"$my test'escaping quote(\\\")\"}h2", shadowSelector, ":before {content: \"\\\\\\\\\"}h2", shadowSelector, ":after {content: \"`\"}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, ":before {content: '$test\"escaping quote(\\')'}h1", shadowSelector, ":after {content: \"$my test'escaping quote(\\\")\"}h2", shadowSelector, ":before {content: \"\\\\\\\\\"}h2", shadowSelector, ":after {content: \"`\"}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/escape-string-characters/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, ":before {content: '$test\"escaping quote(\\')'}h1", shadowSelector, ":after {content: \"$my test'escaping quote(\\\")\"}h2", shadowSelector, ":before {content: \"\\\\\\\\\"}h2", shadowSelector, ":after {content: \"`\"}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[hidden]", shadowSelector, " {}[lang=\"fr\"]", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[hidden]", shadowSelector, " {}[lang=\"fr\"]", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/global-html-attributes/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[hidden]", shadowSelector, " {}[lang=\"fr\"]", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? ":host(.foo) {}" : [hostSelector, ".foo {}"].join('')), (nativeShadow ? [":host(.foo) span", shadowSelector, " {}"].join('') : [hostSelector, ".foo span", shadowSelector, " {}"].join('')), (nativeShadow ? ":host(:hover) {}" : [hostSelector, ":hover {}"].join('')), (nativeShadow ? ":host(.foo, .bar) {}" : [hostSelector, ".foo,", hostSelector, ".bar {}"].join(''))].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [(nativeShadow ? ":host(.foo) {}" : [hostSelector, ".foo {}"].join('')), (nativeShadow ? [":host(.foo) span", shadowSelector, " {}"].join('') : [hostSelector, ".foo span", shadowSelector, " {}"].join('')), (nativeShadow ? ":host(:hover) {}" : [hostSelector, ":hover {}"].join('')), (nativeShadow ? ":host(.foo, .bar) {}" : [hostSelector, ".foo,", hostSelector, ".bar {}"].join(''))].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host-functional/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? ":host(.foo) {}" : [hostSelector, ".foo {}"].join('')), (nativeShadow ? [":host(.foo) span", shadowSelector, " {}"].join('') : [hostSelector, ".foo span", shadowSelector, " {}"].join('')), (nativeShadow ? ":host(:hover) {}" : [hostSelector, ":hover {}"].join('')), (nativeShadow ? ":host(.foo, .bar) {}" : [hostSelector, ".foo,", hostSelector, ".bar {}"].join(''))].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return (nativeShadow ? ":host {}" : [hostSelector, " {}"].join(''));
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return (nativeShadow ? ":host {}" : [hostSelector, " {}"].join(''));
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/host/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return (nativeShadow ? ":host {}" : [hostSelector, " {}"].join(''));
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["[turkey='val']", shadowSelector, " {}[keyboard='val']", shadowSelector, " {}[notif\\:true='val']", shadowSelector, " {}[notfor\\:item='val']", shadowSelector, " {}[notfor\\:each='val']", shadowSelector, " {}[notiterator\\:name='val']", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[turkey='val']", shadowSelector, " {}[keyboard='val']", shadowSelector, " {}[notif\\:true='val']", shadowSelector, " {}[notfor\\:item='val']", shadowSelector, " {}[notfor\\:each='val']", shadowSelector, " {}[notiterator\\:name='val']", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/lwc-reserved-similarButAllowed-rule/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["[turkey='val']", shadowSelector, " {}[keyboard='val']", shadowSelector, " {}[notif\\:true='val']", shadowSelector, " {}[notfor\\:item='val']", shadowSelector, " {}[notfor\\:each='val']", shadowSelector, " {}[notiterator\\:name='val']", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["@media screen and (max-width: 768px) {", (nativeShadow ? ":host {width: calc(50% - 1rem);}" : [hostSelector, " {width: calc(50% - 1rem);}"].join('')), "}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@media screen and (max-width: 768px) {", (nativeShadow ? ":host {width: calc(50% - 1rem);}" : [hostSelector, " {width: calc(50% - 1rem);}"].join('')), "}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query-with-host/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@media screen and (max-width: 768px) {", (nativeShadow ? ":host {width: calc(50% - 1rem);}" : [hostSelector, " {width: calc(50% - 1rem);}"].join('')), "}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@media screen and (min-width: 900px) {h1", shadowSelector, " {}}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@media screen and (min-width: 900px) {h1", shadowSelector, " {}}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/media-query/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["@media screen and (min-width: 900px) {h1", shadowSelector, " {}}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [(nativeShadow ? [":host(.selected) button", shadowSelector, " {color: #0070d2;}"].join('') : [hostSelector, ".selected button", shadowSelector, " {color: #0070d2;}"].join('')), (nativeShadow ? [":host:not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('') : [hostSelector, ":not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('')), (nativeShadow ? [":host:not(.selected):hover button", shadowSelector, ",:host button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('') : [hostSelector, ":not(.selected):hover button", shadowSelector, ",", hostSelector, " button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('')), "button:focus", shadowSelector, " {outline: none;box-shadow: none;background-color: #f3f2f2;}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? [":host(.selected) button", shadowSelector, " {color: #0070d2;}"].join('') : [hostSelector, ".selected button", shadowSelector, " {color: #0070d2;}"].join('')), (nativeShadow ? [":host:not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('') : [hostSelector, ":not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('')), (nativeShadow ? [":host:not(.selected):hover button", shadowSelector, ",:host button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('') : [hostSelector, ":not(.selected):hover button", shadowSelector, ",", hostSelector, " button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('')), "button:focus", shadowSelector, " {outline: none;box-shadow: none;background-color: #f3f2f2;}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-line/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? [":host(.selected) button", shadowSelector, " {color: #0070d2;}"].join('') : [hostSelector, ".selected button", shadowSelector, " {color: #0070d2;}"].join('')), (nativeShadow ? [":host:not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('') : [hostSelector, ":not(.selected) button", shadowSelector, " {color: #6d6d70;transition: all .2s ease-in-out;}"].join('')), (nativeShadow ? [":host:not(.selected):hover button", shadowSelector, ",:host button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('') : [hostSelector, ":not(.selected):hover button", shadowSelector, ",", hostSelector, " button:focus", shadowSelector, " {color: #005fb2;transform: scale(1.2);}"].join('')), "button:focus", shadowSelector, " {outline: none;box-shadow: none;background-color: #f3f2f2;}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["h1", shadowSelector, ", h2", shadowSelector, " {}h1", shadowSelector, ",h2", shadowSelector, "{}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, ", h2", shadowSelector, " {}h1", shadowSelector, ",h2", shadowSelector, "{}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/multi-selectors/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, ", h2", shadowSelector, " {}h1", shadowSelector, ",h2", shadowSelector, "{}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
@@ -3,10 +3,10 @@ import varResolver from "custom-properties-resolver";
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [".a", shadowSelector, " {box-shadow: ", varResolver("--lwc-c-active-button-box-shadow","0 0 2px " + varResolver("--lwc-brand-accessible","#0070d2")), ";}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
@@ -1,20 +1,12 @@
 import varResolver from "custom-properties-resolver";
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [".a", shadowSelector, " {box-shadow: ", varResolver("--lwc-c-active-button-box-shadow","0 0 2px " + varResolver("--lwc-brand-accessible","#0070d2")), ";}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/nester-vars-compounded/expected.js
@@ -1,5 +1,20 @@
 import varResolver from "custom-properties-resolver";
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [".a", shadowSelector, " {box-shadow: ", varResolver("--lwc-c-active-button-box-shadow","0 0 2px " + varResolver("--lwc-brand-accessible","#0070d2")), ";}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [":not(p)", shadowSelector, " {}p:not(.foo, .bar)", shadowSelector, " {}:matches(ol, li, span)", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [":not(p)", shadowSelector, " {}p:not(.foo, .bar)", shadowSelector, " {}:matches(ol, li, span)", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-functional-selector/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [":not(p)", shadowSelector, " {}p:not(.foo, .bar)", shadowSelector, " {}:matches(ol, li, span)", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [":checked", shadowSelector, " {}ul", shadowSelector, " li:first-child", shadowSelector, " a", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [":checked", shadowSelector, " {}ul", shadowSelector, " li:first-child", shadowSelector, " a", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-class-selector/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [":checked", shadowSelector, " {}ul", shadowSelector, " li:first-child", shadowSelector, " a", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [shadowSelector, "::after {}h1", shadowSelector, "::before {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [shadowSelector, "::after {}h1", shadowSelector, "::before {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [shadowSelector, "::after {}h1", shadowSelector, "::before {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, " {}.foo", shadowSelector, " {}[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["h1", shadowSelector, " {}.foo", shadowSelector, " {}[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/simple-selectors/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["h1", shadowSelector, " {}.foo", shadowSelector, " {}[data-foo]", shadowSelector, " {}[data-foo=\"bar\"]", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["@supports (display: flex) {h1", shadowSelector, " {}}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@supports (display: flex) {h1", shadowSelector, " {}}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/support-query/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["@supports (display: flex) {h1", shadowSelector, " {}}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
@@ -1,4 +1,19 @@
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["*", shadowSelector, " {}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
@@ -1,19 +1,11 @@
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["*", shadowSelector, " {}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/universal-selector/expected.js
@@ -2,10 +2,10 @@
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["*", shadowSelector, " {}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
@@ -3,10 +3,10 @@ import varResolver from "custom-properties-resolver";
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ";}div", shadowSelector, " {border: ", varResolver("--border","1px solid rgba(0,0,0,0.1)"), ";}div", shadowSelector, " {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
@@ -1,20 +1,12 @@
 import varResolver from "custom-properties-resolver";
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ";}div", shadowSelector, " {border: ", varResolver("--border","1px solid rgba(0,0,0,0.1)"), ";}div", shadowSelector, " {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-multiple/expected.js
@@ -1,5 +1,20 @@
 import varResolver from "custom-properties-resolver";
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ";}div", shadowSelector, " {border: ", varResolver("--border","1px solid rgba(0,0,0,0.1)"), ";}div", shadowSelector, " {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
@@ -1,20 +1,12 @@
 import varResolver from "custom-properties-resolver";
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
@@ -1,5 +1,20 @@
 import varResolver from "custom-properties-resolver";
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function-nested/expected.js
@@ -3,10 +3,10 @@ import varResolver from "custom-properties-resolver";
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
@@ -1,5 +1,20 @@
 import varResolver from "custom-properties-resolver";
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color","black"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color"), " important;}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
@@ -3,10 +3,10 @@ import varResolver from "custom-properties-resolver";
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color","black"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color"), " important;}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-function/expected.js
@@ -1,20 +1,12 @@
 import varResolver from "custom-properties-resolver";
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return ["div", shadowSelector, " {color: ", varResolver("--lwc-color"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color","black"), ";}div", shadowSelector, " {color: ", varResolver("--lwc-color"), " important;}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
@@ -1,5 +1,20 @@
 import varResolver from "custom-properties-resolver";
-function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+
+
+var cachedStylesheet
+
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? [":host {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('') : [hostSelector, " {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('')), (nativeShadow ? [":host(.foo) {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('') : [hostSelector, ".foo {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('')), "div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";display: \"block\";}"].join('');
+}
+
+function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+  if (nativeShadow && hasAdoptedStyleSheets) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(hostSelector, shadowSelector, nativeShadow);
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
@@ -1,20 +1,12 @@
 import varResolver from "custom-properties-resolver";
 
 
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow) {
+function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
   return [(nativeShadow ? [":host {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('') : [hostSelector, " {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('')), (nativeShadow ? [":host(.foo) {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('') : [hostSelector, ".foo {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('')), "div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";display: \"block\";}"].join('');
 }
 
-function stylesheet(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
-  if (nativeShadow && hasAdoptedStyleSheets) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(hostSelector, shadowSelector, nativeShadow));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(hostSelector, shadowSelector, nativeShadow);
-}
+var stylesheet = createCachingCssGenerator(generateCss);
+
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-host-combined/expected.js
@@ -3,10 +3,10 @@ import varResolver from "custom-properties-resolver";
 
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(hostSelector, shadowSelector, nativeShadow, hasAdoptedStyleSheets) {
+function generateCss(hostSelector, shadowSelector, nativeShadow) {
   return [(nativeShadow ? [":host {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('') : [hostSelector, " {color: ", varResolver("--lwc-color"), ";padding: 10px;}"].join('')), (nativeShadow ? [":host(.foo) {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('') : [hostSelector, ".foo {background: linear-gradient(to top,", varResolver("--lwc-color"), ",", varResolver("--lwc-other"), ");}"].join('')), "div", shadowSelector, " {background: ", varResolver("--lwc-color",varResolver("--lwc-other","black")), ";display: \"block\";}"].join('');
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -70,7 +70,7 @@ function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER},
   return ${serializedStyle};
 }
 
-var stylesheet = createCachingCssGenerator(generateCss);
+const stylesheet = createCachingCssGenerator(generateCss);
 \n`;
 
         // add import at the end

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -26,6 +26,7 @@ interface Token {
 const HOST_SELECTOR_IDENTIFIER = 'hostSelector';
 const SHADOW_SELECTOR_IDENTIFIER = 'shadowSelector';
 const SHADOW_DOM_ENABLED_IDENTIFIER = 'nativeShadow';
+const HAS_ADOPTED_STYLESHEETS_IDENTIFIER = 'hasAdoptedStyleSheets';
 const STYLESHEET_IDENTIFIER = 'stylesheet';
 const VAR_RESOLVER_IDENTIFIER = 'varResolver';
 
@@ -56,10 +57,29 @@ export default function serialize(result: Result, config: Config): string {
     const serializedStyle = serializeCss(result, collectVarFunctions).trim();
 
     if (serializedStyle) {
-        // inline function
-        buffer += `function stylesheet(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}) {\n`;
-        buffer += `  return ${serializedStyle};\n`;
-        buffer += `}\n`;
+        // In the case where adopted stylesheets (aka construtable stylesheets) are supported,
+        // we use a fast path where the CSSStyleSheet object is cached. This avoids having to use
+        // some kind of mapping from strings to CSSStyleSheet objects somewhere, since the whole point
+        // of adoptedStyleSheets is to avoid duplication. Also with native shadow, the string never changes,
+        // so there is no point running stylesheet() over and over again to do costly string concatenation,
+        // so that's another benefit of caching the CSSStyleSheet object.
+        buffer += `\n
+var cachedStylesheet
+
+function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}) {
+  return ${serializedStyle};
+}
+
+function stylesheet(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}, ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
+  if (${SHADOW_DOM_ENABLED_IDENTIFIER} && ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
+    if (!cachedStylesheet) {
+      cachedStylesheet = new CSSStyleSheet();
+      cachedStylesheet.replaceSync(generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}));
+    }
+    return cachedStylesheet; // fast path
+  }
+  return generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER});
+}\n`;
 
         // add import at the end
         stylesheetList.push(STYLESHEET_IDENTIFIER);

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -64,22 +64,14 @@ export default function serialize(result: Result, config: Config): string {
         // so there is no point running stylesheet() over and over again to do costly string concatenation,
         // so that's another benefit of caching the CSSStyleSheet object.
         buffer += `\n
-var cachedStylesheet
+import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}) {
+function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}, ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
   return ${serializedStyle};
 }
 
-function stylesheet(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}, ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
-  if (${SHADOW_DOM_ENABLED_IDENTIFIER} && ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
-    if (!cachedStylesheet) {
-      cachedStylesheet = new CSSStyleSheet();
-      cachedStylesheet.replaceSync(generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}));
-    }
-    return cachedStylesheet; // fast path
-  }
-  return generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER});
-}\n`;
+var stylesheet = createCachingCssGenerator(generateCss);
+\n`;
 
         // add import at the end
         stylesheetList.push(STYLESHEET_IDENTIFIER);

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -26,7 +26,6 @@ interface Token {
 const HOST_SELECTOR_IDENTIFIER = 'hostSelector';
 const SHADOW_SELECTOR_IDENTIFIER = 'shadowSelector';
 const SHADOW_DOM_ENABLED_IDENTIFIER = 'nativeShadow';
-const HAS_ADOPTED_STYLESHEETS_IDENTIFIER = 'hasAdoptedStyleSheets';
 const STYLESHEET_IDENTIFIER = 'stylesheet';
 const VAR_RESOLVER_IDENTIFIER = 'varResolver';
 
@@ -57,16 +56,10 @@ export default function serialize(result: Result, config: Config): string {
     const serializedStyle = serializeCss(result, collectVarFunctions).trim();
 
     if (serializedStyle) {
-        // In the case where adopted stylesheets (aka construtable stylesheets) are supported,
-        // we use a fast path where the CSSStyleSheet object is cached. This avoids having to use
-        // some kind of mapping from strings to CSSStyleSheet objects somewhere, since the whole point
-        // of adoptedStyleSheets is to avoid duplication. Also with native shadow, the string never changes,
-        // so there is no point running stylesheet() over and over again to do costly string concatenation,
-        // so that's another benefit of caching the CSSStyleSheet object.
         buffer += `\n
 import { createCachingCssGenerator } from 'lwc';
 
-function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}, ${HAS_ADOPTED_STYLESHEETS_IDENTIFIER}) {
+function generateCss(${HOST_SELECTOR_IDENTIFIER}, ${SHADOW_SELECTOR_IDENTIFIER}, ${SHADOW_DOM_ENABLED_IDENTIFIER}) {
   return ${serializedStyle};
 }
 

--- a/packages/integration-karma/test/native-shadow/style/style.spec.js
+++ b/packages/integration-karma/test/native-shadow/style/style.spec.js
@@ -1,0 +1,30 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+describe('style', () => {
+    let container;
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+    afterEach(() => {
+        document.body.removeChild(container);
+        container = undefined;
+    });
+
+    it('style scoping works correctly', () => {
+        const style = document.createElement('style');
+        style.textContent = 'div { color: blue }';
+        const div = document.createElement('div');
+        div.textContent = 'hello';
+        const component = createElement('x-component', { is: Component });
+        container.appendChild(style);
+        container.appendChild(div);
+        container.appendChild(component);
+
+        expect(getComputedStyle(div).color).toEqual('rgb(0, 0, 255)'); // blue
+        expect(getComputedStyle(component.shadowRoot.querySelector('div')).color).toEqual(
+            'rgb(255, 0, 0)'
+        ); // red
+    });
+});

--- a/packages/integration-karma/test/native-shadow/style/x/component/component.css
+++ b/packages/integration-karma/test/native-shadow/style/x/component/component.css
@@ -1,0 +1,3 @@
+div {
+    color: red;
+}

--- a/packages/integration-karma/test/native-shadow/style/x/component/component.html
+++ b/packages/integration-karma/test/native-shadow/style/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+  <div>hello world</div>
+</template>

--- a/packages/integration-karma/test/native-shadow/style/x/component/component.js
+++ b/packages/integration-karma/test/native-shadow/style/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Component extends LightningElement {}

--- a/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -101,8 +101,14 @@ if (process.env.NATIVE_SHADOW) {
         document.body.appendChild(elm);
 
         return Promise.resolve().then(() => {
-            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map((xSimple) =>
-                xSimple.shadowRoot.querySelector('style')
+            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map(
+                (xSimple) => {
+                    // if constructable stylesheets are supported, return that rather than <style> tags
+                    return (
+                        xSimple.shadowRoot.adoptedStyleSheets ||
+                        xSimple.shadowRoot.querySelector('style')
+                    );
+                }
             );
 
             expect(styles[0]).toBeTruthy();


### PR DESCRIPTION
## Details

This is a rewrite of a previous PR: #2290

Background:

- [Constructable stylesheets](https://developers.google.com/web/updates/2019/02/constructable-stylesheets)
- [Chrome status](https://www.chromestatus.com/feature/5394843094220800)

Based on [a small benchmark](https://salesforce.quip.com/KFHaA0ZaUREI) of rendering the same element 1,000 times, with that element containing a 1,000-line CSS file (a somewhat extreme example, but good for a benchmark), the end-to-end rendering time was improved from ~380ms to ~180ms (on my MacBook Pro).

The main savings come from not needing to create a `<style>` element for each component. Instead, we just append a `CSSStyleSheet` object to `cmp.shadowRoot.adoptedStyleSheets`.

I also went ahead and added an optimization for the `stylesheet()` function to cache the output (which never changes in the case of native shadow), but this is less of a huge improvement unless the CSS file for the component is large (in which case the string concatenation takes a long time). But it seems sensible to do this anyway so we don't need to create `CSSStyleSheet` objects over and over again, or have some kind of system for de-duping them.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item

W-9125079