### PR TITLE
chore(package): remove rollup-plugin-typescript entirely

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "rollup": "^2.52.8",
     "rollup-plugin-compat": "^0.22.2",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-typescript": "^1.0.1",
     "tslib": "^2.3.0",
     "typescript": "^4.3.5",
     "worker-farm": "^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6445,11 +6445,6 @@ estree-walker@^0.3.0:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
   integrity sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=
 
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -11529,21 +11524,6 @@ rollup-plugin-terser@^7.0.2:
     jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
-
-rollup-plugin-typescript@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.1.tgz#86565033b714c3d1f3aba510aad3dc519f7091e9"
-  integrity sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==
-  dependencies:
-    resolve "^1.10.0"
-    rollup-pluginutils "^2.5.0"
-
-rollup-pluginutils@^2.5.0:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rollup-pluginutils@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Details

Related: #2422

This removes the deprecated `rollup-plugin-typescript` entirely. Instead, we use Babel to generate the ES5 builds for the `lwc` package.

I looked at the compiled output, and the `.min.js` files are slightly larger, but only by a few KBs. Nothing stands out to me that we could do to remove the extra KBs.

![Screen Shot 2021-07-22 at 2 09 32 PM](https://user-images.githubusercontent.com/283842/126710849-356442a7-929a-41a1-bbda-3806cb591be0.png)

We _could_ use `@rollup/plugin-babel`, but it seems unnecessary to me as it's pretty straightforward to just use `@babel/core` directly. Plus, we are already doing this [elsewhere](https://github.com/salesforce/lwc/blob/9675ae066cce503e4bd50a21bb094bf727b9a11d/packages/%40lwc/compiler/src/transformers/javascript.ts#L31-L44).

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`