### PR TITLE
fix(engine-core): avoid mangling ids in native shadow mode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -688,7 +688,7 @@ export function fid(url: string | undefined | null): string | null | undefined {
     }
     const { idx, renderMode, shadowMode } = vmBeingRendered;
     // Apply transformation only for fragment-only-urls, and only in shadow DOM
-    if (/^#/.test(url) && renderMode === RenderMode.Shadow && shadowMode === ShadowMode.Synthetic) {
+    if (shadowMode === ShadowMode.Synthetic && renderMode === RenderMode.Shadow && /^#/.test(url)) {
         return `${url}-${idx}`;
     }
     return url;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -661,8 +661,8 @@ export function gid(id: string | undefined | null): string | null | undefined {
     if (isNull(id)) {
         return null;
     }
-    const { idx, renderMode } = vmBeingRendered;
-    if (renderMode === RenderMode.Shadow) {
+    const { idx, renderMode, shadowMode } = vmBeingRendered;
+    if (shadowMode === ShadowMode.Synthetic && renderMode === RenderMode.Shadow) {
         return StringReplace.call(id, /\S+/g, (id) => `${id}-${idx}`);
     }
     return id;
@@ -686,10 +686,10 @@ export function fid(url: string | undefined | null): string | null | undefined {
     if (isNull(url)) {
         return null;
     }
-    const { renderMode } = vmBeingRendered;
+    const { idx, renderMode, shadowMode } = vmBeingRendered;
     // Apply transformation only for fragment-only-urls, and only in shadow DOM
-    if (/^#/.test(url) && renderMode === RenderMode.Shadow) {
-        return `${url}-${vmBeingRendered!.idx}`;
+    if (/^#/.test(url) && renderMode === RenderMode.Shadow && shadowMode === ShadowMode.Synthetic) {
+        return `${url}-${idx}`;
     }
     return url;
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
@@ -6,7 +6,7 @@
       contenteditable="true"
       draggable="true"
       hidden
-      id="foo-0"
+      id="foo"
       itemprop="foo"
       spellcheck="true"
       tabindex="-1"

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
@@ -6,7 +6,7 @@
       data-test="test"
       draggable="true"
       hidden
-      id="foo-0"
+      id="foo"
       itemprop="foo"
       lang="fr"
       spellcheck="true"

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attributes-aria/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attributes-aria/expected.html
@@ -1,7 +1,7 @@
 <x-attributes-aria>
   <template shadowroot="open">
-    <span id="label-id-0">This is a section</span>
-    <div aria-describedby="label-id-0">I am section</div>
+    <span id="label-id">This is a section</span>
+    <div aria-describedby="label-id">I am section</div>
     <div
       role="progressbar"
       aria-valuemin="0"

--- a/packages/integration-karma/test/light-dom/ids/index.spec.js
+++ b/packages/integration-karma/test/light-dom/ids/index.spec.js
@@ -31,30 +31,29 @@ describe('Light DOM IDs and fragment links', () => {
 
     // Remove this test when this is fixed: https://github.com/salesforce/lwc/issues/1150
     it('should only mangle non-dangling hrefs in shadow DOM', () => {
-        document.body.appendChild(createElement('x-one', { is: One }));
-        document.body.appendChild(createElement('x-shadow', { is: Shadow }));
+        const light = createElement('x-one', { is: One });
+        const shadow = createElement('x-shadow', { is: Shadow });
+        document.body.appendChild(light);
+        document.body.appendChild(shadow);
 
-        expect(document.body.querySelector('x-one .foo').id).toEqual('foo');
-        expect(document.body.querySelector('x-one .bar').id).toEqual('bar');
-        expect(document.body.querySelector('x-shadow').shadowRoot.querySelector('.foo').id).toMatch(
-            /^foo-\d+$/
-        );
-        expect(
-            document.body.querySelector('x-shadow').shadowRoot.querySelector('.quux').id
-        ).toMatch(/^quux-\d+$/);
+        expect(light.querySelector('.foo').id).toEqual('foo');
+        expect(light.querySelector('.bar').id).toEqual('bar');
+        expect(light.querySelector('.go-to-foo').href).toMatch(/#foo$/);
+        expect(light.querySelector('.go-to-bar').href).toMatch(/#bar$/);
+        expect(light.querySelector('.go-to-quux').href).toMatch(/#quux$/);
 
-        expect(document.body.querySelector('x-one .go-to-foo').href).toMatch(/#foo$/);
-        expect(document.body.querySelector('x-one .go-to-bar').href).toMatch(/#bar$/);
-        expect(document.body.querySelector('x-one .go-to-quux').href).toMatch(/#quux$/);
-
-        expect(
-            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-foo').href
-        ).toMatch(/#foo-\d+$/);
-        expect(
-            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-bar').href
-        ).toMatch(/#bar-\d+$/);
-        expect(
-            document.body.querySelector('x-shadow').shadowRoot.querySelector('.go-to-quux').href
-        ).toMatch(/#quux-\d+$/);
+        if (process.env.NATIVE_SHADOW) {
+            expect(shadow.shadowRoot.querySelector('.foo').id).toEqual('foo');
+            expect(shadow.shadowRoot.querySelector('.quux').id).toEqual('quux');
+            expect(shadow.shadowRoot.querySelector('.go-to-foo').href).toMatch(/#foo$/);
+            expect(shadow.shadowRoot.querySelector('.go-to-bar').href).toMatch(/#bar$/);
+            expect(shadow.shadowRoot.querySelector('.go-to-quux').href).toMatch(/#quux$/);
+        } else {
+            expect(shadow.shadowRoot.querySelector('.foo').id).toMatch(/^foo-\d+$/);
+            expect(shadow.shadowRoot.querySelector('.quux').id).toMatch(/^quux-\d+$/);
+            expect(shadow.shadowRoot.querySelector('.go-to-foo').href).toMatch(/#foo-\d+$/);
+            expect(shadow.shadowRoot.querySelector('.go-to-bar').href).toMatch(/#bar-\d+$/);
+            expect(shadow.shadowRoot.querySelector('.go-to-quux').href).toMatch(/#quux-\d+$/);
+        }
     });
 });

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,30 +1,52 @@
 import { createElement } from 'lwc';
 import Test from 'x/test';
 
-it('should entrust id scoping to native shadow (static)', () => {
-    const elm = createElement('x-test', { is: Test });
-    document.body.appendChild(elm);
-    const div = elm.shadowRoot.querySelector('#shizuoka');
-    expect(div).not.toBeNull();
-});
+if (process.env.COMPAT) {
+    it('should fallback to id-mangling (static)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const div = elm.shadowRoot.querySelector('.shizuoka');
+        const input = elm.shadowRoot.querySelector('.idref-static');
 
-it('should entrust id scoping to native shadow (dynamic)', () => {
-    const elm = createElement('x-test', { is: Test });
-    document.body.appendChild(elm);
-    const div = elm.shadowRoot.querySelector('#yamanashi');
-    expect(div).not.toBeNull();
-});
+        expect(div.id).toMatch(/^shizuoka-\w+$/);
+        expect(input.ariaDescribedBy).toContain(div.id);
+    });
 
-it('should entrust idref scoping to native shadow (static)', () => {
-    const elm = createElement('x-test', { is: Test });
-    document.body.appendChild(elm);
-    const input = elm.shadowRoot.querySelector('[aria-describedby="shizuoka yamanashi"]');
-    expect(input).not.toBeNull();
-});
+    it('should fallback to id-mangling (dynamic)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const div = elm.shadowRoot.querySelector('.yamanashi');
+        const input = elm.shadowRoot.querySelector('.idref-dynamic');
 
-it('should entrust idref scoping to native shadow (dynamic)', () => {
-    const elm = createElement('x-test', { is: Test });
-    document.body.appendChild(elm);
-    const input = elm.shadowRoot.querySelector('[aria-labelledby="yamanashi shizuoka"]');
-    expect(input).not.toBeNull();
-});
+        expect(div.id).toMatch(/^yamanashi-\w+$/);
+        expect(input.ariaLabelledBy).toContain(div.id);
+    });
+} else {
+    it('should entrust id scoping to native shadow (static)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const div = elm.shadowRoot.querySelector('#shizuoka');
+        expect(div).not.toBeNull();
+    });
+
+    it('should entrust id scoping to native shadow (dynamic)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const div = elm.shadowRoot.querySelector('#yamanashi');
+        expect(div).not.toBeNull();
+    });
+
+    it('should entrust idref scoping to native shadow (static)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const input = elm.shadowRoot.querySelector('[aria-describedby="shizuoka yamanashi"]');
+        expect(input).not.toBeNull();
+    });
+
+    it('should entrust idref scoping to native shadow (dynamic)', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        const input = elm.shadowRoot.querySelector('[aria-labelledby="yamanashi shizuoka"]');
+        expect(input).not.toBeNull();
+    });
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,0 +1,30 @@
+import { createElement } from 'lwc';
+import Test from 'x/test';
+
+it('should entrust id scoping to native shadow (static)', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
+    const div = elm.shadowRoot.querySelector('#shizuoka');
+    expect(div).not.toBeNull();
+});
+
+it('should entrust id scoping to native shadow (dynamic)', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
+    const div = elm.shadowRoot.querySelector('#yamanashi');
+    expect(div).not.toBeNull();
+});
+
+it('should entrust idref scoping to native shadow (static)', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
+    const input = elm.shadowRoot.querySelector('[aria-describedby="shizuoka yamanashi"]');
+    expect(input).not.toBeNull();
+});
+
+it('should entrust idref scoping to native shadow (dynamic)', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
+    const input = elm.shadowRoot.querySelector('[aria-labelledby="yamanashi shizuoka"]');
+    expect(input).not.toBeNull();
+});

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,27 +1,7 @@
 import { createElement } from 'lwc';
 import Test from 'x/test';
 
-if (process.env.COMPAT) {
-    it('should fallback to id-mangling (static)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const div = elm.shadowRoot.querySelector('.shizuoka');
-        const input = elm.shadowRoot.querySelector('.idref-static');
-
-        expect(div.id).toMatch(/^shizuoka-\w+$/);
-        expect(input.ariaDescribedBy).toContain(div.id);
-    });
-
-    it('should fallback to id-mangling (dynamic)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const div = elm.shadowRoot.querySelector('.yamanashi');
-        const input = elm.shadowRoot.querySelector('.idref-dynamic');
-
-        expect(div.id).toMatch(/^yamanashi-\w+$/);
-        expect(input.ariaLabelledBy).toContain(div.id);
-    });
-} else {
+if (!process.env.COMPAT) {
     it('should entrust id scoping to native shadow (static)', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.html
@@ -1,6 +1,6 @@
 <template>
-    <div id="shizuoka">shizuoka</div>
-    <div id={yamanashi}>yamanashi</div>
-    <input aria-describedby="shizuoka yamanashi">
-    <input aria-labelledby={ariaLabelledBy}>
+    <div class="shizuoka" id="shizuoka">shizuoka</div>
+    <div class="yamanashi" id={yamanashi}>yamanashi</div>
+    <input class="idref-static" aria-describedby="shizuoka yamanashi">
+    <input class="idref-dynamic" aria-labelledby={ariaLabelledBy}>
 </template>

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.html
@@ -1,0 +1,6 @@
+<template>
+    <div id="shizuoka">shizuoka</div>
+    <div id={yamanashi}>yamanashi</div>
+    <input aria-describedby="shizuoka yamanashi">
+    <input aria-labelledby={ariaLabelledBy}>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.js
@@ -1,0 +1,13 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+
+    get yamanashi() {
+        return 'yamanashi';
+    }
+
+    get ariaLabelledBy() {
+        return 'yamanashi shizuoka';
+    }
+}

--- a/packages/integration-karma/test/synthetic-shadow/scoped-id/multiple-idrefs.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/scoped-id/multiple-idrefs.spec.js
@@ -10,8 +10,14 @@ it('should handle multiple idrefs when set dynamically', () => {
     const hokkaido = elm.shadowRoot.querySelector('.hokkaido');
     const input = elm.shadowRoot.querySelector('.dynamic');
 
-    expect(aomori.id).toMatch(/^aomori-\w+/);
-    expect(hokkaido.id).toMatch(/^hokkaido-\w+/);
+    if (process.env.NATIVE_SHADOW) {
+        expect(aomori.id).toMatch(/^aomori$/);
+        expect(hokkaido.id).toMatch(/^hokkaido$/);
+    } else {
+        expect(aomori.id).toMatch(/^aomori-\w+/);
+        expect(hokkaido.id).toMatch(/^hokkaido-\w+/);
+    }
+
     expect(input.ariaLabelledBy).toContain(aomori.id);
     expect(input.ariaLabelledBy).toContain(hokkaido.id);
 });
@@ -24,8 +30,14 @@ it('should handle multiple idrefs when set statically', () => {
     const iwate = elm.shadowRoot.querySelector('.iwate');
     const input = elm.shadowRoot.querySelector('.static');
 
-    expect(aomori.id).toMatch(/^aomori-\w+/);
-    expect(iwate.id).toMatch(/^iwate-\w+/);
+    if (process.env.NATIVE_SHADOW) {
+        expect(aomori.id).toMatch(/^aomori$/);
+        expect(iwate.id).toMatch(/^iwate$/);
+    } else {
+        expect(aomori.id).toMatch(/^aomori-\w+/);
+        expect(iwate.id).toMatch(/^iwate-\w+/);
+    }
+
     expect(input.ariaLabelledBy).toContain(aomori.id);
     expect(input.ariaLabelledBy).toContain(iwate.id);
 });


### PR DESCRIPTION
## Details

Allow native shadow encapsulation to handle scoping of ids.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅

## GUS work item

W-9229039