### PR TITLE
feat: add compiler option to enable light DOM components

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -54,6 +54,7 @@ export interface TransformOptions {
     experimentalDynamicComponent?: DynamicComponentConfig;
     outputConfig?: OutputConfig;
     isExplicitImport?: boolean;
+    experimentalLightDOMComponent?: boolean;
 }
 
 export interface NormalizedTransformOptions extends TransformOptions {
@@ -61,6 +62,7 @@ export interface NormalizedTransformOptions extends TransformOptions {
     stylesheetConfig: NormalizedStylesheetConfig;
     experimentalDynamicComponent: NormalizedDynamicComponentConfig;
     isExplicitImport: boolean;
+    experimentalLightDOMComponent?: boolean;
 }
 
 export interface NormalizedStylesheetConfig extends StylesheetConfig {

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -112,6 +112,7 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
                 outputConfig: { sourcemap: mergedPluginOptions.sourcemap },
                 stylesheetConfig: mergedPluginOptions.stylesheetConfig,
                 experimentalDynamicComponent: mergedPluginOptions.experimentalDynamicComponent,
+                experimentalLightDOMComponent: mergedPluginOptions.experimentalLightDOMComponent,
             });
 
             return { code, map };


### PR DESCRIPTION
## Details

Adds a flag to `@lwc/compiler` to enable light DOM components: `experimentalLightDOMComponent`. It's assumed false by default.

The goal of this is to allow us to work on light DOM while all new work is gated behind this flag.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9155929
