### PR TITLE
feat(engine-core): Prevent slotting in light DOM components

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -171,7 +171,7 @@ export function allocateChildrenHook(vnode: VCustomElement, vm: VM) {
             hasShadow(vm) || children.length === 0,
             `Invalid usage of ${getComponentTag(
                 vm
-            )}. Light DOM components don't support yet slotting.`
+            )}. Light DOM components don't support slotting yet.`
         );
     }
 

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -12,6 +12,7 @@ import {
     runWithBoundaryProtection,
     getAssociatedVMIfPresent,
     VM,
+    hasShadow,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
@@ -24,6 +25,8 @@ import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef } from './def';
+
+import { getComponentTag } from '../shared/format';
 
 const noop = () => void 0;
 
@@ -161,8 +164,17 @@ export function allocateChildrenHook(vnode: VCustomElement, vm: VM) {
     //
     // In case #2, we will always get a fresh VCustomElement.
     const children = vnode.aChildren || vnode.children;
-
     vm.aChildren = children;
+
+    if (process.env.NODE_ENV !== 'production') {
+        assert.isTrue(
+            hasShadow(vm) || children.length === 0,
+            `Invalid usage of ${getComponentTag(
+                vm
+            )}. Light DOM components don't support yet slotting.`
+        );
+    }
+
     if (isTrue(vm.renderer.syntheticShadow)) {
         // slow path
         allocateInSlot(vm, children);

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -23,7 +23,7 @@ import {
 
 import { LightningElement } from './base-lightning-element';
 import { globalHTMLProperties } from './attributes';
-import { getAssociatedVM, getAssociatedVMIfPresent } from './vm';
+import { getAssociatedVM, getAssociatedVMIfPresent, hasShadow, VM } from './vm';
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 
@@ -218,6 +218,14 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
 // Custom Elements Restrictions:
 // -----------------------------
 
+function reportInvalidSlotMutationInLightDOM(vm: VM): never {
+    throw new Error(
+        `Invalid DOM operation on ${getComponentTag(
+            vm
+        )}. Light DOM component don't allow imperative slotted content.`
+    );
+}
+
 function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDescriptorMap {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
@@ -229,7 +237,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
     const originalOuterHTMLDescriptor = getPropertyDescriptor(elm, 'outerHTML')!;
     const originalTextContentDescriptor = getPropertyDescriptor(elm, 'textContent')!;
 
-    return {
+    const descriptors: PropertyDescriptorMap = {
         innerHTML: generateAccessorDescriptor({
             get(this: HTMLElement): string {
                 return originalInnerHTMLDescriptor.get!.call(this);
@@ -275,6 +283,48 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
             },
         }),
     };
+
+    const vm = getAssociatedVM(elm);
+    if (!hasShadow(vm)) {
+        const { appendChild, insertBefore, removeChild, replaceChild } = elm;
+
+        assign(descriptors, {
+            insertBefore: generateDataDescriptor({
+                value(this: Node, newNode: Node, referenceNode: Node) {
+                    if (!isDomMutationAllowed) {
+                        reportInvalidSlotMutationInLightDOM(vm);
+                    }
+                    return insertBefore.call(this, newNode, referenceNode);
+                },
+            }),
+            appendChild: generateDataDescriptor({
+                value(this: Node, aChild: Node) {
+                    if (!isDomMutationAllowed) {
+                        reportInvalidSlotMutationInLightDOM(vm);
+                    }
+                    return appendChild.call(this, aChild);
+                },
+            }),
+            removeChild: generateDataDescriptor({
+                value(this: Node, aChild: Node) {
+                    if (!isDomMutationAllowed) {
+                        reportInvalidSlotMutationInLightDOM(vm);
+                    }
+                    return removeChild.call(this, aChild);
+                },
+            }),
+            replaceChild: generateDataDescriptor({
+                value(this: Node, newChild: Node, oldChild: Node) {
+                    if (!isDomMutationAllowed) {
+                        reportInvalidSlotMutationInLightDOM(vm);
+                    }
+                    return replaceChild.call(this, newChild, oldChild);
+                },
+            }),
+        });
+    }
+
+    return descriptors;
 }
 
 function getComponentRestrictionsDescriptors(): PropertyDescriptorMap {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -604,12 +604,6 @@ function getErrorBoundaryVM(vm: VM): VM | undefined {
 // NOTE: we should probably more this routine to the synthetic shadow folder
 // and get the allocation to be cached by in the elm instead of in the VM
 export function allocateInSlot(vm: VM, children: VNodes) {
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            isObject(vm.cmpSlots),
-            `When doing manual allocation, there must be a cmpSlots object available.`
-        );
-    }
     const { cmpSlots: oldSlots } = vm;
     const cmpSlots = (vm.cmpSlots = create(null));
     for (let i = 0, len = children.length; i < len; i += 1) {

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -1,0 +1,23 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+
+import Slotted from 'x/slotted';
+
+describe('slotted content', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+    });
+
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+    });
+
+    it('should throws when attempting to render a slotted content in the light DOM', () => {
+        const element = createElement('x-slotted', { is: Slotted });
+
+        expect(() => {
+            document.body.appendChild(element);
+        }).toThrowError(
+            /Invalid usage of <x-container>\. Light DOM components don't support yet slotting\./
+        );
+    });
+});

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Slotted from 'x/slotted';
+import Container from 'x/container';
 
 describe('slotted content', () => {
     beforeEach(() => {
@@ -19,5 +20,36 @@ describe('slotted content', () => {
         }).toThrowError(
             /Invalid usage of <x-container>\. Light DOM components don't support slotting yet\./
         );
+    });
+});
+
+describe('imperative slotted content', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+    });
+
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+    });
+
+    [
+        ['Node.prototype.insertBefore', (elm) => elm.insertBefore(document.createElement('div'))],
+        ['Node.prototype.appendChild', (elm) => elm.appendChild(document.createElement('div'))],
+        ['Node.prototype.removeChild', (elm) => elm.removeChild(elm.firstChild)],
+        [
+            'Node.prototype.replaceChild',
+            (elm) => elm.replaceChild(elm.firstChild, document.createElement('div')),
+        ],
+    ].forEach(([operation, fn]) => {
+        it(`throws an error when invoking ${operation}`, () => {
+            const element = createElement('x-container', { is: Container });
+            document.body.appendChild(element);
+
+            expect(() => {
+                fn(element);
+            }).toThrowError(
+                /Invalid DOM operation on <x-container>\. Light DOM component don't allow imperative slotted content\./
+            );
+        });
     });
 });

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -11,13 +11,13 @@ describe('slotted content', () => {
         setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
     });
 
-    it('should throws when attempting to render a slotted content in the light DOM', () => {
+    it('should throw when attempting to render a slotted content in the light DOM', () => {
         const element = createElement('x-slotted', { is: Slotted });
 
         expect(() => {
             document.body.appendChild(element);
         }).toThrowError(
-            /Invalid usage of <x-container>\. Light DOM components don't support yet slotting\./
+            /Invalid usage of <x-container>\. Light DOM components don't support slotting yet\./
         );
     });
 });

--- a/packages/integration-karma/test/light-dom/slotting/x/container/container.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/container/container.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/integration-karma/test/light-dom/slotting/x/container/container.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/container/container.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {
+    static shadow = false;
+}

--- a/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.html
@@ -1,0 +1,5 @@
+<template>
+    <x-container>
+        slotted content
+    </x-container>
+</template>

--- a/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.js
@@ -1,5 +1,3 @@
 import { LightningElement } from 'lwc';
 
-export default class Slotted extends LightningElement {
-    static shadow = false;
-}
+export default class Slotted extends LightningElement {}

--- a/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/slotted/slotted.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Slotted extends LightningElement {
+    static shadow = false;
+}


### PR DESCRIPTION
## Details

With this PR, slotting content into a light DOM component throws an error in DEV mode. This restriction will be lifted once we enable support for slotting in the light DOM.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
