### PR TITLE
refactor(template-compiler): Move all LWC directives to the LWC AST

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -488,7 +488,8 @@ export const ParserDiagnostics = {
 
     LWC_RENDER_MODE_INVALID_VALUE: {
         code: 1133,
-        message: 'Invalid value for "lwc:render-mode". \'lwc:render-mode\' can only be set to {0}',
+        message:
+            'Invalid value for "lwc:render-mode". \'lwc:render-mode\' can only be set to "shadow", or "light"',
         level: DiagnosticLevel.Error,
         url: '',
     },

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -50,8 +50,23 @@ const RENDER_APIS: { [primitive in RenderPrimitive]: RenderPrimitiveDefinition }
 };
 
 export default class CodeGen {
+    /** The AST root. */
+    readonly root: IRElement;
+
+    /** The template render mode. */
     readonly renderMode: LWCDirectiveRenderMode;
+
+    /** Indicates wether the generated code should produce preserve HTML comments or not. */
     readonly preserveComments: boolean;
+
+    /**
+     * This flag indicates if a the generated code should scope the template fragment id. It is set
+     * to true if the template also contains ids.
+     *
+     * TODO [#1150]: Remove this code once we can figure out how to do this in a deterministic
+     * fashion.
+     */
+    readonly scopeFragmentId: boolean;
 
     currentId = 0;
     currentKey = 0;
@@ -64,9 +79,19 @@ export default class CodeGen {
     memorizedIds: t.Identifier[] = [];
     referencedComponents: Set<string> = new Set();
 
-    constructor({ root, config }: { root: IRElement; config: ResolvedConfig }) {
+    constructor({
+        root,
+        config,
+        scopeFragmentId,
+    }: {
+        root: IRElement;
+        config: ResolvedConfig;
+        scopeFragmentId: boolean;
+    }) {
+        this.root = root;
         this.renderMode = root.lwc?.renderMode ?? LWCDirectiveRenderMode.shadow;
-        this.preserveComments = root.lwc?.preserveComments ? true : config.preserveHtmlComments;
+        this.preserveComments = root.lwc?.preserveComments?.value ?? config.preserveHtmlComments;
+        this.scopeFragmentId = scopeFragmentId;
     }
 
     generateKey() {

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -56,12 +56,12 @@ export default class CodeGen {
     /** The template render mode. */
     readonly renderMode: LWCDirectiveRenderMode;
 
-    /** Indicates wether the generated code should produce preserve HTML comments or not. */
+    /** Indicates whether the generated code should preserve HTML comments or not. */
     readonly preserveComments: boolean;
 
     /**
-     * This flag indicates if a the generated code should scope the template fragment id. It is set
-     * to true if the template also contains ids.
+     * This flag indicates if the generated code should scope the template fragment id. It is set to
+     * true if the template also contains ids.
      *
      * TODO [#1150]: Remove this code once we can figure out how to do this in a deterministic
      * fashion.

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -5,8 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as esutils from 'esutils';
+import { ResolvedConfig } from '../config';
 
 import * as t from '../shared/estree';
+import { IRElement, LWCDirectiveRenderMode } from '../shared/types';
 import { toPropertyName } from '../shared/utils';
 
 type RenderPrimitive =
@@ -48,6 +50,9 @@ const RENDER_APIS: { [primitive in RenderPrimitive]: RenderPrimitiveDefinition }
 };
 
 export default class CodeGen {
+    readonly renderMode: LWCDirectiveRenderMode;
+    readonly preserveComments: boolean;
+
     currentId = 0;
     currentKey = 0;
 
@@ -58,6 +63,11 @@ export default class CodeGen {
     slotNames: Set<string> = new Set();
     memorizedIds: t.Identifier[] = [];
     referencedComponents: Set<string> = new Set();
+
+    constructor({ root, config }: { root: IRElement; config: ResolvedConfig }) {
+        this.renderMode = root.lwc?.renderMode ?? LWCDirectiveRenderMode.shadow;
+        this.preserveComments = root.lwc?.preserveComments ? true : config.preserveHtmlComments;
+    }
 
     generateKey() {
         return this.currentKey++;

--- a/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import State from '../../state';
 import * as t from '../../shared/estree';
 import { TEMPLATE_FUNCTION_NAME, TEMPLATE_MODULES_PARAMETER } from '../../shared/constants';
 
@@ -31,11 +30,7 @@ import { identifierFromComponentName, generateTemplateMetadata } from '../helper
  * return tmpl;
  * ```
  */
-export function format(
-    templateFn: t.FunctionDeclaration,
-    state: State,
-    codeGen: CodeGen
-): t.Program {
+export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
     const lookups = Array.from(codeGen.referencedComponents)
         .sort()
         .map((name) => {
@@ -51,7 +46,7 @@ export function format(
             ]);
         });
 
-    const metadata = generateTemplateMetadata(state, codeGen);
+    const metadata = generateTemplateMetadata(codeGen);
 
     return t.program([
         ...lookups,

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -14,7 +14,6 @@ import {
 
 import CodeGen from '../codegen';
 import { identifierFromComponentName, generateTemplateMetadata } from '../helpers';
-import State from '../../state';
 
 function generateComponentImports(codeGen: CodeGen): t.ImportDeclaration[] {
     return Array.from(codeGen.referencedComponents).map((name) => {
@@ -56,16 +55,12 @@ function generateLwcApisImport(codeGen: CodeGen): t.ImportDeclaration {
  * registerTemplate(tmpl);
  * ```
  */
-export function format(
-    templateFn: t.FunctionDeclaration,
-    state: State,
-    codeGen: CodeGen
-): t.Program {
+export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
     codeGen.usedLwcApis.add(SECURE_REGISTER_TEMPLATE_METHOD_NAME);
 
     const imports = [...generateComponentImports(codeGen), generateLwcApisImport(codeGen)];
 
-    const metadata = generateTemplateMetadata(state, codeGen);
+    const metadata = generateTemplateMetadata(codeGen);
 
     const templateBody = [
         templateFn,

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -56,7 +56,7 @@ export function shouldFlatten(children: IRNode[], codeGen: CodeGen): boolean {
 }
 
 /**
- * Returns true if the AST element or if any of its descendant uses an id attribute.
+ * Returns true if the AST element or any of its descendants use an id attribute.
  */
 export function hasIdAttribute(element: IRElement): boolean {
     if (element.attrs?.id || element.props?.id) {

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -55,6 +55,23 @@ export function shouldFlatten(children: IRNode[], codeGen: CodeGen): boolean {
     );
 }
 
+/**
+ * Returns true if the AST element or if any of its descendant uses an id attribute.
+ */
+export function hasIdAttribute(element: IRElement): boolean {
+    if (element.attrs?.id || element.props?.id) {
+        return true;
+    }
+
+    for (const child of element.children) {
+        if (child.type === 'element' && hasIdAttribute(child)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export function memorizeHandler(
     codeGen: CodeGen,
     element: IRElement,

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import State from '../state';
-
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
 import { IRElement, IRNode, LWCDirectiveRenderMode } from '../shared/types';
@@ -45,15 +43,15 @@ export function containsDynamicChildren(children: IRNode[]): boolean {
     return children.some((child) => isElement(child) && isDynamic(child));
 }
 
-export function shouldFlatten(children: IRNode[], state: State): boolean {
+export function shouldFlatten(children: IRNode[], codeGen: CodeGen): boolean {
     return children.some(
         (child) =>
             isElement(child) &&
             (isDynamic(child) ||
                 !!child.forEach ||
                 !!child.forOf ||
-                (state.renderMode === 'light' && child.tag === 'slot') ||
-                (isTemplate(child) && shouldFlatten(child.children, state)))
+                (codeGen.renderMode === LWCDirectiveRenderMode.light && child.tag === 'slot') ||
+                (isTemplate(child) && shouldFlatten(child.children, codeGen)))
     );
 }
 
@@ -82,7 +80,7 @@ export function memorizeHandler(
     return handler;
 }
 
-export function generateTemplateMetadata(state: State, codeGen: CodeGen): t.Statement[] {
+export function generateTemplateMetadata(codeGen: CodeGen): t.Statement[] {
     const metadataExpressions: t.Statement[] = [];
 
     if (codeGen.slotNames.size) {
@@ -109,7 +107,7 @@ export function generateTemplateMetadata(state: State, codeGen: CodeGen): t.Stat
     metadataExpressions.push(t.expressionStatement(stylesheetsMetadata));
 
     // ignore when shadow because we don't want to modify template unnecessarily
-    if (state.renderMode === LWCDirectiveRenderMode.light) {
+    if (codeGen.renderMode === LWCDirectiveRenderMode.light) {
         const renderModeMetadata = t.assignmentExpression(
             '=',
             t.memberExpression(t.identifier(TEMPLATE_FUNCTION_NAME), t.identifier('renderMode')),

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -9,7 +9,7 @@ import * as astring from 'astring';
 import { isBooleanAttribute } from '@lwc/shared';
 import { TemplateErrors, generateCompilerError } from '@lwc/errors';
 
-import State from '../state';
+import { ResolvedConfig } from '../config';
 
 import {
     isCommentNode,
@@ -39,6 +39,7 @@ import {
     containsDynamicChildren,
     parseClassNames,
     parseStyleText,
+    hasIdAttribute,
 } from './helpers';
 
 import { format as formatModule } from './formatters/module';
@@ -54,7 +55,7 @@ import {
 } from '../parser/attribute';
 import { SVG_NAMESPACE_URI } from '../parser/constants';
 
-function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expression {
+function transform(codeGen: CodeGen): t.Expression {
     function transformElement(element: IRElement): t.Expression {
         const databag = elementDataBag(element);
         let res: t.Expression;
@@ -292,7 +293,7 @@ function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expressio
                     return codeGen.genScopedId(expression);
                 }
                 if (
-                    state.shouldScopeFragmentId &&
+                    codeGen.scopeFragmentId &&
                     isAllowedFragOnlyUrlsXHTML(tagName, attr.name, namespaceURI)
                 ) {
                     return codeGen.genScopedFragId(expression);
@@ -329,7 +330,7 @@ function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expressio
                     return codeGen.genScopedId(attr.value);
                 }
                 if (
-                    state.shouldScopeFragmentId &&
+                    codeGen.scopeFragmentId &&
                     isAllowedFragOnlyUrlsXHTML(tagName, attr.name, namespaceURI) &&
                     isFragmentOnlyUrl(attr.value)
                 ) {
@@ -457,15 +458,11 @@ function transform(root: IRElement, codeGen: CodeGen, state: State): t.Expressio
         return t.objectExpression(data);
     }
 
-    return transformChildren(root.children);
+    return transformChildren(codeGen.root.children);
 }
 
-function generateTemplateFunction(
-    templateRoot: IRElement,
-    state: State,
-    codeGen: CodeGen
-): t.FunctionDeclaration {
-    const returnedValue = transform(templateRoot, codeGen, state);
+function generateTemplateFunction(codeGen: CodeGen): t.FunctionDeclaration {
+    const returnedValue = transform(codeGen);
 
     const args = [
         TEMPLATE_PARAMS.API,
@@ -528,16 +525,18 @@ function generateTemplateFunction(
     );
 }
 
-export default function (root: IRElement, state: State): string {
+export default function (root: IRElement, config: ResolvedConfig): string {
+    const scopeFragmentId = hasIdAttribute(root);
     const codeGen = new CodeGen({
         root,
-        config: state.config,
+        config,
+        scopeFragmentId,
     });
 
-    const templateFunction = generateTemplateFunction(root, state, codeGen);
+    const templateFunction = generateTemplateFunction(codeGen);
 
     let program: t.Program;
-    switch (state.config.format) {
+    switch (config.format) {
         case 'function':
             program = formatFunction(templateFunction, codeGen);
             break;

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -47,7 +47,7 @@ export default function compile(source: string, config: Config): TemplateCompile
         );
 
         if (!hasParsingError && parsingResults.root) {
-            code = generate(parsingResults.root, state);
+            code = generate(parsingResults.root, options);
         }
     } catch (error) {
         const diagnostic = normalizeToDiagnostic(ParserDiagnostics.GENERIC_PARSING_ERROR, error);
@@ -82,6 +82,6 @@ export function compileToFunction(source: string): Function {
         throw generateCompilerError(TemplateErrors.INVALID_TEMPLATE);
     }
 
-    const code = generate(parsingResults.root, state);
+    const code = generate(parsingResults.root, options);
     return new Function(TEMPLATE_MODULES_PARAMETER, code);
 }

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -50,7 +50,6 @@ import {
     IRExpressionAttribute,
     IRNode,
     IRText,
-    isLWCDirectiveRenderMode,
     LWCDirectiveDomMode,
     LWCDirectiveRenderMode,
     LWCDirectives,
@@ -135,28 +134,6 @@ export default function parse(source: string, state: State): TemplateParseResult
         return { warnings };
     }
 
-    const preserveComments =
-        templateRoot.attrs.some(
-            ({ name }) => name === ROOT_TEMPLATE_DIRECTIVES.PRESERVE_COMMENTS
-        ) || state.config.preserveHtmlComments;
-
-    const renderModeAttribute = templateRoot.attrs.find(
-        ({ name }) => name === ROOT_TEMPLATE_DIRECTIVES.RENDER_MODE
-    );
-    if (renderModeAttribute) {
-        const renderMode = renderModeAttribute.value;
-        if (isLWCDirectiveRenderMode(renderMode)) {
-            state.renderMode = renderMode;
-        } else {
-            const possibleValues = Object.values(LWCDirectiveRenderMode)
-                .map((value) => `"${value}"`)
-                .join(', or ');
-            warnOnElement(ParserDiagnostics.LWC_RENDER_MODE_INVALID_VALUE, templateRoot, [
-                possibleValues,
-            ]);
-        }
-    }
-
     const root = parseElement(templateRoot);
 
     function parseElement(elementNode: parse5.AST.Default.Element, parent?: IRElement): IRElement {
@@ -196,7 +173,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             } else if (treeAdapter.isTextNode(child)) {
                 const textNodes = parseText(child, parent);
                 parsedChildren.push(...textNodes);
-            } else if (treeAdapter.isCommentNode(child) && preserveComments) {
+            } else if (treeAdapter.isCommentNode(child)) {
                 const commentNode = parseComment(child, parent);
                 parsedChildren.push(commentNode);
             }
@@ -344,11 +321,10 @@ export default function parse(source: string, state: State): TemplateParseResult
             return;
         }
 
-        if (element.parent === undefined && ROOT_TEMPLATE_DIRECTIVES_SET.has(lwcAttribute.name)) {
-            return;
-        }
-
-        if (!LWC_DIRECTIVE_SET.has(lwcAttribute.name)) {
+        if (
+            !LWC_DIRECTIVE_SET.has(lwcAttribute.name) &&
+            !ROOT_TEMPLATE_DIRECTIVES_SET.has(lwcAttribute.name)
+        ) {
             // unknown lwc directive
             return warnOnElement(ParserDiagnostics.UNKNOWN_LWC_DIRECTIVE, element.__original, [
                 lwcAttribute.name,
@@ -359,8 +335,60 @@ export default function parse(source: string, state: State): TemplateParseResult
         const lwcOpts = {};
         applyLwcDynamicDirective(element, lwcOpts);
         applyLwcDomDirective(element, lwcOpts);
+        applyLwcRenderModeDirective(element, lwcOpts);
+        applyLwcPreserveCommentsDirective(element, lwcOpts);
 
         element.lwc = lwcOpts;
+    }
+
+    function applyLwcRenderModeDirective(element: IRElement, lwcOpts: LWCDirectives) {
+        const lwcRenderModeAttribute = getTemplateAttribute(
+            element,
+            ROOT_TEMPLATE_DIRECTIVES.RENDER_MODE
+        );
+
+        if (!lwcRenderModeAttribute) {
+            return;
+        }
+
+        if (
+            lwcRenderModeAttribute.type !== IRAttributeType.String ||
+            (lwcRenderModeAttribute.value !== 'shadow' && lwcRenderModeAttribute.value !== 'light')
+        ) {
+            return warnOnElement(
+                ParserDiagnostics.LWC_RENDER_MODE_INVALID_VALUE,
+                element.__original
+            );
+        }
+
+        if (element.parent) {
+            return warnOnElement(ParserDiagnostics.UNKNOWN_LWC_DIRECTIVE, element.__original, [
+                ROOT_TEMPLATE_DIRECTIVES.RENDER_MODE,
+                `<${element.tag}>`,
+            ]);
+        }
+
+        lwcOpts.renderMode = lwcRenderModeAttribute.value as LWCDirectiveRenderMode;
+    }
+
+    function applyLwcPreserveCommentsDirective(element: IRElement, lwcOpts: LWCDirectives) {
+        const lwcPreserveCommentAttribute = getTemplateAttribute(
+            element,
+            ROOT_TEMPLATE_DIRECTIVES.PRESERVE_COMMENTS
+        );
+
+        if (!lwcPreserveCommentAttribute) {
+            return;
+        }
+
+        if (element.parent || lwcPreserveCommentAttribute.type !== IRAttributeType.Boolean) {
+            return warnOnElement(ParserDiagnostics.UNKNOWN_LWC_DIRECTIVE, element.__original, [
+                ROOT_TEMPLATE_DIRECTIVES.RENDER_MODE,
+                `<${element.tag}>`,
+            ]);
+        }
+
+        lwcOpts.preserveComments = lwcPreserveCommentAttribute;
     }
 
     function applyLwcDynamicDirective(element: IRElement, lwcOpts: LWCDirectives) {
@@ -406,7 +434,7 @@ export default function parse(source: string, state: State): TemplateParseResult
 
         removeAttribute(element, LWC_DIRECTIVES.DOM);
 
-        if (state.renderMode === LWCDirectiveRenderMode.light) {
+        if (getRenderMode(element) === LWCDirectiveRenderMode.light) {
             return warnOnElement(
                 ParserDiagnostics.LWC_DOM_INVALID_IN_LIGHT_DOM,
                 element.__original,
@@ -623,10 +651,12 @@ export default function parse(source: string, state: State): TemplateParseResult
             );
         }
 
-        if (state.renderMode === LWCDirectiveRenderMode.light) {
+        // Can't handle slots in applySlot because it would be too late for class and style attrs
+        if (getRenderMode(element) === LWCDirectiveRenderMode.light) {
             const invalidAttrs = attrsList
                 .filter(({ name }) => name !== 'name')
                 .map(({ name }) => name);
+
             if (invalidAttrs.length > 0) {
                 return warnOnElement(
                     ParserDiagnostics.LWC_LIGHT_SLOT_INVALID_ATTRIBUTES,
@@ -964,6 +994,21 @@ export default function parse(source: string, state: State): TemplateParseResult
                 })
             );
         }
+    }
+
+    function getRenderMode(element: IRElement): LWCDirectiveRenderMode {
+        let current: IRElement | undefined = element;
+
+        while (current) {
+            const renderMode = current.lwc?.renderMode;
+            if (renderMode) {
+                return renderMode;
+            }
+
+            current = current.parent;
+        }
+
+        return LWCDirectiveRenderMode.shadow;
     }
 
     function warnOnElement(

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -776,10 +776,6 @@ export default function parse(source: string, state: State): TemplateParseResult
                 removeAttribute(element, name);
             }
         });
-
-        if (!state.shouldScopeFragmentId && (element.props?.id || element.attrs?.id)) {
-            state.shouldScopeFragmentId = true;
-        }
     }
 
     function validateElement(element: IRElement) {

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -54,10 +54,6 @@ export enum LWCDirectiveRenderMode {
     light = 'light',
 }
 
-export function isLWCDirectiveRenderMode(str: string): str is LWCDirectiveRenderMode {
-    return str === LWCDirectiveRenderMode.shadow || str === LWCDirectiveRenderMode.light;
-}
-
 export interface LWCDirectiveDynamic {
     prop: string;
 }
@@ -65,6 +61,8 @@ export interface LWCDirectiveDynamic {
 export interface LWCDirectives {
     dom?: LWCDirectiveDomMode;
     dynamic?: TemplateExpression;
+    renderMode?: LWCDirectiveRenderMode;
+    preserveComments?: IRBooleanAttribute;
 }
 
 export interface IRElement {

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -6,7 +6,6 @@
  */
 
 import { ResolvedConfig } from './config';
-import { LWCDirectiveRenderMode } from './shared/types';
 
 export default class State {
     config: ResolvedConfig;
@@ -19,7 +18,6 @@ export default class State {
      * fashion.
      */
     shouldScopeFragmentId: boolean = false;
-    renderMode: LWCDirectiveRenderMode = LWCDirectiveRenderMode.shadow;
 
     constructor(config: ResolvedConfig) {
         this.config = config;

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -10,15 +10,6 @@ import { ResolvedConfig } from './config';
 export default class State {
     config: ResolvedConfig;
 
-    /**
-     * This flag indicates if a the generated code should scope the template fragment id. It is set
-     * to true if the template also contains ids.
-     *
-     * TODO [#1150]: Remove this code once we can figure out how to do this in a deterministic
-     * fashion.
-     */
-    shouldScopeFragmentId: boolean = false;
-
     constructor(config: ResolvedConfig) {
         this.config = config;
     }


### PR DESCRIPTION
## Details

This PR is a step closer to the new final AST shape without introducing any breaking change. With this PR, the `lwc:render-mode` and `lwc:preserve-comments` directives are now part of the generated LWC AST. 

As a side effect, it allows removing the `State` object from the codegen phase. That said a full AST transversal is still needed to know if the generated id attributes should be scoped or not. 

In a follow-up PR, the plan is to completely get rid of the `State` object in the parsing phase as well in favor of a proper `Parser` object. This `Parser` object would be in charge of carrying the current parsing state and handle diagnostics. This change should greatly simplify the parser logic. 

**Review note:** Since both commits are orthogonal from one another, I would recommend reviewing each commit separately. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 