### PR TITLE
test: use Jest snapshots for rollup-plugin tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ The [MIT license][license] governs your use of Lightning Web Components.
 [salesforce-stackexchange]: https://salesforce.stackexchange.com/questions/tagged/lightning-web-components
 [contributing]: https://github.com/salesforce/lwc/blob/master/CONTRIBUTING.md
 [license]: https://github.com/salesforce/lwc/blob/master/LICENSE
+

--- a/README.md
+++ b/README.md
@@ -44,4 +44,3 @@ The [MIT license][license] governs your use of Lightning Web Components.
 [salesforce-stackexchange]: https://salesforce.stackexchange.com/questions/tagged/lightning-web-components
 [contributing]: https://github.com/salesforce/lwc/blob/master/CONTRIBUTING.md
 [license]: https://github.com/salesforce/lwc/blob/master/LICENSE
-

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -1,5 +1,5 @@
 (function (lwc) {
-  "use strict";
+  'use strict';
 
   var __callKey1 = Proxy.callKey1;
 
@@ -16,13 +16,11 @@
   }
 
   function _setPrototypeOf(o, p) {
-    _setPrototypeOf =
-      Object.setPrototypeOf ||
-      function _setPrototypeOf(o, p) {
-        __setKey(o, "__proto__", p);
+    _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
+      __setKey(o, "__proto__", p);
 
-        return o;
-      };
+      return o;
+    };
 
     return _setPrototypeOf(o, p);
   }
@@ -32,32 +30,20 @@
       throw new TypeError("Super expression must either be null or a function");
     }
 
-    __setKey(
-      subClass,
-      "prototype",
-      Object.create(
-        superClass &&
-          (superClass._ES5ProxyType
-            ? superClass.get("prototype")
-            : superClass.prototype),
-        {
-          constructor: {
-            value: subClass,
-            writable: true,
-            configurable: true,
-          },
-        }
-      )
-    );
+    __setKey(subClass, "prototype", Object.create(superClass && (superClass._ES5ProxyType ? superClass.get("prototype") : superClass.prototype), {
+      constructor: {
+        value: subClass,
+        writable: true,
+        configurable: true
+      }
+    }));
 
     if (superClass) _setPrototypeOf(subClass, superClass);
   }
 
   function _assertThisInitialized(self) {
     if (self === void 0) {
-      throw new ReferenceError(
-        "this hasn't been initialised - super() hasn't been called"
-      );
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
     }
 
     return self;
@@ -72,43 +58,26 @@
   }
 
   function _getPrototypeOf(o) {
-    _getPrototypeOf = Object.setPrototypeOf
-      ? Object.getPrototypeOf
-      : function _getPrototypeOf(o) {
-          return (
-            (o._ES5ProxyType ? o.get("__proto__") : o.__proto__) ||
-            Object.getPrototypeOf(o)
-          );
-        };
+    _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
+      return (o._ES5ProxyType ? o.get("__proto__") : o.__proto__) || Object.getPrototypeOf(o);
+    };
     return _getPrototypeOf(o);
   }
 
   var __concat = Proxy.concat;
 
   function stylesheet(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : __callKey1(
-          [hostSelector, " {color: var(--lwc-my-color);}"],
-          "join",
-          ""
-        );
+    return nativeShadow ? ":host {color: var(--lwc-my-color);}" : __callKey1([hostSelector, " {color: var(--lwc-my-color);}"], "join", '');
   }
 
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {
     var api_dynamic = $api._ES5ProxyType ? $api.get("d") : $api.d,
-      api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
-    return [
-      api_element(
-        "div",
-        {
-          key: 0,
-        },
-        [api_dynamic($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x)]
-      ),
-    ];
+        api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
+    return [api_element("div", {
+      key: 0
+    }, [api_dynamic($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x)])];
   }
 
   var _tmpl$1 = lwc.registerTemplate(tmpl$1);
@@ -116,70 +85,19 @@
   __setKey(tmpl$1, "stylesheets", []);
 
   if (_implicitStylesheets) {
-    __callKey2(
-      (tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets)
-        .push,
-      "apply",
-      tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets,
-      _implicitStylesheets
-    );
+    __callKey2((tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets).push, "apply", tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets, _implicitStylesheets);
   }
 
   __setKey(tmpl$1, "stylesheetTokens", {
     hostAttribute: "x-foo_foo-host",
-    shadowAttribute: "x-foo_foo",
+    shadowAttribute: "x-foo_foo"
   });
 
-  function _createSuper$1(Derived) {
-    var hasNativeReflectConstruct = _isNativeReflectConstruct$1();
-    return function _createSuperInternal() {
-      var Super = _getPrototypeOf(Derived),
-        result;
-      if (hasNativeReflectConstruct) {
-        var _getPrototypeOf2;
-        var NewTarget =
-          ((_getPrototypeOf2 = _getPrototypeOf(this)),
-          _getPrototypeOf2._ES5ProxyType
-            ? _getPrototypeOf2.get("constructor")
-            : _getPrototypeOf2.constructor);
-        result = __callKey3(Reflect, "construct", Super, arguments, NewTarget);
-      } else {
-        result = __callKey2(Super, "apply", this, arguments);
-      }
-      return _possibleConstructorReturn(this, result);
-    };
-  }
+  function _createSuper$1(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct$1(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
-  function _isNativeReflectConstruct$1() {
-    var _construct;
-    if (
-      typeof Reflect === "undefined" ||
-      !(Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct)
-    )
-      return false;
-    if (
-      ((_construct = Reflect._ES5ProxyType
-        ? Reflect.get("construct")
-        : Reflect.construct),
-      _construct._ES5ProxyType ? _construct.get("sham") : _construct.sham)
-    )
-      return false;
-    if (typeof Proxy === "function") return true;
-    try {
-      __callKey1(
-        Boolean.prototype._ES5ProxyType
-          ? Boolean.prototype.get("valueOf")
-          : Boolean.prototype.valueOf,
-        "call",
-        __callKey3(Reflect, "construct", Boolean, [], function () {})
-      );
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
+  function _isNativeReflectConstruct$1() { var _construct; if (typeof Reflect === "undefined" || !(Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct)) return false; if (_construct = Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct, _construct._ES5ProxyType ? _construct.get("sham") : _construct.sham) return false; if (typeof Proxy === "function") return true; try { __callKey1(Boolean.prototype._ES5ProxyType ? Boolean.prototype.get("valueOf") : Boolean.prototype.valueOf, "call", __callKey3(Reflect, "construct", Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
-  var Foo = /*#__PURE__*/ (function (_LightningElement) {
+  var Foo = /*#__PURE__*/function (_LightningElement) {
     _inherits(Foo, _LightningElement);
 
     var _super = _createSuper$1(Foo);
@@ -189,20 +107,11 @@
 
       _classCallCheck(this, Foo);
 
-      for (
-        var _len = arguments.length, args = new Array(_len), _key = 0;
-        _key < _len;
-        _key++
-      ) {
+      for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         __setKey(args, _key, arguments[_key]);
       }
 
-      _this = __callKey2(
-        _super._ES5ProxyType ? _super.get("call") : _super.call,
-        "apply",
-        _super,
-        __concat([this], args)
-      );
+      _this = __callKey2(_super._ES5ProxyType ? _super.get("call") : _super.call, "apply", _super, __concat([this], args));
 
       __setKey(_this, "x", void 0);
 
@@ -210,47 +119,34 @@
     }
 
     return Foo;
-  })(lwc.LightningElement);
+  }(lwc.LightningElement);
 
   lwc.registerDecorators(Foo, {
     publicProps: {
       x: {
-        config: 0,
-      },
-    },
+        config: 0
+      }
+    }
   });
 
   var _xFoo = lwc.registerComponent(Foo, {
-    tmpl: _tmpl$1,
+    tmpl: _tmpl$1
   });
 
   function tmpl($api, $cmp, $slotset, $ctx) {
     var api_custom_element = $api._ES5ProxyType ? $api.get("c") : $api.c,
-      api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
-    return [
-      api_element(
-        "div",
-        {
-          classMap: {
-            container: true,
-          },
-          key: 0,
-        },
-        [
-          api_custom_element(
-            "x-foo",
-            _xFoo,
-            {
-              props: {
-                x: "1",
-              },
-              key: 1,
-            },
-            []
-          ),
-        ]
-      ),
-    ];
+        api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
+    return [api_element("div", {
+      classMap: {
+        "container": true
+      },
+      key: 0
+    }, [api_custom_element("x-foo", _xFoo, {
+      props: {
+        "x": "1"
+      },
+      key: 1
+    }, [])])];
   }
 
   var _tmpl = lwc.registerTemplate(tmpl);
@@ -259,59 +155,14 @@
 
   __setKey(tmpl, "stylesheetTokens", {
     hostAttribute: "x-app_app-host",
-    shadowAttribute: "x-app_app",
+    shadowAttribute: "x-app_app"
   });
 
-  function _createSuper(Derived) {
-    var hasNativeReflectConstruct = _isNativeReflectConstruct();
-    return function _createSuperInternal() {
-      var Super = _getPrototypeOf(Derived),
-        result;
-      if (hasNativeReflectConstruct) {
-        var _getPrototypeOf2;
-        var NewTarget =
-          ((_getPrototypeOf2 = _getPrototypeOf(this)),
-          _getPrototypeOf2._ES5ProxyType
-            ? _getPrototypeOf2.get("constructor")
-            : _getPrototypeOf2.constructor);
-        result = __callKey3(Reflect, "construct", Super, arguments, NewTarget);
-      } else {
-        result = __callKey2(Super, "apply", this, arguments);
-      }
-      return _possibleConstructorReturn(this, result);
-    };
-  }
+  function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
-  function _isNativeReflectConstruct() {
-    var _construct;
-    if (
-      typeof Reflect === "undefined" ||
-      !(Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct)
-    )
-      return false;
-    if (
-      ((_construct = Reflect._ES5ProxyType
-        ? Reflect.get("construct")
-        : Reflect.construct),
-      _construct._ES5ProxyType ? _construct.get("sham") : _construct.sham)
-    )
-      return false;
-    if (typeof Proxy === "function") return true;
-    try {
-      __callKey1(
-        Boolean.prototype._ES5ProxyType
-          ? Boolean.prototype.get("valueOf")
-          : Boolean.prototype.valueOf,
-        "call",
-        __callKey3(Reflect, "construct", Boolean, [], function () {})
-      );
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
+  function _isNativeReflectConstruct() { var _construct; if (typeof Reflect === "undefined" || !(Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct)) return false; if (_construct = Reflect._ES5ProxyType ? Reflect.get("construct") : Reflect.construct, _construct._ES5ProxyType ? _construct.get("sham") : _construct.sham) return false; if (typeof Proxy === "function") return true; try { __callKey1(Boolean.prototype._ES5ProxyType ? Boolean.prototype.get("valueOf") : Boolean.prototype.valueOf, "call", __callKey3(Reflect, "construct", Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
-  var App = /*#__PURE__*/ (function (_LightningElement) {
+  var App = /*#__PURE__*/function (_LightningElement) {
     _inherits(App, _LightningElement);
 
     var _super = _createSuper(App);
@@ -329,17 +180,18 @@
     }
 
     return App;
-  })(lwc.LightningElement);
+  }(lwc.LightningElement);
 
   var App$1 = lwc.registerComponent(App, {
-    tmpl: _tmpl,
+    tmpl: _tmpl
   });
 
-  var container = __callKey1(document, "getElementById", "main");
+  var container = __callKey1(document, "getElementById", 'main');
 
-  var element = lwc.createElement("x-app", {
-    is: App$1,
+  var element = lwc.createElement('x-app', {
+    is: App$1
   });
 
   __callKey1(container, "appendChild", element);
-})(LWC);
+
+}(LWC));

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -1,103 +1,86 @@
 (function (lwc) {
-  "use strict";
+    'use strict';
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
-  }
-  var _implicitStylesheets = [stylesheet];
-
-  function tmpl$1($api, $cmp, $slotset, $ctx) {
-    const { d: api_dynamic, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          key: 0,
-        },
-        [api_dynamic($cmp.x)]
-      ),
-    ];
-  }
-  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
-  tmpl$1.stylesheets = [];
-
-  if (_implicitStylesheets) {
-    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
-  }
-  tmpl$1.stylesheetTokens = {
-    hostAttribute: "x-foo_foo-host",
-    shadowAttribute: "x-foo_foo",
-  };
-
-  class Foo extends lwc.LightningElement {
-    constructor(...args) {
-      super(...args);
-      this.x = void 0;
+    function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+      return (nativeShadow ? ":host {color: var(--lwc-my-color);}" : [hostSelector, " {color: var(--lwc-my-color);}"].join(''));
     }
-  }
+    var _implicitStylesheets = [stylesheet];
 
-  lwc.registerDecorators(Foo, {
-    publicProps: {
-      x: {
-        config: 0,
-      },
-    },
-  });
-
-  var _xFoo = lwc.registerComponent(Foo, {
-    tmpl: _tmpl$1,
-  });
-
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const { c: api_custom_element, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          classMap: {
-            container: true,
-          },
-          key: 0,
-        },
-        [
-          api_custom_element(
-            "x-foo",
-            _xFoo,
-            {
-              props: {
-                x: "1",
-              },
-              key: 1,
-            },
-            []
-          ),
-        ]
-      ),
-    ];
-  }
-  var _tmpl = lwc.registerTemplate(tmpl);
-  tmpl.stylesheets = [];
-  tmpl.stylesheetTokens = {
-    hostAttribute: "x-app_app-host",
-    shadowAttribute: "x-app_app",
-  };
-
-  class App extends lwc.LightningElement {
-    constructor() {
-      super();
-      this.list = [];
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
+      const {d: api_dynamic, h: api_element} = $api;
+      return [api_element("div", {
+        key: 0
+      }, [api_dynamic($cmp.x)])];
     }
-  }
+    var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+    tmpl$1.stylesheets = [];
 
-  var App$1 = lwc.registerComponent(App, {
-    tmpl: _tmpl,
-  });
 
-  const container = document.getElementById("main");
-  const element = lwc.createElement("x-app", {
-    is: App$1,
-  });
-  container.appendChild(element);
-})(LWC);
+    if (_implicitStylesheets) {
+      tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+    }
+    tmpl$1.stylesheetTokens = {
+      hostAttribute: "x-foo_foo-host",
+      shadowAttribute: "x-foo_foo"
+    };
+
+    class Foo extends lwc.LightningElement {
+      constructor(...args) {
+        super(...args);
+        this.x = void 0;
+      }
+
+    }
+
+    lwc.registerDecorators(Foo, {
+      publicProps: {
+        x: {
+          config: 0
+        }
+      }
+    });
+
+    var _xFoo = lwc.registerComponent(Foo, {
+      tmpl: _tmpl$1
+    });
+
+    function tmpl($api, $cmp, $slotset, $ctx) {
+      const {c: api_custom_element, h: api_element} = $api;
+      return [api_element("div", {
+        classMap: {
+          "container": true
+        },
+        key: 0
+      }, [api_custom_element("x-foo", _xFoo, {
+        props: {
+          "x": "1"
+        },
+        key: 1
+      }, [])])];
+    }
+    var _tmpl = lwc.registerTemplate(tmpl);
+    tmpl.stylesheets = [];
+    tmpl.stylesheetTokens = {
+      hostAttribute: "x-app_app-host",
+      shadowAttribute: "x-app_app"
+    };
+
+    class App extends lwc.LightningElement {
+      constructor() {
+        super();
+        this.list = [];
+      }
+
+    }
+
+    var App$1 = lwc.registerComponent(App, {
+      tmpl: _tmpl
+    });
+
+    const container = document.getElementById('main');
+    const element = lwc.createElement('x-app', {
+      is: App$1
+    });
+    container.appendChild(element);
+
+}(LWC));

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -1,118 +1,90 @@
 (function (lwc, varResolver) {
-  "use strict";
+    'use strict';
 
-  function _interopDefaultLegacy(e) {
-    return e && typeof e === "object" && "default" in e ? e : { default: e };
-  }
+    function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
-  var varResolver__default = /*#__PURE__*/ _interopDefaultLegacy(varResolver);
+    var varResolver__default = /*#__PURE__*/_interopDefaultLegacy(varResolver);
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? [
-          ":host {color: ",
-          varResolver__default["default"]("--lwc-my-color"),
-          ";}",
-        ].join("")
-      : [
-          hostSelector,
-          " {color: ",
-          varResolver__default["default"]("--lwc-my-color"),
-          ";}",
-        ].join("");
-  }
-  var _implicitStylesheets = [stylesheet];
-
-  function tmpl$1($api, $cmp, $slotset, $ctx) {
-    const { d: api_dynamic, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          key: 0,
-        },
-        [api_dynamic($cmp.x)]
-      ),
-    ];
-  }
-  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
-  tmpl$1.stylesheets = [];
-
-  if (_implicitStylesheets) {
-    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
-  }
-  tmpl$1.stylesheetTokens = {
-    hostAttribute: "x-foo_foo-host",
-    shadowAttribute: "x-foo_foo",
-  };
-
-  class Foo extends lwc.LightningElement {
-    constructor(...args) {
-      super(...args);
-      this.x = void 0;
+    function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+      return (nativeShadow ? [":host {color: ", varResolver__default['default']("--lwc-my-color"), ";}"].join('') : [hostSelector, " {color: ", varResolver__default['default']("--lwc-my-color"), ";}"].join(''));
     }
-  }
+    var _implicitStylesheets = [stylesheet];
 
-  lwc.registerDecorators(Foo, {
-    publicProps: {
-      x: {
-        config: 0,
-      },
-    },
-  });
-
-  var _xFoo = lwc.registerComponent(Foo, {
-    tmpl: _tmpl$1,
-  });
-
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const { c: api_custom_element, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          classMap: {
-            container: true,
-          },
-          key: 0,
-        },
-        [
-          api_custom_element(
-            "x-foo",
-            _xFoo,
-            {
-              props: {
-                x: "1",
-              },
-              key: 1,
-            },
-            []
-          ),
-        ]
-      ),
-    ];
-  }
-  var _tmpl = lwc.registerTemplate(tmpl);
-  tmpl.stylesheets = [];
-  tmpl.stylesheetTokens = {
-    hostAttribute: "x-app_app-host",
-    shadowAttribute: "x-app_app",
-  };
-
-  class App extends lwc.LightningElement {
-    constructor() {
-      super();
-      this.list = [];
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
+      const {d: api_dynamic, h: api_element} = $api;
+      return [api_element("div", {
+        key: 0
+      }, [api_dynamic($cmp.x)])];
     }
-  }
+    var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+    tmpl$1.stylesheets = [];
 
-  var App$1 = lwc.registerComponent(App, {
-    tmpl: _tmpl,
-  });
 
-  const container = document.getElementById("main");
-  const element = lwc.createElement("x-app", {
-    is: App$1,
-  });
-  container.appendChild(element);
-})(LWC, resolveCss);
+    if (_implicitStylesheets) {
+      tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+    }
+    tmpl$1.stylesheetTokens = {
+      hostAttribute: "x-foo_foo-host",
+      shadowAttribute: "x-foo_foo"
+    };
+
+    class Foo extends lwc.LightningElement {
+      constructor(...args) {
+        super(...args);
+        this.x = void 0;
+      }
+
+    }
+
+    lwc.registerDecorators(Foo, {
+      publicProps: {
+        x: {
+          config: 0
+        }
+      }
+    });
+
+    var _xFoo = lwc.registerComponent(Foo, {
+      tmpl: _tmpl$1
+    });
+
+    function tmpl($api, $cmp, $slotset, $ctx) {
+      const {c: api_custom_element, h: api_element} = $api;
+      return [api_element("div", {
+        classMap: {
+          "container": true
+        },
+        key: 0
+      }, [api_custom_element("x-foo", _xFoo, {
+        props: {
+          "x": "1"
+        },
+        key: 1
+      }, [])])];
+    }
+    var _tmpl = lwc.registerTemplate(tmpl);
+    tmpl.stylesheets = [];
+    tmpl.stylesheetTokens = {
+      hostAttribute: "x-app_app-host",
+      shadowAttribute: "x-app_app"
+    };
+
+    class App extends lwc.LightningElement {
+      constructor() {
+        super();
+        this.list = [];
+      }
+
+    }
+
+    var App$1 = lwc.registerComponent(App, {
+      tmpl: _tmpl
+    });
+
+    const container = document.getElementById('main');
+    const element = lwc.createElement('x-app', {
+      is: App$1
+    });
+    container.appendChild(element);
+
+}(LWC, resolveCss));

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -1,0 +1,103 @@
+(function (lwc) {
+  "use strict";
+
+  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+    return nativeShadow
+      ? ":host {color: var(--lwc-my-color);}"
+      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
+  }
+  var _implicitStylesheets = [stylesheet];
+
+  function tmpl$1($api, $cmp, $slotset, $ctx) {
+    const { d: api_dynamic, h: api_element } = $api;
+    return [
+      api_element(
+        "div",
+        {
+          key: 0,
+        },
+        [api_dynamic($cmp.x)]
+      ),
+    ];
+  }
+  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+  tmpl$1.stylesheets = [];
+
+  if (_implicitStylesheets) {
+    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+  }
+  tmpl$1.stylesheetTokens = {
+    hostAttribute: "x-foo_foo-host",
+    shadowAttribute: "x-foo_foo",
+  };
+
+  class Foo extends lwc.LightningElement {
+    constructor(...args) {
+      super(...args);
+      this.x = void 0;
+    }
+  }
+
+  lwc.registerDecorators(Foo, {
+    publicProps: {
+      x: {
+        config: 0,
+      },
+    },
+  });
+
+  var _xFoo = lwc.registerComponent(Foo, {
+    tmpl: _tmpl$1,
+  });
+
+  function tmpl($api, $cmp, $slotset, $ctx) {
+    const { c: api_custom_element, h: api_element } = $api;
+    return [
+      api_element(
+        "div",
+        {
+          classMap: {
+            container: true,
+          },
+          key: 0,
+        },
+        [
+          api_custom_element(
+            "x-foo",
+            _xFoo,
+            {
+              props: {
+                x: "1",
+              },
+              key: 1,
+            },
+            []
+          ),
+        ]
+      ),
+    ];
+  }
+  var _tmpl = lwc.registerTemplate(tmpl);
+  tmpl.stylesheets = [];
+  tmpl.stylesheetTokens = {
+    hostAttribute: "x-app_app-host",
+    shadowAttribute: "x-app_app",
+  };
+
+  class App extends lwc.LightningElement {
+    constructor() {
+      super();
+      this.list = [];
+    }
+  }
+
+  var App$1 = lwc.registerComponent(App, {
+    tmpl: _tmpl,
+  });
+
+  const container = document.getElementById("main");
+  const element = lwc.createElement("x-app", {
+    is: App$1,
+  });
+  container.appendChild(element);
+})(LWC);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -1,103 +1,86 @@
 (function (lwc) {
-  "use strict";
+    'use strict';
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
-  }
-  var _implicitStylesheets = [stylesheet];
-
-  function tmpl$1($api, $cmp, $slotset, $ctx) {
-    const { d: api_dynamic, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          key: 0,
-        },
-        [api_dynamic($cmp.x)]
-      ),
-    ];
-  }
-  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
-  tmpl$1.stylesheets = [];
-
-  if (_implicitStylesheets) {
-    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
-  }
-  tmpl$1.stylesheetTokens = {
-    hostAttribute: "x-foo_foo-host",
-    shadowAttribute: "x-foo_foo",
-  };
-
-  class Foo extends lwc.LightningElement {
-    constructor(...args) {
-      super(...args);
-      this.x = void 0;
+    function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+      return (nativeShadow ? ":host {color: var(--lwc-my-color);}" : [hostSelector, " {color: var(--lwc-my-color);}"].join(''));
     }
-  }
+    var _implicitStylesheets = [stylesheet];
 
-  lwc.registerDecorators(Foo, {
-    publicProps: {
-      x: {
-        config: 0,
-      },
-    },
-  });
-
-  var _xFoo = lwc.registerComponent(Foo, {
-    tmpl: _tmpl$1,
-  });
-
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const { c: api_custom_element, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          classMap: {
-            container: true,
-          },
-          key: 0,
-        },
-        [
-          api_custom_element(
-            "x-foo",
-            _xFoo,
-            {
-              props: {
-                x: "1",
-              },
-              key: 1,
-            },
-            []
-          ),
-        ]
-      ),
-    ];
-  }
-  var _tmpl = lwc.registerTemplate(tmpl);
-  tmpl.stylesheets = [];
-  tmpl.stylesheetTokens = {
-    hostAttribute: "x-app_app-host",
-    shadowAttribute: "x-app_app",
-  };
-
-  class App extends lwc.LightningElement {
-    constructor() {
-      super();
-      this.list = [];
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
+      const {d: api_dynamic, h: api_element} = $api;
+      return [api_element("div", {
+        key: 0
+      }, [api_dynamic($cmp.x)])];
     }
-  }
+    var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+    tmpl$1.stylesheets = [];
 
-  var App$1 = lwc.registerComponent(App, {
-    tmpl: _tmpl,
-  });
 
-  const container = document.getElementById("main");
-  const element = lwc.createElement("x-app", {
-    is: App$1,
-  });
-  container.appendChild(element);
-})(LWC);
+    if (_implicitStylesheets) {
+      tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+    }
+    tmpl$1.stylesheetTokens = {
+      hostAttribute: "x-foo_foo-host",
+      shadowAttribute: "x-foo_foo"
+    };
+
+    class Foo extends lwc.LightningElement {
+      constructor(...args) {
+        super(...args);
+        this.x = void 0;
+      }
+
+    }
+
+    lwc.registerDecorators(Foo, {
+      publicProps: {
+        x: {
+          config: 0
+        }
+      }
+    });
+
+    var _xFoo = lwc.registerComponent(Foo, {
+      tmpl: _tmpl$1
+    });
+
+    function tmpl($api, $cmp, $slotset, $ctx) {
+      const {c: api_custom_element, h: api_element} = $api;
+      return [api_element("div", {
+        classMap: {
+          "container": true
+        },
+        key: 0
+      }, [api_custom_element("x-foo", _xFoo, {
+        props: {
+          "x": "1"
+        },
+        key: 1
+      }, [])])];
+    }
+    var _tmpl = lwc.registerTemplate(tmpl);
+    tmpl.stylesheets = [];
+    tmpl.stylesheetTokens = {
+      hostAttribute: "x-app_app-host",
+      shadowAttribute: "x-app_app"
+    };
+
+    class App extends lwc.LightningElement {
+      constructor() {
+        super();
+        this.list = [];
+      }
+
+    }
+
+    var App$1 = lwc.registerComponent(App, {
+      tmpl: _tmpl
+    });
+
+    const container = document.getElementById('main');
+    const element = lwc.createElement('x-app', {
+      is: App$1
+    });
+    container.appendChild(element);
+
+}(LWC));

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -1,109 +1,92 @@
 (function (lwc) {
-  "use strict";
+    'use strict';
 
-  function stylesheet(hostSelector, shadowSelector, nativeShadow) {
-    return nativeShadow
-      ? ":host {color: var(--lwc-my-color);}"
-      : [hostSelector, " {color: var(--lwc-my-color);}"].join("");
-  }
-  var _implicitStylesheets = [stylesheet];
-
-  function tmpl$1($api, $cmp, $slotset, $ctx) {
-    const { d: api_dynamic, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          key: 0,
-        },
-        [api_dynamic($cmp.x)]
-      ),
-    ];
-  }
-  var _tmpl$1 = lwc.registerTemplate(tmpl$1);
-  tmpl$1.stylesheets = [];
-
-  if (_implicitStylesheets) {
-    tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
-  }
-  tmpl$1.stylesheetTokens = {
-    hostAttribute: "ts-foo_foo-host",
-    shadowAttribute: "ts-foo_foo",
-  };
-
-  class Foo extends lwc.LightningElement {
-    constructor(...args) {
-      super(...args);
-      this.x = void 0;
+    function stylesheet(hostSelector, shadowSelector, nativeShadow) {
+      return (nativeShadow ? ":host {color: var(--lwc-my-color);}" : [hostSelector, " {color: var(--lwc-my-color);}"].join(''));
     }
-  }
+    var _implicitStylesheets = [stylesheet];
 
-  lwc.registerDecorators(Foo, {
-    publicProps: {
-      x: {
-        config: 0,
-      },
-    },
-  });
-
-  var _tsFoo = lwc.registerComponent(Foo, {
-    tmpl: _tmpl$1,
-  });
-
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const { c: api_custom_element, h: api_element } = $api;
-    return [
-      api_element(
-        "div",
-        {
-          classMap: {
-            container: true,
-          },
-          key: 0,
-        },
-        [
-          api_custom_element(
-            "ts-foo",
-            _tsFoo,
-            {
-              props: {
-                x: "1",
-              },
-              key: 1,
-            },
-            []
-          ),
-        ]
-      ),
-    ];
-  }
-  var _tmpl = lwc.registerTemplate(tmpl);
-  tmpl.stylesheets = [];
-  tmpl.stylesheetTokens = {
-    hostAttribute: "ts-app_app-host",
-    shadowAttribute: "ts-app_app",
-  };
-
-  class App extends lwc.LightningElement {
-    constructor() {
-      super();
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
+      const {d: api_dynamic, h: api_element} = $api;
+      return [api_element("div", {
+        key: 0
+      }, [api_dynamic($cmp.x)])];
     }
-  }
+    var _tmpl$1 = lwc.registerTemplate(tmpl$1);
+    tmpl$1.stylesheets = [];
 
-  var App$1 = lwc.registerComponent(App, {
-    tmpl: _tmpl,
-  });
 
-  function doNothing() {
-    return;
-  }
+    if (_implicitStylesheets) {
+      tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
+    }
+    tmpl$1.stylesheetTokens = {
+      hostAttribute: "ts-foo_foo-host",
+      shadowAttribute: "ts-foo_foo"
+    };
 
-  // @ts-ignore
-  const container = document.getElementById("main");
-  const element = lwc.createElement("ts-app", {
-    is: App$1,
-  });
-  container.appendChild(element); // testing relative import works
+    class Foo extends lwc.LightningElement {
+      constructor(...args) {
+        super(...args);
+        this.x = void 0;
+      }
 
-  console.log(">>", doNothing());
-})(LWC);
+    }
+
+    lwc.registerDecorators(Foo, {
+      publicProps: {
+        x: {
+          config: 0
+        }
+      }
+    });
+
+    var _tsFoo = lwc.registerComponent(Foo, {
+      tmpl: _tmpl$1
+    });
+
+    function tmpl($api, $cmp, $slotset, $ctx) {
+      const {c: api_custom_element, h: api_element} = $api;
+      return [api_element("div", {
+        classMap: {
+          "container": true
+        },
+        key: 0
+      }, [api_custom_element("ts-foo", _tsFoo, {
+        props: {
+          "x": "1"
+        },
+        key: 1
+      }, [])])];
+    }
+    var _tmpl = lwc.registerTemplate(tmpl);
+    tmpl.stylesheets = [];
+    tmpl.stylesheetTokens = {
+      hostAttribute: "ts-app_app-host",
+      shadowAttribute: "ts-app_app"
+    };
+
+    class App extends lwc.LightningElement {
+      constructor() {
+        super();
+      }
+
+    }
+
+    var App$1 = lwc.registerComponent(App, {
+      tmpl: _tmpl
+    });
+
+    function doNothing() {
+      return;
+    }
+
+    // @ts-ignore
+    const container = document.getElementById('main');
+    const element = lwc.createElement('ts-app', {
+      is: App$1
+    });
+    container.appendChild(element); // testing relative import works
+
+    console.log('>>', doNothing());
+
+}(LWC));

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -4,26 +4,17 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const fs = require('fs');
 const path = require('path');
 const rollup = require('rollup');
 const prettier = require('prettier');
 const rollupCompat = require('rollup-plugin-compat');
 const rollupCompile = require('../index');
+require('jest-utils-lwc-internals');
 
 function pretty(str) {
     return prettier.format(str, {
         parser: 'babel',
     });
-}
-
-function fsExpected(fileName, actual) {
-    const fullFileName = path.join(fixturesDir, `${fileName}.js`);
-    if (!fs.existsSync(fullFileName)) {
-        fs.writeFileSync(fullFileName, actual, 'utf8');
-    }
-    const expected = fs.readFileSync(fullFileName, 'utf8');
-    expect(actual).toBe(expected);
 }
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -37,7 +28,9 @@ describe('default configuration', () => {
     it(`simple app`, () => {
         const entry = path.join(simpleAppDir, 'main.js');
         return doRollup(entry, { compat: false }).then(({ code: actual }) => {
-            fsExpected('expected_default_config_simple_app', pretty(actual));
+            expect(pretty(actual)).toMatchFile(
+                path.join(fixturesDir, 'expected_default_config_simple_app.js')
+            );
         });
     });
 
@@ -54,7 +47,9 @@ describe('default configuration', () => {
             },
         };
         return doRollup(entry, { compat: false }, rollupCompileOptions).then(({ code: actual }) => {
-            fsExpected('expected_default_config_simple_app_css_resolver', pretty(actual));
+            expect(pretty(actual)).toMatchFile(
+                path.join(fixturesDir, 'expected_default_config_simple_app_css_resolver.js')
+            );
         });
     });
 
@@ -78,7 +73,9 @@ describe('rollup with custom options', () => {
         };
 
         return doRollup(entry, { compat: false }, rollupOptions).then(({ code: actual }) => {
-            fsExpected('expected_default_config_simple_app', pretty(actual));
+            expect(pretty(actual)).toMatchFile(
+                path.join(fixturesDir, 'expected_default_config_simple_app_relative.js')
+            );
         });
     });
 });
@@ -87,7 +84,9 @@ describe('rollup in compat mode', () => {
     it(`simple app`, () => {
         const entry = path.join(simpleAppDir, 'main.js');
         return doRollup(entry, { compat: true }).then(({ code: actual }) => {
-            fsExpected('expected_compat_config_simple_app', pretty(actual));
+            expect(pretty(actual)).toMatchFile(
+                path.join(fixturesDir, 'expected_compat_config_simple_app.js')
+            );
         });
     });
 });
@@ -96,7 +95,9 @@ describe('typescript relative import', () => {
     it(`should resolve to .ts file`, () => {
         const entry = path.join(tsAppDir, 'main.ts');
         return doRollup(entry, { compat: false }).then(({ code: actual }) => {
-            fsExpected('expected_default_config_ts_simple_app', pretty(actual));
+            expect(pretty(actual)).toMatchFile(
+                path.join(fixturesDir, 'expected_default_config_ts_simple_app.js')
+            );
         });
     });
 });

--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.js
@@ -6,16 +6,9 @@
  */
 const path = require('path');
 const rollup = require('rollup');
-const prettier = require('prettier');
 const rollupCompat = require('rollup-plugin-compat');
 const rollupCompile = require('../index');
 require('jest-utils-lwc-internals');
-
-function pretty(str) {
-    return prettier.format(str, {
-        parser: 'babel',
-    });
-}
 
 const fixturesDir = path.join(__dirname, 'fixtures');
 const simpleAppDir = path.join(fixturesDir, 'simple_app/src');
@@ -28,7 +21,7 @@ describe('default configuration', () => {
     it(`simple app`, () => {
         const entry = path.join(simpleAppDir, 'main.js');
         return doRollup(entry, { compat: false }).then(({ code: actual }) => {
-            expect(pretty(actual)).toMatchFile(
+            expect(actual).toMatchFile(
                 path.join(fixturesDir, 'expected_default_config_simple_app.js')
             );
         });
@@ -47,7 +40,7 @@ describe('default configuration', () => {
             },
         };
         return doRollup(entry, { compat: false }, rollupCompileOptions).then(({ code: actual }) => {
-            expect(pretty(actual)).toMatchFile(
+            expect(actual).toMatchFile(
                 path.join(fixturesDir, 'expected_default_config_simple_app_css_resolver.js')
             );
         });
@@ -59,7 +52,7 @@ describe('default configuration', () => {
             preserveHtmlComments: true,
         };
         return doRollup(entry, { compat: false }, rollupCompileOptions).then(({ code: actual }) => {
-            expect(pretty(actual)).toContain('Application container');
+            expect(actual).toContain('Application container');
         });
     });
 });
@@ -73,7 +66,7 @@ describe('rollup with custom options', () => {
         };
 
         return doRollup(entry, { compat: false }, rollupOptions).then(({ code: actual }) => {
-            expect(pretty(actual)).toMatchFile(
+            expect(actual).toMatchFile(
                 path.join(fixturesDir, 'expected_default_config_simple_app_relative.js')
             );
         });
@@ -84,7 +77,7 @@ describe('rollup in compat mode', () => {
     it(`simple app`, () => {
         const entry = path.join(simpleAppDir, 'main.js');
         return doRollup(entry, { compat: true }).then(({ code: actual }) => {
-            expect(pretty(actual)).toMatchFile(
+            expect(actual).toMatchFile(
                 path.join(fixturesDir, 'expected_compat_config_simple_app.js')
             );
         });
@@ -95,7 +88,7 @@ describe('typescript relative import', () => {
     it(`should resolve to .ts file`, () => {
         const entry = path.join(tsAppDir, 'main.ts');
         return doRollup(entry, { compat: false }).then(({ code: actual }) => {
-            expect(pretty(actual)).toMatchFile(
+            expect(actual).toMatchFile(
                 path.join(fixturesDir, 'expected_default_config_ts_simple_app.js')
             );
         });


### PR DESCRIPTION
## Details

In #2294 we added Jest snapshot tests, but we didn't add them for the `rollup-plugin` tests. This PR fixes that, removing the previous homegrown `fsExpected` helper function.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`