### PR TITLE
perf(engine): Remove VNodes traversal for SVG elements

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -80,7 +80,7 @@ export interface VNodeData {
     styleMap?: VNodeStyle;
     context?: CustomElementContext;
     on?: On;
-    ns?: string; // for SVGs
+    svg?: boolean;
 }
 
 export interface Hooks<N extends VNode> {

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -19,7 +19,6 @@ import {
     isTrue,
     isUndefined,
     KEY__SHADOW_RESOLVER,
-    StringCharCodeAt,
     StringReplace,
     toString,
 } from '@lwc/shared';
@@ -102,10 +101,6 @@ export interface RenderAPI {
     co(text: string): VComment;
 }
 
-const CHAR_S = 115;
-const CHAR_V = 118;
-const CHAR_G = 103;
-const NamespaceAttributeForSVG = 'http://www.w3.org/2000/svg';
 const SymbolIterator = Symbol.iterator;
 
 const TextHook: Hooks<VText> = {
@@ -148,10 +143,10 @@ const ElementHook: Hooks<VElement> = {
         const {
             sel,
             owner,
-            data: { ns },
+            data: { svg },
         } = vnode;
         const { renderer } = owner;
-        const elm = renderer.createElement(sel, ns);
+        const elm = renderer.createElement(sel, svg);
 
         linkNodeToShadow(elm, owner);
         fallbackElmHook(elm, vnode);
@@ -263,21 +258,6 @@ function linkNodeToShadow(elm: Node, owner: VM) {
     }
 }
 
-// TODO [#1136]: this should be done by the compiler, adding ns to every sub-element
-function addNS(vnode: VElement) {
-    const { data, children, sel } = vnode;
-    data.ns = NamespaceAttributeForSVG;
-    // TODO [#1275]: review why `sel` equal `foreignObject` should get this `ns`
-    if (isArray(children) && sel !== 'foreignObject') {
-        for (let j = 0, n = children.length; j < n; ++j) {
-            const childNode = children[j];
-            if (childNode != null && childNode.hook === ElementHook) {
-                addNS(childNode as VElement);
-            }
-        }
-    }
-}
-
 function addVNodeToChildLWC(vnode: VCustomElement) {
     ArrayPush.call(getVMBeingRendered()!.velements, vnode);
 }
@@ -323,9 +303,11 @@ export function h(sel: string, data: ElementCompilerData, children: VNodes): VEl
             }
         });
     }
-    const { key } = data;
+
     let text, elm;
-    const vnode: VElement = {
+    const { key } = data;
+
+    return {
         sel,
         data,
         children,
@@ -335,15 +317,6 @@ export function h(sel: string, data: ElementCompilerData, children: VNodes): VEl
         hook: ElementHook,
         owner: vmBeingRendered,
     };
-    if (
-        sel.length === 3 &&
-        StringCharCodeAt.call(sel, 0) === CHAR_S &&
-        StringCharCodeAt.call(sel, 1) === CHAR_V &&
-        StringCharCodeAt.call(sel, 2) === CHAR_G
-    ) {
-        addNS(vnode);
-    }
-    return vnode;
 }
 
 // [t]ab[i]ndex function

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -101,6 +101,7 @@ export interface RenderAPI {
     co(text: string): VComment;
 }
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 const SymbolIterator = Symbol.iterator;
 
 const TextHook: Hooks<VText> = {
@@ -146,7 +147,9 @@ const ElementHook: Hooks<VElement> = {
             data: { svg },
         } = vnode;
         const { renderer } = owner;
-        const elm = renderer.createElement(sel, svg);
+
+        const namespace = isTrue(svg) ? SVG_NAMESPACE : undefined;
+        const elm = renderer.createElement(sel, namespace);
 
         linkNodeToShadow(elm, owner);
         fallbackElmHook(elm, vnode);

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -13,7 +13,7 @@ export interface Renderer<N = HostNode, E = HostElement> {
     syntheticShadow: boolean;
     insert(node: N, parent: E, anchor: N | null): void;
     remove(node: N, parent: E): void;
-    createElement(tagName: string, namespace?: string): E;
+    createElement(tagName: string, isSvg?: boolean): E;
     createText(content: string): N;
     createComment(content: string): N;
     nextSibling(node: N): N | null;

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -13,7 +13,7 @@ export interface Renderer<N = HostNode, E = HostElement> {
     syntheticShadow: boolean;
     insert(node: N, parent: E, anchor: N | null): void;
     remove(node: N, parent: E): void;
-    createElement(tagName: string, isSvg?: boolean): E;
+    createElement(tagName: string, namespace?: string): E;
     createText(content: string): N;
     createComment(content: string): N;
     nextSibling(node: N): N | null;

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -28,6 +28,7 @@ if (process.env.NODE_ENV === 'development') {
     };
 }
 
+const svgNS = 'http://www.w3.org/2000/svg';
 const globalStylesheetsParentElement: Element = document.head || document.body || document;
 
 let getCustomElement, defineCustomElement, HTMLElementConstructor;
@@ -95,10 +96,8 @@ export const renderer: Renderer<Node, Element> = {
 
     syntheticShadow: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
 
-    createElement(tagName: string, namespace: string): Element {
-        return isUndefined(namespace)
-            ? document.createElement(tagName)
-            : document.createElementNS(namespace, tagName);
+    createElement(tagName: string, isSVG: boolean): Element {
+        return isSVG ? document.createElementNS(svgNS, tagName) : document.createElement(tagName);
     },
 
     createText(content: string): Node {

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -28,7 +28,6 @@ if (process.env.NODE_ENV === 'development') {
     };
 }
 
-const svgNS = 'http://www.w3.org/2000/svg';
 const globalStylesheetsParentElement: Element = document.head || document.body || document;
 
 let getCustomElement, defineCustomElement, HTMLElementConstructor;
@@ -96,8 +95,10 @@ export const renderer: Renderer<Node, Element> = {
 
     syntheticShadow: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
 
-    createElement(tagName: string, isSVG: boolean): Element {
-        return isSVG ? document.createElementNS(svgNS, tagName) : document.createElement(tagName);
+    createElement(tagName: string, namespace: string): Element {
+        return isUndefined(namespace)
+            ? document.createElement(tagName)
+            : document.createElementNS(namespace, tagName);
     },
 
     createText(content: string): Node {

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -19,7 +19,6 @@ import { HostElement, HostNodeType } from '../types';
 const FakeRootElement: HostElement = {
     type: HostNodeType.Element,
     name: 'fake-root-element',
-    namespace: 'ssr',
     parent: null,
     shadowRoot: null,
     children: [],

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -25,11 +25,10 @@ function unsupportedMethod(name: string): () => never {
     };
 }
 
-function createElement(name: string, namespace?: string): HostElement {
+function createElement(name: string): HostElement {
     return {
         type: HostNodeType.Element,
         name,
-        namespace,
         parent: null,
         shadowRoot: null,
         children: [],

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -42,7 +42,6 @@ export interface HostElement {
     name: string;
     parent: HostElement | null;
     shadowRoot: HostShadowRoot | null;
-    namespace?: string;
     children: HostChildNode[];
     attributes: HostAttribute[];
     eventListeners: Record<string, Function[]>;

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -67,6 +67,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           focusable: "true",
         },
         key: 3,
+        svg: true,
       },
       [
         api_element(
@@ -81,6 +82,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 4,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
@@ -6,6 +6,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "svg",
       {
         key: 0,
+        svg: true,
       },
       api_iterator($cmp.lines, function (line) {
         return api_element(
@@ -18,6 +19,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               y2: line.y2,
             },
             key: api_key(1, line.key),
+            svg: true,
           },
           []
         );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -13,6 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "aria-hidden": "true",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
@@ -27,6 +28,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 1,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -11,12 +11,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           xmlns: "http://www.w3.org/2000/svg",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
           "defs",
           {
             key: 1,
+            svg: true,
           },
           [
             api_element(
@@ -31,6 +33,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   primitiveUnits: "objectBoundingBox",
                 },
                 key: 2,
+                svg: true,
               },
               [
                 api_element(
@@ -45,6 +48,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       "flood-opacity": "0.75",
                     },
                     key: 3,
+                    svg: true,
                   },
                   []
                 ),
@@ -58,6 +62,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   primitiveUnits: "objectBoundingBox",
                 },
                 key: 4,
+                svg: true,
               },
               [
                 api_element(
@@ -72,6 +77,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       mode: "multiply",
                     },
                     key: 5,
+                    svg: true,
                   },
                   []
                 ),
@@ -85,6 +91,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   primitiveUnits: "objectBoundingBox",
                 },
                 key: 6,
+                svg: true,
               },
               [
                 api_element(
@@ -97,6 +104,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       height: "50%",
                     },
                     key: 7,
+                    svg: true,
                   },
                   [
                     api_element(
@@ -106,6 +114,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                           in: "SourceGraphic",
                         },
                         key: 8,
+                        svg: true,
                       },
                       []
                     ),
@@ -116,6 +125,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                           in: "FillPaint",
                         },
                         key: 9,
+                        svg: true,
                       },
                       []
                     ),
@@ -134,6 +144,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               "stroke-width": "4",
             },
             key: 10,
+            svg: true,
           },
           [
             api_element(
@@ -144,6 +155,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   height: "200",
                 },
                 key: 11,
+                svg: true,
               },
               []
             ),
@@ -155,6 +167,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   y2: "200",
                 },
                 key: 12,
+                svg: true,
               },
               []
             ),
@@ -166,6 +179,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   y2: "200",
                 },
                 key: 13,
+                svg: true,
               },
               []
             ),
@@ -182,6 +196,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               r: "90",
             },
             key: 14,
+            svg: true,
           },
           []
         ),
@@ -192,6 +207,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               transform: "translate(200 0)",
             },
             key: 15,
+            svg: true,
           },
           [
             api_element(
@@ -203,6 +219,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   "stroke-width": "4",
                 },
                 key: 16,
+                svg: true,
               },
               [
                 api_element(
@@ -213,6 +230,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       height: "200",
                     },
                     key: 17,
+                    svg: true,
                   },
                   []
                 ),
@@ -224,6 +242,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       y2: "200",
                     },
                     key: 18,
+                    svg: true,
                   },
                   []
                 ),
@@ -235,6 +254,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       y2: "200",
                     },
                     key: 19,
+                    svg: true,
                   },
                   []
                 ),
@@ -251,6 +271,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   r: "90",
                 },
                 key: 20,
+                svg: true,
               },
               []
             ),
@@ -263,6 +284,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               transform: "translate(0 200)",
             },
             key: 21,
+            svg: true,
           },
           [
             api_element(
@@ -274,6 +296,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   "stroke-width": "4",
                 },
                 key: 22,
+                svg: true,
               },
               [
                 api_element(
@@ -284,6 +307,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       height: "200",
                     },
                     key: 23,
+                    svg: true,
                   },
                   []
                 ),
@@ -295,6 +319,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       y2: "200",
                     },
                     key: 24,
+                    svg: true,
                   },
                   []
                 ),
@@ -306,6 +331,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       y2: "200",
                     },
                     key: 25,
+                    svg: true,
                   },
                   []
                 ),
@@ -323,6 +349,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   r: "90",
                 },
                 key: 26,
+                svg: true,
               },
               []
             ),
@@ -341,6 +368,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "xmlns:xlink": "http://www.w3.org/1999/xlink",
         },
         key: 27,
+        svg: true,
       },
       [
         api_element(
@@ -355,6 +383,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               height: "248",
             },
             key: 28,
+            svg: true,
           },
           []
         ),
@@ -362,6 +391,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "g",
           {
             key: 29,
+            svg: true,
           },
           [
             api_element(
@@ -375,6 +405,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   filter: "url(#Default)",
                 },
                 key: 30,
+                svg: true,
               },
               []
             ),
@@ -390,6 +421,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   stroke: "green",
                 },
                 key: 31,
+                svg: true,
               },
               []
             ),
@@ -404,6 +436,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   filter: "url(#Fitted)",
                 },
                 key: 32,
+                svg: true,
               },
               []
             ),
@@ -419,6 +452,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   stroke: "green",
                 },
                 key: 33,
+                svg: true,
               },
               []
             ),
@@ -433,6 +467,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   filter: "url(#Shifted)",
                 },
                 key: 34,
+                svg: true,
               },
               []
             ),
@@ -448,6 +483,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   stroke: "green",
                 },
                 key: 35,
+                svg: true,
               },
               []
             ),
@@ -465,12 +501,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               height: "120",
             },
             key: 36,
+            svg: true,
           },
           [
             api_element(
               "desc",
               {
                 key: 37,
+                svg: true,
               },
               [api_text("Produces a 3D lighting effect.")]
             ),
@@ -483,6 +521,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   result: "blur",
                 },
                 key: 38,
+                svg: true,
               },
               []
             ),
@@ -496,6 +535,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   result: "offsetBlur",
                 },
                 key: 39,
+                svg: true,
               },
               []
             ),
@@ -511,6 +551,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   result: "specOut",
                 },
                 key: 40,
+                svg: true,
               },
               [
                 api_element(
@@ -522,6 +563,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       z: "20000",
                     },
                     key: 41,
+                    svg: true,
                   },
                   []
                 ),
@@ -537,6 +579,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   result: "specOut",
                 },
                 key: 42,
+                svg: true,
               },
               []
             ),
@@ -554,6 +597,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   result: "litPaint",
                 },
                 key: 43,
+                svg: true,
               },
               []
             ),
@@ -561,6 +605,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               "feMerge",
               {
                 key: 44,
+                svg: true,
               },
               [
                 api_element(
@@ -570,6 +615,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       in: "offsetBlur",
                     },
                     key: 45,
+                    svg: true,
                   },
                   []
                 ),
@@ -580,6 +626,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       in: "litPaint",
                     },
                     key: 46,
+                    svg: true,
                   },
                   []
                 ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -16,6 +16,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               height: "180",
             },
             key: 1,
+            svg: true,
           },
           [
             api_element(
@@ -25,6 +26,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   transform: "translate(3,3)",
                 },
                 key: 2,
+                svg: true,
               },
               [
                 api_element(
@@ -34,6 +36,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       transform: "translate(250,0)",
                     },
                     key: 3,
+                    svg: true,
                   },
                   [
                     api_element(
@@ -45,6 +48,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                           "xlink:href": "javascript:alert(1)",
                         },
                         key: 4,
+                        svg: true,
                       },
                       [
                         api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -10,12 +10,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           width: "400",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
           "defs",
           {
             key: 1,
+            svg: true,
           },
           [
             api_element(
@@ -29,6 +31,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   y2: "0%",
                 },
                 key: 2,
+                svg: true,
               },
               [
                 api_element(
@@ -42,6 +45,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       offset: "0%",
                     },
                     key: 3,
+                    svg: true,
                   },
                   []
                 ),
@@ -56,6 +60,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                       offset: "100%",
                     },
                     key: 4,
+                    svg: true,
                   },
                   []
                 ),
@@ -74,6 +79,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               fill: "url(#grad1)",
             },
             key: 5,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
@@ -11,12 +11,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           viewport: "0 0 100 100",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
           "defs",
           {
             key: 1,
+            svg: true,
           },
           [
             api_element(
@@ -30,6 +32,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   fill: "black",
                 },
                 key: 2,
+                svg: true,
               },
               []
             ),
@@ -44,6 +47,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   fill: "red",
                 },
                 key: 3,
+                svg: true,
               },
               []
             ),
@@ -61,6 +65,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 4,
+            svg: true,
           },
           []
         ),
@@ -76,6 +81,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 5,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
@@ -11,12 +11,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           viewport: "0 0 100 100",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
           "defs",
           {
             key: 1,
+            svg: true,
           },
           [
             api_element(
@@ -30,6 +32,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   fill: "black",
                 },
                 key: 2,
+                svg: true,
               },
               []
             ),
@@ -44,6 +47,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   fill: "red",
                 },
                 key: 3,
+                svg: true,
               },
               []
             ),
@@ -61,6 +65,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 4,
+            svg: true,
           },
           []
         ),
@@ -76,6 +81,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 5,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -13,6 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           xmlns: "http://www.w3.org/2000/svg",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
@@ -24,6 +25,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               fill: "red",
             },
             key: 1,
+            svg: true,
           },
           []
         ),
@@ -37,6 +39,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               fill: "green",
             },
             key: 2,
+            svg: true,
           },
           []
         ),
@@ -51,6 +54,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               fill: "white",
             },
             key: 3,
+            svg: true,
           },
           [api_text("SVG")]
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -10,6 +10,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           height: "200",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
@@ -23,6 +24,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               width: "200",
             },
             key: 1,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -6,12 +6,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "svg",
       {
         key: 0,
+        svg: true,
       },
       [
         api_element(
           "a",
           {
             key: 1,
+            svg: true,
           },
           []
         ),
@@ -19,6 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "circle",
           {
             key: 2,
+            svg: true,
           },
           []
         ),
@@ -26,6 +29,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "defs",
           {
             key: 3,
+            svg: true,
           },
           []
         ),
@@ -33,6 +37,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "desc",
           {
             key: 4,
+            svg: true,
           },
           []
         ),
@@ -40,6 +45,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "ellipse",
           {
             key: 5,
+            svg: true,
           },
           []
         ),
@@ -47,6 +53,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "filter",
           {
             key: 6,
+            svg: true,
           },
           []
         ),
@@ -54,6 +61,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "g",
           {
             key: 7,
+            svg: true,
           },
           []
         ),
@@ -61,6 +69,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "line",
           {
             key: 8,
+            svg: true,
           },
           []
         ),
@@ -68,6 +77,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "marker",
           {
             key: 9,
+            svg: true,
           },
           []
         ),
@@ -75,6 +85,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "mask",
           {
             key: 10,
+            svg: true,
           },
           []
         ),
@@ -82,6 +93,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "path",
           {
             key: 11,
+            svg: true,
           },
           []
         ),
@@ -89,6 +101,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "pattern",
           {
             key: 12,
+            svg: true,
           },
           []
         ),
@@ -96,6 +109,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "polygon",
           {
             key: 13,
+            svg: true,
           },
           []
         ),
@@ -103,6 +117,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "polyline",
           {
             key: 14,
+            svg: true,
           },
           []
         ),
@@ -110,6 +125,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "rect",
           {
             key: 15,
+            svg: true,
           },
           []
         ),
@@ -117,6 +133,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "stop",
           {
             key: 16,
+            svg: true,
           },
           []
         ),
@@ -124,6 +141,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "symbol",
           {
             key: 17,
+            svg: true,
           },
           []
         ),
@@ -131,6 +149,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "text",
           {
             key: 18,
+            svg: true,
           },
           []
         ),
@@ -138,6 +157,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "title",
           {
             key: 19,
+            svg: true,
           },
           []
         ),
@@ -145,6 +165,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "tspan",
           {
             key: 20,
+            svg: true,
           },
           []
         ),
@@ -152,6 +173,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           "use",
           {
             key: 21,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
@@ -13,6 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           title: "when needed",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
@@ -27,6 +28,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 1,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -13,6 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           title: "when needed",
         },
         key: 0,
+        svg: true,
       },
       [
         api_element(
@@ -27,6 +28,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               ),
             },
             key: 1,
+            svg: true,
           },
           []
         ),

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -51,6 +51,7 @@ import {
     isIdReferencingAttribute,
     isSvgUseHref,
 } from '../parser/attribute';
+import { SVG_NAMESPACE_URI } from '../parser/constants';
 
 function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expression {
     function transformElement(element: IRElement): t.Expression {
@@ -424,6 +425,11 @@ function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expressio
                 return memorizeHandler(codeGen, element, componentHandler, handler);
             });
             data.push(t.property(t.identifier('on'), onObj));
+        }
+
+        // SVG handling
+        if (element.namespace === SVG_NAMESPACE_URI) {
+            data.push(t.property(t.identifier('svg'), t.literal(true)));
         }
 
         return t.objectExpression(data);

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -176,7 +176,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             enter(node) {
                 const elementNode = node as parse5.AST.Default.Element;
 
-                const element = createElement(elementNode.tagName, node);
+                const element = createElement(node);
                 element.attrsList = elementNode.attrs;
 
                 if (!root) {

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -16,12 +16,13 @@ import {
     IRComment,
 } from './types';
 
-export function createElement(tag: string, original: HTMLElement): IRElement {
+export function createElement(original: HTMLElement): IRElement {
     return {
         type: 'element',
         __original: original,
 
-        tag,
+        tag: original.tagName,
+        namespace: original.namespaceURI,
         attrsList: [],
         children: [],
     };

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -29,9 +29,9 @@ export type TemplateParseResult = {
     warnings: CompilerDiagnostic[];
 };
 
-export type HTMLComment = parse5.AST.CommentNode;
-export type HTMLText = parse5.AST.TextNode;
-export type HTMLElement = parse5.AST.Element;
+export type HTMLComment = parse5.AST.Default.CommentNode;
+export type HTMLText = parse5.AST.Default.TextNode;
+export type HTMLElement = parse5.AST.Default.Element;
 export type HTMLNode = HTMLElement | HTMLComment | HTMLText;
 
 export interface SlotDefinition {
@@ -74,6 +74,7 @@ export interface LWCDirectives {
 export interface IRElement {
     type: 'element';
     tag: string;
+    namespace: string;
 
     attrsList: parse5.AST.Default.Attribute[];
 


### PR DESCRIPTION
## Details

This PR removes the runtime VNodes traversal when rendering SVG elements. A new optional `svg` property is added to the `data` object by the compiler, this property indicated whether the element should be created under the SVG namespace or not.

The special handling for `foreignObject` has been removed since this tag can only belong to the SVG namespace. I traced back the addition of this branch back to 2017. Back then we still used a JSX parser for the template which didn't have namespace information. Now that we are using parse5, I don't see the value of keeping this special case around.

Fix #1275, #1136.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
