### PR TITLE
perf(synthetic-shadow): optimize patchedAddEventListener

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
@@ -39,6 +39,8 @@ function patchedAddEventListener(
         // @ts-ignore type-mismatch
         return nativeAddEventListener.apply(this, args);
     }
+    // Fast path. This function is optimized to avoid ArraySlice because addEventListener is called
+    // very frequently, and it provides a measurable perf boost to avoid so much array cloning.
 
     const wrappedListener = getEventListenerWrapper(listener) as EventListenerOrEventListenerObject;
     // The third argument is optional, so passing in `undefined` for `optionsOrCapture` gives capture=false

--- a/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
+++ b/packages/integration-karma/test/shadow-dom/EventTarget-methods/EventTarget.addEventListener.spec.js
@@ -98,6 +98,18 @@ describe('EventTarget.addEventListener', () => {
         expect(() => nodes.button.addEventListener('dummy', undefined)).not.toThrowError(TypeError);
     });
 
+    it('should accept null as third parameter', () => {
+        expect(() => nodes.button.addEventListener('dummy', null, null)).not.toThrowError(
+            TypeError
+        );
+    });
+
+    it('should accept undefined as third parameter', () => {
+        expect(() => nodes.button.addEventListener('dummy', undefined, undefined)).not.toThrowError(
+            TypeError
+        );
+    });
+
     if (!process.env.COMPAT) {
         // Safari 10 does not throw these errors even though they are part of the spec
         it('should throw error when second parameter is not passed', () => {


### PR DESCRIPTION
## Details

This is a micro-optimization for `patchedAddEventListener`. Basically it avoids cloning an Array of arguments every time `addEventListener` is called.

Running Tachometer with 1% horizon and 30 minute timeout, all tests are <1% unchanged except for:
- `dom-ss-slot-create-container` (1%-2% faster)
- `dom-ss-slot-update-slotted-content` (1% faster)
- `dom-wc-append-1k` (1% faster)
- `dom-wc-create-10k` (1%-2% faster)
- `dom-wc-create-1k` (1% faster).

<details><summary>Full results</summary>

```



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
├─────────────┼─────────────────┤
│       Bytes │ 237.78 KiB      │
└─────────────┴─────────────────┘

┌─────────────────────────────────────┬─────────────┬─────────────────────┬────────────────────────────────────────┬────────────────────────────────────────┐
│ Benchmark                           │ Version     │            Avg time │ vs dom-tablecmp-create-10k-this-change │ vs dom-tablecmp-create-10k-tip-of-tree │
│                                     │             │                     │                                        │                            tip-of-tree │
├─────────────────────────────────────┼─────────────┼─────────────────────┼────────────────────────────────────────┼────────────────────────────────────────┤
│ dom-tablecmp-create-10k-this-change │ <none>      │ 978.68ms - 983.13ms │                                        │                                 unsure │
│                                     │             │                     │                               -        │                              -0% - +0% │
│                                     │             │                     │                                        │                      -3.64ms - +3.13ms │
├─────────────────────────────────────┼─────────────┼─────────────────────┼────────────────────────────────────────┼────────────────────────────────────────┤
│ dom-tablecmp-create-10k-tip-of-tree │ tip-of-tree │ 978.60ms - 983.71ms │                                 unsure │                                        │
│                                     │             │                     │                              -0% - +0% │                               -        │
│                                     │             │                     │                      -3.13ms - +3.64ms │                                        │
└─────────────────────────────────────┴─────────────┴─────────────────────┴────────────────────────────────────────┴────────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
├─────────────┼─────────────────┤
│       Bytes │ 237.78 KiB      │
└─────────────┴─────────────────┘

┌────────────────────────────────────┬─────────────┬─────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┐
│ Benchmark                          │ Version     │            Avg time │ vs dom-tablecmp-create-1k-this-change │ vs dom-tablecmp-create-1k-tip-of-tree │
│                                    │             │                     │                                       │                           tip-of-tree │
├────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┤
│ dom-tablecmp-create-1k-this-change │ <none>      │ 155.72ms - 156.62ms │                                       │                                unsure │
│                                    │             │                     │                              -        │                             -0% - +0% │
│                                    │             │                     │                                       │                     -0.49ms - +0.71ms │
├────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┤
│ dom-tablecmp-create-1k-tip-of-tree │ tip-of-tree │ 155.66ms - 156.46ms │                                unsure │                                       │
│                                    │             │                     │                             -0% - +0% │                              -        │
│                                    │             │                     │                     -0.71ms - +0.49ms │                                       │
└────────────────────────────────────┴─────────────┴─────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
├─────────────┼─────────────────┤
│       Bytes │ 237.89 KiB      │
└─────────────┴─────────────────┘

┌────────────────────────────────────┬─────────────┬─────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┐
│ Benchmark                          │ Version     │            Avg time │ vs dom-tablecmp-append-1k-this-change │ vs dom-tablecmp-append-1k-tip-of-tree │
│                                    │             │                     │                                       │                           tip-of-tree │
├────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┤
│ dom-tablecmp-append-1k-this-change │ <none>      │ 129.04ms - 129.67ms │                                       │                                unsure │
│                                    │             │                     │                              -        │                             -0% - +1% │
│                                    │             │                     │                                       │                     -0.15ms - +0.68ms │
├────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┤
│ dom-tablecmp-append-1k-tip-of-tree │ tip-of-tree │ 128.82ms - 129.36ms │                                unsure │                                       │
│                                    │             │                     │                             -1% - +0% │                              -        │
│                                    │             │                     │                     -0.68ms - +0.15ms │                                       │
└────────────────────────────────────┴─────────────┴─────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done

⠋ Auto-sample 70 (timeout in 58m56s)

┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 170             │
└─────────────┴─────────────────┘

┌──────────────────────────────┬─────────────┬────────────┬─────────────────────┬─────────────────────────────────┬─────────────────────────────────┐
│ Benchmark                    │ Version     │ Bytes      │            Avg time │ vs dom-wc-create-1k-this-change │ vs dom-wc-create-1k-tip-of-tree │
│                              │             │            │                     │                                 │                     tip-of-tree │
├──────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────┼─────────────────────────────────┤
│ dom-wc-create-1k-this-change │ <none>      │ 410.30 KiB │ 222.16ms - 222.74ms │                                 │                          faster │
│                              │             │            │                     │                        -        │                         1% - 1% │
│                              │             │            │                     │                                 │                 2.26ms - 3.07ms │
├──────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────┼─────────────────────────────────┤
│ dom-wc-create-1k-tip-of-tree │ tip-of-tree │ 410.08 KiB │ 224.83ms - 225.40ms │                          slower │                                 │
│                              │             │            │                     │                         1% - 1% │                        -        │
│                              │             │            │                     │                 2.26ms - 3.07ms │                                 │
└──────────────────────────────┴─────────────┴────────────┴─────────────────────┴─────────────────────────────────┴─────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done

⠋ Auto-sample 2720 (timeout in 0m0s)
┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 2820            │
└─────────────┴─────────────────┘

┌──────────────────────────────┬─────────────┬────────────┬─────────────────────┬─────────────────────────────────┬─────────────────────────────────┐
│ Benchmark                    │ Version     │ Bytes      │            Avg time │ vs dom-wc-append-1k-this-change │ vs dom-wc-append-1k-tip-of-tree │
│                              │             │            │                     │                                 │                     tip-of-tree │
├──────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────┼─────────────────────────────────┤
│ dom-wc-append-1k-this-change │ <none>      │ 410.42 KiB │ 191.89ms - 192.12ms │                                 │                          faster │
│                              │             │            │                     │                        -        │                         1% - 1% │
│                              │             │            │                     │                                 │                 1.63ms - 1.95ms │
├──────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────┼─────────────────────────────────┤
│ dom-wc-append-1k-tip-of-tree │ tip-of-tree │ 410.20 KiB │ 193.68ms - 193.91ms │                          slower │                                 │
│                              │             │            │                     │                         1% - 1% │                        -        │
│                              │             │            │                     │                 1.63ms - 1.95ms │                                 │
└──────────────────────────────┴─────────────┴────────────┴─────────────────────┴─────────────────────────────────┴─────────────────────────────────┘

NOTE Hit 60 minute auto-sample timeout trying to resolve horizon(s)
Consider a longer --timeout or different --horizon

Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
└─────────────┴─────────────────┘

┌───────────────────────────────┬─────────────┬────────────┬───────────────────────┬──────────────────────────────────┬──────────────────────────────────┐
│ Benchmark                     │ Version     │ Bytes      │              Avg time │ vs dom-wc-create-10k-this-change │ vs dom-wc-create-10k-tip-of-tree │
│                               │             │            │                       │                                  │                      tip-of-tree │
├───────────────────────────────┼─────────────┼────────────┼───────────────────────┼──────────────────────────────────┼──────────────────────────────────┤
│ dom-wc-create-10k-this-change │ <none>      │ 410.31 KiB │ 1519.14ms - 1527.94ms │                                  │                           faster │
│                               │             │            │                       │                         -        │                          1% - 2% │
│                               │             │            │                       │                                  │                18.91ms - 32.29ms │
├───────────────────────────────┼─────────────┼────────────┼───────────────────────┼──────────────────────────────────┼──────────────────────────────────┤
│ dom-wc-create-10k-tip-of-tree │ tip-of-tree │ 410.09 KiB │ 1544.10ms - 1554.19ms │                           slower │                                  │
│                               │             │            │                       │                          1% - 2% │                         -        │
│                               │             │            │                       │                18.91ms - 32.29ms │                                  │
└───────────────────────────────┴─────────────┴────────────┴───────────────────────┴──────────────────────────────────┴──────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done

⠋ Auto-sample 100 (timeout in 57m58s)

┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 200             │
└─────────────┴─────────────────┘

┌────────────────────────────────────────────────┬─────────────┬────────────┬───────────────────┬───────────────────────────────────────────────────┬───────────────────────────────────────────────────┐
│ Benchmark                                      │ Version     │ Bytes      │          Avg time │ vs dom-ss-slot-update-slotted-content-this-change │ vs dom-ss-slot-update-slotted-content-tip-of-tree │
│                                                │             │            │                   │                                                   │                                       tip-of-tree │
├────────────────────────────────────────────────┼─────────────┼────────────┼───────────────────┼───────────────────────────────────────────────────┼───────────────────────────────────────────────────┤
│ dom-ss-slot-update-slotted-content-this-change │ <none>      │ 410.52 KiB │ 98.87ms - 99.17ms │                                                   │                                            faster │
│                                                │             │            │                   │                                          -        │                                           1% - 1% │
│                                                │             │            │                   │                                                   │                                   0.55ms - 0.96ms │
├────────────────────────────────────────────────┼─────────────┼────────────┼───────────────────┼───────────────────────────────────────────────────┼───────────────────────────────────────────────────┤
│ dom-ss-slot-update-slotted-content-tip-of-tree │ tip-of-tree │ 410.31 KiB │ 99.64ms - 99.92ms │                                            slower │                                                   │
│                                                │             │            │                   │                                           1% - 1% │                                          -        │
│                                                │             │            │                   │                                   0.55ms - 0.96ms │                                                   │
└────────────────────────────────────────────────┴─────────────┴────────────┴───────────────────┴───────────────────────────────────────────────────┴───────────────────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
└─────────────┴─────────────────┘

┌──────────────────────────────────────────┬─────────────┬────────────┬─────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┐
│ Benchmark                                │ Version     │ Bytes      │            Avg time │ vs dom-ss-slot-create-container-this-change │ vs dom-ss-slot-create-container-tip-of-tree │
│                                          │             │            │                     │                                             │                                 tip-of-tree │
├──────────────────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┤
│ dom-ss-slot-create-container-this-change │ <none>      │ 410.53 KiB │ 176.33ms - 177.02ms │                                             │                                      faster │
│                                          │             │            │                     │                                    -        │                                     1% - 2% │
│                                          │             │            │                     │                                             │                             2.05ms - 3.19ms │
├──────────────────────────────────────────┼─────────────┼────────────┼─────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┤
│ dom-ss-slot-create-container-tip-of-tree │ tip-of-tree │ 410.32 KiB │ 178.84ms - 179.75ms │                                      slower │                                             │
│                                          │             │            │                     │                                     1% - 2% │                                    -        │
│                                          │             │            │                     │                             2.05ms - 3.19ms │                                             │
└──────────────────────────────────────────┴─────────────┴────────────┴─────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done

⠋ Auto-sample 30 (timeout in 59m24s)

┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 130             │
├─────────────┼─────────────────┤
│       Bytes │ 236.50 KiB      │
└─────────────┴─────────────────┘

┌──────────────────────────────────┬─────────────┬─────────────────────┬─────────────────────────────────────┬─────────────────────────────────────┐
│ Benchmark                        │ Version     │            Avg time │ vs dom-table-create-10k-this-change │ vs dom-table-create-10k-tip-of-tree │
│                                  │             │                     │                                     │                         tip-of-tree │
├──────────────────────────────────┼─────────────┼─────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┤
│ dom-table-create-10k-this-change │ <none>      │ 357.65ms - 360.95ms │                                     │                              unsure │
│                                  │             │                     │                            -        │                           -1% - +0% │
│                                  │             │                     │                                     │                   -3.43ms - +1.28ms │
├──────────────────────────────────┼─────────────┼─────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┤
│ dom-table-create-10k-tip-of-tree │ tip-of-tree │ 358.69ms - 362.06ms │                              unsure │                                     │
│                                  │             │                     │                           -0% - +1% │                            -        │
│                                  │             │                     │                   -1.28ms - +3.43ms │                                     │
└──────────────────────────────────┴─────────────┴─────────────────────┴─────────────────────────────────────┴─────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
├─────────────┼─────────────────┤
│       Bytes │ 227.26 KiB      │
└─────────────┴─────────────────┘

┌────────────────────────────────────────┬─────────────┬─────────────────────┬───────────────────────────────────────────┬───────────────────────────────────────────┐
│ Benchmark                              │ Version     │            Avg time │ vs server-tablecmp-render-10k-this-change │ vs server-tablecmp-render-10k-tip-of-tree │
│                                        │             │                     │                                           │                               tip-of-tree │
├────────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────┼───────────────────────────────────────────┤
│ server-tablecmp-render-10k-this-change │ <none>      │ 458.33ms - 462.94ms │                                           │                                    unsure │
│                                        │             │                     │                                  -        │                                 -1% - +1% │
│                                        │             │                     │                                           │                         -2.83ms - +3.46ms │
├────────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────┼───────────────────────────────────────────┤
│ server-tablecmp-render-10k-tip-of-tree │ tip-of-tree │ 458.18ms - 462.45ms │                                    unsure │                                           │
│                                        │             │                     │                                 -1% - +1% │                                  -        │
│                                        │             │                     │                         -3.46ms - +2.83ms │                                           │
└────────────────────────────────────────┴─────────────┴─────────────────────┴───────────────────────────────────────────┴───────────────────────────────────────────┘


Re-using git checkout:
  https://github.com/salesforce/lwc.git#nolan/tachometer
  /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/93f78738900c5c82da26e62815efccfc149e8603a80935a58ba50dd1b6c131ed


Re-using NPM install dir:
 /var/folders/py/qs7bwkmn6jl05zh98q37sykw0000gq/T/tachometer/versions/33069a37e6f75b20f3d243facafdcffc7dfd053c4f7b2ae0ee9af3e2a3089555

[----------------------------------------------------------] launching chromeRunning benchmarks

[==========================================================] done



┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 91.0.4472.164   │
├─────────────┼─────────────────┤
│ Sample size │ 100             │
├─────────────┼─────────────────┤
│       Bytes │ 227.21 KiB      │
└─────────────┴─────────────────┘

┌─────────────────────────────────────┬─────────────┬─────────────────────┬────────────────────────────────────────┬────────────────────────────────────────┐
│ Benchmark                           │ Version     │            Avg time │ vs server-table-render-10k-this-change │ vs server-table-render-10k-tip-of-tree │
│                                     │             │                     │                                        │                            tip-of-tree │
├─────────────────────────────────────┼─────────────┼─────────────────────┼────────────────────────────────────────┼────────────────────────────────────────┤
│ server-table-render-10k-this-change │ <none>      │ 444.03ms - 447.21ms │                                        │                                 unsure │
│                                     │             │                     │                               -        │                              -0% - +1% │
│                                     │             │                     │                                        │                      -0.36ms - +3.75ms │
├─────────────────────────────────────┼─────────────┼─────────────────────┼────────────────────────────────────────┼────────────────────────────────────────┤
│ server-table-render-10k-tip-of-tree │ tip-of-tree │ 442.63ms - 445.22ms │                                 unsure │                                        │
│                                     │             │                     │                              -1% - +0% │                               -        │
│                                     │             │                     │                      -3.75ms - +0.36ms │                                        │
└─────────────────────────────────────┴─────────────┴─────────────────────┴────────────────────────────────────────┴────────────────────────────────────────┘

lerna success exec Executed command in 1 package: "yarn test"
✨  Done in 5556.17s.
```

</details>

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item

W-9558964
