### PR TITLE
perf: assign locker live property directly

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -43,7 +43,6 @@ import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import { HTMLElementConstructor } from './base-bridge-element';
 import { lockerLivePropertyKey } from './membrane';
-import { EmptyObject } from './utils';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -215,7 +214,7 @@ export const LightningElement: LightningElementConstructor = function (
     }
 
     // Making the component instance a live value when using Locker to support expandos.
-    defineProperty(component, lockerLivePropertyKey, EmptyObject);
+    (this as any)[lockerLivePropertyKey] = undefined;
 
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);

--- a/packages/integration-karma/test/component/locker-live-property/index.spec.js
+++ b/packages/integration-karma/test/component/locker-live-property/index.spec.js
@@ -1,0 +1,14 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+if (!process.env.COMPAT) {
+    // Symbol not supported
+    describe('locker-live-property', () => {
+        it('should pass the hasOwnProperty check for the locker live property', () => {
+            const elm = createElement('x-component', { is: Component });
+            document.body.appendChild(elm);
+
+            expect(elm.shadowRoot.querySelector('div').textContent).toEqual('true');
+        });
+    });
+}

--- a/packages/integration-karma/test/component/locker-live-property/x/component/component.html
+++ b/packages/integration-karma/test/component/locker-live-property/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+  <div>{isLiveObject}</div>
+</template>

--- a/packages/integration-karma/test/component/locker-live-property/x/component/component.js
+++ b/packages/integration-karma/test/component/locker-live-property/x/component/component.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    get isLiveObject() {
+        // See https://github.com/salesforce/locker/blob/7ae9538/packages/%40locker/shared/src/LiveObject.ts#L18
+        return Object.prototype.hasOwnProperty.call(this, Symbol.for('@@lockerLiveValue'));
+    }
+}


### PR DESCRIPTION
## Details

- [Slack thread for context](https://salesforce-internal.slack.com/archives/G0213GSKXA6/p1625604188079300)

In theory, it should make component construction faster to avoid `defineProperty()` for the `lockerLivePropertyKey` and just do an assignment directly. Also, Locker is only checking `Object.hasOwnProperty()` for this, so it doesn't matter whether we do direct assignment or `defineProperty()`.

Using Tachometer (100 min sample size, 2% horizon, 60 minute timeout), with the `dom-wc-create-10k` benchmark, the improvement is 1-2%:

![Screen Shot 2021-07-12 at 3 15 16 PM](https://user-images.githubusercontent.com/283842/125367048-432cae80-e32c-11eb-9c80-d7adb20d94c3.png)

Just to be safe, I re-ran with 1% horizon and 90 minute timeout, and got a similar result:

![Screen Shot 2021-07-12 at 4 13 28 PM](https://user-images.githubusercontent.com/283842/125367063-4aec5300-e32c-11eb-815d-b60d6929dccb.png)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item

W-9558964
