### PR TITLE
test: add note about test which may fail locally

### DIFF
--- a/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
@@ -5,7 +5,7 @@ import Container from 'x/container';
 // Test for yourself: https://bl.ocks.org/nolanlawson/raw/d8ddc518041e9bf12498b8b50b39df95/
 // So this test may "flap" during local development if your browser window isn't focused (e.g. you're focused on
 // the DevTools instead).
-it('should retarget relatedTarget (note this test may fail if the browser window is not focused)', function () {
+it('should retarget relatedTarget', function () {
     const elm = createElement('x-container', { is: Container });
     document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
@@ -1,7 +1,11 @@
 import { createElement } from 'lwc';
 import Container from 'x/container';
 
-it('should retarget relatedTarget', function () {
+// Note that focusin events are not fired in Chrome and Firefox if the browser content window is not focused.
+// Test for yourself: https://bl.ocks.org/nolanlawson/raw/d8ddc518041e9bf12498b8b50b39df95/
+// So this test may "flap" during local development if your browser window isn't focused (e.g. you're focused on
+// the DevTools instead).
+it('should retarget relatedTarget (note this test may fail if the browser window is not focused)', function () {
     const elm = createElement('x-container', { is: Container });
     document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
+++ b/packages/integration-karma/test/events/focus-event-related-target/index.spec.js
@@ -12,5 +12,9 @@ it('should retarget relatedTarget', function () {
     elm.focusFirstInput();
     elm.focusSecondInput();
 
-    expect(elm.relatedTargetClassName).toBe('first');
+    expect(elm.relatedTargetClassName)
+        .withContext(
+            'This test may "flap" during local development if your browser window isn\'t focused'
+        )
+        .toBe('first');
 });


### PR DESCRIPTION
## Details

While researching the Firefox flapper, this test was driving me a bit nuts because it seemed to be flapping too. Only later did I realize that this test only flaps if the browser content window isn't focused, and only in some browsers.

This PR adds a note to the test to hopefully save the next person from going on a wild goose chase trying to figure out why the test is flapping. 😅 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`