### PR TITLE
chore(compiler): Remove spread operator transformation

### DIFF
--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -25,7 +25,6 @@
     "dependencies": {
         "@babel/core": "~7.13.8",
         "@babel/plugin-proposal-class-properties": "~7.13.0",
-        "@babel/plugin-proposal-object-rest-spread": "~7.13.8",
         "@lwc/babel-plugin-component": "2.0.0-rc.0",
         "@lwc/errors": "2.0.0-rc.0",
         "@lwc/shared": "2.0.0-rc.0",

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -41,13 +41,3 @@ it('should transform class fields', async () => {
 
     expect(code).not.toContain('foo;');
 });
-
-it('should object spread', async () => {
-    const actual = `
-        export const test = { ...a, b: 1 }
-    `;
-    const { code } = await transform(actual, 'foo.js', TRANSFORMATION_OPTIONS);
-
-    expect(code).toContain('b: 1');
-    expect(code).not.toContain('...a');
-});

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -7,7 +7,6 @@
 import * as babel from '@babel/core';
 
 import babelClassPropertiesPlugin from '@babel/plugin-proposal-class-properties';
-import babelObjectRestSpreadPlugin from '@babel/plugin-proposal-object-rest-spread';
 import lwcClassTransformPlugin from '@lwc/babel-plugin-component';
 
 import { normalizeToCompilerError, TransformerErrors } from '@lwc/errors';
@@ -34,10 +33,6 @@ export default function scriptTransform(
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
                 [babelClassPropertiesPlugin, { loose: true }],
-
-                // This plugin should be removed in a future version. The object-rest-spread is
-                // already a stage 4 feature. The LWC compile should leave this syntax untouched.
-                babelObjectRestSpreadPlugin,
             ],
             filename,
             sourceMaps: sourcemap,

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,7 +428,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
 
-"@babel/plugin-proposal-object-rest-spread@7.13.8", "@babel/plugin-proposal-object-rest-spread@^7.13.8", "@babel/plugin-proposal-object-rest-spread@~7.13.8":
+"@babel/plugin-proposal-object-rest-spread@7.13.8", "@babel/plugin-proposal-object-rest-spread@^7.13.8":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz#5d210a4d727d6ce3b18f9de82cc99a3964eed60a"
   integrity sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==


### PR DESCRIPTION
## Details

This PR removes the automatic spread operator transformation from the compiler. It was originally added here when the spread operator was still at stage 3. This feature was released with ES2018, and is supported by [92% of the browsers](https://caniuse.com/?search=Object%20spread).

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

To keep this behavior intact consumers have to run the spread operator transformation on their own.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
