### PR TITLE
refactor(compiler): clean up type definitions

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -7,22 +7,27 @@
 import { CompilerValidationErrors, invariant } from '@lwc/errors';
 import { isUndefined, isBoolean, isObject } from '@lwc/shared';
 
-const DEFAULT_OPTIONS = {
-    isExplicitImport: false,
+type RecursiveRequired<T> = {
+    [P in keyof T]-?: RecursiveRequired<T[P]>;
 };
 
-const DEFAULT_DYNAMIC_CMP_CONFIG: NormalizedDynamicComponentConfig = {
+const DEFAULT_OPTIONS = {
+    isExplicitImport: false,
+    preserveHtmlComments: false,
+};
+
+const DEFAULT_DYNAMIC_CMP_CONFIG: Required<DynamicComponentConfig> = {
     loader: '',
     strictSpecifier: true,
 };
 
-const DEFAULT_STYLESHEET_CONFIG: NormalizedStylesheetConfig = {
+const DEFAULT_STYLESHEET_CONFIG: RecursiveRequired<StylesheetConfig> = {
     customProperties: {
         resolution: { type: 'native' },
     },
 };
 
-const DEFAULT_OUTPUT_CONFIG: NormalizedOutputConfig = {
+const DEFAULT_OUTPUT_CONFIG: Required<OutputConfig> = {
     minify: false,
     sourcemap: false,
 };
@@ -40,11 +45,9 @@ export interface OutputConfig {
     sourcemap?: boolean;
 }
 
-export type DynamicComponentConfig = Partial<NormalizedDynamicComponentConfig>;
-
-export interface NormalizedDynamicComponentConfig {
-    loader: string;
-    strictSpecifier: boolean;
+export interface DynamicComponentConfig {
+    loader?: string;
+    strictSpecifier?: boolean;
 }
 
 export interface TransformOptions {
@@ -57,22 +60,10 @@ export interface TransformOptions {
     preserveHtmlComments?: boolean;
 }
 
-export interface NormalizedTransformOptions extends TransformOptions {
-    outputConfig: NormalizedOutputConfig;
-    stylesheetConfig: NormalizedStylesheetConfig;
-    experimentalDynamicComponent: NormalizedDynamicComponentConfig;
-    isExplicitImport: boolean;
-}
-
-export interface NormalizedStylesheetConfig extends StylesheetConfig {
-    customProperties: {
-        resolution: CustomPropertiesResolution;
-    };
-}
-
-export interface NormalizedOutputConfig extends OutputConfig {
-    minify: boolean;
-    sourcemap: boolean;
+type RequiredTransformOptions = Omit<TransformOptions, 'name' | 'namespace'>;
+export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTransformOptions> {
+    name?: string;
+    namespace?: string;
 }
 
 export function validateTransformOptions(options: TransformOptions): NormalizedTransformOptions {
@@ -132,19 +123,19 @@ function validateOutputConfig(config: OutputConfig) {
 }
 
 function normalizeOptions(options: TransformOptions): NormalizedTransformOptions {
-    const outputConfig: NormalizedOutputConfig = {
+    const outputConfig: Required<OutputConfig> = {
         ...DEFAULT_OUTPUT_CONFIG,
         ...options.outputConfig,
     };
 
-    const stylesheetConfig: NormalizedStylesheetConfig = {
+    const stylesheetConfig: RecursiveRequired<StylesheetConfig> = {
         customProperties: {
             ...DEFAULT_STYLESHEET_CONFIG.customProperties,
             ...(options.stylesheetConfig && options.stylesheetConfig.customProperties),
         },
     };
 
-    const experimentalDynamicComponent = {
+    const experimentalDynamicComponent: Required<DynamicComponentConfig> = {
         ...DEFAULT_DYNAMIC_CMP_CONFIG,
         ...options.experimentalDynamicComponent,
     };

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -27,12 +27,14 @@ export default function templateTransform(
     filename: string,
     options: NormalizedTransformOptions
 ): TransformResult {
-    let result;
+    const { experimentalDynamicComponent, preserveHtmlComments } = options;
+    const experimentalDynamicDirective = Boolean(experimentalDynamicComponent);
 
+    let result;
     try {
         result = compile(src, {
-            experimentalDynamicDirective: !!options.experimentalDynamicComponent,
-            preserveHtmlComments: !!options.preserveHtmlComments,
+            experimentalDynamicDirective,
+            preserveHtmlComments,
         });
     } catch (e) {
         throw normalizeToCompilerError(TransformerErrors.HTML_TRANSFORMER_ERROR, e, { filename });

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -60,7 +60,7 @@ function validateArguments(src: string, filename: string) {
     invariant(isString(filename), TransformerErrors.INVALID_ID, [filename]);
 }
 
-export function transformFile(
+function transformFile(
     src: string,
     filename: string,
     options: NormalizedTransformOptions


### PR DESCRIPTION
## Details

Provides a default value for `preserveHtmlComments` instead of casting `undefined` to `boolean`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

TD-0089604