### PR TITLE
Revert "feat(synthetic-shadow): enable innerText shadow dom semantics by default (#2247)"

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -11,8 +11,8 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_REACTIVE_SETTER: null,
     ENABLE_HMR: null,
     // Flag to toggle on/off the enforcement of innerText/outerText shadow dom semantic in elements when using synthetic shadow.
-    // Note: Elements outside the lwc boundary are controlled by the ENABLE_ELEMENT_PATCH flag.
-    DISABLE_INNER_OUTER_TEXT_PATCH: null,
+    // Note: Once active, elements outside the lwc boundary are controlled by the ENABLE_ELEMENT_PATCH flag.
+    ENABLE_INNER_OUTER_TEXT_PATCH: null,
     // Flags to toggle on/off the enforcement of shadow dom semantic in element/node outside lwc boundary when using synthetic shadow.
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_NODE_LIST_PATCH: null,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -197,7 +197,7 @@ defineProperties(HTMLElement.prototype, {
 if (innerTextGetter !== null && innerTextSetter !== null) {
     defineProperty(HTMLElement.prototype, 'innerText', {
         get(this: HTMLElement): string {
-            if (featureFlags.DISABLE_INNER_OUTER_TEXT_PATCH) {
+            if (!featureFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
                 return innerTextGetter!.call(this);
             }
 
@@ -230,7 +230,7 @@ if (outerTextGetter !== null && outerTextSetter !== null) {
     // As a setter, it removes the current node and replaces it with the given text.
     defineProperty(HTMLElement.prototype, 'outerText', {
         get(this: HTMLElement): string {
-            if (featureFlags.DISABLE_INNER_OUTER_TEXT_PATCH) {
+            if (!featureFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
                 return outerTextGetter!.call(this);
             }
 

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -2,24 +2,12 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
 
 if (!process.env.NATIVE_SHADOW) {
-    describe('DISABLE_INNER_OUTER_TEXT_PATCH flag', () => {
-        let elm;
-        beforeEach(() => {
-            elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
-        });
+    beforeAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', true);
+    });
 
-        it('should get innerText of custom element when DISABLE_INNER_OUTER_TEXT_PATCH = true', () => {
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', true);
-            expect(elm.innerText).not.toBe('');
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', false);
-        });
-
-        it('should get outerText of custom element when DISABLE_INNER_OUTER_TEXT_PATCH = true', () => {
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', true);
-            expect(elm.outerText).not.toBe('');
-            setFeatureFlagForTest('DISABLE_INNER_OUTER_TEXT_PATCH', false);
-        });
+    afterAll(() => {
+        setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', false);
     });
 
     describe('innerText', () => {

--- a/packages/integration-tests/src/components/dom/test-inner-text/inner-text.spec.js
+++ b/packages/integration-tests/src/components/dom/test-inner-text/inner-text.spec.js
@@ -23,7 +23,7 @@ describe('innerText computations in input click handler', () => {
         await browser.url(URL);
     });
 
-    it('should compute input.innerText in click handler without the input becoming unusable', async () => {
+    it('should allow to type in input when input.innerText is computed in the handler', async () => {
         const target = await browser.shadowDeep$(
             'integration-inner-text',
             'input.handler-computes-inner-text-input'
@@ -36,7 +36,7 @@ describe('innerText computations in input click handler', () => {
         assert.strictEqual(actual, 'test value');
     });
 
-    it('should compute div.innerText in click handler without the input becoming unusable', async () => {
+    it('should allow to type in input when (other element) div.innerText is computed in the handler', async () => {
         const target = await browser.shadowDeep$(
             'integration-inner-text',
             'input.handler-computes-inner-text-div'

--- a/packages/integration-tests/src/components/dom/test-inner-text/inner-text.spec.js
+++ b/packages/integration-tests/src/components/dom/test-inner-text/inner-text.spec.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assert = require('assert');
+
+/**
+ * innerText polyfill relies on the browser selection API.
+ * Unfortunately, because of a bug in Chrome and Safari browsers,
+ * an input becomes unusable when clicked and while handling the click event  the (polyfilled) innerText is computed
+ *
+ * Minimal repro of Chrome and Safari issue: https://gist.github.com/nolanlawson/c7d8ed3d43dbb4a018fb392467fae365
+ *
+ * Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1208631
+ * Safari bug: https://bugs.webkit.org/show_bug.cgi?id=225723
+ */
+describe('innerText computations in input click handler', () => {
+    const URL = '/inner-text/';
+
+    before(async () => {
+        await browser.url(URL);
+    });
+
+    it('should compute input.innerText in click handler without the input becoming unusable', async () => {
+        const target = await browser.shadowDeep$(
+            'integration-inner-text',
+            'input.handler-computes-inner-text-input'
+        );
+        await target.click();
+
+        await browser.keys('test value');
+
+        const actual = await target.getValue();
+        assert.strictEqual(actual, 'test value');
+    });
+
+    it('should compute div.innerText in click handler without the input becoming unusable', async () => {
+        const target = await browser.shadowDeep$(
+            'integration-inner-text',
+            'input.handler-computes-inner-text-div'
+        );
+        await target.click();
+
+        await browser.keys('test value');
+
+        const actual = await target.getValue();
+        assert.strictEqual(actual, 'test value');
+    });
+});

--- a/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.html
+++ b/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.html
@@ -1,0 +1,6 @@
+<template>
+    <input class="handler-computes-inner-text-input" type="text" onclick={computeInputInnerText} />
+    <input class="handler-computes-inner-text-div" type="text" onclick={computeDivInnerText} />
+
+    <div>some text</div>
+</template>

--- a/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.js
+++ b/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.js
@@ -1,17 +1,7 @@
-import { LightningElement, api } from 'lwc';
+import { LightningElement } from 'lwc';
 
 export default class InnerText extends LightningElement {
     _innerText = null;
-
-    @api
-    getTypedText() {
-        return this.template.querySelector('input').value;
-    }
-
-    @api
-    getInnerText() {
-        return this._innerText;
-    }
 
     computeInputInnerText(evt) {
         this._innerText = evt.target.innerText;

--- a/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.js
+++ b/packages/integration-tests/src/components/dom/test-inner-text/integration/inner-text/inner-text.js
@@ -1,0 +1,23 @@
+import { LightningElement, api } from 'lwc';
+
+export default class InnerText extends LightningElement {
+    _innerText = null;
+
+    @api
+    getTypedText() {
+        return this.template.querySelector('input').value;
+    }
+
+    @api
+    getInnerText() {
+        return this._innerText;
+    }
+
+    computeInputInnerText(evt) {
+        this._innerText = evt.target.innerText;
+    }
+
+    computeDivInnerText(evt) {
+        this._innerText = evt.target.innerText;
+    }
+}


### PR DESCRIPTION
## Details

This PR makes the innerText patch to be disabled by default.

The `innerText` patch relies on the selection API to calculate the "innerText" of text nodes. There's a bug on [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1208631) and [Safari](https://bugs.webkit.org/show_bug.cgi?id=225723), in which removing and then re-adding ranges to the selection during an input click does not restore cursor/focus in the input, making it unusable.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`