### PR TITLE
fix: fix incosistent attribute behavior for undefined attrs

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -56,7 +56,7 @@ function updateAttrs(oldVnode: VElement, vnode: VElement) {
             } else if (StringCharCodeAt.call(key, 5) === ColonCharCode) {
                 // Assume xlink namespace
                 setAttribute(elm, key, cur as string, xlinkNS);
-            } else if (isNull(cur)) {
+            } else if (isNull(cur) || isUndefined(cur)) {
                 removeAttribute(elm, key);
             } else {
                 setAttribute(elm, key, cur as string);

--- a/packages/integration-karma/test/template/attributes/index.spec.js
+++ b/packages/integration-karma/test/template/attributes/index.spec.js
@@ -33,10 +33,10 @@ it(`should remove the existing attribute if set to null`, () => {
 
 it(`should remove the existing attribute if set to undefined`, () => {
     const elm = createElement('x-test', { is: Test });
-    elm.attr = 'initial value';
+    elm.attr = undefined;
     document.body.appendChild(elm);
 
-    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial value');
+    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
 
     elm.attr = undefined;
     return Promise.resolve().then(() => {

--- a/packages/integration-karma/test/template/attributes/index.spec.js
+++ b/packages/integration-karma/test/template/attributes/index.spec.js
@@ -33,10 +33,10 @@ it(`should remove the existing attribute if set to null`, () => {
 
 it(`should remove the existing attribute if set to undefined`, () => {
     const elm = createElement('x-test', { is: Test });
-    elm.attr = undefined;
+    elm.attr = 'initial value';
     document.body.appendChild(elm);
 
-    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
+    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial value');
 
     elm.attr = undefined;
     return Promise.resolve().then(() => {

--- a/packages/integration-karma/test/template/attributes/index.spec.js
+++ b/packages/integration-karma/test/template/attributes/index.spec.js
@@ -30,3 +30,17 @@ it(`should remove the existing attribute if set to null`, () => {
         expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
     });
 });
+
+it(`should remove the existing attribute if set to undefined`, () => {
+    const elm = createElement('x-test', { is: Test });
+    elm.attr = 'initial value';
+    document.body.appendChild(elm);
+
+    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial value');
+
+    elm.attr = undefined;
+    return Promise.resolve().then(() => {
+        expect(elm.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
+        expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
+    });
+});


### PR DESCRIPTION
## Details
If the initial value of an attr is `undefined`, we don't add the attribute. But if we assign it to something else and then assign it back to undefined, we don't remove the attribute. We set it to the string `'undefined'`. This fix, removes the attribute, maintaining it consistent with the initial case.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅

## GUS work item
<!--Work ID in text, no links -->
