### PR TITLE
perf(engine-core): remove explicitly duplicated code

### DIFF
--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
@@ -4,15 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const { create } = Object;
-
-const { splice: ArraySplice, indexOf: ArrayIndexOf, push: ArrayPush } = Array.prototype;
+import { create, isUndefined, ArraySplice, ArrayIndexOf, ArrayPush } from '@lwc/shared';
 
 const TargetToReactiveRecordMap: WeakMap<object, ReactiveRecord> = new WeakMap();
-
-function isUndefined(obj: any): obj is undefined {
-    return obj === undefined;
-}
 
 /**
  * An Observed MemberProperty Record represents the list of all Reactive Observers,


### PR DESCRIPTION
## Details

This is complementary to #2416. (So I opened a separate PR to keep things simple.)

Inside of `@lwc/engine-core`, we have some helper functions that could be imported from `@lwc/shared`, but which were inlined instead.

I can't see why these couldn't just be imported from `@lwc/engine-core`, so we can avoid some duplication.

File size improvements:

| File | Before | After |
| --- | --- | --- |
| `esm/es2017/engine-dom.js` | 235,397 bytes | 235,194 bytes |
| `esm/es2017/engine-server.js` | 225,285 bytes | 225,082 bytes |

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-8054984
