### PR TITLE
chore: Release to latest dist tag by default

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -50,7 +50,7 @@ try {
     }
 
     const [, releaseBranch] = result;
-    const distTag = releaseBranch === 'master' ? 'next' : releaseBranch;
+    const distTag = releaseBranch === 'master' ? 'latest' : releaseBranch;
     ARGS.push('--dist-tag', distTag);
 
     console.log(


### PR DESCRIPTION
## Details

The automated release process currently publishes packages with the `next` dist tag. On a weekly cadence, we need to update the previous release dist tag to `latest`.

This process was put in place to give us time to test a release before marking it as the latest one. I don't think this extra release step is needed anymore because we are now following strict semantic versioning and because of the maturity of the CI pipeline.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 