### PR TITLE
fix: log compiler warning on duplicate slots

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1137
+ * Next error code: 1139
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -513,4 +513,16 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Error,
         url: '',
     },
+    NO_DUPLICATE_SLOTS: {
+        code: 1137,
+        message: 'Invalid duplicate slot ({0}).',
+        level: DiagnosticLevel.Warning,
+        url: '',
+    },
+    NO_SLOTS_IN_ITERATOR: {
+        code: 1138,
+        message: 'Invalid slot ({0}). A slot cannot appear inside of an iterator.',
+        level: DiagnosticLevel.Warning,
+        url: '',
+    },
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <slot></slot>
+    <slot></slot>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
@@ -1,0 +1,25 @@
+import { registerTemplate } from "lwc";
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { s: api_slot } = $api;
+  return [
+    api_slot(
+      "",
+      {
+        key: 0,
+      },
+      [],
+      $slotset
+    ),
+    api_slot(
+      "",
+      {
+        key: 1,
+      },
+      [],
+      $slotset
+    ),
+  ];
+}
+export default registerTemplate(tmpl);
+tmpl.slots = [""];
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1137,
+            "message": "LWC1137: Invalid duplicate slot (default).",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 5,
+                "start": 33,
+                "length": 13
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <slot name="foo"></slot>
+    <slot name="foo"></slot>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
@@ -1,0 +1,31 @@
+import { registerTemplate } from "lwc";
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { s: api_slot } = $api;
+  return [
+    api_slot(
+      "foo",
+      {
+        attrs: {
+          name: "foo",
+        },
+        key: 0,
+      },
+      [],
+      $slotset
+    ),
+    api_slot(
+      "foo",
+      {
+        attrs: {
+          name: "foo",
+        },
+        key: 1,
+      },
+      [],
+      $slotset
+    ),
+  ];
+}
+export default registerTemplate(tmpl);
+tmpl.slots = ["foo"];
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1137,
+            "message": "LWC1137: Invalid duplicate slot (name=\"foo\").",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 5,
+                "start": 44,
+                "length": 24
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/actual.html
@@ -1,0 +1,7 @@
+<template>
+  <template for:each={items} for:item="item">
+    <div key={item}>
+      <slot></slot>
+    </div>
+  </template>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
@@ -1,0 +1,25 @@
+import { registerTemplate } from "lwc";
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = $api;
+  return api_iterator($cmp.items, function (item) {
+    return api_element(
+      "div",
+      {
+        key: api_key(0, item),
+      },
+      [
+        api_slot(
+          "",
+          {
+            key: 1,
+          },
+          [],
+          $slotset
+        ),
+      ]
+    );
+  });
+}
+export default registerTemplate(tmpl);
+tmpl.slots = [""];
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1138,
+            "message": "LWC1138: Invalid slot (default). A slot cannot appear inside of an iterator.",
+            "level": 2,
+            "location": {
+                "line": 4,
+                "column": 7,
+                "start": 84,
+                "length": 13
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -617,6 +617,19 @@ function applySlot(ctx: ParserCtx, element: IRElement, parsedAttr: ParsedAttribu
     }
 
     element.slotName = name;
+
+    const alreadySeen = ctx.seenSlots.has(name);
+    ctx.seenSlots.add(name);
+
+    if (alreadySeen) {
+        return ctx.warnOnIRNode(ParserDiagnostics.NO_DUPLICATE_SLOTS, element, [
+            name === '' ? 'default' : `name="${name}"`,
+        ]);
+    } else if (isInIteration(ctx, element)) {
+        return ctx.warnOnIRNode(ParserDiagnostics.NO_SLOTS_IN_ITERATOR, element, [
+            name === '' ? 'default' : `name="${name}"`,
+        ]);
+    }
 }
 
 function applyAttributes(ctx: ParserCtx, element: IRElement, parsedAttr: ParsedAttribute) {

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -41,6 +41,7 @@ export default class ParserCtx {
 
     readonly warnings: CompilerDiagnostic[] = [];
     readonly seenIds: Set<string> = new Set();
+    readonly seenSlots: Set<string> = new Set();
 
     readonly parentStack: IRElement[] = [];
 


### PR DESCRIPTION
## Details

Fixes #1734

If a template contains multiple slots with the same name (or multiple default slots), the compiler should emit a warning. The template is invalid in that case, since there's no real reason to have duplicates.

This also fixes a discrepancy between how synthetic and native shadow DOM deal with duplicate slots (#1734, #2351).

## Does this PR introduce breaking changes?

* ✅  `No, it does not introduce breaking changes.`

Any existing template with duplicate slots, when running in synthetic shadow mode, will currently (and incorrectly) render the slotted content multiple times. After this change, those same templates will log a compile-time warning.

## GUS work item

W-7255094
