### PR TITLE
fix: preserve original ids/fragments in light DOM

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -647,7 +647,7 @@ export function gid(id: string | undefined | null): string | null | undefined {
     if (isNull(id)) {
         return null;
     }
-    if (isNull(vmBeingRendered) || hasShadow(vmBeingRendered)) {
+    if (hasShadow(vmBeingRendered!)) {
         return `${id}-${vmBeingRendered!.idx}`; // only transform IDs in shadow DOM
     }
     return id;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -672,7 +672,7 @@ export function fid(url: string | undefined | null): string | null | undefined {
         return null;
     }
     // Apply transformation only for fragment-only-urls, and only in shadow DOM
-    if (/^#/.test(url) && (isNull(vmBeingRendered) || hasShadow(vmBeingRendered))) {
+    if (/^#/.test(url) && hasShadow(vmBeingRendered!)) {
         return `${url}-${vmBeingRendered!.idx}`;
     }
     return url;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -647,7 +647,10 @@ export function gid(id: string | undefined | null): string | null | undefined {
     if (isNull(id)) {
         return null;
     }
-    return `${id}-${vmBeingRendered!.idx}`;
+    if (isNull(vmBeingRendered) || hasShadow(vmBeingRendered)) {
+        return `${id}-${vmBeingRendered!.idx}`; // only transform IDs in shadow DOM
+    }
+    return id;
 }
 
 // [f]ragment [id] function
@@ -668,8 +671,8 @@ export function fid(url: string | undefined | null): string | null | undefined {
     if (isNull(url)) {
         return null;
     }
-    // Apply transformation only for fragment-only-urls
-    if (/^#/.test(url)) {
+    // Apply transformation only for fragment-only-urls, and only in shadow DOM
+    if (/^#/.test(url) && (isNull(vmBeingRendered) || hasShadow(vmBeingRendered))) {
         return `${url}-${vmBeingRendered!.idx}`;
     }
     return url;

--- a/packages/integration-karma/test/light-dom/ids/index.spec.js
+++ b/packages/integration-karma/test/light-dom/ids/index.spec.js
@@ -1,0 +1,60 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+
+import One from 'x/one';
+import Two from 'x/two';
+import Shadow from 'x/shadow';
+
+describe('Light DOM IDs and fragment links', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+    });
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+    });
+    it('should not mangle IDs or hrefs in light DOM', () => {
+        document.body.appendChild(createElement('x-one', { is: One }));
+        document.body.appendChild(createElement('x-two', { is: Two }));
+
+        expect(document.body.querySelector('x-one .foo').id).toEqual('foo');
+        expect(document.body.querySelector('x-one .bar').id).toEqual('bar');
+        expect(document.body.querySelector('x-two .foo').id).toEqual('foo');
+        expect(document.body.querySelector('x-two .quux').id).toEqual('quux');
+
+        expect(document.body.querySelector('x-one .go-to-foo').href).toMatch(/#foo$/);
+        expect(document.body.querySelector('x-one .go-to-bar').href).toMatch(/#bar$/);
+        expect(document.body.querySelector('x-one .go-to-quux').href).toMatch(/#quux$/);
+
+        expect(document.body.querySelector('x-two .go-to-foo').href).toMatch(/#foo$/);
+        expect(document.body.querySelector('x-two .go-to-bar').href).toMatch(/#bar$/);
+        expect(document.body.querySelector('x-two .go-to-quux').href).toMatch(/#quux$/);
+    });
+
+    // Remove this test when this is fixed: https://github.com/salesforce/lwc/issues/1150
+    it('should only mangle non-dangling hrefs in shadow DOM', () => {
+        document.body.appendChild(createElement('x-one', { is: One }));
+        document.body.appendChild(createElement('x-shadow', { is: Shadow }));
+
+        expect(document.body.querySelector('x-one .foo').id).toEqual('foo');
+        expect(document.body.querySelector('x-one .bar').id).toEqual('bar');
+        expect(document.body.querySelector('x-shadow').shadowRoot.querySelector('.foo').id).toMatch(
+            /^foo-\d+$/
+        );
+        expect(
+            document.body.querySelector('x-shadow').shadowRoot.querySelector('.quux').id
+        ).toMatch(/^quux-\d+$/);
+
+        expect(document.body.querySelector('x-one .go-to-foo').href).toMatch(/#foo$/);
+        expect(document.body.querySelector('x-one .go-to-bar').href).toMatch(/#bar$/);
+        expect(document.body.querySelector('x-one .go-to-quux').href).toMatch(/#quux$/);
+
+        expect(
+            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-foo').href
+        ).toMatch(/#foo-\d+$/);
+        expect(
+            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-bar').href
+        ).toMatch(/#bar-\d+$/);
+        expect(
+            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-quux').href
+        ).toMatch(/#quux-\d+$/);
+    });
+});

--- a/packages/integration-karma/test/light-dom/ids/x/one/one.html
+++ b/packages/integration-karma/test/light-dom/ids/x/one/one.html
@@ -1,0 +1,7 @@
+<template>
+  <div class="foo" id="foo">foo</div>
+  <div class="bar" id="bar">bar</div>
+  <a class="go-to-foo" href="#foo">Go to foo</a>
+  <a class="go-to-bar" href="#bar">Go to bar</a>
+  <a class="go-to-quux" href="#quux">Go to quux</a>
+</template>

--- a/packages/integration-karma/test/light-dom/ids/x/one/one.js
+++ b/packages/integration-karma/test/light-dom/ids/x/one/one.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class One extends LightningElement {
+    static shadow = false;
+}

--- a/packages/integration-karma/test/light-dom/ids/x/shadow/shadow.html
+++ b/packages/integration-karma/test/light-dom/ids/x/shadow/shadow.html
@@ -1,0 +1,7 @@
+<template>
+  <div class="foo" id="foo">foo</div>
+  <div class="quux" id="quux">quux</div>
+  <a class="go-to-foo" href="#foo">Go to foo</a>
+  <a class="go-to-quux" href="#quux">Go to quux</a>
+  <a class="go-to-bar" href="#bar">Go to bar</a>
+</template>

--- a/packages/integration-karma/test/light-dom/ids/x/shadow/shadow.js
+++ b/packages/integration-karma/test/light-dom/ids/x/shadow/shadow.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Shadow extends LightningElement {}

--- a/packages/integration-karma/test/light-dom/ids/x/two/two.html
+++ b/packages/integration-karma/test/light-dom/ids/x/two/two.html
@@ -1,0 +1,7 @@
+<template>
+    <div class="foo" id="foo">foo</div>
+    <div class="quux" id="quux">quux</div>
+    <a class="go-to-foo" href="#foo">Go to foo</a>
+    <a class="go-to-quux" href="#quux">Go to quux</a>
+    <a class="go-to-bar" href="#bar">Go to bar</a>
+</template>

--- a/packages/integration-karma/test/light-dom/ids/x/two/two.js
+++ b/packages/integration-karma/test/light-dom/ids/x/two/two.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Two extends LightningElement {
+    static shadow = false;
+}


### PR DESCRIPTION
## Details

When rendering to the light DOM, avoid mangling IDs/fragments, e.g. transforming `foo` into `foo-1` or `#foo` into `#foo-1`.

Note that because of https://github.com/salesforce/lwc/issues/1150 we can't actually guarantee the correct semantics for references between two components, where one is a light component and the other is a shadow component. So this means that, for light DOM elements, we essentially just never mangle any ids or fragments.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9224059
