### PR TITLE
refactor(engine-core): move preferNativeShadow and renderMode values to ComponentDef

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -24,6 +24,7 @@ import {
     toString,
 } from '@lwc/shared';
 import { logError } from '../shared/logger';
+import { RenderMode } from './def';
 import { invokeEventListener } from './invoker';
 import { getVMBeingRendered } from './template';
 import { EmptyArray, EmptyObject } from './utils';
@@ -31,7 +32,6 @@ import {
     appendVM,
     getAssociatedVMIfPresent,
     removeVM,
-    RenderMode,
     rerenderVM,
     runConnectedCallback,
     ShadowMode,

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -24,6 +24,7 @@ import {
     KEY__SYNTHETIC_MODE,
     setPrototypeOf,
 } from '@lwc/shared';
+import features from '@lwc/features';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
@@ -186,11 +187,8 @@ export const LightningElement: LightningElementConstructor = function (
     }
 
     const vm = vmBeingConstructed;
-    const {
-        elm,
-        renderer,
-        def: { bridge },
-    } = vm;
+    const { elm, renderer, def } = vm;
+    const { bridge } = def;
 
     if (process.env.NODE_ENV !== 'production') {
         renderer.assertInstanceOfHTMLElement?.(
@@ -221,6 +219,16 @@ export const LightningElement: LightningElementConstructor = function (
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);
     associateVM(elm, vm);
+
+    if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
+        const { ctor, renderMode } = def;
+        assert.isTrue(
+            renderMode !== 'light',
+            `${
+                ctor.name || 'Anonymous class'
+            } is an invalid LWC component. Light DOM components are not available in this environment.`
+        );
+    }
 
     if (vm.renderMode === RenderMode.Shadow) {
         attachShadow(vm);

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -25,10 +25,11 @@ import {
     setPrototypeOf,
 } from '@lwc/shared';
 import features from '@lwc/features';
+import { RenderMode } from './def';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
-import { associateVM, getAssociatedVM, RenderMode, ShadowMode, VM } from './vm';
+import { associateVM, getAssociatedVM, ShadowMode, VM } from './vm';
 import { componentValueMutated, componentValueObserved } from './mutation-tracker';
 import {
     patchComponentWithRestrictions,
@@ -129,7 +130,7 @@ export interface LightningElementConstructor {
 
     delegatesFocus?: boolean;
     preferNativeShadow?: boolean;
-    renderMode?: 'shadow' | 'light';
+    renderMode?: 'light' | 'shadow';
 }
 
 type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
@@ -223,7 +224,7 @@ export const LightningElement: LightningElementConstructor = function (
     if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
         const { ctor, renderMode } = def;
         assert.isTrue(
-            renderMode !== 'light',
+            renderMode !== RenderMode.Light,
             `${
                 ctor.name || 'Anonymous class'
             } is an invalid LWC component. Light DOM components are not available in this environment.`

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -188,7 +188,7 @@ export const LightningElement: LightningElementConstructor = function (
     }
 
     const vm = vmBeingConstructed;
-    const { elm, renderer, def } = vm;
+    const { def, elm, renderer } = vm;
     const { bridge } = def;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -222,11 +222,10 @@ export const LightningElement: LightningElementConstructor = function (
     associateVM(elm, vm);
 
     if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
-        const { ctor, renderMode } = def;
         assert.isTrue(
-            renderMode !== RenderMode.Light,
+            def.renderMode !== RenderMode.Light,
             `${
-                ctor.name || 'Anonymous class'
+                def.name || 'Anonymous class'
             } is an invalid LWC component. Light DOM components are not available in this environment.`
         );
     }

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -150,18 +150,14 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
     errorCallback = errorCallback || superDef.errorCallback;
     render = render || superDef.render;
 
-    let preferNativeShadow: boolean;
+    let preferNativeShadow = superDef.preferNativeShadow;
     if (!isUndefined(ctorPreferNativeShadow)) {
         preferNativeShadow = Boolean(ctorPreferNativeShadow);
-    } else {
-        preferNativeShadow = superDef.preferNativeShadow;
     }
 
-    let renderMode: RenderMode;
+    let renderMode = superDef.renderMode;
     if (!isUndefined(ctorRenderMode)) {
         renderMode = ctorRenderMode === 'light' ? RenderMode.Light : RenderMode.Shadow;
-    } else {
-        renderMode = superDef.renderMode;
     }
 
     const template = getComponentRegisteredTemplate(Ctor) || superDef.template;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -13,7 +13,6 @@
  * shape of a component. It is also used internally to apply extra optimizations.
  */
 
-import features from '@lwc/features';
 import {
     assert,
     assign,
@@ -118,15 +117,6 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
                 `Invalid value for static property renderMode: '${ctorRenderMode}'. renderMode must be either 'light' or 'shadow'.`
             );
         }
-    }
-
-    if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
-        assert.isTrue(
-            ctorRenderMode !== 'light',
-            `${
-                Ctor.name || 'Anonymous class'
-            } is an invalid LWC component. Light DOM components are not available in this environment.`
-        );
     }
 
     const decoratorsMeta = getDecoratorsMeta(Ctor);

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -46,6 +46,11 @@ import {
 } from '../shared/circular-module-dependencies';
 import { getComponentOrSwappedComponent } from './hot-swaps';
 
+export enum RenderMode {
+    Light,
+    Shadow,
+}
+
 export interface ComponentDef {
     name: string;
     wire: PropertyDescriptorMap | undefined;
@@ -54,7 +59,7 @@ export interface ComponentDef {
     methods: PropertyDescriptorMap;
     template: Template;
     preferNativeShadow: boolean;
-    renderMode: 'light' | 'shadow';
+    renderMode: RenderMode;
     ctor: LightningElementConstructor;
     bridge: HTMLElementConstructor;
     connectedCallback?: LightningElement['connectedCallback'];
@@ -152,9 +157,9 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         preferNativeShadow = superDef.preferNativeShadow;
     }
 
-    let renderMode: 'light' | 'shadow';
+    let renderMode: RenderMode;
     if (!isUndefined(ctorRenderMode)) {
-        renderMode = ctorRenderMode === 'light' ? 'light' : 'shadow';
+        renderMode = ctorRenderMode === 'light' ? RenderMode.Light : RenderMode.Shadow;
     } else {
         renderMode = superDef.renderMode;
     }
@@ -265,7 +270,7 @@ const lightingElementDef: ComponentDef = {
     propsConfig: EmptyObject,
     methods: EmptyObject,
     preferNativeShadow: false,
-    renderMode: 'shadow',
+    renderMode: RenderMode.Shadow,
     wire: EmptyObject,
     bridge: BaseBridgeElement,
     template: defaultEmptyTemplate,

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -12,7 +12,6 @@ import {
     runWithBoundaryProtection,
     getAssociatedVMIfPresent,
     VM,
-    RenderMode,
     ShadowMode,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
@@ -25,7 +24,7 @@ import modStaticClassName from './modules/static-class-attr';
 import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
-import { getComponentInternalDef } from './def';
+import { getComponentInternalDef, RenderMode } from './def';
 
 const noop = () => void 0;
 

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -19,8 +19,8 @@ import { logError } from '../shared/logger';
 import { VNode, VNodes } from '../3rdparty/snabbdom/types';
 import * as api from './api';
 import { RenderAPI } from './api';
+import { RenderMode } from './def';
 import {
-    RenderMode,
     resetComponentRoot,
     runWithBoundaryProtection,
     ShadowMode,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -10,17 +10,19 @@ import {
     ArrayUnshift,
     assert,
     create,
+    createHiddenField,
+    getHiddenField,
+    getOwnPropertyNames,
+    globalThis,
     isArray,
     isFalse,
     isNull,
     isObject,
     isTrue,
     isUndefined,
+    KEY__IS_NATIVE_SHADOW_ROOT_DEFINED,
     keys,
-    createHiddenField,
-    getHiddenField,
     setHiddenField,
-    getOwnPropertyNames,
 } from '@lwc/shared';
 
 import {
@@ -50,6 +52,8 @@ import { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
 
 type ShadowRootMode = 'open' | 'closed';
+
+const isNativeShadowRootDefined = globalThis[KEY__IS_NATIVE_SHADOW_ROOT_DEFINED];
 
 export interface TemplateCache {
     [key: string]: any;
@@ -257,6 +261,18 @@ export function createVM<HostNode, HostElement>(
 ): VM {
     const { mode, owner, renderer, tagName } = options;
 
+    const renderMode = def.renderMode === 'light' ? RenderMode.Light : RenderMode.Shadow;
+
+    let shadowMode;
+    if (renderer.syntheticShadow) {
+        shadowMode =
+            isTrue(def.preferNativeShadow) && isNativeShadowRootDefined
+                ? ShadowMode.Native
+                : ShadowMode.Synthetic;
+    } else {
+        shadowMode = ShadowMode.Native;
+    }
+
     const vm: VM = {
         elm,
         def,
@@ -277,6 +293,9 @@ export function createVM<HostNode, HostElement>(
         oar: create(null),
         cmpTemplate: null,
 
+        renderMode,
+        shadowMode,
+
         context: {
             hostAttribute: undefined,
             shadowAttribute: undefined,
@@ -289,8 +308,6 @@ export function createVM<HostNode, HostElement>(
         tro: null!, // Set synchronously after the VM creation.
         component: null!, // Set synchronously by the LightningElement constructor.
         cmpRoot: null!, // Set synchronously by the LightningElement constructor.
-        renderMode: null!, // Set synchronously by the LightningElement constructor.
-        shadowMode: null!, // Set synchronously by the LightningElement constructor.
 
         callHook,
         setHook,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -261,8 +261,6 @@ export function createVM<HostNode, HostElement>(
 ): VM {
     const { mode, owner, renderer, tagName } = options;
 
-    const renderMode = def.renderMode === 'light' ? RenderMode.Light : RenderMode.Shadow;
-
     let shadowMode;
     if (renderer.syntheticShadow) {
         shadowMode =
@@ -293,7 +291,7 @@ export function createVM<HostNode, HostElement>(
         oar: create(null),
         cmpTemplate: null,
 
-        renderMode,
+        renderMode: def.renderMode,
         shadowMode,
 
         context: {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -266,7 +266,7 @@ export function createVM<HostNode, HostElement>(
     let shadowMode;
     if (renderer.syntheticShadow) {
         shadowMode =
-            isTrue(def.preferNativeShadow) && isNativeShadowRootDefined
+            def.preferNativeShadow && isNativeShadowRootDefined
                 ? ShadowMode.Native
                 : ShadowMode.Synthetic;
     } else {

--- a/packages/integration-karma/test/light-dom/basic/index.spec.js
+++ b/packages/integration-karma/test/light-dom/basic/index.spec.js
@@ -3,6 +3,15 @@ import { createElement, setFeatureFlagForTest, LightningElement } from 'lwc';
 import Test from 'x/test';
 import InvalidRenderMode from 'x/invalidRenderMode';
 
+describe('Light DOM enablement', () => {
+    it('should throw error when feature is not enabled', () => {
+        expect(() => createElement('x-test', { is: Test })).toThrowErrorDev(
+            Error,
+            /Light DOM components are not available in this environment/
+        );
+    });
+});
+
 describe('Basic Light DOM', () => {
     beforeEach(() => {
         setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
@@ -16,13 +25,6 @@ describe('Basic Light DOM', () => {
 
         expect(elm.shadowRoot).toBeNull();
         expect(elm.firstChild.innerText).toEqual('Hello, Light DOM');
-    });
-    it('should throw error when feature is disabled', () => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-        expect(() => createElement('x-test', { is: Test })).toThrowErrorDev(
-            Error,
-            'Assert Violation: Test is an invalid LWC component. Light DOM components are not available in this environment.'
-        );
     });
 
     it('should return null for template', () => {

--- a/packages/integration-karma/test/light-dom/basic/index.spec.js
+++ b/packages/integration-karma/test/light-dom/basic/index.spec.js
@@ -3,15 +3,6 @@ import { createElement, setFeatureFlagForTest, LightningElement } from 'lwc';
 import Test from 'x/test';
 import InvalidRenderMode from 'x/invalidRenderMode';
 
-describe('Light DOM enablement', () => {
-    it('should throw error when feature is not enabled', () => {
-        expect(() => createElement('x-test', { is: Test })).toThrowErrorDev(
-            Error,
-            /Light DOM components are not available in this environment/
-        );
-    });
-});
-
 describe('Basic Light DOM', () => {
     beforeEach(() => {
         setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
@@ -25,6 +16,13 @@ describe('Basic Light DOM', () => {
 
         expect(elm.shadowRoot).toBeNull();
         expect(elm.firstChild.innerText).toEqual('Hello, Light DOM');
+    });
+    it('should throw error when feature is disabled', () => {
+        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+        expect(() => createElement('x-test', { is: Test })).toThrowErrorDev(
+            Error,
+            'Assert Violation: Test is an invalid LWC component. Light DOM components are not available in this environment.'
+        );
     });
 
     it('should return null for template', () => {


### PR DESCRIPTION
## Details

These values should be read once and cached before construction.

## Does this PR introduce breaking changes?

No

## GUS work item

W-9357285