### PR TITLE
fix: shadowRoot instanceof ShadowRoot should be true

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -6,7 +6,10 @@
  */
 import { isNull } from '@lwc/shared';
 
-export const NativeShadowRoot: any = typeof ShadowRoot !== 'undefined' ? ShadowRoot : null;
+let NativeShadowRoot: any = null;
+if (typeof ShadowRoot !== 'undefined') {
+    NativeShadowRoot = ShadowRoot;
+}
 
 export const isNativeShadowRootDefined = !isNull(NativeShadowRoot);
 

--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -6,10 +6,7 @@
  */
 import { isNull } from '@lwc/shared';
 
-let NativeShadowRoot: any = null;
-if (typeof ShadowRoot !== 'undefined') {
-    NativeShadowRoot = ShadowRoot;
-}
+export const NativeShadowRoot: any = typeof ShadowRoot !== 'undefined' ? ShadowRoot : null;
 
 export const isNativeShadowRootDefined = !isNull(NativeShadowRoot);
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -22,6 +22,7 @@ import {
     getHiddenField,
     setHiddenField,
     getPrototypeOf,
+    isObject,
 } from '@lwc/shared';
 import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import { dispatchEvent } from '../env/event-target';
@@ -631,8 +632,10 @@ SyntheticShadowRoot.prototype = create(DocumentFragment.prototype, SyntheticShad
 // `this.shadowRoot instanceof ShadowRoot` should evaluate to true even for synthetic shadow
 defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
     value: function (object: any): boolean {
+        // Technically we should walk up the entire prototype chain, but with SyntheticShadowRoot
+        // it's reasonable to assume that no one is doing any deep subclasses here.
         return (
-            !isUndefined(object) &&
+            isObject(object) &&
             !isNull(object) &&
             (isInstanceOfNativeShadowRoot(object) ||
                 getPrototypeOf(object) === SyntheticShadowRoot.prototype)

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -21,6 +21,7 @@ import {
     createHiddenField,
     getHiddenField,
     setHiddenField,
+    getPrototypeOf,
 } from '@lwc/shared';
 import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import { dispatchEvent } from '../env/event-target';
@@ -46,7 +47,7 @@ import {
     appendChild,
     COMMENT_NODE,
 } from '../env/node';
-import { isNativeShadowRootDefined } from '../env/shadow-root';
+import { isInstanceOfNativeShadowRoot, isNativeShadowRootDefined } from '../env/shadow-root';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { retarget } from '../3rdparty/polymer/retarget';
@@ -626,6 +627,18 @@ export function SyntheticShadowRoot() {
     throw new TypeError('Illegal constructor');
 }
 SyntheticShadowRoot.prototype = create(DocumentFragment.prototype, SyntheticShadowRootDescriptors);
+
+// `this.shadowRoot instanceof ShadowRoot` should evaluate to true even for synthetic shadow
+defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
+    value: function (object: any): boolean {
+        return (
+            !isUndefined(object) &&
+            !isNull(object) &&
+            (isInstanceOfNativeShadowRoot(object) ||
+                getPrototypeOf(object) === SyntheticShadowRoot.prototype)
+        );
+    },
+});
 
 /**
  * This method is only intended to be used in non-production mode in IE11

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -47,7 +47,7 @@ import {
     appendChild,
     COMMENT_NODE,
 } from '../env/node';
-import { isInstanceOfNativeShadowRoot, isNativeShadowRootDefined } from '../env/shadow-root';
+import { isNativeShadowRootDefined, NativeShadowRoot } from '../env/shadow-root';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { retarget } from '../3rdparty/polymer/retarget';
@@ -634,7 +634,7 @@ defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
         return (
             !isUndefined(object) &&
             !isNull(object) &&
-            (isInstanceOfNativeShadowRoot(object) ||
+            (object instanceof NativeShadowRoot ||
                 getPrototypeOf(object) === SyntheticShadowRoot.prototype)
         );
     },

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -47,7 +47,7 @@ import {
     appendChild,
     COMMENT_NODE,
 } from '../env/node';
-import { isNativeShadowRootDefined, NativeShadowRoot } from '../env/shadow-root';
+import { isInstanceOfNativeShadowRoot, isNativeShadowRootDefined } from '../env/shadow-root';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { retarget } from '../3rdparty/polymer/retarget';
@@ -634,7 +634,7 @@ defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
         return (
             !isUndefined(object) &&
             !isNull(object) &&
-            (object instanceof NativeShadowRoot ||
+            (isInstanceOfNativeShadowRoot(object) ||
                 getPrototypeOf(object) === SyntheticShadowRoot.prototype)
         );
     },

--- a/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
@@ -1,8 +1,23 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
 describe('shadowRoot instanceof', () => {
-    it('shadowRoot should have instanceof ShadowRoot === true', () => {
-        const el = document.createElement('div');
-        const shadowRoot = el.attachShadow({ mode: 'open' });
-        expect(shadowRoot instanceof ShadowRoot).toEqual(true);
+    if (process.env.NATIVE_SHADOW) {
+        it('div.attachShadow() should have instanceof ShadowRoot === true', () => {
+            const el = document.createElement('div');
+            const shadowRoot = el.attachShadow({ mode: 'open' });
+            document.body.appendChild(el);
+            expect(shadowRoot instanceof ShadowRoot).toEqual(true);
+        });
+    }
+
+    it('element.shadowRoot should have instanceof ShadowRoot === true', () => {
+        const el = createElement('x-component', { is: Component });
+        document.body.appendChild(el);
+        expect(el.shadowRoot instanceof ShadowRoot).toEqual(true);
+    });
+
+    it('non-shadow roots should have instanceof ShadowRoot === false', () => {
         expect(document.createElement('div') instanceof ShadowRoot).toEqual(false);
         expect(document.createDocumentFragment() instanceof ShadowRoot).toEqual(false);
         expect(undefined instanceof ShadowRoot).toEqual(false);

--- a/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import Component from 'x/component';
 
 describe('shadowRoot instanceof', () => {
-    if (process.env.NATIVE_SHADOW) {
+    if (!process.env.COMPAT) {
+        // Can't test in compat because `attachShadow()` isn't supported on generic elements
         it('div.attachShadow() should have instanceof ShadowRoot === true', () => {
             const el = document.createElement('div');
             const shadowRoot = el.attachShadow({ mode: 'open' });

--- a/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
@@ -20,6 +20,7 @@ describe('shadowRoot instanceof', () => {
     it('non-shadow roots should have instanceof ShadowRoot === false', () => {
         expect(document.createElement('div') instanceof ShadowRoot).toEqual(false);
         expect(document.createDocumentFragment() instanceof ShadowRoot).toEqual(false);
+        expect({} instanceof ShadowRoot).toEqual(false);
         expect(undefined instanceof ShadowRoot).toEqual(false);
         expect(null instanceof ShadowRoot).toEqual(false);
     });

--- a/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/index.spec.js
@@ -1,0 +1,11 @@
+describe('shadowRoot instanceof', () => {
+    it('shadowRoot should have instanceof ShadowRoot === true', () => {
+        const el = document.createElement('div');
+        const shadowRoot = el.attachShadow({ mode: 'open' });
+        expect(shadowRoot instanceof ShadowRoot).toEqual(true);
+        expect(document.createElement('div') instanceof ShadowRoot).toEqual(false);
+        expect(document.createDocumentFragment() instanceof ShadowRoot).toEqual(false);
+        expect(undefined instanceof ShadowRoot).toEqual(false);
+        expect(null instanceof ShadowRoot).toEqual(false);
+    });
+});

--- a/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/x/component/component.js
+++ b/packages/integration-karma/test/synthetic-shadow/shadow-root-instanceof/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Makes it so that `shadowRoot instanceof ShadowRoot` works, even in synthetic shadow mode.

~~This PR is on top of #2356 because it relies on those changes. I'm opening this PR to start running CI tests early.~~

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9317606
