### PR TITLE
fix(babel-plugin-component): fix transformation of ClassDeclarations that have an id

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/decorators.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/decorators.spec.js
@@ -194,3 +194,76 @@ describe('decorators', () => {
         }
     );
 });
+
+describe('transform large input file', () => {
+    beforeEach(() => {
+        // Disable console.error because babel logs warnings if the file size is > 500KB
+        const { error: originalConsoleError } = console;
+        // eslint-disable-next-line no-console
+        console.error = jest.spyOn(console, 'error').mockImplementation((...args) => {
+            if (
+                args.length > 0 &&
+                // To be sure we are not letting any other real problems slip
+                args[0]
+                    .toString()
+                    .includes('[BABEL] Note: The code generator has deoptimised the styling of')
+            ) {
+                return;
+            }
+            originalConsoleError(...args);
+        });
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    const blob = 'export const Bar = "' + 'x'.repeat(500000) + '";';
+
+    const stubClassDeclaration = `
+        import { LightningElement, api } from 'lwc';
+        export default class Foo extends LightningElement {
+            @api
+            prop;
+        }
+    `;
+
+    const stubClassExpression = `
+        import { LightningElement, api } from 'lwc';
+        const Foo = class extends LightningElement {
+            @api
+            prop;
+        }
+        export default Foo;
+    `;
+
+    pluginTest(
+        'should transform decorators on ClassDeclaration in a large input file',
+        stubClassDeclaration + blob,
+        {
+            output: {
+                code:
+                    'import{registerDecorators as _registerDecorators,registerComponent as _registerComponent,LightningElement}from"lwc";' +
+                    'import _tmpl from"./test.html";' +
+                    'class Foo extends LightningElement{prop;}' +
+                    // _registerDecorators is an ExpressionStatement, ends with a semicolon
+                    '_registerDecorators(Foo,{publicProps:{prop:{config:0}}});' +
+                    'export default _registerComponent(Foo,{tmpl:_tmpl});' +
+                    blob,
+            },
+        }
+    );
+
+    pluginTest(
+        'should transform decorators on ClassExpression in a large input file',
+        stubClassExpression + blob,
+        {
+            output: {
+                code:
+                    'import{registerDecorators as _registerDecorators,registerComponent as _registerComponent,LightningElement}from"lwc";' +
+                    'import _tmpl from"./test.html";' +
+                    'const Foo=_registerDecorators(class extends LightningElement{prop;},{publicProps:{prop:{config:0}}});' +
+                    'export default _registerComponent(Foo,{tmpl:_tmpl});' +
+                    blob,
+            },
+        }
+    );
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
@@ -40,7 +40,7 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'transform track decorator preserve intial value',
+        'transform track decorator preserve initial value',
         `
         import { track } from 'lwc';
         export default class Test {


### PR DESCRIPTION
## Details
Component class transformation introduces a registerDecorators() call expression.
This expression needs to be wrapped in a statement to protect its validty incase the code is minified(which babel does when input size is more than 500kb).

Fixes #2336


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9266461
