### PR TITLE
fix: preserve HTMLSlotElement.prototype.children behavior in native slots

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -40,6 +40,7 @@ import {
     isNodeOwnedBy,
     getAllMatches,
     getFilteredChildNodes,
+    isSyntheticSlotElement,
 } from './traverse';
 import { getTextContent } from '../3rdparty/polymer/text-content';
 import { getShadowRoot, isHostElement, getIE11FakeShadowRootPlaceholder } from './shadow-root';
@@ -49,11 +50,12 @@ import { isGlobalPatchingSkipped } from '../shared/utils';
 
 /**
  * This method checks whether or not the content of the node is computed
- * based on the light-dom slotting mechanism. This applies to slot elements
- * and elements with shadow dom attached to them.
+ * based on the light-dom slotting mechanism. This applies to synthetic slot elements
+ * and elements with shadow dom attached to them. It doesn't apply to native slot elements
+ * because we don't want to patch the children getters for those elements.
  */
 export function hasMountedChildren(node: Node): boolean {
-    return isSlotElement(node) || isHostElement(node);
+    return isSyntheticSlotElement(node) || isHostElement(node);
 }
 
 function getShadowParent(node: Node, value: ParentNode & Node): (Node & ParentNode) | null {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    ArrayReduce,
-    ArrayPush,
-    assert,
-    isNull,
-    isUndefined,
-    KEY__SHADOW_TOKEN_PRIVATE,
-} from '@lwc/shared';
+import { ArrayReduce, ArrayPush, assert, isNull, isUndefined } from '@lwc/shared';
 import {
     getHost,
     SyntheticShadowRootInterface,
@@ -27,7 +20,7 @@ import {
     DOCUMENT_POSITION_CONTAINS,
     parentElementGetter,
 } from '../env/node';
-import { getNodeKey, getNodeNearestOwnerKey } from '../shared/node-ownership';
+import { getNodeKey, getNodeNearestOwnerKey, isNodeShadowed } from '../shared/node-ownership';
 import { arrayFromCollection } from '../shared/utils';
 
 // when finding a slot in the DOM, we can fold it if it is contained
@@ -130,7 +123,7 @@ export function getNodeOwner(node: Node): HTMLElement | null {
 }
 
 export function isSyntheticSlotElement(node: Node): node is HTMLSlotElement {
-    return isSlotElement(node) && KEY__SHADOW_TOKEN_PRIVATE in node;
+    return isSlotElement(node) && isNodeShadowed(node);
 }
 
 export function isSlotElement(node: Node): node is HTMLSlotElement {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayReduce, ArrayPush, assert, isNull, isUndefined } from '@lwc/shared';
+import {
+    ArrayReduce,
+    ArrayPush,
+    assert,
+    isNull,
+    isUndefined,
+    KEY__SHADOW_TOKEN_PRIVATE,
+} from '@lwc/shared';
 import {
     getHost,
     SyntheticShadowRootInterface,
@@ -120,6 +127,10 @@ export function getNodeOwner(node: Node): HTMLElement | null {
         return null;
     }
     return nodeOwner as HTMLElement;
+}
+
+export function isSyntheticSlotElement(node: Node): node is HTMLSlotElement {
+    return isSlotElement(node) && KEY__SHADOW_TOKEN_PRIVATE in node;
 }
 
 export function isSlotElement(node: Node): node is HTMLSlotElement {

--- a/packages/integration-karma/test/native-shadow/children/index.spec.js
+++ b/packages/integration-karma/test/native-shadow/children/index.spec.js
@@ -1,0 +1,33 @@
+import { createElement } from 'lwc';
+import Slottable from 'x/slottable';
+
+describe('children', () => {
+    function expectOneSpanChild(slot) {
+        expect(slot.children.length).toEqual(1);
+        expect(slot.childElementCount).toEqual(1);
+        expect(slot.firstElementChild && slot.firstElementChild.tagName).toEqual('SPAN');
+        expect(slot.lastElementChild && slot.lastElementChild.tagName).toEqual('SPAN');
+        expect(slot.firstChild && slot.firstChild.tagName).toEqual('SPAN');
+        expect(slot.lastChild && slot.lastChild.tagName).toEqual('SPAN');
+        expect(slot.hasChildNodes()).toEqual(true);
+        expect(slot.childNodes.length).toEqual(1);
+    }
+
+    it('should have correct HTMLSlotElement.prototype.children behavior for slots created outside LWC', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        el.attachShadow({ mode: 'open' }).innerHTML = '<slot><span>fallback</span></slot>';
+
+        const slot = el.shadowRoot.querySelector('slot');
+        expectOneSpanChild(slot);
+    });
+
+    it('should have correct HTMLSlotElement.prototype.children behavior for LWC-created slots', () => {
+        const el = createElement('x-slottable', { is: Slottable });
+        document.body.appendChild(el);
+
+        const slot = el.shadowRoot.querySelector('slot');
+        expectOneSpanChild(slot);
+    });
+});

--- a/packages/integration-karma/test/native-shadow/children/index.spec.js
+++ b/packages/integration-karma/test/native-shadow/children/index.spec.js
@@ -13,15 +13,18 @@ describe('children', () => {
         expect(slot.childNodes.length).toEqual(1);
     }
 
-    it('should have correct HTMLSlotElement.prototype.children behavior for slots created outside LWC', () => {
-        const el = document.createElement('div');
-        document.body.appendChild(el);
+    // attachShadow() is not supported on arbitrary elements in compat mode
+    if (!process.env.COMPAT) {
+        it('should have correct HTMLSlotElement.prototype.children behavior for slots created outside LWC', () => {
+            const el = document.createElement('div');
+            document.body.appendChild(el);
 
-        el.attachShadow({ mode: 'open' }).innerHTML = '<slot><span>fallback</span></slot>';
+            el.attachShadow({ mode: 'open' }).innerHTML = '<slot><span>fallback</span></slot>';
 
-        const slot = el.shadowRoot.querySelector('slot');
-        expectOneSpanChild(slot);
-    });
+            const slot = el.shadowRoot.querySelector('slot');
+            expectOneSpanChild(slot);
+        });
+    }
 
     it('should have correct HTMLSlotElement.prototype.children behavior for LWC-created slots', () => {
         const el = createElement('x-slottable', { is: Slottable });

--- a/packages/integration-karma/test/native-shadow/children/x/slottable/slottable.html
+++ b/packages/integration-karma/test/native-shadow/children/x/slottable/slottable.html
@@ -1,0 +1,3 @@
+<template>
+  <slot><span>fallback</span></slot>
+</template>

--- a/packages/integration-karma/test/native-shadow/children/x/slottable/slottable.js
+++ b/packages/integration-karma/test/native-shadow/children/x/slottable/slottable.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Ensures that `HTMLSlotElement.prototype.children` behaves correctly in both native and synthetic slots.

Fixes #2135

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8582701