### PR TITLE
fix: don't use babel "loose" mode in light DOM

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -54,6 +54,7 @@ export interface TransformOptions {
     experimentalDynamicComponent?: DynamicComponentConfig;
     outputConfig?: OutputConfig;
     isExplicitImport?: boolean;
+    experimentalLightDOMComponent?: boolean;
 }
 
 export interface NormalizedTransformOptions extends TransformOptions {
@@ -61,6 +62,7 @@ export interface NormalizedTransformOptions extends TransformOptions {
     stylesheetConfig: NormalizedStylesheetConfig;
     experimentalDynamicComponent: NormalizedDynamicComponentConfig;
     isExplicitImport: boolean;
+    experimentalLightDOMComponent?: boolean;
 }
 
 export interface NormalizedStylesheetConfig extends StylesheetConfig {

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -33,7 +33,10 @@ export default function scriptTransform(
             configFile: false,
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
-                [babelClassPropertiesPlugin, { loose: true }],
+                // Loose mode is only required for light DOM, due to the static field (`shadow`).
+                // It may introduce some side effects or perf impact to use strict mode, so
+                // we should only use strict mode when light DOM is enabled.
+                [babelClassPropertiesPlugin, { loose: !options.experimentalLightDOMComponent }],
 
                 // This plugin should be removed in a future version. The object-rest-spread is
                 // already a stage 4 feature. The LWC compile should leave this syntax untouched.

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -33,7 +33,7 @@ export default function scriptTransform(
             configFile: false,
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
-                // Loose mode is only required for light DOM, due to the static field (`shadow`).
+                // Strict (not `loose`) mode is only required for light DOM, due to the static field (`shadow`).
                 // It may introduce some side effects or perf impact to use strict mode, so
                 // we should only use strict mode when light DOM is enabled.
                 [babelClassPropertiesPlugin, { loose: !options.experimentalLightDOMComponent }],

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_lightdom_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_lightdom_config_simple_app.js
@@ -1,0 +1,118 @@
+(function (lwc) {
+  "use strict";
+
+  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+    return nativeShadow
+      ? ":host {color: var(--lwc-my-color);}"
+      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
+  }
+  var _implicitStylesheets = [stylesheet];
+
+  function tmpl$1($api, $cmp, $slotset, $ctx) {
+    const { d: api_dynamic, h: api_element } = $api;
+    return [
+      api_element(
+        "div",
+        {
+          key: 0,
+        },
+        [api_dynamic($cmp.x)]
+      ),
+    ];
+  }
+  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+  tmpl$1.stylesheets = [];
+
+  if (_implicitStylesheets) {
+    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+  }
+  tmpl$1.stylesheetTokens = {
+    hostAttribute: "x-foo_foo-host",
+    shadowAttribute: "x-foo_foo",
+  };
+
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      obj[key] = value;
+    }
+    return obj;
+  }
+
+  class Foo extends lwc.LightningElement {
+    constructor(...args) {
+      super(...args);
+
+      _defineProperty(this, "x", void 0);
+    }
+  }
+
+  lwc.registerDecorators(Foo, {
+    publicProps: {
+      x: {
+        config: 0,
+      },
+    },
+  });
+
+  var _xFoo = lwc.registerComponent(Foo, {
+    tmpl: _tmpl$1,
+  });
+
+  function tmpl($api, $cmp, $slotset, $ctx) {
+    const { c: api_custom_element, h: api_element } = $api;
+    return [
+      api_element(
+        "div",
+        {
+          classMap: {
+            container: true,
+          },
+          key: 0,
+        },
+        [
+          api_custom_element(
+            "x-foo",
+            _xFoo,
+            {
+              props: {
+                x: "1",
+              },
+              key: 1,
+            },
+            []
+          ),
+        ]
+      ),
+    ];
+  }
+  var _tmpl = lwc.registerTemplate(tmpl);
+  tmpl.stylesheets = [];
+  tmpl.stylesheetTokens = {
+    hostAttribute: "x-app_app-host",
+    shadowAttribute: "x-app_app",
+  };
+
+  class App extends lwc.LightningElement {
+    constructor() {
+      super();
+      this.list = [];
+    }
+  }
+
+  var App$1 = lwc.registerComponent(App, {
+    tmpl: _tmpl,
+  });
+
+  const container = document.getElementById("main");
+  const element = lwc.createElement("x-app", {
+    is: App$1,
+  });
+  container.appendChild(element);
+})(LWC);

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -82,6 +82,17 @@ describe('rollup in compat mode', () => {
     });
 });
 
+describe('rollup in light DOM mode', () => {
+    it(`simple app`, () => {
+        const entry = path.join(simpleAppDir, 'main.js');
+        return doRollup(entry, {}, { experimentalLightDOMComponent: true }).then(
+            ({ code: actual }) => {
+                fsExpected('expected_lightdom_config_simple_app', pretty(actual));
+            }
+        );
+    });
+});
+
 describe('typescript relative import', () => {
     it(`should resolve to .ts file`, () => {
         const entry = path.join(tsAppDir, 'main.ts');

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -112,6 +112,7 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
                 outputConfig: { sourcemap: mergedPluginOptions.sourcemap },
                 stylesheetConfig: mergedPluginOptions.stylesheetConfig,
                 experimentalDynamicComponent: mergedPluginOptions.experimentalDynamicComponent,
+                experimentalLightDOMComponent: mergedPluginOptions.experimentalLightDOMComponent,
             });
 
             return { code, map };


### PR DESCRIPTION
## Details

Light DOM will need Babel to not run in "loose" mode for class fields in order to work correctly. This PR ensures we run in strict mode when light DOM is enabled.

Note that this PR is rebased on top of #2295 because it doesn't make sense without it. Relevant commit: https://github.com/salesforce/lwc/pull/2296/commits/99ca3431f16b3a053ea23dab2a07cdcfd57f2f37

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9141416
