### PR TITLE
fix: clear performance marks and measures

### DIFF
--- a/packages/@lwc/engine-core/src/framework/performance-timing.ts
+++ b/packages/@lwc/engine-core/src/framework/performance-timing.ts
@@ -52,7 +52,7 @@ function end(measureName: string, markName: string) {
     // Clear the created marks and measure to avoid filling the performance entries buffer.
     // Note: Even if the entries get deleted, existing PerformanceObservers preserve a copy of those entries.
     performance.clearMarks(markName);
-    performance.clearMarks(measureName);
+    performance.clearMeasures(measureName);
 }
 
 function noop() {

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -53,6 +53,11 @@ describe('Profiler Sanity Test', () => {
         expect(filteredEvents).toEqual(expectedEvents);
     }
 
+    function expectNoMarksOrMeasures() {
+        expect(performance.getEntriesByType('mark').length).toEqual(0);
+        expect(performance.getEntriesByType('measure').length).toEqual(0);
+    }
+
     it('container first render without activating list', async () => {
         const profilerEvents = enableProfilerAndRegisterBuffer();
         await generateContainer();
@@ -62,6 +67,7 @@ describe('Profiler Sanity Test', () => {
         matchEventsOfTypeFor(OperationId.patch, X_CONTAINER, profilerEvents);
         matchEventsOfTypeFor(OperationId.connectedCallback, X_CONTAINER, profilerEvents);
         matchEventsOfTypeFor(OperationId.renderedCallback, X_CONTAINER, profilerEvents);
+        expectNoMarksOrMeasures();
     });
 
     it('activate children in iteration in container', async () => {
@@ -76,6 +82,7 @@ describe('Profiler Sanity Test', () => {
         matchEventsOfTypeFor(OperationId.constructor, X_ITEM, profilerEvents);
         matchEventsOfTypeFor(OperationId.render, X_ITEM, profilerEvents);
         matchEventsOfTypeFor(OperationId.patch, X_ITEM, profilerEvents);
+        expectNoMarksOrMeasures();
     });
 
     it('error callback counted properly', async () => {
@@ -96,5 +103,6 @@ describe('Profiler Sanity Test', () => {
             { opId: OperationId.errorCallback, phase: Phase.Stop, name: X_ERROR_CHILD },
         ];
         expect(profilerEvents).toEqual(expectedEvents);
+        expectNoMarksOrMeasures();
     });
 });

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -7,8 +7,8 @@ describe('Profiler Sanity Test', () => {
     // so we can't just check for 0.
     const hasPerfMarksAndMeasures =
         typeof performance !== 'undefined' && performance.getEntriesByType;
-    let numMarksBeforeTest = 0;
-    let numMeasuresBeforeTest = 0;
+    let numMarksBeforeTest;
+    let numMeasuresBeforeTest;
 
     beforeEach(() => {
         if (hasPerfMarksAndMeasures) {

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -2,15 +2,18 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Profiler Sanity Test', () => {
+    // Count the number of marks/measures before and after the test to ensure the profiler
+    // doesn't leak any. Note that other tests/libraries may be adding their own marks/measures,
+    // so we can't just check for 0.
     const hasPerfMarksAndMeasures =
         typeof performance !== 'undefined' && performance.getEntriesByType;
-    let numMarks = 0;
-    let numMeasures = 0;
+    let numMarksBeforeTest = 0;
+    let numMeasuresBeforeTest = 0;
 
     beforeEach(() => {
         if (hasPerfMarksAndMeasures) {
-            numMarks = performance.getEntriesByType('mark').length;
-            numMeasures = performance.getEntriesByType('measure').length;
+            numMarksBeforeTest = performance.getEntriesByType('mark').length;
+            numMeasuresBeforeTest = performance.getEntriesByType('measure').length;
         }
     });
 
@@ -20,8 +23,8 @@ describe('Profiler Sanity Test', () => {
 
         // No marks or measures added by the profiler
         if (hasPerfMarksAndMeasures) {
-            expect(performance.getEntriesByType('mark').length).toEqual(numMarks);
-            expect(performance.getEntriesByType('measure').length).toEqual(numMeasures);
+            expect(performance.getEntriesByType('mark').length).toEqual(numMarksBeforeTest);
+            expect(performance.getEntriesByType('measure').length).toEqual(numMeasuresBeforeTest);
         }
     });
 

--- a/packages/integration-karma/test/profiler/sanity/profiler.spec.js
+++ b/packages/integration-karma/test/profiler/sanity/profiler.spec.js
@@ -54,8 +54,10 @@ describe('Profiler Sanity Test', () => {
     }
 
     function expectNoMarksOrMeasures() {
-        expect(performance.getEntriesByType('mark').length).toEqual(0);
-        expect(performance.getEntriesByType('measure').length).toEqual(0);
+        if (typeof performance !== 'undefined' && performance.getEntriesByType) {
+            expect(performance.getEntriesByType('mark').length).toEqual(0);
+            expect(performance.getEntriesByType('measure').length).toEqual(0);
+        }
     }
 
     it('container first render without activating list', async () => {


### PR DESCRIPTION
## Details

As noticed by @tariqrafique (https://github.com/salesforce/lwc/pull/2400#discussion_r671405601), we're not actually clearing performance measures correctly. This fixes that, and adds a test to confirm the behavior.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

Technically this is a breaking change if someone is relying on `performance.getEntriesByType('measure')` and expecting to  find LWC measures in there. Hopefully nobody is doing that – they should use the unstable profiler API instead.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
