### PR TITLE
fix: add flag to disable preferNativeShadow by default

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -27,6 +27,7 @@ import {
     isUndefined,
     keys,
 } from '@lwc/shared';
+import features from '@lwc/features';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
 import { Template } from './template';
@@ -108,6 +109,15 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
             Ctor.constructor,
             `Missing ${ctorName}.constructor, ${ctorName} should have a "constructor" property.`
         );
+
+        if (!features.ENABLE_PREFER_NATIVE_SHADOW) {
+            assert.isFalse(
+                'preferNativeShadow' in Ctor,
+                `${
+                    ctorName || 'Anonymous class'
+                } is an invalid LWC component. \`preferNativeShadow\` is not available in this environment.`
+            );
+        }
 
         if (!isUndefined(ctorPreferNativeShadow)) {
             assert.invariant(

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -22,6 +22,7 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
     ENABLE_LIGHT_DOM_COMPONENTS: null,
     ENABLE_RETARGETING_FOR_UNPATCHED_LISTENERS: null,
+    ENABLE_PREFER_NATIVE_SHADOW: null,
 };
 export default featureFlagLookup;
 

--- a/packages/integration-karma/test/mixed-shadow-mode/LightningElement.preferNativeShadow/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/LightningElement.preferNativeShadow/index.spec.js
@@ -1,16 +1,32 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
 
-it('should throw for invalid values', () => {
-    expect(() => {
-        createElement('x-invalid', { is: Invalid });
-    }).toThrowError(/Invalid value for static property preferNativeShadow: 'true'/);
+describe('preferNativeShadow flag enabled', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', true);
+    });
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', false);
+    });
+    it('should throw for invalid values', () => {
+        expect(() => {
+            createElement('x-invalid', { is: Invalid });
+        }).toThrowError(/Invalid value for static property preferNativeShadow: 'true'/);
+    });
+
+    it('should not throw for valid values', () => {
+        expect(() => {
+            createElement('x-valid', { is: Valid });
+        }).not.toThrowError();
+    });
 });
 
-it('should not throw for valid values', () => {
-    expect(() => {
-        createElement('x-valid', { is: Valid });
-    }).not.toThrowError();
+describe('preferNativeShadow flag disabled', () => {
+    it('should disallow preferNativeShadow by default', () => {
+        expect(() => {
+            createElement('x-invalid', { is: Invalid });
+        }).toThrowError(/`preferNativeShadow` is not available in this environment./);
+    });
 });

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
@@ -7,6 +7,12 @@ import NativeLightSynthetic from 'x/nativeLightSynthetic';
 
 if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
     describe('composition', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', true);
+        });
+        afterEach(() => {
+            setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', false);
+        });
         describe('disallow composing synthetic within native', () => {
             it('basic case', () => {
                 expect(() => {

--- a/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
@@ -1,7 +1,13 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import Component from 'x/component';
 
 describe('restrictions', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', true);
+    });
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', false);
+    });
     let elm;
     beforeEach(() => {
         elm = createElement('x-component', { is: Component });

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,32 +1,40 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import Test from 'x/test';
 
 if (!process.env.COMPAT) {
-    it('should entrust id scoping to native shadow (static)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const div = elm.shadowRoot.querySelector('#shizuoka');
-        expect(div).not.toBeNull();
-    });
+    describe('scoped-ids', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', true);
+        });
+        afterEach(() => {
+            setFeatureFlagForTest('ENABLE_PREFER_NATIVE_SHADOW', false);
+        });
+        it('should entrust id scoping to native shadow (static)', () => {
+            const elm = createElement('x-test', { is: Test });
+            document.body.appendChild(elm);
+            const div = elm.shadowRoot.querySelector('#shizuoka');
+            expect(div).not.toBeNull();
+        });
 
-    it('should entrust id scoping to native shadow (dynamic)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const div = elm.shadowRoot.querySelector('#yamanashi');
-        expect(div).not.toBeNull();
-    });
+        it('should entrust id scoping to native shadow (dynamic)', () => {
+            const elm = createElement('x-test', { is: Test });
+            document.body.appendChild(elm);
+            const div = elm.shadowRoot.querySelector('#yamanashi');
+            expect(div).not.toBeNull();
+        });
 
-    it('should entrust idref scoping to native shadow (static)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const input = elm.shadowRoot.querySelector('[aria-describedby="shizuoka yamanashi"]');
-        expect(input).not.toBeNull();
-    });
+        it('should entrust idref scoping to native shadow (static)', () => {
+            const elm = createElement('x-test', { is: Test });
+            document.body.appendChild(elm);
+            const input = elm.shadowRoot.querySelector('[aria-describedby="shizuoka yamanashi"]');
+            expect(input).not.toBeNull();
+        });
 
-    it('should entrust idref scoping to native shadow (dynamic)', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        const input = elm.shadowRoot.querySelector('[aria-labelledby="yamanashi shizuoka"]');
-        expect(input).not.toBeNull();
+        it('should entrust idref scoping to native shadow (dynamic)', () => {
+            const elm = createElement('x-test', { is: Test });
+            document.body.appendChild(elm);
+            const input = elm.shadowRoot.querySelector('[aria-labelledby="yamanashi shizuoka"]');
+            expect(input).not.toBeNull();
+        });
     });
 }


### PR DESCRIPTION
## Details

Adds a runtime flag, `ENABLE_PREFER_NATIVE_SHADOW`, which needs to be set in order to use `preferNativeShadow`. Currently it throws if the static property is set at all (regardless of the value).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9492763
