### PR TITLE
test: add test to confirm "next error code" comment is updated

### DIFF
--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import path from 'path';
+import fs from 'fs';
 import { hasOwnProperty } from '@lwc/shared';
 import * as CompilerErrors from '../compiler/error-info';
 import { LWCErrorInfo } from '../shared/types';
@@ -74,5 +76,23 @@ describe('error validation', () => {
         }
 
         traverseErrorInfo(CompilerErrors, checkUniqueness, 'compiler');
+    });
+
+    it('Next error code is updated', () => {
+        const errorCodes: number[] = [];
+        traverseErrorInfo(
+            CompilerErrors,
+            (error) => {
+                errorCodes.push(error.code);
+            },
+            'compiler'
+        );
+        const expectedNextErrorCode = 1 + Math.max(...errorCodes);
+        const errorInfo = fs.readFileSync(
+            path.join(__dirname, '../compiler/error-info/index.ts'),
+            'utf-8'
+        );
+        const actualNextErrorCode = parseInt(errorInfo.match(/Next error code: (\d+)/)![1], 10);
+        expect(actualNextErrorCode).toEqual(expectedNextErrorCode);
     });
 });

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -78,7 +78,7 @@ describe('error validation', () => {
         traverseErrorInfo(CompilerErrors, checkUniqueness, 'compiler');
     });
 
-    it('Next error code is updated in src/compiler/error-info/index.ts', () => {
+    it('"Next error code: XXXX" comment is updated in src/compiler/error-info/index.ts', () => {
         let lastErrorCode = 1001;
         traverseErrorInfo(
             CompilerErrors,

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -78,7 +78,7 @@ describe('error validation', () => {
         traverseErrorInfo(CompilerErrors, checkUniqueness, 'compiler');
     });
 
-    it('Next error code is updated', () => {
+    it('Next error code is updated in src/compiler/error-info/index.ts', () => {
         const errorCodes: number[] = [];
         traverseErrorInfo(
             CompilerErrors,

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -79,15 +79,15 @@ describe('error validation', () => {
     });
 
     it('Next error code is updated in src/compiler/error-info/index.ts', () => {
-        const errorCodes: number[] = [];
+        let lastErrorCode = 1001;
         traverseErrorInfo(
             CompilerErrors,
             (error) => {
-                errorCodes.push(error.code);
+                lastErrorCode = Math.max(lastErrorCode, error.code);
             },
             'compiler'
         );
-        const expectedNextErrorCode = 1 + Math.max(...errorCodes);
+        const expectedNextErrorCode = 1 + lastErrorCode;
         const errorInfo = fs.readFileSync(
             path.join(__dirname, '../compiler/error-info/index.ts'),
             'utf-8'

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -6,7 +6,7 @@
  */
 /**
  * TODO [W-5678919]: implement script to determine the next available error code
- * Next error code: 1126
+ * Next error code: 1136
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * TODO [W-5678919]: implement script to determine the next available error code
  * Next error code: 1136
  */
 


### PR DESCRIPTION
## Details

As discussed here: https://github.com/salesforce/lwc/pull/2372#discussion_r652445115

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`