### PR TITLE
refactor(template-compiler): Make AST traversal recursive

### DIFF
--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as astring from 'astring';
-import * as parse5 from 'parse5-with-errors';
 
 import { isBooleanAttribute } from '@lwc/shared';
 import { TemplateErrors, generateCompilerError } from '@lwc/errors';
@@ -273,7 +272,7 @@ function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expressio
     }
 
     function computeAttrValue(attr: IRAttribute, element: IRElement): t.Expression {
-        const { namespaceURI, tagName } = element.__original as parse5.AST.Default.Element;
+        const { namespaceURI, tagName } = element.__original;
         const isUsedAsAttribute = isAttribute(element, attr.name);
 
         switch (attr.type) {

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -9,17 +9,6 @@ import * as he from 'he';
 
 import { CompilerDiagnostic, generateCompilerDiagnostic, ParserDiagnostics } from '@lwc/errors';
 
-interface NodeVisitor<N extends parse5.AST.Default.Node> {
-    enter?: (node: N) => void;
-    exit?: (node: N) => void;
-}
-
-interface Visitor {
-    Comment?: NodeVisitor<parse5.AST.Default.CommentNode>;
-    Text?: NodeVisitor<parse5.AST.Default.TextNode>;
-    Element?: NodeVisitor<parse5.AST.Default.Element>;
-}
-
 export const treeAdapter = parse5.treeAdapters.default;
 
 export function parseHTML(source: string) {
@@ -52,45 +41,6 @@ export function parseHTML(source: string) {
         fragment,
         errors,
     };
-}
-
-export function traverseHTML(node: parse5.AST.Default.Node, visitor: Visitor): void {
-    let nodeVisitor: NodeVisitor<any> | undefined;
-    switch (node.nodeName) {
-        case '#comment':
-            nodeVisitor = visitor.Comment;
-            break;
-
-        case '#text':
-            nodeVisitor = visitor.Text;
-            break;
-
-        case '#document-fragment':
-            break;
-
-        default:
-            nodeVisitor = visitor.Element;
-    }
-
-    if (nodeVisitor && nodeVisitor.enter) {
-        nodeVisitor.enter(node);
-    }
-
-    // Node children are accessed differently depending on the node type:
-    //  - standard elements have their children associated on the node itself
-    //  - while the template node children are present on the content property.
-    const children = treeAdapter.getChildNodes(treeAdapter.getTemplateContent(node) || node);
-
-    // Traverse the node children if necessary.
-    if (children !== undefined) {
-        for (const child of children) {
-            traverseHTML(child as parse5.AST.Default.Node, visitor);
-        }
-    }
-
-    if (nodeVisitor && nodeVisitor.exit) {
-        nodeVisitor.exit(node);
-    }
 }
 
 export function getSource(source: string, location: parse5.MarkupData.Location): string {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -189,18 +189,16 @@ export default function parse(source: string, state: State): TemplateParseResult
             treeAdapter.getTemplateContent(__original) ?? __original
         );
 
-        if (children !== undefined) {
-            for (const child of children) {
-                if (treeAdapter.isElementNode(child)) {
-                    const elmNode = parseElement(child, parent);
-                    parsedChildren.push(elmNode);
-                } else if (treeAdapter.isTextNode(child)) {
-                    const textNodes = parseText(child, parent);
-                    parsedChildren.push(...textNodes);
-                } else if (treeAdapter.isCommentNode(child) && preserveComments) {
-                    const commentNode = parseComment(child, parent);
-                    parsedChildren.push(commentNode);
-                }
+        for (const child of children) {
+            if (treeAdapter.isElementNode(child)) {
+                const elmNode = parseElement(child, parent);
+                parsedChildren.push(elmNode);
+            } else if (treeAdapter.isTextNode(child)) {
+                const textNodes = parseText(child, parent);
+                parsedChildren.push(...textNodes);
+            } else if (treeAdapter.isCommentNode(child) && preserveComments) {
+                const commentNode = parseComment(child, parent);
+                parsedChildren.push(commentNode);
             }
         }
 

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -171,13 +171,11 @@ export default function parse(source: string, state: State): TemplateParseResult
         applyKey(element);
         applyLwcDirectives(element);
         applyAttributes(element);
-        validateClosingTag(element);
         validateElement(element);
         validateAttributes(element);
         validateProperties(element);
 
         parseChildren(element);
-
         validateChildren(element);
 
         return element;
@@ -286,29 +284,6 @@ export default function parse(source: string, state: State): TemplateParseResult
             warnAt(ParserDiagnostics.MISSING_ROOT_TEMPLATE_TAG);
         } else {
             return templateTag as parse5.AST.Default.Element;
-        }
-    }
-
-    function validateClosingTag(element: IRElement) {
-        const { startTag, endTag } = element.__original.__location!;
-
-        const isVoidElement = VOID_ELEMENT_SET.has(element.tag);
-        const missingClosingTag = !!startTag && !endTag;
-
-        if (!isVoidElement && missingClosingTag) {
-            addDiagnostic(
-                generateCompilerDiagnostic(ParserDiagnostics.NO_MATCHING_CLOSING_TAGS, {
-                    messageArgs: [element.tag],
-                    origin: {
-                        location: {
-                            line: startTag.startLine || startTag.line,
-                            column: startTag.startCol || startTag.col,
-                            start: startTag.startOffset,
-                            length: startTag.endOffset - startTag.startOffset,
-                        },
-                    },
-                })
-            );
         }
     }
 
@@ -804,9 +779,9 @@ export default function parse(source: string, state: State): TemplateParseResult
 
         const { startTag, endTag } = node.__location!;
         const isVoidElement = VOID_ELEMENT_SET.has(element.tag);
-        const missingClosingTag = !!startTag && !endTag;
+        const hasClosingTag = !!startTag && endTag;
 
-        if (!isVoidElement && missingClosingTag) {
+        if (!isVoidElement && !hasClosingTag) {
             addDiagnostic(
                 generateCompilerDiagnostic(ParserDiagnostics.NO_MATCHING_CLOSING_TAGS, {
                     messageArgs: [element.tag],

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -186,22 +186,19 @@ export default function parse(source: string, state: State): TemplateParseResult
 
         const parsedChildren: IRNode[] = [];
         const children = treeAdapter.getChildNodes(
-            treeAdapter.getTemplateContent(__original) || __original
+            treeAdapter.getTemplateContent(__original) ?? __original
         );
 
         if (children !== undefined) {
             for (const child of children) {
                 if (treeAdapter.isElementNode(child)) {
-                    const elmNode = parseElement(child as parse5.AST.Default.Element, parent);
+                    const elmNode = parseElement(child, parent);
                     parsedChildren.push(elmNode);
                 } else if (treeAdapter.isTextNode(child)) {
-                    const textNodes = parseText(child as parse5.AST.Default.TextNode, parent);
+                    const textNodes = parseText(child, parent);
                     parsedChildren.push(...textNodes);
                 } else if (treeAdapter.isCommentNode(child) && preserveComments) {
-                    const commentNode = parseComment(
-                        child as parse5.AST.Default.CommentNode,
-                        parent
-                    );
+                    const commentNode = parseComment(child, parent);
                     parsedChildren.push(commentNode);
                 }
             }
@@ -268,22 +265,19 @@ export default function parse(source: string, state: State): TemplateParseResult
         const validRoots = documentFragment.childNodes.filter(
             (child) =>
                 treeAdapter.isElementNode(child) ||
-                (treeAdapter.isTextNode(child) &&
-                    treeAdapter.getTextNodeContent(child).trim().length)
+                (treeAdapter.isTextNode(child) && child.value.trim().length)
         );
 
         if (validRoots.length > 1) {
             warnOnElement(ParserDiagnostics.MULTIPLE_ROOTS_FOUND, documentFragment.childNodes[1]);
         }
 
-        const templateTag = documentFragment.childNodes.find((child) =>
-            treeAdapter.isElementNode(child)
-        );
+        const [root] = validRoots;
 
-        if (!templateTag) {
+        if (!root || !treeAdapter.isElementNode(root)) {
             warnAt(ParserDiagnostics.MISSING_ROOT_TEMPLATE_TAG);
         } else {
-            return templateTag as parse5.AST.Default.Element;
+            return root;
         }
     }
 

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -906,7 +906,6 @@ export default function parse(source: string, state: State): TemplateParseResult
     function validateProperties(element: IRElement) {
         const { tag, props, __original: node } = element;
 
-
         if (props !== undefined) {
             for (const propName in props) {
                 const { name: attrName, type, value } = props[propName];
@@ -1000,7 +999,11 @@ export default function parse(source: string, state: State): TemplateParseResult
         }
     }
 
-    function warnOnElement(errorInfo: LWCErrorInfo, node: parse5.AST.Default.Node, messageArgs?: any[]) {
+    function warnOnElement(
+        errorInfo: LWCErrorInfo,
+        node: parse5.AST.Default.Node,
+        messageArgs?: any[]
+    ) {
         const getLocation = (
             toLocate?: parse5.AST.Node
         ): { line: number; column: number; start: number; length: number } => {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -85,6 +85,7 @@ import {
     SUPPORTED_SVG_TAGS,
     SVG_NAMESPACE_URI,
     VALID_IF_MODIFIER,
+    VOID_ELEMENT_SET,
 } from './constants';
 
 function isStyleElement(irElement: IRElement) {
@@ -186,6 +187,7 @@ export default function parse(source: string, state: State): TemplateParseResult
                 }
 
                 validateInlineStyleElement(element);
+                validateClosingTag(element);
 
                 applyForEach(element);
                 applyIterator(element);

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -16,31 +16,37 @@ import {
     IRComment,
 } from './types';
 
-export function createElement(original: HTMLElement): IRElement {
+export function createElement(original: HTMLElement, parent?: IRElement): IRElement {
     return {
         type: 'element',
-        __original: original,
-
         tag: original.tagName,
         namespace: original.namespaceURI,
-        attrsList: [],
+        attrsList: original.attrs,
+        parent,
         children: [],
+        __original: original,
     };
 }
 
-export function createText(original: HTMLText, value: string | TemplateExpression): IRText {
+export function createText(
+    original: HTMLText,
+    parent: IRElement,
+    value: string | TemplateExpression
+): IRText {
     return {
         type: 'text',
-        __original: original,
+        parent,
         value,
+        __original: original,
     };
 }
 
-export function createComment(original: HTMLComment, value: string): IRComment {
+export function createComment(original: HTMLComment, parent: IRElement, value: string): IRComment {
     return {
         type: 'comment',
-        __original: original,
+        parent,
         value,
+        __original: original,
     };
 }
 

--- a/packages/@lwc/template-compiler/typings/parse5.d.ts
+++ b/packages/@lwc/template-compiler/typings/parse5.d.ts
@@ -7,13 +7,6 @@
 import 'parse5-with-errors';
 
 declare module 'parse5-with-errors' {
-    export namespace Errors {
-        export class ParsingError {
-            lwcCode: number;
-        }
-    }
-
-    // jsdom uses updated parse5 with a different interface
     export namespace MarkupData {
         export class StartTagLocation {
             startLine: number;
@@ -23,6 +16,19 @@ declare module 'parse5-with-errors' {
         export class Location {
             startLine: number;
             startCol: number;
+        }
+    }
+
+    export namespace AST {
+        export interface TreeAdapter {
+            getTemplateContent(
+                templateElement: AST.Default.Element
+            ): AST.Default.DocumentFragment | undefined;
+            getChildNodes(node: AST.Default.ParentNode): AST.Default.Node[];
+            isTextNode(node: AST.Default.Node): node is AST.Default.TextNode;
+            isCommentNode(node: AST.Default.Node): node is AST.Default.CommentNode;
+            isDocumentTypeNode(node: AST.Default.Node): node is AST.Default.DocumentType;
+            isElementNode(node: AST.Default.Node): node is AST.Default.Element;
         }
     }
 }


### PR DESCRIPTION
## Details

This PR is in preparation for LWC template compiler rework. It changes the way the parse5 AST is turned into an LWC AST. 

Today the template compiler uses a visitor pattern with a stack to convert each pasrse5 AST node into the "equivalent" LWC template AST node. Using a visitor pattern to map from one AST shape to another creates more issues than it resolves: complex control flow, requires to keep a stack to track parents, etc.

In this PR, the visitor traversal is turned into a simple recursive traversal.  

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 