### PR TITLE
test: clean the DOM between each karma test

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -17,6 +17,12 @@ import {
 import { Renderer } from '@lwc/engine-core';
 
 const globalStylesheets: { [content: string]: true } = create(null);
+
+if (process.env.NODE_ENV === 'development') {
+    // @ts-ignore
+    window.__lwcGlobalStylesheets = globalStylesheets;
+}
+
 const globalStylesheetsParentElement: Element = document.head || document.body || document;
 
 let getCustomElement, defineCustomElement, HTMLElementConstructor;

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -20,7 +20,11 @@ const globalStylesheets: { [content: string]: true } = create(null);
 
 if (process.env.NODE_ENV === 'development') {
     // @ts-ignore
-    window.__lwcGlobalStylesheets = globalStylesheets;
+    window.__lwcResetGlobalStylesheets = () => {
+        for (const key of Object.keys(globalStylesheets)) {
+            delete globalStylesheets[key];
+        }
+    };
 }
 
 const globalStylesheetsParentElement: Element = document.head || document.body || document;

--- a/packages/integration-karma/README.md
+++ b/packages/integration-karma/README.md
@@ -44,3 +44,4 @@ COVERAGE=1 yarn test                                # Run all the test once and 
 -   Some of the test command options are available in the test suite on the global `process.env` object:
     -   `process.env.COMPAT`: is set to `false` by default and `true` if the `--compat` flag is passed
     -   `process.env.NATIVE_SHADOW`: is set to `false` by default and `true` if the `--native-shadow` flag is passed
+-   The test setup file (`test-setup.js`) will automatically clean up the DOM before and after each test. So you don't have to do anything to clean up. However, you should use `beforeEach()` rather than `beforeAll()` to add DOM elements for your test, so that the cleanup code can properly clean up the DOM.

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -43,9 +43,7 @@ beforeAll(function () {
     originalBodyChildren = Array.prototype.slice.call(document.body.children);
 });
 
-// There's no way I'm aware of to run a test after every other test has run, so we just throw
-// an error in the afterAll() here if the test fails. This causes the test process to exit
-// with a non-zero exit code.
+// Throwing an Error in afterAll will cause a non-zero exit code
 afterAll(function () {
     var headChildren = Array.prototype.slice.call(document.head.children);
     var bodyChildren = Array.prototype.slice.call(document.body.children);

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -33,3 +33,29 @@ afterEach(function () {
     // that already has the style, even though we just removed it
     window.__lwcResetGlobalStylesheets();
 });
+
+// Run some logic before all tests have run and after all tests have run to ensure that
+// no test dirtied the DOM with leftover elements
+var originalHeadChildren;
+var originalBodyChildren;
+beforeAll(function () {
+    originalHeadChildren = Array.prototype.slice.call(document.head.children);
+    originalBodyChildren = Array.prototype.slice.call(document.body.children);
+});
+
+afterAll(function () {
+    var headChildren = Array.prototype.slice.call(document.head.children);
+    var bodyChildren = Array.prototype.slice.call(document.body.children);
+
+    headChildren.forEach(function (child, i) {
+        if (originalHeadChildren[i] !== child) {
+            throw new Error('Unexpected element left in the <head> by a test: ' + child.outerHTML);
+        }
+    });
+
+    bodyChildren.forEach(function (child, i) {
+        if (originalBodyChildren[i] !== child) {
+            throw new Error('Unexpected element left in the <body> by a test: ' + child.outerHTML);
+        }
+    });
+});

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -31,7 +31,5 @@ afterEach(function () {
     knownChildren = undefined;
     // Need to clear this or else the engine will think there's a <style> in the <head>
     // that already has the style, even though we just removed it
-    Object.keys(window.__lwcGlobalStylesheets).forEach(function (key) {
-        delete window.__lwcGlobalStylesheets[key];
-    });
+    window.__lwcResetGlobalStylesheets();
 });

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -7,25 +7,31 @@
 
 // Global beforeEach/afterEach/etc logic to run before and after each test
 
-let knownChildren;
+var knownChildren;
 
 // After each test, clean up any DOM elements that were inserted into the document
 // <head> or <body>, plus any global <style>s the engine might think are there.
 
-beforeEach(() => {
-    knownChildren = new Set([...document.head.children, ...document.body.children]);
+function getChildren() {
+    return []
+        .concat(Array.prototype.slice.apply(document.head.children))
+        .concat(Array.prototype.slice.apply(document.body.children));
+}
+
+beforeEach(function () {
+    knownChildren = getChildren();
 });
 
-afterEach(() => {
-    for (const child of [...document.head.children, ...document.body.children]) {
-        if (!knownChildren.has(child)) {
-            child.remove();
+afterEach(function () {
+    getChildren().forEach(function (child) {
+        if (knownChildren.indexOf(child) === -1) {
+            child.parentElement.removeChild(child);
         }
-    }
+    });
     knownChildren = undefined;
     // Need to clear this or else the engine will think there's a <style> in the <head>
     // that already has the style, even though we just removed it
-    for (const key of Object.keys(window.__lwcGlobalStylesheets)) {
+    Object.keys(window.__lwcGlobalStylesheets).forEach(function (key) {
         delete window.__lwcGlobalStylesheets[key];
-    }
+    });
 });

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// Global beforeEach/afterEach/etc logic to run before and after each test
+
+let knownChildren;
+
+// After each test, clean up any DOM elements that were inserted into the document
+// <head> or <body>, plus any global <style>s the engine might think are there.
+
+beforeEach(() => {
+    knownChildren = new Set([...document.head.children, ...document.body.children]);
+});
+
+afterEach(() => {
+    for (const child of [...document.head.children, ...document.body.children]) {
+        if (!knownChildren.has(child)) {
+            child.remove();
+        }
+    }
+    knownChildren = undefined;
+    // Need to clear this or else the engine will think there's a <style> in the <head>
+    // that already has the style, even though we just removed it
+    for (const key of Object.keys(window.__lwcGlobalStylesheets)) {
+        delete window.__lwcGlobalStylesheets[key];
+    }
+});

--- a/packages/integration-karma/helpers/test-setup.js
+++ b/packages/integration-karma/helpers/test-setup.js
@@ -43,6 +43,9 @@ beforeAll(function () {
     originalBodyChildren = Array.prototype.slice.call(document.body.children);
 });
 
+// There's no way I'm aware of to run a test after every other test has run, so we just throw
+// an error in the afterAll() here if the test fails. This causes the test process to exit
+// with a non-zero exit code.
 afterAll(function () {
     var headChildren = Array.prototype.slice.call(document.head.children);
     var bodyChildren = Array.prototype.slice.call(document.body.children);

--- a/packages/integration-karma/scripts/karma-configs/base.js
+++ b/packages/integration-karma/scripts/karma-configs/base.js
@@ -90,9 +90,6 @@ module.exports = (config) => {
         // The grep flag is consumed at runtime by jasmine to filter what suite to run.
         client: {
             args: [...config.client.args, '--grep', GREP],
-            jasmine: {
-                random: false, // required for clean-dom/index.spec.js to run in consistent order
-            },
         },
     });
 

--- a/packages/integration-karma/scripts/karma-configs/base.js
+++ b/packages/integration-karma/scripts/karma-configs/base.js
@@ -90,6 +90,9 @@ module.exports = (config) => {
         // The grep flag is consumed at runtime by jasmine to filter what suite to run.
         client: {
             args: [...config.client.args, '--grep', GREP],
+            jasmine: {
+                random: false, // required for clean-dom/index.spec.js to run in consistent order
+            },
         },
     });
 

--- a/packages/integration-karma/scripts/karma-configs/base.js
+++ b/packages/integration-karma/scripts/karma-configs/base.js
@@ -27,6 +27,7 @@ const WIRE_SERVICE_COMPAT = getModulePath('wire-service', 'iife', 'es5', 'dev');
 const POLYFILL_COMPAT = require.resolve('es5-proxy-compat/polyfills.js');
 const TEST_UTILS = require.resolve('../../helpers/test-utils');
 const WIRE_SETUP = require.resolve('../../helpers/wire-setup');
+const TEST_SETUP = require.resolve('../../helpers/test-setup');
 
 function createPattern(location, config = {}) {
     return {
@@ -51,6 +52,7 @@ function getFiles() {
         frameworkFiles.push(createPattern(WIRE_SERVICE));
     }
     frameworkFiles.push(createPattern(WIRE_SETUP));
+    frameworkFiles.push(createPattern(TEST_SETUP));
 
     return [
         ...frameworkFiles,

--- a/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleChild/lifecycleChild.js
+++ b/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleChild/lifecycleChild.js
@@ -3,15 +3,11 @@ import { LightningElement } from 'lwc';
 export default class Child extends LightningElement {
     constructor() {
         super();
-        if (window.timingBuffer) {
-            window.timingBuffer.push('child:constructor');
-        }
+        window.timingBuffer.push('child:constructor');
     }
 
     connectedCallback() {
-        if (window.timingBuffer) {
-            window.timingBuffer.push('child:connectedCallback');
-        }
+        window.timingBuffer.push('child:connectedCallback');
     }
 
     disconnectedCallback() {
@@ -21,8 +17,6 @@ export default class Child extends LightningElement {
     }
 
     renderedCallback() {
-        if (window.timingBuffer) {
-            window.timingBuffer.push('child:renderedCallback');
-        }
+        window.timingBuffer.push('child:renderedCallback');
     }
 }

--- a/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleChild/lifecycleChild.js
+++ b/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleChild/lifecycleChild.js
@@ -3,18 +3,26 @@ import { LightningElement } from 'lwc';
 export default class Child extends LightningElement {
     constructor() {
         super();
-        window.timingBuffer.push('child:constructor');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:constructor');
+        }
     }
 
     connectedCallback() {
-        window.timingBuffer.push('child:connectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:connectedCallback');
+        }
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('child:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:disconnectedCallback');
+        }
     }
 
     renderedCallback() {
-        window.timingBuffer.push('child:renderedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:renderedCallback');
+        }
     }
 }

--- a/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleParent/lifecycleParent.js
+++ b/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleParent/lifecycleParent.js
@@ -3,18 +3,26 @@ import { LightningElement } from 'lwc';
 export default class LifecycleParent extends LightningElement {
     constructor() {
         super();
-        window.timingBuffer.push('parent:constructor');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:constructor');
+        }
     }
 
     connectedCallback() {
-        window.timingBuffer.push('parent:connectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:connectedCallback');
+        }
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('parent:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:disconnectedCallback');
+        }
     }
 
     renderedCallback() {
-        window.timingBuffer.push('parent:renderedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:renderedCallback');
+        }
     }
 }

--- a/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleParent/lifecycleParent.js
+++ b/packages/integration-karma/test/api/CustomElementConstructor-getter/x/lifecycleParent/lifecycleParent.js
@@ -3,15 +3,11 @@ import { LightningElement } from 'lwc';
 export default class LifecycleParent extends LightningElement {
     constructor() {
         super();
-        if (window.timingBuffer) {
-            window.timingBuffer.push('parent:constructor');
-        }
+        window.timingBuffer.push('parent:constructor');
     }
 
     connectedCallback() {
-        if (window.timingBuffer) {
-            window.timingBuffer.push('parent:connectedCallback');
-        }
+        window.timingBuffer.push('parent:connectedCallback');
     }
 
     disconnectedCallback() {
@@ -21,8 +17,6 @@ export default class LifecycleParent extends LightningElement {
     }
 
     renderedCallback() {
-        if (window.timingBuffer) {
-            window.timingBuffer.push('parent:renderedCallback');
-        }
+        window.timingBuffer.push('parent:renderedCallback');
     }
 }

--- a/packages/integration-karma/test/component/aom-setter/index.spec.js
+++ b/packages/integration-karma/test/component/aom-setter/index.spec.js
@@ -4,34 +4,36 @@ import Parent from 'x/parent';
 
 import RoleTester, { roleSetterCallCount } from 'x/roleTester';
 
-let parent;
+describe('aom-setter', () => {
+    let parent;
 
-beforeAll(() => {
-    parent = createElement('x-parent', { is: Parent });
-    document.body.appendChild(parent);
-});
+    beforeEach(() => {
+        parent = createElement('x-parent', { is: Parent });
+        document.body.appendChild(parent);
+    });
 
-it('should override native AOM setter and render text content', () => {
-    const child = parent.shadowRoot.querySelector('x-child');
-    const elm = child.shadowRoot.querySelector('span');
-    expect(elm.textContent).toBe('KIX to HKG');
-});
+    it('should override native AOM setter and render text content', () => {
+        const child = parent.shadowRoot.querySelector('x-child');
+        const elm = child.shadowRoot.querySelector('span');
+        expect(elm.textContent).toBe('KIX to HKG');
+    });
 
-it('should disable default behavior of DOM reflection when invoking a custom AOM setter', () => {
-    const child = parent.shadowRoot.querySelector('x-child');
-    expect(child.hasAttribute('aria-label')).toBe(false);
-});
+    it('should disable default behavior of DOM reflection when invoking a custom AOM setter', () => {
+        const child = parent.shadowRoot.querySelector('x-child');
+        expect(child.hasAttribute('aria-label')).toBe(false);
+    });
 
-it('should reflect AOM attribute for native element', () => {
-    const elm = parent.shadowRoot.querySelector('div');
-    expect(elm.getAttribute('aria-label')).toBe('KIX to HKG');
-});
+    it('should reflect AOM attribute for native element', () => {
+        const elm = parent.shadowRoot.querySelector('div');
+        expect(elm.getAttribute('aria-label')).toBe('KIX to HKG');
+    });
 
-describe('#role', () => {
-    it('should call setter when defined', () => {
-        const element = createElement('prop-getter-aria-role', { is: RoleTester });
-        document.body.appendChild(element);
-        element.role = 'tab';
-        expect(roleSetterCallCount).toBe(1);
+    describe('#role', () => {
+        it('should call setter when defined', () => {
+            const element = createElement('prop-getter-aria-role', { is: RoleTester });
+            document.body.appendChild(element);
+            element.role = 'tab';
+            expect(roleSetterCallCount).toBe(1);
+        });
     });
 });

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/child/child.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/child/child.js
@@ -13,7 +13,9 @@ export default class Child extends LightningElement {
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('child:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:disconnectedCallback');
+        }
     }
 
     renderedCallback() {

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/parent/parent.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/parent/parent.js
@@ -11,7 +11,9 @@ export default class Parent extends LightningElement {
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('parent:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:disconnectedCallback');
+        }
     }
 
     renderedCallback() {

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/parentIf/parentIf.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/parentIf/parentIf.js
@@ -8,7 +8,9 @@ export default class ParentIf extends LightningElement {
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('parentIf:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parentIf:disconnectedCallback');
+        }
     }
 
     renderedCallback() {

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/parentProp/parentProp.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/parentProp/parentProp.js
@@ -8,7 +8,9 @@ export default class ParentProp extends LightningElement {
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('parentProp:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parentProp:disconnectedCallback');
+        }
     }
 
     renderedCallback() {

--- a/packages/integration-karma/test/component/lifecycle-callbacks/x/single/single.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/x/single/single.js
@@ -13,7 +13,9 @@ export default class Single extends LightningElement {
     }
 
     disconnectedCallback() {
-        window.timingBuffer.push('single:disconnectedCallback');
+        if (window.timingBuffer) {
+            window.timingBuffer.push('single:disconnectedCallback');
+        }
     }
 
     renderedCallback() {

--- a/packages/integration-karma/test/misc/clean-dom/index.spec.js
+++ b/packages/integration-karma/test/misc/clean-dom/index.spec.js
@@ -1,0 +1,21 @@
+describe('clean DOM', () => {
+    it('inserts elements to dirty the DOM', () => {
+        // insert to the body
+        const el = document.createElement('div');
+        el.className = 'yolo';
+        document.body.appendChild(el);
+        expect(document.querySelector('.yolo')).toEqual(el);
+
+        // insert to the head as well
+        const style = document.createElement('style');
+        style.textContent = 'html { background-color: green }';
+        style.id = 'the-style';
+        document.head.appendChild(style);
+        expect(document.querySelector('#the-style')).toEqual(style);
+    });
+
+    it('DOM is clean after each test', () => {
+        expect(document.querySelector('.yolo')).toBeNull();
+        expect(document.querySelector('#the-style')).toBeNull();
+    });
+});

--- a/packages/integration-karma/test/misc/clean-dom/index.spec.js
+++ b/packages/integration-karma/test/misc/clean-dom/index.spec.js
@@ -1,23 +1,24 @@
 describe('clean DOM', () => {
-    it('inserts elements to dirty the DOM', () => {
-        // insert to the body
-        const el = document.createElement('div');
-        el.className = 'yolo';
-        document.body.appendChild(el);
-        expect(document.querySelector('.yolo')).toEqual(el);
+    // We do two identical tests here because Jasmine randomizes the order of tests, so we can't
+    // be sure which one will dirty the DOM and which one will check that it's clean.
+    for (let i = 0; i < 2; i++) {
+        it(`DOM is clean after each test ${i + 1}`, () => {
+            // insert to the body
+            const el = document.createElement('div');
+            el.className = `body-${i}`;
+            document.body.appendChild(el);
+            expect(document.querySelector(`.body-${i}`)).toEqual(el);
 
-        // insert to the head as well
-        const style = document.createElement('style');
-        style.textContent = 'html { background-color: green }';
-        style.id = 'the-style';
-        document.head.appendChild(style);
-        expect(document.querySelector('#the-style')).toEqual(style);
-    });
+            // insert to the head as well
+            const style = document.createElement('style');
+            style.textContent = 'html { background-color: green }';
+            style.className = `head-${i}`;
+            document.head.appendChild(style);
+            expect(document.querySelector(`.head-${i}`)).toEqual(style);
 
-    // ordering of tests is guaranteed when using `random: false` option in Jasmine
-    // https://jasmine.github.io/api/edge/Configuration#random
-    it('DOM is clean after each test', () => {
-        expect(document.querySelector('.yolo')).toBeNull();
-        expect(document.querySelector('#the-style')).toBeNull();
-    });
+            // check that we don't have dirty DOM nodes from the other test
+            expect(document.querySelector(`.body-${1 - i}`)).toBeNull();
+            expect(document.querySelector(`.head-${1 - i}`)).toBeNull();
+        });
+    }
 });

--- a/packages/integration-karma/test/misc/clean-dom/index.spec.js
+++ b/packages/integration-karma/test/misc/clean-dom/index.spec.js
@@ -14,6 +14,8 @@ describe('clean DOM', () => {
         expect(document.querySelector('#the-style')).toEqual(style);
     });
 
+    // ordering of tests is guaranteed when using `random: false` option in Jasmine
+    // https://jasmine.github.io/api/edge/Configuration#random
     it('DOM is clean after each test', () => {
         expect(document.querySelector('.yolo')).toBeNull();
         expect(document.querySelector('#the-style')).toBeNull();

--- a/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
+++ b/packages/integration-karma/test/misc/cross-domain-iframe/index.spec.js
@@ -16,7 +16,7 @@ it('should not throw when unwrapping contentWindow', () => {
 describe('HTMLIFrameElement.contentWindow patching', () => {
     let iframe, sameOriginFrame;
 
-    beforeAll(() => {
+    beforeEach(() => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedElements.spec.js
@@ -5,7 +5,7 @@ import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 function testAssignedElements(testDescription, getContainer) {
     let container;
 
-    beforeAll(() => {
+    beforeEach(() => {
         container = getContainer();
     });
 

--- a/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
+++ b/packages/integration-karma/test/native-shadow/HTMLSlotElement-properties/HTMLSlotElement.assignedNodes.spec.js
@@ -5,7 +5,7 @@ import NativeSlottedBasic from './x/NativeBasic/NativeBasic';
 function testAssignedNodes(testDescription, getContainer) {
     let container;
 
-    beforeAll(() => {
+    beforeEach(() => {
         container = getContainer();
     });
 

--- a/packages/integration-karma/test/polyfills/document-body-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/document-body-properties/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import XTest from 'x/test';
 
 describe('should not provide access to elements inside shadow tree', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         const elm = createElement('x-test-document-body-properties', { is: XTest });
         document.body.appendChild(elm);
     });
@@ -34,17 +34,12 @@ describe('should provide access to elements outside shadow tree', () => {
     let container;
     // randomize the selectors so that it does not interfere with the test suite above
     const random = Math.floor(Math.random() * 100);
-    beforeAll(() => {
+    beforeEach(() => {
         container = document.createElement('div');
         document.body.appendChild(container);
         container.innerHTML = `<div class='in-the-shadow-${random}'></div>
                                <input name='in-the-shadow-${random}'>`;
         container.appendChild(document.createElement(`x-unique-tag-name-${random}`));
-    });
-    afterAll(() => {
-        if (container) {
-            document.body.removeChild(container);
-        }
     });
 
     function testMethodReturnsNode(api, selector) {

--- a/packages/integration-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/document-properties/index.spec.js
@@ -3,7 +3,7 @@ import XTest from 'x/test';
 import XWithLwcDomManual from 'x/withLwcDomManual';
 
 describe('should not provide access to elements inside shadow tree', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         const elm = createElement('x-test-document-properties', { is: XTest });
         document.body.appendChild(elm);
     });
@@ -77,17 +77,12 @@ describe('should provide access to elements outside shadow tree', () => {
     let container;
     // randomize the selectors so that it does not interfere with the test suite above
     const random = Math.floor(Math.random() * 100);
-    beforeAll(() => {
+    beforeEach(() => {
         container = document.createElement('div');
         document.body.appendChild(container);
         container.innerHTML = `<div class='in-the-shadow-${random}' id='in-the-shadow-${random}'></div>
                                <input name='in-the-shadow-${random}'>`;
         container.appendChild(document.createElement(`x-unique-tag-name-${random}`));
-    });
-    afterAll(() => {
-        if (container) {
-            document.body.removeChild(container);
-        }
     });
 
     function testMethodReturnsNode(api, selector) {

--- a/packages/integration-karma/test/shadow-dom/Document-properties/leak-tests.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Document-properties/leak-tests.spec.js
@@ -3,7 +3,7 @@ import { createElement } from 'lwc';
 import Leak from 'x/leak';
 
 let elm;
-beforeAll(() => {
+beforeEach(() => {
     elm = createElement('x-leak', { is: Leak });
     document.body.appendChild(elm);
 });

--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -144,8 +144,11 @@ describe('EventTarget.addEventListener', () => {
         }
 
         describe('without options', () => {
-            const container = createElement('x-container', { is: Container });
-            document.body.appendChild(container);
+            let container;
+            beforeEach(() => {
+                container = createElement('x-container', { is: Container });
+                document.body.appendChild(container);
+            });
 
             it('should be discarded on host elements', () => {
                 test({
@@ -168,8 +171,11 @@ describe('EventTarget.addEventListener', () => {
         });
 
         describe('with options', () => {
-            const container = createElement('x-container', { is: Container });
-            document.body.appendChild(container);
+            let container;
+            beforeEach(() => {
+                container = createElement('x-container', { is: Container });
+                document.body.appendChild(container);
+            });
 
             // TODO [#2253]: Uncomment test once options are supported on host/root.
             /*
@@ -217,8 +223,11 @@ describe('EventTarget.addEventListener', () => {
         });
 
         describe('with different options', () => {
-            const container = createElement('x-container', { is: Container });
-            document.body.appendChild(container);
+            let container;
+            beforeEach(() => {
+                container = createElement('x-container', { is: Container });
+                document.body.appendChild(container);
+            });
 
             // TODO [#2253]: Uncomment test once options are supported on host/root.
             /*

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-properties/HTMLSlotElement-assigned.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-properties/HTMLSlotElement-assigned.spec.js
@@ -10,7 +10,7 @@ describe('ignore non direct host children', () => {
     let elm;
     let nodes;
 
-    beforeAll(() => {
+    beforeEach(() => {
         elm = createElement('x-no-direct-child', { is: NoDirectChild });
         document.body.appendChild(elm);
 
@@ -44,7 +44,7 @@ describe('fallback content basic', () => {
     let elm;
     let nodes;
 
-    beforeAll(() => {
+    beforeEach(() => {
         elm = createElement('x-basic', { is: Basic });
         document.body.appendChild(elm);
 
@@ -76,7 +76,7 @@ describe('fallback content slots in slots', () => {
     let elm;
     let nodes;
 
-    beforeAll(() => {
+    beforeEach(() => {
         elm = createElement('x-slots-in-slots', { is: SlotsInSlots });
         document.body.appendChild(elm);
 
@@ -104,7 +104,7 @@ describe('fallback content complex', () => {
     let elm;
     let nodes;
 
-    beforeAll(() => {
+    beforeEach(() => {
         elm = createElement('x-complex', { is: Complex });
         document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -47,7 +47,7 @@ if (!process.env.NATIVE_SHADOW) {
             elementOutsideLWC,
             rootLwcElement,
             cmpShadow;
-        beforeAll(() => {
+        beforeEach(() => {
             spyOn(console, 'error'); // ignore warning about manipulating node without lwc:dom="manual"
             const elm = createElement('x-container', { is: Container });
 

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -3,8 +3,11 @@ import Container from 'x/container';
 
 if (!process.env.NATIVE_SHADOW) {
     describe('DISABLE_INNER_OUTER_TEXT_PATCH flag', () => {
-        const elm = createElement('x-container', { is: Container });
-        document.body.appendChild(elm);
+        let elm;
+        beforeEach(() => {
+            elm = createElement('x-container', { is: Container });
+            document.body.appendChild(elm);
+        });
 
         it('should get innerText of custom element when DISABLE_INNER_OUTER_TEXT_PATCH = true', () => {
             setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', true);
@@ -20,8 +23,11 @@ if (!process.env.NATIVE_SHADOW) {
     });
 
     describe('innerText', () => {
-        const elm = createElement('x-container', { is: Container });
-        document.body.appendChild(elm);
+        let elm;
+        beforeEach(() => {
+            elm = createElement('x-container', { is: Container });
+            document.body.appendChild(elm);
+        });
 
         it('should return textContent when text within element is not selectable', () => {
             const testCase = elm.shadowRoot.querySelector('.non-selectable-text');
@@ -158,8 +164,11 @@ Cat`);
     // Firefox does not have outerText.
     if (outerTextDescriptor) {
         describe('outerText', () => {
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
+            let elm;
+            beforeEach(() => {
+                elm = createElement('x-container', { is: Container });
+                document.body.appendChild(elm);
+            });
 
             it('should not go inside custom element shadow', () => {
                 const testElement = elm.shadowRoot.querySelector('.without-slotted-content');

--- a/packages/integration-karma/test/template/attribute-id/aria.spec.js
+++ b/packages/integration-karma/test/template/attribute-id/aria.spec.js
@@ -20,7 +20,7 @@ function testAria(type, create) {
     describe(`${type} aria attribute values`, () => {
         let elm;
 
-        beforeAll(() => {
+        beforeEach(() => {
             elm = create();
             document.body.appendChild(elm);
         });

--- a/packages/integration-karma/test/template/attribute-id/href.spec.js
+++ b/packages/integration-karma/test/template/attribute-id/href.spec.js
@@ -8,7 +8,7 @@ function testHref(type, create) {
     describe(`${type} href attribute values`, () => {
         let elm;
 
-        beforeAll(() => {
+        beforeEach(() => {
             elm = create();
             document.body.appendChild(elm);
         });


### PR DESCRIPTION
## Details

For the `integration-karma` tests, it would be nice if the DOM were clean between each test. This matters less for things like shadow DOM, but for light DOM it starts to have an impact since elements are more likely to affect each other (e.g. styling).

This PR adds a setup script that runs between each test to clean out the `document.head` and `document.body`, as well as adding a test that would fail without this PR in place (I checked).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`