### PR TITLE
docs: document Sauce tunnel ID for integration tests

### DIFF
--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -86,7 +86,13 @@ See the Sauce Labs [documentation](https://wiki.saucelabs.com/display/DOCS/Setti
 
 1. Download Sauce Connect and unzip
 2. `cd` into the unzipped directory
-3. Run `bin/sc -u YOUR_USERNAME -k YOUR_ACCESS_KEY` with your username and key from above
+3. Run `bin/sc -u YOUR_USERNAME -k YOUR_ACCESS_KEY -i YOUR_TUNNEL_ID` with your username, key from above, and tunnel ID (see below)
+
+You will also need to set the `SAUCE_TUNNEL_ID` environment variable when running the tests, so that the tests know which tunnel to use:
+
+```
+SAUCE_TUNNEL_ID=my-tunnel-id
+```
 
 ### Modifying Browsers
 


### PR DESCRIPTION
## Details

Small documentation change. I ran into this when running the integration tests – you need to specify the Sauce Labs tunnel ID, e.g. when testing IE11.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`