### PR TITLE
fix: ensure restrictions are applied for both synthetic and native shadow

### DIFF
--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -203,7 +203,7 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
                 // programmatically into its Component's shadow root
                 if (!isUndefined(options)) {
                     logError(
-                        'The `addEventListener` method in `LightningElement` does not support any options.',
+                        'The `addEventListener` method on ShadowRoot does not support any options.',
                         getAssociatedVMIfPresent(this)
                     );
                 }

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
@@ -1,0 +1,82 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+describe('restrictions', () => {
+    let elm;
+    beforeEach(() => {
+        elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+    });
+
+    describe('ShadowRoot', () => {
+        it('innerHTML', () => {
+            expect(() => {
+                elm.setInnerHtmlOnShadowRoot();
+            }).toThrowError(TypeError, 'Invalid attempt to set innerHTML on ShadowRoot.');
+        });
+        it('textContent', () => {
+            expect(() => {
+                elm.setTextContentOnShadowRoot();
+            }).toThrowError(TypeError, 'Invalid attempt to set textContent on ShadowRoot.');
+        });
+        it('addEventListener', () => {
+            expect(() => {
+                elm.addEventListenerWithOptions();
+            }).toLogErrorDev(
+                'Error: [LWC error]: The `addEventListener` method on ShadowRoot does not support any options.\n'
+            );
+        });
+    });
+
+    describe('custom element', () => {
+        it('innerHTML', () => {
+            expect(() => {
+                elm.innerHTML = '<div></div>';
+            }).toThrowError(TypeError, 'Invalid attempt to set innerHTML on HTMLElement.');
+        });
+        it('outerHTML', () => {
+            expect(() => {
+                elm.outerHTML = '<div></div>';
+            }).toThrowError(TypeError, 'Invalid attempt to set outerHTML on HTMLElement.');
+        });
+        it('textContent', () => {
+            expect(() => {
+                elm.textContent = '<div></div>';
+            }).toThrowError(TypeError, 'Invalid attempt to set textContent on HTMLElement.');
+        });
+        it('addEventListener', () => {
+            expect(() => {
+                elm.addEventListener('click', () => {}, { once: true });
+            }).toLogErrorDev(
+                'Error: [LWC error]: The `addEventListener` method in `LightningElement` does not support any options.\n'
+            );
+        });
+    });
+
+    describe('LightningElement', () => {
+        it('dispatchEvent', () => {
+            expect(() => {
+                elm.dispatchEventWithInvalidName();
+            }).toLogErrorDev(
+                'Error: [LWC error]: Invalid event type "UPPERCASE-AND-HYPHENS" dispatched in element <x-component>. Event name must start with a lowercase letter and followed only lowercase letters, numbers, and underscores\n'
+            );
+        });
+
+        it('get className', () => {
+            expect(() => {
+                elm.getClassName();
+            }).toLogErrorDev(
+                'Error: [LWC error]: Accessing the global HTML property "className" is disabled.\n' +
+                    'Using the `className` property is an anti-pattern because of slow runtime behavior and potential conflicts with classes provided by the owner element. Use the `classList` API instead.\n'
+            );
+        });
+
+        it('set accessKeyLabel', () => {
+            expect(() => {
+                elm.setAccessKeyLabel('foo');
+            }).toLogErrorDev(
+                'Error: [LWC error]: The global HTML property `accessKeyLabel` is read-only.\n'
+            );
+        });
+    });
+});

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
@@ -72,4 +72,12 @@ describe('restrictions', () => {
             );
         });
     });
+
+    describe('Element', () => {
+        it('should throw on setting outerHTML', () => {
+            expect(() => {
+                elm.shadowRoot.querySelector('div').outerHTML = '';
+            }).toThrowError(TypeError, 'Invalid attempt to set outerHTML on Element.');
+        });
+    });
 });

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
@@ -19,13 +19,6 @@ describe('restrictions', () => {
                 elm.setTextContentOnShadowRoot();
             }).toThrowError(TypeError, 'Invalid attempt to set textContent on ShadowRoot.');
         });
-        it('addEventListener', () => {
-            expect(() => {
-                elm.addEventListenerWithOptions();
-            }).toLogErrorDev(
-                'Error: [LWC error]: The `addEventListener` method on ShadowRoot does not support any options.\n'
-            );
-        });
     });
 
     describe('custom element', () => {

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+  <div></div>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
@@ -1,0 +1,40 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static preferNativeShadow = true;
+
+    @api
+    setInnerHtmlOnShadowRoot() {
+        this.template.innerHTML = '<div></div>';
+    }
+
+    @api
+    setTextContentOnShadowRoot() {
+        this.template.textContent = 'foo';
+    }
+
+    @api
+    addEventListenerWithOptions() {
+        this.template.addEventListener('scroll', () => {}, { passive: true });
+    }
+
+    @api
+    getTagName() {
+        return this.tagName;
+    }
+
+    @api
+    dispatchEventWithInvalidName() {
+        this.dispatchEvent(new CustomEvent('UPPERCASE-AND-HYPHENS'));
+    }
+
+    @api
+    getClassName() {
+        return this.className;
+    }
+
+    @api
+    setAccessKeyLabel(accessKeyLabel) {
+        this.accessKeyLabel = accessKeyLabel;
+    }
+}

--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -209,7 +209,7 @@ describe('EventTarget.addEventListener', () => {
                 expect(() => {
                     container.shadowRoot.addEventListener('test', () => {}, {});
                 }).toLogErrorDev(
-                    /The `addEventListener` method in `LightningElement` does not support any options./
+                    /The `addEventListener` method on ShadowRoot does not support any options./
                 );
             });
 
@@ -261,7 +261,7 @@ describe('EventTarget.addEventListener', () => {
                 expect(() => {
                     container.shadowRoot.addEventListener('test', () => {}, {});
                 }).toLogErrorDev(
-                    /The `addEventListener` method in `LightningElement` does not support any options./
+                    /The `addEventListener` method on ShadowRoot does not support any options./
                 );
             });
 


### PR DESCRIPTION
## Details

Adds tests (which will run in both native and synthetic mode) to ensure that restrictions from [restrictions.ts](https://github.com/salesforce/lwc/blob/11943c7cdfc8d505827bd86e477f9b8ff7ce84d3/packages/%40lwc/engine-core/src/framework/restrictions.ts) are applied.

Here is my audit of the restrictions:

- `patchElementWithRestrictions` – this only applies to `lwc:dom="manual"` which is not needed in native mode
- `patchShadowRootWithRestrictions` – ✅  (except `addEventListener` which is already covered [here](https://github.com/salesforce/lwc/blob/4013ec09107e8393b1087de0e59197b1ee69ac86/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js))
- `patchCustomElementWithRestrictions` – ✅ 
- `patchComponentWithRestrictions` – already covered in [an existing test](https://github.com/salesforce/lwc/blob/d93e2963d8d32b138ce9ed130d98e7bef84b3d74/packages/integration-karma/test/component/LightningElement.tagName/index.spec.js#L5-L12).
- `patchLightningElementPrototypeWithRestrictions` – ✅ 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9318295
