### PR TITLE
test: fix firefox flapper in native shadow style test

### DIFF
--- a/packages/integration-karma/test/shadow-dom/stylesheet/x/multiTemplates/a.css
+++ b/packages/integration-karma/test/shadow-dom/stylesheet/x/multiTemplates/a.css
@@ -1,3 +1,4 @@
 div {
     margin-left: 10px;
+    margin-right: 0;
 }

--- a/packages/integration-karma/test/shadow-dom/stylesheet/x/multiTemplates/b.css
+++ b/packages/integration-karma/test/shadow-dom/stylesheet/x/multiTemplates/b.css
@@ -1,3 +1,4 @@
 div {
+    margin-left: 0;
     margin-right: 10px;
 }


### PR DESCRIPTION
## Details

I managed to actually repro the Firefox flapper described in https://github.com/salesforce/lwc/pull/2304 . I can repro in Firefox 88 on Mac, only when using native shadow.

Apparently Firefox sometimes ends up in a dirty state where it believes that

```css
div {
    margin-left: 10px;
}
```

being replaced with

```css
div {
    margin-right: 10px;
}
```

means that both `margin-left` and `margin-right` are 10px.

This PR fixes it by adding an explicit 0px to both stylesheets. AFAICT this fixes the flapper.

In parallel, we can of course dive deeper and file a bug on Firefox.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`