### PR TITLE
test: attempt to fix firefox flapper in karma tests

### DIFF
--- a/packages/integration-karma/test/shadow-dom/stylesheet/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/stylesheet/index.spec.js
@@ -23,12 +23,17 @@ describe('shadow encapsulation', () => {
         expect(window.getComputedStyle(div).marginLeft).toBe('10px');
         expect(window.getComputedStyle(div).marginRight).toBe('0px');
 
-        elm.toggleTemplate();
-        return Promise.resolve().then(() => {
-            const div = elm.shadowRoot.querySelector('div');
-            expect(window.getComputedStyle(div).marginLeft).toBe('0px');
-            expect(window.getComputedStyle(div).marginRight).toBe('10px');
-        });
+        // Toggle the template and check its style in rAF callback to work
+        // around Firefox flapper: https://github.com/salesforce/lwc/pull/2303#issuecomment-825041996
+        return new Promise((resolve) => requestAnimationFrame(resolve))
+            .then(() => {
+                elm.toggleTemplate();
+            })
+            .then(() => {
+                const div = elm.shadowRoot.querySelector('div');
+                expect(window.getComputedStyle(div).marginLeft).toBe('0px');
+                expect(window.getComputedStyle(div).marginRight).toBe('10px');
+            });
     });
 });
 


### PR DESCRIPTION
## Details

Background: https://github.com/salesforce/lwc/pull/2303#issuecomment-824959963

This is one of my favorite kind of bugs, because I can't repro with Firefox 88 on Mac or in Saucelabs on Windows 7, but we see this like ~70% of the time in our CI tests.

This is my hunch as to what will fix the flapper, so I figure I will just run the CI tests a few times and see if the flapper is gone.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`