### PR TITLE
fix(babel-plugin-component): fix transformation of ClassDeclarations that have an id

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/track-decorator.spec.js
@@ -40,7 +40,7 @@ describe('Transform property', () => {
     );
 
     pluginTest(
-        'transform track decorator preserve intial value',
+        'transform track decorator preserve initial value',
         `
         import { track } from 'lwc';
         export default class Test {


### PR DESCRIPTION
## Details

Component class transformation introduces a registerDecorators() call expression.
This expression needs to be wrapped in a statement to protect its validty incase the code is minified(which babel does when input size is more than 500kb).

Fixes #2336

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9266461
