### PR TITLE
perf: avoid duplicate @lwc/shared code

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -23,9 +23,11 @@
         "dist/",
         "types/"
     ],
-    "devDependencies": {
+    "dependencies": {
         "@lwc/features": "2.2.8",
-        "@lwc/shared": "2.2.8",
+        "@lwc/shared": "2.2.8"
+    },
+    "devDependencies": {
         "observable-membrane": "1.0.1"
     },
     "publishConfig": {

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -27,7 +27,7 @@ function rollupFeaturesPlugin() {
     };
 }
 
-const { version } = require('../package.json');
+const { version, dependencies, peerDependencies } = require('../package.json');
 
 const banner = `/* proxy-compat-disable */`;
 const footer = `/* version: ${version} */`;
@@ -66,5 +66,5 @@ module.exports = {
         }
     },
 
-    external: ['@lwc/features', '@lwc/shared'],
+    external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
 };

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -65,4 +65,6 @@ module.exports = {
             throw new Error(message);
         }
     },
+
+    external: ['@lwc/features', '@lwc/shared'],
 };

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -23,7 +23,7 @@
         "dist/",
         "types/"
     ],
-    "devDependencies": {
+    "dependencies": {
         "@lwc/shared": "2.2.8"
     },
     "publishConfig": {

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -36,6 +36,7 @@ function rollupConfig({ format }) {
                 typescript: require('typescript'),
             }),
         ],
+        external: ['@lwc/shared'],
     };
 }
 

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -8,7 +8,7 @@ const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescript = require('rollup-plugin-typescript');
 
-const { version } = require('../../package.json');
+const { version, dependencies, peerDependencies } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/flags.ts');
 const targetDirectory = path.resolve(__dirname, '../../dist');
 const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
@@ -36,7 +36,7 @@ function rollupConfig({ format }) {
                 typescript: require('typescript'),
             }),
         ],
-        external: ['@lwc/shared'],
+        external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
     };
 }
 


### PR DESCRIPTION
## Details

This removes duplication of code from `@lwc/shared` in `@lwc/engine-dom` and `@lwc/engine-server`. Here are the file sizes before and after:

| File | Before | After |
| --- | --- | --- |
| `esm/es2017/engine-dom.js` |232K |220K |
| `esm/es2017/engine-server.js` |224K |212K |

The downside of this change is that `@lwc/shared` is now a dependency (not devDependency) of `@lwc/engine-core` and `@lwc/features`. So this could break anyone who is depending on the `dist/` files for those packages not containing any external dependencies.

This doesn't seem like a real risk to me, as the main entry points are `@lwc/engine-dom` and `@lwc/synthetic-shadow`. (Speaking of which, this PR does _not_ fix duplication of `@lwc/shared` between those two, since they're designed to be standalone and self-contained. So we have to duplicate the shared code.)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

Not really, unless people are dropping `@lwc/engine-core/dist/engine-core.js` or `@lwc/features/dist/flags.js` into `<script>` tags and expecting it to work.

## GUS work item
W-8054984
