### PR TITLE
chore(compiler): Deprecate unused minify output config

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -48,7 +48,7 @@ export interface OutputConfig {
     sourcemap?: boolean;
 
     /**
-     * @deprecated The minify property has not effect of the generated output.
+     * @deprecated The minify property has no effect on the generated output.
      */
     minify?: boolean;
 }

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -41,8 +41,16 @@ export interface StylesheetConfig {
 }
 
 export interface OutputConfig {
-    minify?: boolean;
+    /**
+     * If `true` a source map is generated for the transformed file.
+     * @default false
+     */
     sourcemap?: boolean;
+
+    /**
+     * @deprecated The minify property has not effect of the generated output.
+     */
+    minify?: boolean;
 }
 
 export interface DynamicComponentConfig {
@@ -109,12 +117,6 @@ function isUndefinedOrBoolean(property: any): boolean {
 }
 
 function validateOutputConfig(config: OutputConfig) {
-    invariant(
-        isUndefinedOrBoolean(config.minify),
-        CompilerValidationErrors.INVALID_MINIFY_PROPERTY,
-        [config.minify]
-    );
-
     invariant(
         isUndefinedOrBoolean(config.sourcemap),
         CompilerValidationErrors.INVALID_SOURCEMAP_PROPERTY,

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -122,6 +122,13 @@ function validateOutputConfig(config: OutputConfig) {
         CompilerValidationErrors.INVALID_SOURCEMAP_PROPERTY,
         [config.sourcemap]
     );
+
+    if (!isUndefined(config.minify)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `"OutputConfig.minify" property is deprecated. The value doesn't impact the compilation and can safely be removed.`
+        );
+    }
 }
 
 function normalizeOptions(options: TransformOptions): NormalizedTransformOptions {

--- a/packages/@lwc/compiler/src/transformers/style.ts
+++ b/packages/@lwc/compiler/src/transformers/style.ts
@@ -15,7 +15,6 @@ export default function styleTransform(
     filename: string,
     config: NormalizedTransformOptions
 ): TransformResult {
-    const { minify } = config.outputConfig;
     const { customProperties } = config.stylesheetConfig;
 
     const styleCompilerConfig = {
@@ -24,9 +23,6 @@ export default function styleTransform(
                 customProperties.resolution.type === 'module'
                     ? customProperties.resolution.name
                     : undefined,
-        },
-        outputConfig: {
-            minify,
         },
     };
 

--- a/packages/@lwc/errors/src/compiler/error-info/compiler.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/compiler.ts
@@ -46,13 +46,6 @@ export const CompilerValidationErrors = {
         url: '',
     },
 
-    INVALID_MINIFY_PROPERTY: {
-        code: 1017,
-        message: 'Expected a boolean for outputConfig.minify, received "{0}".',
-        level: DiagnosticLevel.Error,
-        url: '',
-    },
-
     INVALID_NAME_PROPERTY: {
         code: 1018,
         message: 'Expected a string for name, received "{0}".',


### PR DESCRIPTION
## Details

Deprecate `outputConfig.minify` option. This option is not used anymore by the style compiler since #2252.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 