### PR TITLE
perf: make interpolated text nodes generate only 1 vnode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -587,12 +587,9 @@ export function co(text: string): VComment {
     };
 }
 
-// [d]ynamic value to produce a text vnode
-export function d(value: any): VNode | null {
-    if (value == null) {
-        return null;
-    }
-    return t(value);
+// [d]ynamic text
+export function d(value: any): string | any {
+    return value == null ? '' : value;
 }
 
 // [b]ind function

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -73,11 +73,12 @@
   var _implicitStylesheets = [stylesheet];
 
   function tmpl$1($api, $cmp, $slotset, $ctx) {
-    var api_dynamic = $api._ES5ProxyType ? $api.get("d") : $api.d,
+    var api_dynamic_text = $api._ES5ProxyType ? $api.get("d") : $api.d,
+        api_text = $api._ES5ProxyType ? $api.get("t") : $api.t,
         api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
     return [api_element("div", {
       key: 0
-    }, [api_dynamic($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x)])];
+    }, [api_text(api_dynamic_text($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x))])];
   }
 
   var _tmpl$1 = lwc.registerTemplate(tmpl$1);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -7,10 +7,10 @@
     var _implicitStylesheets = [stylesheet];
 
     function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic, h: api_element} = $api;
+      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
       return [api_element("div", {
         key: 0
-      }, [api_dynamic($cmp.x)])];
+      }, [api_text(api_dynamic_text($cmp.x))])];
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
     tmpl$1.stylesheets = [];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -11,10 +11,10 @@
     var _implicitStylesheets = [stylesheet];
 
     function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic, h: api_element} = $api;
+      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
       return [api_element("div", {
         key: 0
-      }, [api_dynamic($cmp.x)])];
+      }, [api_text(api_dynamic_text($cmp.x))])];
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
     tmpl$1.stylesheets = [];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -7,10 +7,10 @@
     var _implicitStylesheets = [stylesheet];
 
     function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic, h: api_element} = $api;
+      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
       return [api_element("div", {
         key: 0
-      }, [api_dynamic($cmp.x)])];
+      }, [api_text(api_dynamic_text($cmp.x))])];
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
     tmpl$1.stylesheets = [];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
@@ -2,10 +2,10 @@
   'use strict';
 
   function tmpl($api, $cmp, $slotset, $ctx) {
-    const {d: api_dynamic, h: api_element} = $api;
+    const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
     return [api_element("pre", {
       key: 0
-    }, [api_dynamic($cmp.hello)])];
+    }, [api_text(api_dynamic_text($cmp.hello))])];
   }
   var _tmpl = lwc.registerTemplate(tmpl);
   tmpl.stylesheets = [];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -7,10 +7,10 @@
     var _implicitStylesheets = [stylesheet];
 
     function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic, h: api_element} = $api;
+      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
       return [api_element("div", {
         key: 0
-      }, [api_dynamic($cmp.x)])];
+      }, [api_text(api_dynamic_text($cmp.x))])];
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
     tmpl$1.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -3,7 +3,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     co: api_comment,
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
+    t: api_text,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -21,7 +22,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             {
               key: api_key(1, color),
             },
-            [api_dynamic(color)]
+            [api_text(api_dynamic_text(color))]
           ),
         ];
       })

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -20,7 +20,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: api_key(1, item.id),
               },
-              [api_text("1"), api_dynamic(item)]
+              [api_text("1" + api_dynamic_text(item))]
             )
           : null;
       })

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
@@ -2,7 +2,7 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
     t: api_text,
     h: api_element,
     i: api_iterator,
@@ -19,7 +19,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, item.id),
           },
-          [api_dynamic(index), api_text(" - "), api_dynamic(item)]
+          [api_text(api_dynamic_text(index) + " - " + api_dynamic_text(item))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "section",
@@ -22,7 +28,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: 2,
               },
-              [api_dynamic(item)]
+              [api_text(api_dynamic_text(item))]
             ),
           ]
         );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "section",
@@ -22,14 +28,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: 2,
               },
-              [api_dynamic(item)]
+              [api_text(api_dynamic_text(item))]
             ),
             api_element(
               "p",
               {
                 key: 3,
               },
-              [api_dynamic($cmp.item2)]
+              [api_text(api_dynamic_text($cmp.item2))]
             ),
           ]
         );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "ul",
@@ -14,7 +20,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             className: item.x,
             key: api_key(1, item.id),
           },
-          [api_dynamic(item)]
+          [api_text(api_dynamic_text(item))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -2,10 +2,10 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
+    t: api_text,
     h: api_element,
     i: api_iterator,
-    t: api_text,
     f: api_flatten,
   } = $api;
   return [
@@ -22,7 +22,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               className: item.x,
               key: api_key(1, item.id),
             },
-            [api_dynamic(item)]
+            [api_text(api_dynamic_text(item))]
           );
         }),
         api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -20,14 +20,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             {
               key: api_key(1, item.keyOne),
             },
-            [api_text("1"), api_dynamic(item)]
+            [api_text("1" + api_dynamic_text(item))]
           ),
           api_element(
             "p",
             {
               key: api_key(2, item.keyTwo),
             },
-            [api_text("2"), api_dynamic(item)]
+            [api_text("2" + api_dynamic_text(item))]
           ),
         ];
       })

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -20,28 +20,28 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             {
               key: api_key(1, item.keyOne),
             },
-            [api_text("1"), api_dynamic(item)]
+            [api_text("1" + api_dynamic_text(item))]
           ),
           api_element(
             "p",
             {
               key: api_key(2, item.keyTwo),
             },
-            [api_text("2"), api_dynamic(item.foo)]
+            [api_text("2" + api_dynamic_text(item.foo))]
           ),
           api_element(
             "p",
             {
               key: api_key(3, item.keyThree),
             },
-            [api_text("3"), api_dynamic($cmp.other)]
+            [api_text("3" + api_dynamic_text($cmp.other))]
           ),
           api_element(
             "p",
             {
               key: api_key(4, item.keyFour),
             },
-            [api_text("4"), api_dynamic($cmp.other.foo)]
+            [api_text("4" + api_dynamic_text($cmp.other.foo))]
           ),
         ];
       })

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
     f: api_flatten,
@@ -22,14 +22,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: api_key(1, item.id),
               },
-              [api_text("1"), api_dynamic(item)]
+              [api_text("1" + api_dynamic_text(item))]
             ),
             api_element(
               "p",
               {
                 key: api_key(2, item.secondId),
               },
-              [api_text("2"), api_dynamic(item)]
+              [api_text("2" + api_dynamic_text(item))]
             ),
           ];
         }),
@@ -38,7 +38,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: 3,
           },
-          [api_text("3"), api_dynamic($cmp.item)]
+          [api_text("3" + api_dynamic_text($cmp.item))]
         ),
       ])
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -19,7 +19,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, item.id),
           },
-          [api_text("1"), api_dynamic(item)]
+          [api_text("1" + api_dynamic_text(item))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, d: api_dynamic } = $api;
+  const { t: api_text, h: api_element, d: api_dynamic_text } = $api;
   return [
     api_element(
       "section",
@@ -17,7 +17,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               [api_text("1")]
             )
           : null,
-        api_dynamic($cmp.foo),
+        api_text(api_dynamic_text($cmp.foo)),
         $cmp.isTrue
           ? api_element(
               "p",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic, t: api_text, h: api_element } = $api;
+  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
   return [
     api_element(
       "section",
@@ -8,9 +8,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         key: 0,
       },
       [
-        $cmp.state.isTrue ? api_dynamic($cmp.foo) : null,
-        $cmp.state.isTrue ? api_text(" ") : null,
-        $cmp.state.isTrue ? api_dynamic($cmp.bar) : null,
+        $cmp.state.isTrue
+          ? api_text(
+              api_dynamic_text($cmp.foo) + " " + api_dynamic_text($cmp.bar)
+            )
+          : null,
       ]
     ),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic, t: api_text, h: api_element } = $api;
+  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
   return [
     api_element(
       "section",
@@ -8,9 +8,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         key: 0,
       },
       [
-        $cmp.isTrue ? api_dynamic($cmp.foo) : null,
-        $cmp.isTrue ? api_text(" ") : null,
-        $cmp.isTrue ? api_dynamic($cmp.bar) : null,
+        $cmp.isTrue
+          ? api_text(
+              api_dynamic_text($cmp.foo) + " " + api_dynamic_text($cmp.bar)
+            )
+          : null,
       ]
     ),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -35,10 +35,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: 2,
               },
-              [api_text("Row: "), api_dynamic(x.index)]
+              [api_text("Row: " + api_dynamic_text(x.index))]
             ),
-            api_text(". Value: "),
-            api_dynamic(x.value),
+            api_text(". Value: " + api_dynamic_text(x.value)),
           ]
         );
       })

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
@@ -3,7 +3,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
+    t: api_text,
     c: api_custom_element,
     i: api_iterator,
     h: api_element,
@@ -21,7 +22,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, item.key),
           },
-          [api_dynamic(item.value)]
+          [api_text(api_dynamic_text(item.value))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "ul",
@@ -13,7 +19,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, item.key),
           },
-          [api_dynamic(item.value)]
+          [api_text(api_dynamic_text(item.value))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "section",
@@ -22,7 +28,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: 2,
               },
-              [api_dynamic(item)]
+              [api_text(api_dynamic_text(item))]
             ),
           ]
         );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "section",
@@ -19,7 +25,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, $cmp.foo.index),
           },
-          [api_dynamic(x.value)]
+          [api_text(api_dynamic_text(x.value))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
@@ -2,7 +2,7 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
     t: api_text,
     h: api_element,
     i: api_iterator,
@@ -23,9 +23,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: api_key(0, feature.value.label),
           },
           [
-            api_dynamic(feature.value.label),
-            api_text(" "),
-            api_dynamic(feature.label),
+            api_text(
+              api_dynamic_text(feature.value.label) +
+                " " +
+                api_dynamic_text(feature.label)
+            ),
           ]
         );
       }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
@@ -1,6 +1,12 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, d: api_dynamic, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+    i: api_iterator,
+  } = $api;
   return [
     api_element(
       "section",
@@ -19,7 +25,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: api_key(1, x.value),
           },
-          [api_dynamic(x.value)]
+          [api_text(api_dynamic_text(x.value))]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -2,8 +2,8 @@ import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
+    d: api_dynamic_text,
     t: api_text,
-    d: api_dynamic,
     h: api_element,
     i: api_iterator,
   } = $api;
@@ -36,10 +36,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 {
                   key: 2,
                 },
-                [api_text("Row: "), api_dynamic(x.index)]
+                [api_text("Row: " + api_dynamic_text(x.index))]
               ),
-              api_text(". Value: "),
-              api_dynamic(x.value),
+              api_text(". Value: " + api_dynamic_text(x.value)),
             ]
           ),
           $cmp.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
@@ -1,18 +1,25 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic, t: api_text, i: api_iterator, f: api_flatten } = $api;
+  const {
+    d: api_dynamic_text,
+    t: api_text,
+    i: api_iterator,
+    f: api_flatten,
+  } = $api;
   return api_flatten([
-    api_dynamic($cmp.val),
-    api_text(" "),
-    api_dynamic($cmp.val[$cmp.state.foo]),
-    api_text(" "),
-    api_dynamic($cmp.val[$cmp.state.foo][$cmp.state.bar]),
+    api_text(
+      api_dynamic_text($cmp.val) +
+        " " +
+        api_dynamic_text($cmp.val[$cmp.state.foo]) +
+        " " +
+        api_dynamic_text($cmp.val[$cmp.state.foo][$cmp.state.bar])
+    ),
     api_iterator($cmp.arr, function (item, index) {
-      return [
-        api_dynamic($cmp.arr[index]),
-        api_text(" "),
-        api_dynamic($cmp.arr[$cmp.state.val]),
-      ];
+      return api_text(
+        api_dynamic_text($cmp.arr[index]) +
+          " " +
+          api_dynamic_text($cmp.arr[$cmp.state.val])
+      );
     }),
   ]);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
@@ -1,7 +1,7 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic } = $api;
-  return [api_dynamic($cmp.text)];
+  const { d: api_dynamic_text, t: api_text } = $api;
+  return [api_text(api_dynamic_text($cmp.text))];
 }
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
@@ -1,13 +1,13 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic, h: api_element } = $api;
+  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
   return [
     api_element(
       "p",
       {
         key: 0,
       },
-      [api_dynamic($cmp.text)]
+      [api_text(api_dynamic_text($cmp.text))]
     ),
   ];
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic, h: api_element } = $api;
+  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
   return [
     api_element(
       "section",
@@ -13,7 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           {
             key: 1,
           },
-          [api_dynamic($cmp.obj.sub)]
+          [api_text(api_dynamic_text($cmp.obj.sub))]
         ),
       ]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -5,7 +5,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     k: api_key,
-    d: api_dynamic,
+    d: api_dynamic_text,
     i: api_iterator,
   } = $api;
   const { _m0 } = $ctx;
@@ -32,7 +32,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: api_key(2, task.id),
           },
           [
-            api_dynamic(task.title),
+            api_text(api_dynamic_text(task.title)),
             api_element(
               "button",
               {


### PR DESCRIPTION
## Details
**This PR** proposes to change the template compilation of text nodes (with interpolated expressions), so it only generates 1 vnode.

Example:
```html
<template>
  <p>Hello {name}</p>
</template>
```
For this example, before this PR, the template function will generate multiple text vnodes for `Hello {name}`:
```js
function tmpl($api, $cmp, $slotset, $ctx) {
   // ...
       [api_text("Hello "), api_dynamic($cmp.name)] // <-- generates 2 vnodes
   // ...
}
```
With this PR, the proposed compilation will be similar to:
```js
function tmpl($api, $cmp, $slotset, $ctx) {
   // ...
       [api_text("Hello " + $cmp.name)] // <-- only 1 vnode
   // ...
}
```

### Implementation Details
Commit containing the functionality: https://github.com/salesforce/lwc/pull/2405/commits/00a56aef25735b33108d78b6a01d901bc3b5d309

Because component bound properties (`$cmp.name` ) may be `null` or `undefined`, we can not directly concatenate bound values, **ideally** the generated output should be `[api_text("Hello " + $cmp.name ?? ""]`

Because the Nullish coalescing operator is not supported on the platform (yet), we have 2 alternatives:

1. Inline the nullish comparison: `[api_text("Hello " + ($cmp.name == null ? "" : $cmp.name))]`.
2. rename+modify the `api_dynamic` so it does the nullish comparison: `[api_text("Hello " + api_dynamic($cmp.name)]`. (`api_dynamic` is defined as `(v) => v ?? ""`)

**This PR uses Option 2**, because despite option 1, will allow the removal of `api_dynamic`, it will also: 1) Increase the size of the compiled bundle (especially in compat), and 2) Access the component property twice.

## Does this PR introduce breaking changes?

* 🚨 `Yes, it does introduce breaking changes.`

Though the risk is minimal, this optimization changes the number of nodes rendered in the DOM. Example:

```html
<template>
    <p>Hello {name}</p>
</template>
```

In the rendered DOM, `p` will have 2 children: `'Hello '` and `'world'` (when name = world); and with this change, it will have only 1: `'Hello world'`.
