### PR TITLE
refactor: move elementFromPoint into shared function

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -35,7 +35,7 @@ import {
 } from './traverse';
 import { getTextContent } from '../3rdparty/polymer/text-content';
 import { createStaticNodeList } from '../shared/static-node-list';
-import { DocumentPrototypeActiveElement, elementFromPoint, createComment } from '../env/document';
+import { DocumentPrototypeActiveElement, createComment } from '../env/document';
 import {
     compareDocumentPosition,
     DOCUMENT_POSITION_CONTAINED_BY,
@@ -49,10 +49,9 @@ import {
     COMMENT_NODE,
 } from '../env/node';
 import { isInstanceOfNativeShadowRoot, isNativeShadowRootDefined } from '../env/shadow-root';
+import { fauxElementFromPoint } from '../shared/faux-element-from-point';
 import { createStaticHTMLCollection } from '../shared/static-html-collection';
 import { getOuterHTML } from '../3rdparty/polymer/outer-html';
-import { retarget } from '../3rdparty/polymer/retarget';
-import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { getInternalChildNodes } from './node';
 import { innerHTMLSetter } from '../env/element';
 import { setNodeKey, setNodeOwnerKey } from '../shared/node-ownership';
@@ -226,11 +225,7 @@ const ShadowRootDescriptors = {
         value(this: SyntheticShadowRootInterface, left: number, top: number) {
             const host = getHost(this);
             const doc = getOwnerDocument(host);
-            const element = elementFromPoint.call(doc, left, top);
-            if (isNull(element)) {
-                return element;
-            }
-            return retarget(this, pathComposer(element, true)) as Element | null;
+            return fauxElementFromPoint(this, doc, left, top);
         },
     },
     elementsFromPoint: {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/document-shadow/polyfill.ts
@@ -14,7 +14,6 @@ import {
     isUndefined,
 } from '@lwc/shared';
 import {
-    elementFromPoint,
     DocumentPrototypeActiveElement,
     getElementById as documentGetElementById,
     getElementsByClassName as documentGetElementsByClassName,
@@ -24,24 +23,17 @@ import {
     querySelectorAll as documentQuerySelectorAll,
 } from '../../env/document';
 import { parentElementGetter } from '../../env/node';
-import { retarget } from '../../3rdparty/polymer/retarget';
-import { pathComposer } from '../../3rdparty/polymer/path-composer';
+import { fauxElementFromPoint } from '../../shared/faux-element-from-point';
 import { getNodeOwnerKey } from '../../shared/node-ownership';
 import { createStaticNodeList } from '../../shared/static-node-list';
 import { createStaticHTMLCollection } from '../../shared/static-html-collection';
 import { arrayFromCollection, isGlobalPatchingSkipped } from '../../shared/utils';
 
 function elemFromPoint(this: Document, left: number, top: number) {
-    const element = elementFromPoint.call(this, left, top);
-    if (isNull(element)) {
-        return element;
-    }
-
-    return retarget(this, pathComposer(element, true)) as Element | null;
+    return fauxElementFromPoint(this, this, left, top);
 }
 
-// https://github.com/Microsoft/TypeScript/issues/14139
-Document.prototype.elementFromPoint = elemFromPoint as (left: number, top: number) => Element;
+Document.prototype.elementFromPoint = elemFromPoint;
 
 // Go until we reach to top of the LWC tree
 defineProperty(Document.prototype, 'activeElement', {

--- a/packages/@lwc/synthetic-shadow/src/shared/faux-element-from-point.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/faux-element-from-point.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isNull } from '@lwc/shared';
+import { elementFromPoint } from '../env/document';
+import { retarget } from '../3rdparty/polymer/retarget';
+import { pathComposer } from '../3rdparty/polymer/path-composer';
+
+export function fauxElementFromPoint(
+    context: Node,
+    doc: Document,
+    left: number,
+    top: number
+): Element | null {
+    const element: Element | null = elementFromPoint.call(doc, left, top);
+    if (isNull(element)) {
+        return element;
+    }
+
+    return retarget(context, pathComposer(element, true)) as Element | null;
+}


### PR DESCRIPTION
## Details

Follow-up to #2381. Refactors `elementFromPoint` so that the logic is shared between `document.elementFromPoint` and `ShadowRoot.elementFromPoint`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`
