### PR TITLE
chore(package): update to @rollup/plugin-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@commitlint/cli": "^12.1.4",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.4.2",
+    "@rollup/plugin-typescript": "^8.2.3",
     "@types/acorn": "^4.0.6",
     "@types/babel__core": "^7.1.15",
     "@types/jest": "^26.0.24",

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
+        "build": "rollup --config scripts/rollup.config.js"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "tsc --emitDeclarationOnly && rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -8,7 +8,6 @@
 /* eslint-env node */
 
 const path = require('path');
-const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
@@ -55,7 +54,6 @@ module.exports = {
         }),
         typescriptPlugin({
             target: 'es2017',
-            typescript,
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
         rollupFeaturesPlugin(),

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -14,6 +14,7 @@ const typescriptPlugin = require('@rollup/plugin-typescript');
 
 const babel = require('@babel/core');
 const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
+const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 
 function rollupFeaturesPlugin() {
     return {
@@ -37,11 +38,7 @@ module.exports = {
 
     output: formats.map((format) => {
         return {
-            file: path.resolve(
-                __dirname,
-                '../dist',
-                `engine-core${format === 'cjs' ? '.cjs' : ''}.js`
-            ),
+            file: `engine-core${format === 'cjs' ? '.cjs' : ''}.js`,
             format,
             banner: banner,
             footer: footer,
@@ -56,6 +53,7 @@ module.exports = {
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
+        writeDistAndTypes(),
         rollupFeaturesPlugin(),
     ],
 

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -11,7 +11,7 @@ const path = require('path');
 const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('rollup-plugin-typescript');
+const typescriptPlugin = require('@rollup/plugin-typescript');
 
 const babel = require('@babel/core');
 const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
@@ -56,6 +56,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             typescript,
+            tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
         rollupFeaturesPlugin(),
     ],

--- a/packages/@lwc/engine-core/tsconfig.json
+++ b/packages/@lwc/engine-core/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "outDir": "types",
+        "sourceMap": false,
+        "outDir": "dist",
+        "declarationDir": "types",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/engine-core/tsconfig.json
+++ b/packages/@lwc/engine-core/tsconfig.json
@@ -3,8 +3,7 @@
 
     "compilerOptions": {
         "sourceMap": false,
-        "outDir": "dist",
-        "declarationDir": "types",
+        "outDir": ".",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
+        "build": "rollup --config scripts/rollup.config.js"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "tsc --emitDeclarationOnly && rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -11,7 +11,7 @@ const path = require('path');
 const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('rollup-plugin-typescript');
+const typescriptPlugin = require('@rollup/plugin-typescript');
 
 const { version } = require('../package.json');
 
@@ -42,6 +42,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             typescript,
+            tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
     ],
 

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -11,7 +11,7 @@ const path = require('path');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
-
+const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../package.json');
 
 const banner = `/* proxy-compat-disable */`;
@@ -23,11 +23,7 @@ module.exports = {
 
     output: formats.map((format) => {
         return {
-            file: path.resolve(
-                __dirname,
-                '../dist',
-                `engine-dom${format === 'cjs' ? '.cjs' : ''}.js`
-            ),
+            file: `engine-dom${format === 'cjs' ? '.cjs' : ''}.js`,
             format,
             banner: banner,
             footer: footer,
@@ -42,6 +38,7 @@ module.exports = {
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
+        writeDistAndTypes(),
     ],
 
     onwarn({ code, message }) {

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -8,7 +8,6 @@
 /* eslint-env node */
 
 const path = require('path');
-const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
@@ -41,7 +40,6 @@ module.exports = {
         }),
         typescriptPlugin({
             target: 'es2017',
-            typescript,
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
     ],

--- a/packages/@lwc/engine-dom/tsconfig.json
+++ b/packages/@lwc/engine-dom/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "outDir": "types",
+        "sourceMap": false,
+        "outDir": "dist",
+        "declarationDir": "types",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/engine-dom/tsconfig.json
+++ b/packages/@lwc/engine-dom/tsconfig.json
@@ -3,8 +3,7 @@
 
     "compilerOptions": {
         "sourceMap": false,
-        "outDir": "dist",
-        "declarationDir": "types",
+        "outDir": ".",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
+        "build": "rollup --config scripts/rollup.config.js"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "tsc --emitDeclarationOnly && rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js && rm -fr types && mv dist/types types"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
-
+const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../package.json');
 
 const banner = `/* proxy-compat-disable */`;
@@ -21,11 +21,7 @@ module.exports = {
 
     output: formats.map((format) => {
         return {
-            file: path.resolve(
-                __dirname,
-                '../dist',
-                `engine-server${format === 'cjs' ? '.cjs' : ''}.js`
-            ),
+            file: `engine-server${format === 'cjs' ? '.cjs' : ''}.js`,
             format,
             banner: banner,
             footer: footer,
@@ -40,6 +36,7 @@ module.exports = {
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
+        writeDistAndTypes(),
     ],
 
     onwarn({ code, message }) {

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -9,7 +9,7 @@ const path = require('path');
 const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('rollup-plugin-typescript');
+const typescriptPlugin = require('@rollup/plugin-typescript');
 
 const { version } = require('../package.json');
 
@@ -40,6 +40,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             typescript,
+            tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
     ],
 

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -6,7 +6,6 @@
  */
 
 const path = require('path');
-const typescript = require('typescript');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
@@ -39,7 +38,6 @@ module.exports = {
         }),
         typescriptPlugin({
             target: 'es2017',
-            typescript,
             tsconfig: path.join(__dirname, '../tsconfig.json'),
         }),
     ],

--- a/packages/@lwc/engine-server/tsconfig.json
+++ b/packages/@lwc/engine-server/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "outDir": "types",
+        "sourceMap": false,
+        "outDir": "dist",
+        "declarationDir": "types",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/engine-server/tsconfig.json
+++ b/packages/@lwc/engine-server/tsconfig.json
@@ -3,8 +3,7 @@
 
     "compilerOptions": {
         "sourceMap": false,
-        "outDir": "dist",
-        "declarationDir": "types",
+        "outDir": ".",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "tsc --emitDeclarationOnly && rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -33,7 +33,6 @@ function rollupConfig({ format }) {
             }),
             typescript({
                 target: 'es2017',
-                typescript: require('typescript'),
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
         ],

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -6,7 +6,7 @@
  */
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescript = require('rollup-plugin-typescript');
+const typescript = require('@rollup/plugin-typescript');
 
 const { version, dependencies, peerDependencies } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/flags.ts');
@@ -34,6 +34,7 @@ function rollupConfig({ format }) {
             typescript({
                 target: 'es2017',
                 typescript: require('typescript'),
+                tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
         ],
         external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -8,9 +8,9 @@ const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescript = require('@rollup/plugin-typescript');
 
+const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version, dependencies, peerDependencies } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/flags.ts');
-const targetDirectory = path.resolve(__dirname, '../../dist');
 const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
 const footer = `/** version: ${version} */`;
 
@@ -22,7 +22,7 @@ function rollupConfig({ format }) {
     return {
         input: entry,
         output: {
-            file: path.join(targetDirectory, generateTargetName({ format })),
+            file: generateTargetName({ format }),
             format,
             banner,
             footer,
@@ -35,6 +35,7 @@ function rollupConfig({ format }) {
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
+            writeDistAndTypes(),
         ],
         external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
     };

--- a/packages/@lwc/features/tsconfig.json
+++ b/packages/@lwc/features/tsconfig.json
@@ -4,8 +4,7 @@
     "compilerOptions": {
         "sourceMap": false,
         "baseUrl": ".",
-        "outDir": "dist",
-        "declarationDir": "types",
+        "outDir": ".",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/features/tsconfig.json
+++ b/packages/@lwc/features/tsconfig.json
@@ -2,8 +2,10 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
+        "sourceMap": false,
         "baseUrl": ".",
-        "outDir": "types",
+        "outDir": "dist",
+        "declarationDir": "types",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -16,7 +16,7 @@
     "typings": "types/index.d.ts",
     "license": "MIT",
     "scripts": {
-        "build": "tsc --emitDeclarationOnly && rollup --config ./scripts/rollup/rollup.config.js",
+        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types",
         "postbuild": "node ../../../scripts/tasks/verify-treeshakable.js ./dist/index.js",
         "clean": "rm -rf dist/ types/"
     },

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -16,7 +16,7 @@
     "typings": "types/index.d.ts",
     "license": "MIT",
     "scripts": {
-        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types",
+        "build": "rollup --config ./scripts/rollup/rollup.config.js",
         "postbuild": "node ../../../scripts/tasks/verify-treeshakable.js ./dist/index.js",
         "clean": "rm -rf dist/ types/"
     },

--- a/packages/@lwc/shared/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/shared/scripts/rollup/rollup.config.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const path = require('path');
-const typescript = require('rollup-plugin-typescript');
+const typescript = require('@rollup/plugin-typescript');
 
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
@@ -26,7 +26,13 @@ function rollupConfig({ format }) {
             banner,
             footer,
         },
-        plugins: [typescript({ target: 'es2017', typescript: require('typescript') })],
+        plugins: [
+            typescript({
+                target: 'es2017',
+                typescript: require('typescript'),
+                tsconfig: path.join(__dirname, '../../tsconfig.json'),
+            }),
+        ],
     };
 }
 

--- a/packages/@lwc/shared/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/shared/scripts/rollup/rollup.config.js
@@ -7,9 +7,9 @@
 const path = require('path');
 const typescript = require('@rollup/plugin-typescript');
 
+const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
-const targetDirectory = path.resolve(__dirname, '../../dist');
 const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
 const footer = `/** version: ${version} */`;
 
@@ -21,7 +21,7 @@ function rollupConfig({ format }) {
     return {
         input: entry,
         output: {
-            file: path.join(targetDirectory, generateTargetName({ format })),
+            file: generateTargetName({ format }),
             format,
             banner,
             footer,
@@ -31,6 +31,7 @@ function rollupConfig({ format }) {
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
+            writeDistAndTypes(),
         ],
     };
 }

--- a/packages/@lwc/shared/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/shared/scripts/rollup/rollup.config.js
@@ -29,7 +29,6 @@ function rollupConfig({ format }) {
         plugins: [
             typescript({
                 target: 'es2017',
-                typescript: require('typescript'),
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
         ],

--- a/packages/@lwc/shared/tsconfig.json
+++ b/packages/@lwc/shared/tsconfig.json
@@ -1,8 +1,10 @@
 {
     "extends": "../../../tsconfig.json",
     "compilerOptions": {
+        "sourceMap": false,
         "baseUrl": ".",
-        "outDir": "types"
+        "outDir": "dist",
+        "declarationDir": "types"
     },
 
     "include": ["src/"]

--- a/packages/@lwc/shared/tsconfig.json
+++ b/packages/@lwc/shared/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "sourceMap": false,
         "baseUrl": ".",
-        "outDir": "dist",
-        "declarationDir": "types"
+        "outDir": "."
     },
 
     "include": ["src/"]

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -16,7 +16,7 @@
     "module": "dist/synthetic-shadow.js",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc --noEmit && rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const typescript = require('typescript');
 const path = require('path');
 const rollupTypescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
@@ -54,7 +53,6 @@ function rollupConfig({ wrap } = {}) {
             }),
             rollupTypescript({
                 target: 'es2017',
-                typescript,
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
             rollupFeaturesPlugin(),

--- a/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
@@ -6,7 +6,7 @@
  */
 const typescript = require('typescript');
 const path = require('path');
-const rollupTypescript = require('rollup-plugin-typescript');
+const rollupTypescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const babel = require('@babel/core');
 const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
@@ -55,6 +55,7 @@ function rollupConfig({ wrap } = {}) {
             rollupTypescript({
                 target: 'es2017',
                 typescript,
+                tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
             rollupFeaturesPlugin(),
         ].filter(Boolean),

--- a/packages/@lwc/synthetic-shadow/tsconfig.json
+++ b/packages/@lwc/synthetic-shadow/tsconfig.json
@@ -2,7 +2,11 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "sourceMap": false,
+        "lib": ["dom", "es2018"],
+        "outDir": "dist",
+        "declaration": false,
+        "declarationDir": null
     },
 
     "include": ["src/"]

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -17,7 +17,7 @@
     "typings": "types/index.d.ts",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "tsc --emitDeclarationOnly && rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -17,7 +17,7 @@
     "typings": "types/index.d.ts",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config ./scripts/rollup/rollup.config.js && rm -fr types && mv dist/types types"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
@@ -6,7 +6,7 @@
  */
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescript = require('rollup-plugin-typescript');
+const typescript = require('@rollup/plugin-typescript');
 
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
@@ -35,6 +35,7 @@ function rollupConfig({ format }) {
             typescript({
                 target: 'es2017',
                 typescript: require('typescript'),
+                tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
         ],
     };

--- a/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
@@ -7,10 +7,9 @@
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescript = require('@rollup/plugin-typescript');
-
+const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
-const targetDirectory = path.resolve(__dirname, '../../dist');
 const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
 const footer = `/** version: ${version} */`;
 
@@ -22,7 +21,7 @@ function rollupConfig({ format }) {
     return {
         input: entry,
         output: {
-            file: path.join(targetDirectory, generateTargetName({ format })),
+            file: generateTargetName({ format }),
             name: 'WireService',
             format,
             banner,
@@ -36,6 +35,7 @@ function rollupConfig({ format }) {
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
+            writeDistAndTypes(),
         ],
     };
 }

--- a/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
@@ -34,7 +34,6 @@ function rollupConfig({ format }) {
             }),
             typescript({
                 target: 'es2017',
-                typescript: require('typescript'),
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
             }),
         ],

--- a/packages/@lwc/wire-service/tsconfig.json
+++ b/packages/@lwc/wire-service/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "outDir": "types",
+        "sourceMap": false,
+        "outDir": "dist",
+        "declarationDir": "types",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/@lwc/wire-service/tsconfig.json
+++ b/packages/@lwc/wire-service/tsconfig.json
@@ -3,8 +3,7 @@
 
     "compilerOptions": {
         "sourceMap": false,
-        "outDir": "dist",
-        "declarationDir": "types",
+        "outDir": ".",
         "lib": ["dom", "es2018"]
     },
 

--- a/packages/lwc/scripts/utils/rollup.js
+++ b/packages/lwc/scripts/utils/rollup.js
@@ -38,6 +38,7 @@ function rollupConfig(config) {
                         preventAssignment: true,
                     }),
                 rollupFeaturesPlugin(prod),
+                // TODO [#2422]: remove rollup-plugin-typescript; we're just using it to transpile to ES5
                 compatMode && rollupTypescriptPlugin({ target, typescript, include: ['/**/*.js'] }),
                 prod && !debug && rollupTerser(),
             ],

--- a/scripts/rollup/writeDistAndTypes.js
+++ b/scripts/rollup/writeDistAndTypes.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const path = require('path');
+
+/**
+ * Small Rollup plugin that writes JavaScript files to `dist/` and TypeScript declaration files to
+ * 'types/`. The reason for this is that `@rollup/plugin-typescript` doesn't make it possible to
+ * write the two file types to two separate directories (without having `types` inside of `dist`).
+ * See: https://github.com/rollup/plugins/blob/e32a9e9/packages/typescript/test/test.js#L52
+ */
+module.exports = function writeDistAndTypes() {
+    return {
+        id: 'write-dist-and-types',
+        generateBundle(options, bundle) {
+            for (const [id, descriptor] of Object.entries(bundle)) {
+                const directory = id.endsWith('.d.ts') ? 'types' : 'dist';
+                descriptor.fileName = path.join(directory, descriptor.fileName);
+            }
+            return null;
+        },
+    };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,14 @@
     "@rollup/pluginutils" "^3.1.0"
     magic-string "^0.25.7"
 
+"@rollup/plugin-typescript@^8.2.3":
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.2.3.tgz#d1aed5dc424623bad8ff026f13f732e7cbeee175"
+  integrity sha512-bSkd+DD3wP9OLU6lPet59B6jJF29/RlxHkbwvOVOcf1nk8eQYWw24HpldEdrPo/WG0QAPD7TqI7+2y5jtdqjww==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -11397,7 +11405,7 @@ resolve-global@1.0.0, resolve-global@^1.0.0:
   dependencies:
     global-dirs "^0.1.1"
 
-resolve@^1.10.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.20.0:
+resolve@^1.10.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
## Details

Fixes #2422

`rollup-plugin-typescript` is deprecated. This PR is step 1 toward removing it in favor of `@rollup/plugin-typescript`.

I ran a diff of the `dist` files before and after to make sure they are exactly the same. They are the same, except for some whitespace in `@lwc/synthetic-shadow/dist/synthetic-shadow.js`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9614477
