### PR TITLE
fix: enable this.shadowRoot for prefersNativeShadow

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -570,7 +570,7 @@ LightningElement.prototype = {
             }
         }
 
-        if (vm.renderMode !== RenderMode.Light && preferNativeShadow) {
+        if (vm.renderMode === RenderMode.Shadow && preferNativeShadow) {
             return vm.cmpRoot;
         }
 

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/index.spec.js
@@ -1,0 +1,36 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+
+import Native from 'x/native';
+import Synthetic from 'x/synthetic';
+import Light from 'x/light';
+
+describe('this.shadowRoot', () => {
+    it('elements that prefer native shadow should support this.shadowRoot', () => {
+        const el = createElement('x-native', { is: Native });
+        document.body.appendChild(el);
+        expect(el.shadowRoot.querySelector('div').textContent).toEqual('true');
+    });
+
+    it('elements that do not prefer native shadow should not support this.shadowRoot', () => {
+        const el = createElement('x-synthetic', { is: Synthetic });
+        document.body.appendChild(el);
+        expect(el.shadowRoot.querySelector('div').textContent).toEqual('false');
+    });
+
+    describe('light DOM', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+        });
+        afterEach(() => {
+            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+        });
+        it('light DOM elements should not support this.shadowRoot', () => {
+            expect(() => {
+                const el = createElement('x-light', { is: Light });
+                document.body.appendChild(el);
+            }).toLogErrorDev(
+                'Error: [LWC error]: `this.shadowRoot` returns null for light DOM components. Since there is no shadow, the rendered content can be accessed via `this` itself. e.g. instead of `this.shadowRoot.querySelector`, use `this.querySelector`.'
+            );
+        });
+    });
+});

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/light/light.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/light/light.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+  <div>{hasShadowRoot}</div>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/light/light.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/light/light.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    get hasShadowRoot() {
+        return this.shadowRoot !== null && this.shadowRoot === this.template;
+    }
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/native/native.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/native/native.html
@@ -1,0 +1,3 @@
+<template>
+  <div>{hasShadowRoot}</div>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/native/native.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/native/native.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+
+    get hasShadowRoot() {
+        return this.shadowRoot !== null && this.shadowRoot === this.template;
+    }
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/synthetic/synthetic.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/synthetic/synthetic.html
@@ -1,0 +1,3 @@
+<template>
+  <div>{hasShadowRoot}</div>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/synthetic/synthetic.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/shadow-root/x/synthetic/synthetic.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    get hasShadowRoot() {
+        return this.shadowRoot !== null && this.shadowRoot === this.template;
+    }
+}


### PR DESCRIPTION
## Details

Enables `this.shadowRoot` inside of a component, but only for components with `static prefersNativeShadow = true`, and only for shadow DOM components. Should work in both synthetic and native mode.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9318266
