### PR TITLE
Revert "feat(synthetic-shadow): enable innerText shadow dom semantics…

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -11,8 +11,8 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
     ENABLE_HMR: null,
     // Flag to toggle on/off the enforcement of innerText/outerText shadow dom semantic in elements when using synthetic shadow.
-    // Note: Elements outside the lwc boundary are controlled by the ENABLE_ELEMENT_PATCH flag.
-    DISABLE_INNER_OUTER_TEXT_PATCH: null,
+    // Note: Once active, elements outside the lwc boundary are controlled by the ENABLE_ELEMENT_PATCH flag.
+    ENABLE_INNER_OUTER_TEXT_PATCH: null,
     // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_NODE_LIST_PATCH: null,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -197,7 +197,7 @@ defineProperties(HTMLElement.prototype, {
 if (innerTextGetter !== null && innerTextSetter !== null) {
     defineProperty(HTMLElement.prototype, 'innerText', {
         get(this: HTMLElement): string {
-            if (featureFlags.DISABLE_INNER_OUTER_TEXT_PATCH) {
+            if (!featureFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
                 return innerTextGetter!.call(this);
             }
 
@@ -230,7 +230,7 @@ if (outerTextGetter !== null && outerTextSetter !== null) {
     // As a setter, it removes the current node and replaces it with the given text.
     defineProperty(HTMLElement.prototype, 'outerText', {
         get(this: HTMLElement): string {
-            if (featureFlags.DISABLE_INNER_OUTER_TEXT_PATCH) {
+            if (!featureFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
                 return outerTextGetter!.call(this);
             }
 

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -2,21 +2,12 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
 
 if (!process.env.NATIVE_SHADOW) {
-    describe('DISABLE_INNER_OUTER_TEXT_PATCH flag', () => {
-        const elm = createElement('x-container', { is: Container });
-        document.body.appendChild(elm);
+    beforeAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', true);
+    });
 
-        it('should get innerText of custom element when DISABLE_INNER_OUTER_TEXT_PATCH = true', () => {
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', true);
-            expect(elm.innerText).not.toBe('');
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', false);
-        });
-
-        it('should get outerText of custom element when DISABLE_INNER_OUTER_TEXT_PATCH = true', () => {
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', true);
-            expect(elm.outerText).not.toBe('');
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', false);
-        });
+    afterAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', false);
     });
 
     describe('innerText', () => {


### PR DESCRIPTION
… by default (#2247)"

This reverts commit 2828a02b48164a799343cfa8d0bd7511afa2dd01.


## Details


* ✅ `No, it does not introduce breaking changes.`
