### PR TITLE
chore: address security vulnerability CVE-2020-28502

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "micromatch": "^4.0.2",
     "meow": "^7.1.1",
     "node-fetch": "^2.6.1",
-    "systeminformation": "^5.3.1"
+    "systeminformation": "^5.3.1",
+    "xmlhttprequest-ssl": "^1.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13243,10 +13243,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@~1.5.4:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
-  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz#dd6899bfbcf684b554e393c30b13b9f3b001a7ee"
+  integrity sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Details
xmlhttprequest-ssl package is reported to have a vulnerability. 
**Usage:** 
Hoisted from "_project_#perf-benchmarks#@best#runner-remote#socket.io-client#engine.io-client#xmlhttprequest-ssl"


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`


If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ / ❌
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ / ❌

## GUS work item
W-7258582
