### PR TITLE
fix: do not throw error when children are appended to host in shadow dom elements

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -222,12 +222,6 @@ export const LightningElement: LightningElementConstructor = function (
     associateVM(component, vm);
     associateVM(elm, vm);
 
-    // Adding extra guard rails in DEV mode.
-    if (process.env.NODE_ENV !== 'production') {
-        patchCustomElementWithRestrictions(elm);
-        patchComponentWithRestrictions(component);
-    }
-
     if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
         assert.invariant(
             !isFalse(ctor.shadow),
@@ -241,6 +235,12 @@ export const LightningElement: LightningElementConstructor = function (
     // doesn't yet declare shadow to be true, leaving it undefined.
     if (!isFalse(ctor.shadow)) {
         attachShadow(vm);
+    }
+
+    // Adding extra guard rails in DEV mode.
+    if (process.env.NODE_ENV !== 'production') {
+        patchCustomElementWithRestrictions(elm);
+        patchComponentWithRestrictions(component);
     }
 
     return this;

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -2,6 +2,7 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Slotted from 'x/slotted';
 import Container from 'x/container';
+import Shadow from 'x/shadow';
 
 describe('slotted content', () => {
     beforeEach(() => {
@@ -51,5 +52,16 @@ describe('imperative slotted content', () => {
                 /Invalid DOM operation on <x-container>\. Light DOM component don't allow imperative slotted content\./
             );
         });
+    });
+});
+
+describe('in shadow dom', () => {
+    it('appending to host should not throw error', () => {
+        expect(() => {
+            const element = createElement('x-container', { is: Shadow });
+            document.body.appendChild(element);
+        }).not.toThrowError(
+            /Invalid DOM operation on <x-container>\. Light DOM component don't allow imperative slotted content\./
+        );
     });
 });

--- a/packages/integration-karma/test/light-dom/slotting/x/shadow/shadow.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/shadow/shadow.html
@@ -1,0 +1,1 @@
+<template> </template>

--- a/packages/integration-karma/test/light-dom/slotting/x/shadow/shadow.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/shadow/shadow.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class Shadow extends LightningElement {
+    connectedCallback() {
+        this.template.host.appendChild(document.createElement('div'));
+    }
+}


### PR DESCRIPTION
## Details
While preventing slotting in Light DOM elements (https://github.com/salesforce/lwc/commit/6214d6568873dce4f0d1ff2920bd898b033404f1), we are checking whether it's a light DOM component too early. `hasShadow` checks if `vm.cmpRoot` is null. But it's being checked even before attaching the shadow in Shadow DOM mode which always fails. This is causing issues where Shadow DOM components are appending children to the host element.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
* 🚨 `Yes, it does introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ / ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ / ❌

## GUS work item
<!--Work ID in text, no links -->
