### PR TITLE
perf: switch synthetic scoping from attributes to classes

### DIFF
--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -72,8 +72,8 @@ function serialize(
     buffer += `}\n`;
 
     buffer += `tmpl.stylesheetTokens = {\n`;
-    buffer += `  hostAttribute: "${scopingAttribute}-host",\n`;
-    buffer += `  shadowAttribute: "${scopingAttribute}"\n`;
+    buffer += `  hostClass: "${scopingAttribute}-host",\n`;
+    buffer += `  shadowClass: "${scopingAttribute}"\n`;
     buffer += `};\n`;
 
     return buffer;

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -103,7 +103,7 @@ export function fallbackElmHook(elm: Element, vnode: VElement) {
         const {
             data: { context },
         } = vnode;
-        const { shadowAttribute } = owner.context;
+        const { shadowClass } = owner.context;
         if (
             !isUndefined(context) &&
             !isUndefined(context.lwc) &&
@@ -114,7 +114,7 @@ export function fallbackElmHook(elm: Element, vnode: VElement) {
         }
         // when running in synthetic shadow mode, we need to set the shadowToken value
         // into each element from the template, so they can be styled accordingly.
-        setElementShadowToken(elm, shadowAttribute);
+        setElementShadowToken(elm, shadowClass);
     }
     if (process.env.NODE_ENV !== 'production') {
         const {
@@ -195,10 +195,10 @@ export function createViewModelHook(elm: HTMLElement, vnode: VCustomElement) {
     const { sel, mode, ctor, owner } = vnode;
     const def = getComponentInternalDef(ctor);
     if (isTrue(owner.renderer.syntheticShadow)) {
-        const { shadowAttribute } = owner.context;
+        const { shadowClass } = owner.context;
         // when running in synthetic shadow mode, we need to set the shadowToken value
         // into each element from the template, so they can be styled accordingly.
-        setElementShadowToken(elm, shadowAttribute);
+        setElementShadowToken(elm, shadowClass);
     }
     createVM(elm, def, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -49,9 +49,9 @@ export function updateSyntheticShadowAttributes(vm: VM, template: Template) {
     let newTokens: TemplateStylesheetTokens | undefined;
 
     // Reset the styling token applied to the host element.
-    const oldHostAttribute = context.hostAttribute;
-    if (!isUndefined(oldHostAttribute)) {
-        renderer.getClassList(elm).remove(oldHostAttribute);
+    const oldHostClass = context.hostClass;
+    if (!isUndefined(oldHostClass)) {
+        renderer.getClassList(elm).remove(oldHostClass);
     }
 
     // Apply the new template styling token to the host element, if the new template has any
@@ -61,12 +61,12 @@ export function updateSyntheticShadowAttributes(vm: VM, template: Template) {
     }
 
     if (!isUndefined(newTokens)) {
-        renderer.getClassList(elm).add(newTokens.hostAttribute);
+        renderer.getClassList(elm).add(newTokens.hostClass);
     }
 
     // Update the styling tokens present on the context object.
-    context.hostAttribute = newTokens?.hostAttribute;
-    context.shadowAttribute = newTokens?.shadowAttribute;
+    context.hostClass = newTokens?.hostClass;
+    context.shadowClass = newTokens?.shadowClass;
 }
 
 function evaluateStylesheetsContent(
@@ -112,8 +112,8 @@ export function getStylesheetsContent(vm: VM, template: Template): string[] {
         // Scoping with the tokens is only necessary for synthetic shadow. For both
         // light DOM elements and native shadow, we just render the CSS as-is.
         if (syntheticShadow && hasShadow(vm) && !isUndefined(stylesheetTokens)) {
-            hostSelector = `.${stylesheetTokens.hostAttribute}`;
-            shadowSelector = `.${stylesheetTokens.shadowAttribute}`;
+            hostSelector = `.${stylesheetTokens.hostClass}`;
+            shadowSelector = `.${stylesheetTokens.shadowClass}`;
         } else {
             hostSelector = '';
             shadowSelector = '';

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -51,7 +51,7 @@ export function updateSyntheticShadowAttributes(vm: VM, template: Template) {
     // Reset the styling token applied to the host element.
     const oldHostAttribute = context.hostAttribute;
     if (!isUndefined(oldHostAttribute)) {
-        renderer.removeAttribute(elm, oldHostAttribute);
+        renderer.getClassList(elm).remove(oldHostAttribute);
     }
 
     // Apply the new template styling token to the host element, if the new template has any
@@ -61,7 +61,7 @@ export function updateSyntheticShadowAttributes(vm: VM, template: Template) {
     }
 
     if (!isUndefined(newTokens)) {
-        renderer.setAttribute(elm, newTokens.hostAttribute, '');
+        renderer.getClassList(elm).add(newTokens.hostAttribute);
     }
 
     // Update the styling tokens present on the context object.
@@ -112,8 +112,8 @@ export function getStylesheetsContent(vm: VM, template: Template): string[] {
         // Scoping with the tokens is only necessary for synthetic shadow. For both
         // light DOM elements and native shadow, we just render the CSS as-is.
         if (syntheticShadow && hasShadow(vm) && !isUndefined(stylesheetTokens)) {
-            hostSelector = `[${stylesheetTokens.hostAttribute}]`;
-            shadowSelector = `[${stylesheetTokens.shadowAttribute}]`;
+            hostSelector = `.${stylesheetTokens.hostAttribute}`;
+            shadowSelector = `.${stylesheetTokens.shadowAttribute}`;
         } else {
             hostSelector = '';
             shadowSelector = '';

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -31,13 +31,13 @@ import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } f
 import { getTemplateOrSwappedTemplate, setActiveVM } from './hot-swaps';
 
 export interface TemplateStylesheetTokens {
-    /** HTML attribute that need to be applied to the host element. This attribute is used for
+    /** HTML class that need to be applied to the host element. This class is used for
      * the `:host` pseudo class CSS selector. */
-    hostAttribute: string;
-    /** HTML attribute that need to the applied to all the element that the template produces.
-     * This attribute is used for style encapsulation when the engine runs with synthetic
+    hostClass: string;
+    /** HTML class that need to the applied to all the element that the template produces.
+     * This class is used for style encapsulation when the engine runs with synthetic
      * shadow. */
-    shadowAttribute: string;
+    shadowClass: string;
 }
 
 export interface Template {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -68,7 +68,7 @@ export enum VMState {
 export interface Context {
     /** The class name used on the host element to scope the style. */
     hostClass: string | undefined;
-    /** The attribute name used on all the elements rendered in the shadow tree to scope the style. */
+    /** The class name used on all the elements rendered in the shadow tree to scope the style. */
     shadowClass: string | undefined;
     /** The VNode injected in all the shadow trees to apply the associated component stylesheets. */
     styleVNode: VNode | null;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -66,7 +66,7 @@ export enum VMState {
 }
 
 export interface Context {
-    /** The attribute name used on the host element to scope the style. */
+    /** The class name used on the host element to scope the style. */
     hostClass: string | undefined;
     /** The attribute name used on all the elements rendered in the shadow tree to scope the style. */
     shadowClass: string | undefined;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -67,9 +67,9 @@ export enum VMState {
 
 export interface Context {
     /** The attribute name used on the host element to scope the style. */
-    hostAttribute: string | undefined;
+    hostClass: string | undefined;
     /** The attribute name used on all the elements rendered in the shadow tree to scope the style. */
-    shadowAttribute: string | undefined;
+    shadowClass: string | undefined;
     /** The VNode injected in all the shadow trees to apply the associated component stylesheets. */
     styleVNode: VNode | null;
     /** Object used by the template function to store information that can be reused between
@@ -266,8 +266,8 @@ export function createVM<HostNode, HostElement>(
         cmpTemplate: null,
 
         context: {
-            hostAttribute: undefined,
-            shadowAttribute: undefined,
+            hostClass: undefined,
+            shadowClass: undefined,
             styleVNode: null,
             tplCache: EmptyObject,
             wiredConnecting: EmptyArray,

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -89,8 +89,8 @@
   }
 
   __setKey(tmpl$1, "stylesheetTokens", {
-    hostAttribute: "x-foo_foo-host",
-    shadowAttribute: "x-foo_foo"
+    hostClass: "x-foo_foo-host",
+    shadowClass: "x-foo_foo"
   });
 
   function _createSuper$1(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct$1(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }
@@ -154,8 +154,8 @@
   __setKey(tmpl, "stylesheets", []);
 
   __setKey(tmpl, "stylesheetTokens", {
-    hostAttribute: "x-app_app-host",
-    shadowAttribute: "x-app_app"
+    hostClass: "x-app_app-host",
+    shadowClass: "x-app_app"
   });
 
   function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -20,8 +20,8 @@
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
     tmpl$1.stylesheetTokens = {
-      hostAttribute: "x-foo_foo-host",
-      shadowAttribute: "x-foo_foo"
+      hostClass: "x-foo_foo-host",
+      shadowClass: "x-foo_foo"
     };
 
     class Foo extends lwc.LightningElement {
@@ -61,8 +61,8 @@
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
     tmpl.stylesheetTokens = {
-      hostAttribute: "x-app_app-host",
-      shadowAttribute: "x-app_app"
+      hostClass: "x-app_app-host",
+      shadowClass: "x-app_app"
     };
 
     class App extends lwc.LightningElement {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -24,8 +24,8 @@
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
     tmpl$1.stylesheetTokens = {
-      hostAttribute: "x-foo_foo-host",
-      shadowAttribute: "x-foo_foo"
+      hostClass: "x-foo_foo-host",
+      shadowClass: "x-foo_foo"
     };
 
     class Foo extends lwc.LightningElement {
@@ -65,8 +65,8 @@
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
     tmpl.stylesheetTokens = {
-      hostAttribute: "x-app_app-host",
-      shadowAttribute: "x-app_app"
+      hostClass: "x-app_app-host",
+      shadowClass: "x-app_app"
     };
 
     class App extends lwc.LightningElement {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -20,8 +20,8 @@
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
     tmpl$1.stylesheetTokens = {
-      hostAttribute: "x-foo_foo-host",
-      shadowAttribute: "x-foo_foo"
+      hostClass: "x-foo_foo-host",
+      shadowClass: "x-foo_foo"
     };
 
     class Foo extends lwc.LightningElement {
@@ -61,8 +61,8 @@
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
     tmpl.stylesheetTokens = {
-      hostAttribute: "x-app_app-host",
-      shadowAttribute: "x-app_app"
+      hostClass: "x-app_app-host",
+      shadowClass: "x-app_app"
     };
 
     class App extends lwc.LightningElement {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -20,8 +20,8 @@
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
     tmpl$1.stylesheetTokens = {
-      hostAttribute: "ts-foo_foo-host",
-      shadowAttribute: "ts-foo_foo"
+      hostClass: "ts-foo_foo-host",
+      shadowClass: "ts-foo_foo"
     };
 
     class Foo extends lwc.LightningElement {
@@ -61,8 +61,8 @@
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
     tmpl.stylesheetTokens = {
-      hostAttribute: "ts-app_app-host",
-      shadowAttribute: "ts-app_app"
+      hostClass: "ts-app_app-host",
+      shadowClass: "ts-app_app"
     };
 
     class App extends lwc.LightningElement {

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -19,7 +19,7 @@ import {
 import validateSelectors from './validate';
 
 import { isDirPseudoClass } from '../utils/rtl';
-import { SHADOW_ATTRIBUTE, HOST_ATTRIBUTE } from '../utils/selectors-scoping';
+import { SHADOW_CLASS, HOST_CLASS } from '../utils/selectors-scoping';
 import { findNode, replaceNodeWith, trimNodeWhitespaces } from '../utils/selector-parser';
 
 type ChildNode = Exclude<Node, Selector>;
@@ -72,17 +72,17 @@ function scopeSelector(selector: Selector) {
                 }
             }
 
-            const shadowAttribute = className({
-                value: SHADOW_ATTRIBUTE,
+            const shadowClass = className({
+                value: SHADOW_CLASS,
             });
 
             if (nodeToScope) {
                 // Add the scoping attribute right after the node scope
-                selector.insertAfter(nodeToScope, shadowAttribute);
+                selector.insertAfter(nodeToScope, shadowClass);
             } else {
                 // Add the scoping token in the first position of the compound selector as a fallback
                 // when there is no node to scope. For example: ::after {}
-                selector.insertBefore(compoundSelector[0], shadowAttribute);
+                selector.insertBefore(compoundSelector[0], shadowClass);
             }
         }
     }
@@ -103,10 +103,10 @@ function transformHost(selector: Selector) {
         const hostIndex = selector.index(hostNode);
 
         // Swap the :host pseudo-class with the host scoping token
-        const hostAttribute = className({
-            value: HOST_ATTRIBUTE,
+        const hostClass = className({
+            value: HOST_CLASS,
         });
-        hostNode.replaceWith(hostAttribute);
+        hostNode.replaceWith(hostClass);
 
         // Generate a unique contextualized version of the selector for each selector pass as argument
         // to the :host

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -13,7 +13,7 @@ import {
     Node,
     Pseudo,
     Tag,
-    attribute,
+    className,
 } from 'postcss-selector-parser';
 
 import validateSelectors from './validate';
@@ -72,10 +72,8 @@ function scopeSelector(selector: Selector) {
                 }
             }
 
-            const shadowAttribute = attribute({
-                attribute: SHADOW_ATTRIBUTE,
-                value: undefined,
-                raws: {},
+            const shadowAttribute = className({
+                value: SHADOW_ATTRIBUTE,
             });
 
             if (nodeToScope) {
@@ -105,10 +103,8 @@ function transformHost(selector: Selector) {
         const hostIndex = selector.index(hostNode);
 
         // Swap the :host pseudo-class with the host scoping token
-        const hostAttribute = attribute({
-            attribute: HOST_ATTRIBUTE,
-            value: undefined,
-            raws: {},
+        const hostAttribute = className({
+            value: HOST_ATTRIBUTE,
         });
         hostNode.replaceWith(hostAttribute);
 

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -9,7 +9,7 @@ import postcssValueParser from 'postcss-value-parser';
 
 import { Config } from './index';
 import { isImportMessage, isVarFunctionMessage } from './utils/message';
-import { HOST_ATTRIBUTE, SHADOW_ATTRIBUTE } from './utils/selectors-scoping';
+import { HOST_CLASS, SHADOW_CLASS } from './utils/selectors-scoping';
 
 enum TokenType {
     text = 'text',
@@ -183,14 +183,14 @@ function tokenizeCssSelector(data: string): Token[] {
     const max = data.length;
 
     while (pos < max) {
-        if (data.indexOf(`.${HOST_ATTRIBUTE}`, pos) === pos) {
+        if (data.indexOf(`.${HOST_CLASS}`, pos) === pos) {
             tokens.push({ type: TokenType.identifier, value: HOST_SELECTOR_IDENTIFIER });
 
-            next += HOST_ATTRIBUTE.length + 1;
-        } else if (data.indexOf(`.${SHADOW_ATTRIBUTE}`, pos) === pos) {
+            next += HOST_CLASS.length + 1;
+        } else if (data.indexOf(`.${SHADOW_CLASS}`, pos) === pos) {
             tokens.push({ type: TokenType.identifier, value: SHADOW_SELECTOR_IDENTIFIER });
 
-            next += SHADOW_ATTRIBUTE.length + 1;
+            next += SHADOW_CLASS.length + 1;
         } else {
             next += 1;
 

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -183,18 +183,18 @@ function tokenizeCssSelector(data: string): Token[] {
     const max = data.length;
 
     while (pos < max) {
-        if (data.indexOf(`[${HOST_ATTRIBUTE}]`, pos) === pos) {
+        if (data.indexOf(`.${HOST_ATTRIBUTE}`, pos) === pos) {
             tokens.push({ type: TokenType.identifier, value: HOST_SELECTOR_IDENTIFIER });
 
-            next += HOST_ATTRIBUTE.length + 2;
-        } else if (data.indexOf(`[${SHADOW_ATTRIBUTE}]`, pos) === pos) {
+            next += HOST_ATTRIBUTE.length + 1;
+        } else if (data.indexOf(`.${SHADOW_ATTRIBUTE}`, pos) === pos) {
             tokens.push({ type: TokenType.identifier, value: SHADOW_SELECTOR_IDENTIFIER });
 
-            next += SHADOW_ATTRIBUTE.length + 2;
+            next += SHADOW_ATTRIBUTE.length + 1;
         } else {
             next += 1;
 
-            while (data.charAt(next) !== '[' && next < max) {
+            while (data.charAt(next) !== '.' && next < max) {
                 next++;
             }
 

--- a/packages/@lwc/style-compiler/src/utils/selectors-scoping.ts
+++ b/packages/@lwc/style-compiler/src/utils/selectors-scoping.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export const HOST_ATTRIBUTE = '__hostAttribute__';
+export const HOST_CLASS = '__hostClass__';
 
-export const SHADOW_ATTRIBUTE = '__shadowAttribute__';
+export const SHADOW_CLASS = '__shadowClass__';

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined, defineProperty } from '@lwc/shared';
-import { setAttribute, removeAttribute } from '../env/element';
 
 const ShadowTokenKey = '$shadowToken$';
 const ShadowTokenPrivateKey = '$$ShadowTokenKey$$';
@@ -29,11 +28,12 @@ export function setShadowToken(node: Node, shadowToken: string | undefined) {
 defineProperty(Element.prototype, ShadowTokenKey, {
     set(this: Element, shadowToken: string | undefined) {
         const oldShadowToken = (this as any)[ShadowTokenPrivateKey];
+        const classes = this.classList;
         if (!isUndefined(oldShadowToken) && oldShadowToken !== shadowToken) {
-            removeAttribute.call(this, oldShadowToken);
+            classes.remove(oldShadowToken);
         }
         if (!isUndefined(shadowToken)) {
-            setAttribute.call(this, shadowToken, '');
+            classes.add(shadowToken);
         }
         (this as any)[ShadowTokenPrivateKey] = shadowToken;
     },

--- a/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
+++ b/packages/integration-tests/src/components/accessibility/test-delegates-focus-click-target-natively-non-focusable/delegates-focus-click-target-natively-non-focusable.spec.js
@@ -30,7 +30,7 @@ describe('when the click target is natively non-focusable', () => {
 
         // The invalid behavior described in issue #1382 causes focus to land on input.tail
         const activeElement = await browser.activeElementShadowDeep();
-        assert.strictEqual(await activeElement.getAttribute('class'), 'integration-child-button');
+        assert.match(await activeElement.getAttribute('class'), /\bintegration-child-button\b/);
     });
 
     it('should apply focus to natively focusable parent (button) when click target is span element', async () => {
@@ -50,6 +50,6 @@ describe('when the click target is natively non-focusable', () => {
 
         // The invalid behavior described in issue #1382 causes focus to land on input.tail
         const activeElement = await browser.activeElementShadowDeep();
-        assert.strictEqual(await activeElement.getAttribute('class'), 'span-button');
+        assert.match(await activeElement.getAttribute('class'), /\bspan-button\b/);
     });
 });


### PR DESCRIPTION
## Details

Switches synthetic shadow from using attributes to classes for style scoping.

I had already done some perf testing using non-LWC benchmarks that demonstrated that classes are faster than attributes, but for this one I wrote [a new benchmark](https://salesforce.quip.com/ndxFAMqqCTLw) using this PR itself, and I still see an improvement, especially in Chrome. This improvement holds even in Chrome Canary, which has [this fix](https://bugs.chromium.org/p/chromium/issues/detail?id=1196474) for selectors like `[foo] *`.

In Safari and Firefox, it's basically a wash.

  | Attributes | Classes | Delta | Delta (%)
-- | -- | -- | -- | --
Chrome 90.0.4430.212 | 537.55 | 453.57 | -83.98 | -15.62%
Chrome Canary 92.0.4506.0 | 653.6 | 568 | -85.6 | -13.10%
Safari 14.1 | 253 | 233 | -20 | -7.91%
Firefox 88.0.1 | 289 | 288 | -1 | -0.35%
Firefox Nightly 90.0a1 | 292 | 300 | 8 | 2.74%

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

Not a breaking change per se, but an observable change. It seems unlikely to me though that these shadow/host tokens will conflict with any classes users are using.

## GUS work item

W-7257730
