### PR TITLE
fix: light DOM can render multiple templates

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -562,6 +562,10 @@ function recursivelyDisconnectChildren(vnodes: VNodes) {
 export function resetShadowRoot(vm: VM) {
     const { children, cmpRoot, renderer } = vm;
 
+    if (!hasShadow(vm)) {
+        return;
+    }
+
     for (let i = 0, len = children.length; i < len; i++) {
         const child = children[i];
 

--- a/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
@@ -1,0 +1,33 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+
+import Multi from 'x/multi';
+
+describe('multiple templates', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+    });
+
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+    });
+
+    it('can render multiple templates with different styles', () => {
+        const element = createElement('x-multi', { is: Multi });
+
+        document.body.appendChild(element);
+
+        expect(element.querySelector('div').textContent).toEqual('a');
+        expect(getComputedStyle(element.querySelector('div')).color).toEqual('rgb(233, 150, 122)');
+        expect(getComputedStyle(element.querySelector('div')).backgroundColor).toEqual(
+            'rgba(0, 0, 0, 0)'
+        );
+        element.next();
+        return Promise.resolve().then(() => {
+            expect(element.querySelector('div').textContent).toEqual('b');
+            expect(getComputedStyle(element.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
+            expect(getComputedStyle(element.querySelector('div')).backgroundColor).toEqual(
+                'rgb(255, 160, 122)'
+            );
+        });
+    });
+});

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multi/a.css
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multi/a.css
@@ -1,0 +1,3 @@
+div {
+    color: darksalmon;
+}

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multi/a.html
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multi/a.html
@@ -1,0 +1,3 @@
+<template>
+  <div>a</div>
+</template>

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multi/b.css
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multi/b.css
@@ -1,0 +1,3 @@
+div {
+    background-color: lightsalmon;
+}

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multi/b.html
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multi/b.html
@@ -1,0 +1,3 @@
+<template>
+  <div>b</div>
+</template>

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multi/multi.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multi/multi.js
@@ -1,0 +1,17 @@
+import { LightningElement, api } from 'lwc';
+import A from './a.html';
+import B from './b.html';
+
+export default class Multi extends LightningElement {
+    static shadow = false;
+    current = A;
+
+    @api
+    next() {
+        this.current = this.current === A ? B : A;
+    }
+
+    render() {
+        return this.current;
+    }
+}


### PR DESCRIPTION
## Details

Before this PR, a light DOM component could not render multiple templates using `render()` – it would throw an error. With this PR, it works correctly and there's a test to verify it.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`