### PR TITLE
fix(engine-core): resolve circular dependencies of module

### DIFF
--- a/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
+++ b/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
@@ -28,7 +28,7 @@ export function resolveCircularModuleDependency<M extends MaybeModule>(
 ): M {
     const module = fn();
 
-    return module && module.__esModule ? module.default : module;
+    return module?.__esModule ? module.default : module;
 }
 
 export function isCircularModuleDependency(obj: unknown): obj is CircularModuleDependency<any> {

--- a/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
+++ b/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
@@ -7,7 +7,7 @@
 
 import { isFunction, hasOwnProperty } from '@lwc/shared';
 
-interface MaybeModule extends Object {
+interface MaybeModule {
     __esModule?: boolean;
     default?: any;
 }

--- a/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
+++ b/packages/@lwc/engine-core/src/shared/circular-module-dependencies.ts
@@ -7,6 +7,11 @@
 
 import { isFunction, hasOwnProperty } from '@lwc/shared';
 
+interface MaybeModule extends Object {
+    __esModule?: boolean;
+    default?: any;
+}
+
 /**
  * When LWC is used in the context of an Aura application, the compiler produces AMD modules, that
  * doesn't resolve properly circular dependencies between modules. In order to circumvent this
@@ -18,8 +23,12 @@ interface CircularModuleDependency<M extends Object> {
     __circular__: boolean;
 }
 
-export function resolveCircularModuleDependency<M = any>(fn: CircularModuleDependency<M>): M {
-    return fn();
+export function resolveCircularModuleDependency<M extends MaybeModule>(
+    fn: CircularModuleDependency<M>
+): M {
+    const module = fn();
+
+    return module && module.__esModule ? module.default : module;
 }
 
 export function isCircularModuleDependency(obj: unknown): obj is CircularModuleDependency<any> {

--- a/packages/integration-karma/test/integrations/aura/index.spec.js
+++ b/packages/integration-karma/test/integrations/aura/index.spec.js
@@ -10,3 +10,14 @@ it('should support component class marked to be resolved as circular reference',
         .shadowRoot.querySelector('.child');
     expect(actual).toBeDefined();
 });
+
+it('should resolve component class of module when it is marked as circular reference', () => {
+    const elm = createElement('x-parent', { is: Parent });
+    elm.renderCircularModule = true;
+    document.body.appendChild(elm);
+    // Verifying that shadow tree was created to ensure the component class was successfully processed
+    const actual = elm.shadowRoot
+        .querySelector('x-child-module-marked-as-circular')
+        .shadowRoot.querySelector('.child');
+    expect(actual).toBeDefined();
+});

--- a/packages/integration-karma/test/integrations/aura/x/childModuleMarkedAsCircular/childModuleMarkedAsCircular.html
+++ b/packages/integration-karma/test/integrations/aura/x/childModuleMarkedAsCircular/childModuleMarkedAsCircular.html
@@ -1,0 +1,3 @@
+<template>
+    <div class='child'>module marked as circular reference</div>
+</template>

--- a/packages/integration-karma/test/integrations/aura/x/childModuleMarkedAsCircular/childModuleMarkedAsCircular.js
+++ b/packages/integration-karma/test/integrations/aura/x/childModuleMarkedAsCircular/childModuleMarkedAsCircular.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc';
+
+class ChildModuleMarkedAsCircular extends LightningElement {}
+
+export default function tmp() {
+    return {
+        default: ChildModuleMarkedAsCircular,
+        __esModule: true,
+    };
+}
+tmp.__circular__ = true;

--- a/packages/integration-karma/test/integrations/aura/x/parent/parent.html
+++ b/packages/integration-karma/test/integrations/aura/x/parent/parent.html
@@ -1,5 +1,7 @@
 <template>
     <div></div>
     <x-child-marked-as-circular></x-child-marked-as-circular>
-    <x-child-marked-as-circular></x-child-marked-as-circular>
+    <template if:true={renderCircularModule}>
+        <x-child-module-marked-as-circular></x-child-module-marked-as-circular>
+    </template>
 </template>

--- a/packages/integration-karma/test/integrations/aura/x/parent/parent.js
+++ b/packages/integration-karma/test/integrations/aura/x/parent/parent.js
@@ -1,3 +1,5 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 
-export default class Parent extends LightningElement {}
+export default class Parent extends LightningElement {
+    @api renderCircularModule = false;
+}


### PR DESCRIPTION
## Details
Fixes an existing issue when resolving circular dependencies injected by Aura. The issue is only visible for a component module (`export default class Foo extends LightningElement`) marked with `__circular__` and also having named exports.

**Note:** The issue was noticed when forcing named exports for internal components on the platform.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`