### PR TITLE
feat: add runtime flag for light dom components

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -20,6 +20,7 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_NODE_PATCH: null,
     // Disables the fix for #2121 where non-composed events are visible outside of their shadow root.
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
+    ENABLE_LIGHT_DOM_COMPONENTS: null,
 };
 export default featureFlagLookup;
 


### PR DESCRIPTION
## Details

Revised version of https://github.com/salesforce/lwc/pull/2295. Adds a runtime flag to enable light DOM components.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9155929
