### PR TITLE
fix: disallow synthetic-within-native composition

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -24,7 +24,7 @@ import {
     keys,
     setHiddenField,
 } from '@lwc/shared';
-
+import { getComponentTag } from '../shared/format';
 import {
     createComponent,
     renderComponent,
@@ -268,9 +268,11 @@ function assertNotSyntheticComposedWithinNative(vm: VM) {
         // Any native shadow component being an ancestor of a synthetic shadow component is disallowed.
         assert.isFalse(
             ancestor.renderMode === RenderMode.Shadow && ancestor.shadowMode === ShadowMode.Native,
-            `${getComponentTag(vm)} (synthetic shadow DOM) cannot be composed inside of ${
-                getComponentTag(ancestor)
-            } (native shadow DOM), because synthetic-within-native composition is disallowed`
+            `${getComponentTag(
+                vm
+            )} (synthetic shadow DOM) cannot be composed inside of ${getComponentTag(
+                ancestor
+            )} (native shadow DOM), because synthetic-within-native composition is disallowed`
         );
     }
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -268,9 +268,9 @@ function assertNotSyntheticComposedWithinNative(vm: VM) {
         // Any native shadow component being an ancestor of a synthetic shadow component is disallowed.
         assert.isFalse(
             ancestor.renderMode === RenderMode.Shadow && ancestor.shadowMode === ShadowMode.Native,
-            `<${vm.tagName}> (synthetic shadow DOM) cannot be composed inside of <${
-                getAssociatedVM(ancestor.elm).tagName
-            }> (native shadow DOM), because synthetic-within-native composition is disallowed`
+            `${getComponentTag(vm)} (synthetic shadow DOM) cannot be composed inside of ${
+                getComponentTag(ancestor)
+            } (native shadow DOM), because synthetic-within-native composition is disallowed`
         );
     }
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -268,9 +268,9 @@ function assertNotSyntheticComposedWithinNative(vm: VM) {
         // Any native shadow component being an ancestor of a synthetic shadow component is disallowed.
         assert.isFalse(
             ancestor.renderMode === RenderMode.Shadow && ancestor.shadowMode === ShadowMode.Native,
-            `<${vm.tagName}> (preferNativeShadow=false) cannot be composed inside of <${
+            `<${vm.tagName}> (synthetic shadow DOM) cannot be composed inside of <${
                 getAssociatedVM(ancestor.elm).tagName
-            }> (preferNativeShadow=true)`
+            }> (native shadow DOM), because synthetic-within-native composition is disallowed`
         );
     }
 }

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
@@ -21,19 +21,12 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                 const elm = createElement('x-native-render-func', { is: NativeRenderFunc });
                 document.body.appendChild(elm);
                 expect(elm.shadowRoot.querySelector('div').textContent).toEqual('hello');
-                // The code we want to test calls `Promise.resolve().then(flushCallbackQueue)`, which would result
-                // in an unhandled promise rejection. To actually capture that promise, we mock `Promise.resolve`.
-                let promise = Promise.resolve();
-                spyOn(Promise, 'resolve').and.returnValue({
-                    then: function (callback) {
-                        promise = promise.then(callback);
-                        return promise;
-                    },
-                });
                 elm.tryToRenderSynthetic = true;
-                return expectAsync(promise).toBeRejectedWithError(
-                    'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native-render-func> (native shadow DOM), because synthetic-within-native composition is disallowed'
-                );
+                return Promise.resolve().then(() => {
+                    expect(elm.error).toEqual(
+                        'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native-render-func> (native shadow DOM), because synthetic-within-native composition is disallowed'
+                    );
+                });
             });
 
             it('synthetic containing slottable native component with synthetic slotted inside should not throw', () => {

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
@@ -13,7 +13,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                     const elm = createElement('x-native', { is: Native });
                     document.body.appendChild(elm);
                 }).toThrowError(
-                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native> (preferNativeShadow=true)'
+                    'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native> (native shadow DOM), because synthetic-within-native composition is disallowed'
                 );
             });
 
@@ -32,7 +32,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                 });
                 elm.tryToRenderSynthetic = true;
                 return expectAsync(promise).toBeRejectedWithError(
-                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-render-func> (preferNativeShadow=true)'
+                    'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native-render-func> (native shadow DOM), because synthetic-within-native composition is disallowed'
                 );
             });
 
@@ -50,7 +50,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                     const elm = createElement('x-native-container', { is: NativeContainer });
                     document.body.appendChild(elm);
                 }).toThrowError(
-                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-container> (preferNativeShadow=true)'
+                    'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native-container> (native shadow DOM), because synthetic-within-native composition is disallowed'
                 );
             });
 
@@ -68,7 +68,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         });
                         document.body.appendChild(elm);
                     }).toThrowError(
-                        'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-light-synthetic> (preferNativeShadow=true)'
+                        'Assert Violation: <x-synthetic> (synthetic shadow DOM) cannot be composed inside of <x-native-light-synthetic> (native shadow DOM), because synthetic-within-native composition is disallowed'
                     );
                 });
             });

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
@@ -1,0 +1,77 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import Native from 'x/native';
+import NativeRenderFunc from 'x/nativeRenderFunc';
+import SyntheticContainer from 'x/syntheticContainer';
+import NativeContainer from 'x/nativeContainer';
+import NativeLightSynthetic from 'x/nativeLightSynthetic';
+
+if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
+    describe('composition', () => {
+        describe('disallow composing synthetic within native', () => {
+            it('basic case', () => {
+                expect(() => {
+                    const elm = createElement('x-native', { is: Native });
+                    document.body.appendChild(elm);
+                }).toThrowError(
+                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native> (preferNativeShadow=true)'
+                );
+            });
+
+            it('dynamic render', () => {
+                const elm = createElement('x-native-render-func', { is: NativeRenderFunc });
+                document.body.appendChild(elm);
+                expect(elm.shadowRoot.querySelector('div').textContent).toEqual('hello');
+                // The code we want to test calls `Promise.resolve().then(flushCallbackQueue)`, which would result
+                // in an unhandled promise rejection. To actually capture that promise, we mock `Promise.resolve`.
+                let promise = Promise.resolve();
+                spyOn(Promise, 'resolve').and.returnValue({
+                    then: function (callback) {
+                        promise = promise.then(callback);
+                        return promise;
+                    },
+                });
+                elm.tryToRenderSynthetic = true;
+                return expectAsync(promise).toBeRejectedWithError(
+                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-render-func> (preferNativeShadow=true)'
+                );
+            });
+
+            it('synthetic containing slottable native component with synthetic slotted inside should not throw', () => {
+                const elm = createElement('x-synthetic-container', { is: SyntheticContainer });
+                document.body.appendChild(elm);
+                expect(
+                    elm.shadowRoot.querySelector('x-synthetic').shadowRoot.querySelector('h1')
+                        .textContent
+                ).toEqual('I am synthetic');
+            });
+
+            it('native containing slottable native component with synthetic slotted inside should throw', () => {
+                expect(() => {
+                    const elm = createElement('x-native-container', { is: NativeContainer });
+                    document.body.appendChild(elm);
+                }).toThrowError(
+                    'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-container> (preferNativeShadow=true)'
+                );
+            });
+
+            describe('using light DOM', () => {
+                beforeEach(() => {
+                    setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
+                });
+                afterEach(() => {
+                    setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
+                });
+                it('synthetic within light within native', () => {
+                    expect(() => {
+                        const elm = createElement('x-native-light-synthetic', {
+                            is: NativeLightSynthetic,
+                        });
+                        document.body.appendChild(elm);
+                    }).toThrowError(
+                        'Assert Violation: <x-synthetic> (preferNativeShadow=false) cannot be composed inside of <x-native-light-synthetic> (preferNativeShadow=true)'
+                    );
+                });
+            });
+        });
+    });
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/light/light.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/light/light.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+  <x-synthetic></x-synthetic>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/light/light.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/light/light.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/native/native.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/native/native.html
@@ -1,0 +1,3 @@
+<template>
+  <x-synthetic></x-synthetic>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/native/native.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/native/native.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeContainer/nativeContainer.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeContainer/nativeContainer.html
@@ -1,0 +1,5 @@
+<template>
+  <x-native-slottable>
+    <x-synthetic></x-synthetic>
+  </x-native-slottable>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeContainer/nativeContainer.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeContainer/nativeContainer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeLightSynthetic/nativeLightSynthetic.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeLightSynthetic/nativeLightSynthetic.html
@@ -1,0 +1,3 @@
+<template>
+  <x-light></x-light>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeLightSynthetic/nativeLightSynthetic.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeLightSynthetic/nativeLightSynthetic.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/nativeRenderFunc.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/nativeRenderFunc.js
@@ -1,0 +1,13 @@
+import { LightningElement, api } from 'lwc';
+import one from './one.html';
+import two from './two.html';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+
+    @api tryToRenderSynthetic = false;
+
+    render() {
+        return this.tryToRenderSynthetic ? two : one;
+    }
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/nativeRenderFunc.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/nativeRenderFunc.js
@@ -5,9 +5,18 @@ import two from './two.html';
 export default class extends LightningElement {
     static preferNativeShadow = true;
 
+    _error = null;
     @api tryToRenderSynthetic = false;
 
     render() {
         return this.tryToRenderSynthetic ? two : one;
+    }
+
+    errorCallback(error) {
+        this._error = error.message;
+    }
+
+    @api get error() {
+        return this._error;
     }
 }

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/one.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/one.html
@@ -1,0 +1,3 @@
+<template>
+  <div>hello</div>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/two.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeRenderFunc/two.html
@@ -1,0 +1,3 @@
+<template>
+  <x-synthetic></x-synthetic>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeSlottable/nativeSlottable.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeSlottable/nativeSlottable.html
@@ -1,0 +1,3 @@
+<template>
+  <slot></slot>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeSlottable/nativeSlottable.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/nativeSlottable/nativeSlottable.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/synthetic/synthetic.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/synthetic/synthetic.html
@@ -1,0 +1,3 @@
+<template>
+  <h1>I am synthetic</h1>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/synthetic/synthetic.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/synthetic/synthetic.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/syntheticContainer/syntheticContainer.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/syntheticContainer/syntheticContainer.html
@@ -1,0 +1,5 @@
+<template>
+  <x-native-slottable>
+    <x-synthetic></x-synthetic>
+  </x-native-slottable>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/x/syntheticContainer/syntheticContainer.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/x/syntheticContainer/syntheticContainer.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Throws an error if synthetic shadow components are composed within native shadow components.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8778376
