### PR TITLE
refactor(template-compiler): Upgrade `parse5` and clean up error location

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -20,11 +20,9 @@
     },
     "devDependencies": {
         "@types/estree": "0.0.48",
-        "@types/he": "^1.1.1"
+        "@types/he": "^1.1.1",
+        "@types/parse5": "^6.0.1"
     },
-    "files": [
-        "dist/"
-    ],
     "dependencies": {
         "@lwc/errors": "2.2.9",
         "@lwc/shared": "2.2.9",
@@ -33,8 +31,11 @@
         "estree-walker": "~2.0.2",
         "esutils": "~2.0.3",
         "he": "~1.2.0",
-        "parse5-with-errors": "~4.0.4"
+        "parse5": "~6.0.1"
     },
+    "files": [
+        "dist/"
+    ],
     "publishConfig": {
         "access": "public"
     }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-empty-tag/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-empty-tag/metadata.json
@@ -10,6 +10,17 @@
                 "start": 15,
                 "length": 10
             }
+        },
+        {
+            "code": 1058,
+            "message": "LWC1058: Invalid HTML syntax: closing-of-element-with-open-child-elements. For more information, please visit https://html.spec.whatwg.org/multipage/parsing.html#parse-error-closing-of-element-with-open-child-elements",
+            "level": 1,
+            "location": {
+                "line": 3,
+                "column": 1,
+                "start": 26,
+                "length": 11
+            }
         }
     ]
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/no-closing-tag/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/no-closing-tag/metadata.json
@@ -8,7 +8,7 @@
                 "line": 2,
                 "column": 5,
                 "start": 15,
-                "length": 3
+                "length": 10
             }
         }
     ]

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -273,7 +273,7 @@ function transform(codeGen: CodeGen): t.Expression {
     }
 
     function computeAttrValue(attr: IRAttribute, element: IRElement): t.Expression {
-        const { namespaceURI, tagName } = element.__original;
+        const { tag, namespace } = element;
         const isUsedAsAttribute = isAttribute(element, attr.name);
 
         switch (attr.type) {
@@ -281,7 +281,7 @@ function transform(codeGen: CodeGen): t.Expression {
                 const expression = bindExpression(attr.value, element);
 
                 // TODO [#2012]: Normalize global boolean attrs values passed to custom elements as props
-                if (isUsedAsAttribute && isBooleanAttribute(attr.name, tagName)) {
+                if (isUsedAsAttribute && isBooleanAttribute(attr.name, tag)) {
                     // We need to do some manipulation to allow the diffing algorithm add/remove the attribute
                     // without handling special cases at runtime.
                     return codeGen.genBooleanAttributeExpr(expression);
@@ -294,16 +294,16 @@ function transform(codeGen: CodeGen): t.Expression {
                 }
                 if (
                     codeGen.scopeFragmentId &&
-                    isAllowedFragOnlyUrlsXHTML(tagName, attr.name, namespaceURI)
+                    isAllowedFragOnlyUrlsXHTML(tag, attr.name, namespace)
                 ) {
                     return codeGen.genScopedFragId(expression);
                 }
-                if (isSvgUseHref(tagName, attr.name, namespaceURI)) {
+                if (isSvgUseHref(tag, attr.name, namespace)) {
                     codeGen.usedLwcApis.add('sanitizeAttribute');
 
                     return t.callExpression(t.identifier('sanitizeAttribute'), [
-                        t.literal(tagName),
-                        t.literal(namespaceURI),
+                        t.literal(tag),
+                        t.literal(namespace),
                         t.literal(attr.name),
                         codeGen.genScopedFragId(expression),
                     ]);
@@ -320,7 +320,7 @@ function transform(codeGen: CodeGen): t.Expression {
                     return t.literal(attr.value.toLowerCase() !== 'false');
                 }
 
-                if (!isUsedAsAttribute && isBooleanAttribute(attr.name, tagName)) {
+                if (!isUsedAsAttribute && isBooleanAttribute(attr.name, tag)) {
                     // We are in presence of a string value, for a recognized boolean attribute, which is used as
                     // property. for these cases, always set the property to true.
                     return t.literal(true);
@@ -331,17 +331,17 @@ function transform(codeGen: CodeGen): t.Expression {
                 }
                 if (
                     codeGen.scopeFragmentId &&
-                    isAllowedFragOnlyUrlsXHTML(tagName, attr.name, namespaceURI) &&
+                    isAllowedFragOnlyUrlsXHTML(tag, attr.name, namespace) &&
                     isFragmentOnlyUrl(attr.value)
                 ) {
                     return codeGen.genScopedFragId(attr.value);
                 }
-                if (isSvgUseHref(tagName, attr.name, namespaceURI)) {
+                if (isSvgUseHref(tag, attr.name, namespace)) {
                     codeGen.usedLwcApis.add('sanitizeAttribute');
 
                     return t.callExpression(t.identifier('sanitizeAttribute'), [
-                        t.literal(tagName),
-                        t.literal(namespaceURI),
+                        t.literal(tag),
+                        t.literal(namespace),
                         t.literal(attr.name),
                         isFragmentOnlyUrl(attr.value)
                             ? codeGen.genScopedFragId(attr.value)

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -162,7 +162,7 @@ export function getAttribute(
     el: IRElement,
     pattern: string | RegExp
 ): parse5.Attribute | undefined {
-    return el.__attrsList.find((attr) =>
+    return el.attrsList.find((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) === pattern
             : !!attributeName(attr).match(pattern)
@@ -170,7 +170,7 @@ export function getAttribute(
 }
 
 export function removeAttribute(el: IRElement, pattern: string | RegExp): void {
-    el.__attrsList = el.__attrsList.filter((attr) =>
+    el.attrsList = el.attrsList.filter((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) !== pattern
             : !attributeName(attr).match(pattern)

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as parse5 from 'parse5-with-errors';
+import * as parse5 from 'parse5';
 import { ParserDiagnostics, generateCompilerError } from '@lwc/errors';
 import { isAriaAttribute, isBooleanAttribute, isGlobalHtmlAttribute } from '@lwc/shared';
 
@@ -81,7 +81,7 @@ export function isFragmentOnlyUrl(url: string): boolean {
 }
 
 export function normalizeAttributeValue(
-    attr: parse5.AST.Default.Attribute,
+    attr: parse5.Attribute,
     raw: string,
     tag: string
 ): {
@@ -153,7 +153,7 @@ export function normalizeAttributeValue(
     return { value, escapedExpression: false };
 }
 
-export function attributeName(attr: parse5.AST.Default.Attribute): string {
+export function attributeName(attr: parse5.Attribute): string {
     const { prefix, name } = attr;
     return prefix ? `${prefix}:${name}` : name;
 }
@@ -161,8 +161,8 @@ export function attributeName(attr: parse5.AST.Default.Attribute): string {
 export function getAttribute(
     el: IRElement,
     pattern: string | RegExp
-): parse5.AST.Default.Attribute | undefined {
-    return el.attrsList.find((attr) =>
+): parse5.Attribute | undefined {
+    return el.__attrsList.find((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) === pattern
             : !!attributeName(attr).match(pattern)
@@ -170,7 +170,7 @@ export function getAttribute(
 }
 
 export function removeAttribute(el: IRElement, pattern: string | RegExp): void {
-    el.attrsList = el.attrsList.filter((attr) =>
+    el.__attrsList = el.__attrsList.filter((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) !== pattern
             : !attributeName(attr).match(pattern)

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -4,17 +4,19 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as parse5 from 'parse5-with-errors';
+import * as parse5 from 'parse5';
 import * as he from 'he';
+
+import defaultTreeAdapter from 'parse5/lib/tree-adapters/default';
 
 import { CompilerDiagnostic, generateCompilerDiagnostic, ParserDiagnostics } from '@lwc/errors';
 
-export const treeAdapter = parse5.treeAdapters.default;
+export const treeAdapter = defaultTreeAdapter;
 
 export function parseHTML(source: string) {
     const errors: CompilerDiagnostic[] = [];
 
-    const onParseError = (err: parse5.Errors.ParsingError) => {
+    const onParseError = (err: parse5.ParsingError) => {
         const { code, startLine, startCol, startOffset, endOffset } = err;
 
         errors.push(
@@ -33,9 +35,9 @@ export function parseHTML(source: string) {
     };
 
     const fragment = parse5.parseFragment(source, {
-        locationInfo: true,
+        sourceCodeLocationInfo: true,
         onParseError,
-    }) as parse5.AST.Default.DocumentFragment;
+    });
 
     return {
         fragment,
@@ -43,7 +45,7 @@ export function parseHTML(source: string) {
     };
 }
 
-export function getSource(source: string, location: parse5.MarkupData.Location): string {
+export function getSource(source: string, location: parse5.Location): string {
     const { startOffset, endOffset } = location;
     return source.slice(startOffset, endOffset);
 }

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -7,11 +7,7 @@
 import * as parse5 from 'parse5';
 import * as he from 'he';
 
-import defaultTreeAdapter from 'parse5/lib/tree-adapters/default';
-
 import { CompilerDiagnostic, generateCompilerDiagnostic, ParserDiagnostics } from '@lwc/errors';
-
-export const treeAdapter = defaultTreeAdapter;
 
 export function parseHTML(source: string) {
     const errors: CompilerDiagnostic[] = [];

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as parse5 from 'parse5';
-import treeAdapter from 'parse5/lib/tree-adapters/default';
 import { hasOwnProperty } from '@lwc/shared';
 
 import {
@@ -40,6 +39,7 @@ import {
 } from './expression';
 
 import * as t from '../shared/estree';
+import * as parse5Utils from '../shared/parse5';
 import { createComment, createElement, createText, isCustomElement } from '../shared/ir';
 import {
     ForEach,
@@ -164,18 +164,16 @@ export default function parse(source: string, state: State): TemplateParseResult
         const { __original } = parent;
 
         const parsedChildren: IRNode[] = [];
-        const children = treeAdapter.getChildNodes(
-            treeAdapter.getTemplateContent(__original) ?? __original
-        );
+        const children = (parse5Utils.getTemplateContent(__original) ?? __original).childNodes;
 
         for (const child of children) {
-            if (treeAdapter.isElementNode(child)) {
+            if (parse5Utils.isElementNode(child)) {
                 const elmNode = parseElement(child, parent);
                 parsedChildren.push(elmNode);
-            } else if (treeAdapter.isTextNode(child)) {
+            } else if (parse5Utils.isTextNode(child)) {
                 const textNodes = parseText(child, parent);
                 parsedChildren.push(...textNodes);
-            } else if (treeAdapter.isCommentNode(child)) {
+            } else if (parse5Utils.isCommentNode(child)) {
                 const commentNode = parseComment(child, parent);
                 parsedChildren.push(commentNode);
             }
@@ -241,8 +239,8 @@ export default function parse(source: string, state: State): TemplateParseResult
         // Filter all the empty text nodes
         const validRoots = documentFragment.childNodes.filter(
             (child) =>
-                treeAdapter.isElementNode(child) ||
-                (treeAdapter.isTextNode(child) && child.value.trim().length)
+                parse5Utils.isElementNode(child) ||
+                (parse5Utils.isTextNode(child) && child.value.trim().length)
         );
 
         if (validRoots.length > 1) {
@@ -252,7 +250,7 @@ export default function parse(source: string, state: State): TemplateParseResult
 
         const [root] = validRoots;
 
-        if (!root || !treeAdapter.isElementNode(root)) {
+        if (!root || !parse5Utils.isElementNode(root)) {
             warnAtLocation(ParserDiagnostics.MISSING_ROOT_TEMPLATE_TAG);
         } else {
             return root;

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as parse5 from 'parse5';
+import treeAdapter from 'parse5/lib/tree-adapters/default';
 import { hasOwnProperty } from '@lwc/shared';
 
 import {
@@ -14,7 +15,7 @@ import {
     normalizeToDiagnostic,
     ParserDiagnostics,
 } from '@lwc/errors';
-import { cleanTextNode, decodeTextContent, getSource, parseHTML, treeAdapter } from './html';
+import { cleanTextNode, decodeTextContent, getSource, parseHTML } from './html';
 
 import {
     attributeName,

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as parse5 from 'parse5';
-import treeAdapter from 'parse5/lib/tree-adapters/default';
+
+import * as parse5Utils from './parse5';
 
 import {
     TemplateIdentifier,
@@ -27,7 +28,7 @@ export function createElement(original: parse5.Element, parent?: IRElement): IRE
     // TODO [#248]: Report a warning when location is not available indicating the original HTML
     // template is not valid.
     let current = original;
-    while (!location && treeAdapter.isElementNode(original.parentNode)) {
+    while (!location && parse5Utils.isElementNode(original.parentNode)) {
         current = original.parentNode;
         location = current.sourceCodeLocation;
     }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -18,16 +18,21 @@ import {
 export function createElement(original: parse5.Element, parent?: IRElement): IRElement {
     let location = original.sourceCodeLocation;
 
-    // TODO [#000]: Add warning when not available.
-
+    // With parse5 automatically recovering from invalid HTML, some AST nodes might not have
+    // location information. For example when a <table> element has a <tr> child element, parse5
+    // creates a <tbody> element in the middle without location information. In this case, we
+    // can safely skip the closing tag validation.
+    //
+    // TODO [#248]: Report a warning when location is not available indicating the original HTML
+    // template is not valid.
     let current = original;
-    while (!location && original.parentNode && treeAdapter.isElementNode(original.parentNode)) {
+    while (!location && treeAdapter.isElementNode(original.parentNode)) {
         current = original.parentNode;
         location = current.sourceCodeLocation;
     }
 
     if (!location) {
-        throw new Error('Invalid source location');
+        throw new Error('Invalid element AST node. Missing source code location.');
     }
 
     return {
@@ -48,7 +53,7 @@ export function createText(
     value: string | TemplateExpression
 ): IRText {
     if (!original.sourceCodeLocation) {
-        throw new Error('Invalid source location');
+        throw new Error('Invalid text AST node. Missing source code location.');
     }
 
     return {
@@ -66,7 +71,7 @@ export function createComment(
     value: string
 ): IRComment {
     if (!original.sourceCodeLocation) {
-        throw new Error('Invalid source location');
+        throw new Error('Invalid comment AST node. Missing source code location.');
     }
 
     return {

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -37,8 +37,8 @@ export function createElement(original: parse5.Element, parent?: IRElement): IRE
         parent,
         children: [],
         location,
+        attrsList: original.attrs,
         __original: original,
-        __attrsList: original.attrs,
     };
 }
 

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -4,48 +4,76 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import * as parse5 from 'parse5';
+import { treeAdapter } from '../parser/html';
 import {
     TemplateIdentifier,
     TemplateExpression,
     IRNode,
     IRText,
     IRElement,
-    HTMLElement,
-    HTMLText,
-    HTMLComment,
     IRComment,
 } from './types';
 
-export function createElement(original: HTMLElement, parent?: IRElement): IRElement {
+export function createElement(original: parse5.Element, parent?: IRElement): IRElement {
+    let location = original.sourceCodeLocation;
+
+    // TODO [#000]: Add warning when not available.
+
+    let current = original;
+    while (!location && original.parentNode && treeAdapter.isElementNode(original.parentNode)) {
+        current = original.parentNode;
+        location = current.sourceCodeLocation;
+    }
+
+    if (!location) {
+        throw new Error('Invalid source location');
+    }
+
     return {
         type: 'element',
         tag: original.tagName,
         namespace: original.namespaceURI,
-        attrsList: original.attrs,
         parent,
         children: [],
+        location,
         __original: original,
+        __attrsList: original.attrs,
     };
 }
 
 export function createText(
-    original: HTMLText,
+    original: parse5.TextNode,
     parent: IRElement,
     value: string | TemplateExpression
 ): IRText {
+    if (!original.sourceCodeLocation) {
+        throw new Error('Invalid source location');
+    }
+
     return {
         type: 'text',
         parent,
         value,
+        location: original.sourceCodeLocation,
         __original: original,
     };
 }
 
-export function createComment(original: HTMLComment, parent: IRElement, value: string): IRComment {
+export function createComment(
+    original: parse5.CommentNode,
+    parent: IRElement,
+    value: string
+): IRComment {
+    if (!original.sourceCodeLocation) {
+        throw new Error('Invalid source location');
+    }
+
     return {
         type: 'comment',
         parent,
         value,
+        location: original.sourceCodeLocation,
         __original: original,
     };
 }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as parse5 from 'parse5';
-import { treeAdapter } from '../parser/html';
+import treeAdapter from 'parse5/lib/tree-adapters/default';
+
 import {
     TemplateIdentifier,
     TemplateExpression,

--- a/packages/@lwc/template-compiler/src/shared/parse5.ts
+++ b/packages/@lwc/template-compiler/src/shared/parse5.ts
@@ -1,0 +1,19 @@
+import * as parse5 from 'parse5';
+
+export function isElementNode(node: parse5.Node): node is parse5.Element {
+    return 'tagName' in node;
+}
+
+export function isCommentNode(node: parse5.Node): node is parse5.CommentNode {
+    return node.nodeName === '#comment';
+}
+
+export function isTextNode(node: parse5.Node): node is parse5.TextNode {
+    return node.nodeName === '#text';
+}
+
+export function getTemplateContent(
+    templateElement: parse5.Element
+): parse5.DocumentFragment | undefined {
+    return (templateElement as any).content;
+}

--- a/packages/@lwc/template-compiler/src/shared/parse5.ts
+++ b/packages/@lwc/template-compiler/src/shared/parse5.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import * as parse5 from 'parse5';
 
 export function isElementNode(node: parse5.Node): node is parse5.Element {

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -60,13 +60,13 @@ export interface LWCDirectives {
     preserveComments?: IRBooleanAttribute;
 }
 
-export interface IRBaseNode<Original extends parse5.Node> {
+export interface IRBaseNode<Parse5Node extends parse5.Node> {
     type: string;
     parent?: IRElement;
     location: parse5.Location;
 
     // TODO [#000]: Remove `__original` property on the `IRBaseNode`.
-    __original: Original;
+    __original: Parse5Node;
 }
 
 export interface IRElement extends IRBaseNode<parse5.Element> {

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -60,13 +60,13 @@ export interface LWCDirectives {
     preserveComments?: IRBooleanAttribute;
 }
 
-export interface IRBaseNode<Parse5Node extends parse5.Node> {
+export interface IRBaseNode<N extends parse5.Node> {
     type: string;
     parent?: IRElement;
     location: parse5.Location;
 
     // TODO [#2432]: Remove `__original` property on the `IRBaseNode`.
-    __original: Parse5Node;
+    __original: N;
 }
 
 export interface IRElement extends IRBaseNode<parse5.Element> {

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -65,7 +65,7 @@ export interface IRBaseNode<Parse5Node extends parse5.Node> {
     parent?: IRElement;
     location: parse5.Location;
 
-    // TODO [#000]: Remove `__original` property on the `IRBaseNode`.
+    // TODO [#2432]: Remove `__original` property on the `IRBaseNode`.
     __original: Parse5Node;
 }
 
@@ -76,7 +76,7 @@ export interface IRElement extends IRBaseNode<parse5.Element> {
     children: IRNode[];
     location: parse5.ElementLocation;
 
-    // TODO [#000]: Remove `attrsList` property from `IRElement`. Instead of storing the original
+    // TODO [#2432]: Remove `attrsList` property from `IRElement`. Instead of storing the original
     // list of attributes produced by parse5 the attribute list should be passed around in the
     // parser.
     attrsList: parse5.Attribute[];

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -60,22 +60,26 @@ export interface LWCDirectives {
     preserveComments?: IRBooleanAttribute;
 }
 
-export interface IRBaseNode {
+export interface IRBaseNode<Original extends parse5.Node> {
     type: string;
     parent?: IRElement;
     location: parse5.Location;
-    __original: parse5.Node;
+
+    // TODO [#000]: Remove `__original` property on the `IRBaseNode`.
+    __original: Original;
 }
 
-export interface IRElement extends IRBaseNode {
+export interface IRElement extends IRBaseNode<parse5.Element> {
     type: 'element';
     tag: string;
     namespace: string;
     children: IRNode[];
-
-    __original: parse5.Element;
-    __attrsList: parse5.Attribute[];
     location: parse5.ElementLocation;
+
+    // TODO [#000]: Remove `attrsList` property from `IRElement`. Instead of storing the original
+    // list of attributes produced by parse5 the attribute list should be passed around in the
+    // parser.
+    attrsList: parse5.Attribute[];
 
     component?: string;
 
@@ -95,16 +99,14 @@ export interface IRElement extends IRBaseNode {
     slotName?: string;
 }
 
-export interface IRText extends IRBaseNode {
+export interface IRText extends IRBaseNode<parse5.TextNode> {
     type: 'text';
     value: string | TemplateExpression;
-    __original: parse5.TextNode;
 }
 
-export interface IRComment extends IRBaseNode {
+export interface IRComment extends IRBaseNode<parse5.CommentNode> {
     type: 'comment';
     value: string;
-    __original: parse5.CommentNode;
 }
 
 export type IRNode = IRComment | IRElement | IRText;

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as parse5 from 'parse5-with-errors';
+import * as parse5 from 'parse5';
 import { CompilerDiagnostic } from '@lwc/errors';
 
 export type TemplateIdentifier = { type: 'Identifier'; name: string };
@@ -28,11 +28,6 @@ export type TemplateParseResult = {
     root?: IRElement | undefined;
     warnings: CompilerDiagnostic[];
 };
-
-export type HTMLComment = parse5.AST.Default.CommentNode;
-export type HTMLText = parse5.AST.Default.TextNode;
-export type HTMLElement = parse5.AST.Default.Element;
-export type HTMLNode = HTMLElement | HTMLComment | HTMLText;
 
 export interface ForEach {
     expression: TemplateExpression;
@@ -65,17 +60,22 @@ export interface LWCDirectives {
     preserveComments?: IRBooleanAttribute;
 }
 
-export interface IRElement {
+export interface IRBaseNode {
+    type: string;
+    parent?: IRElement;
+    location: parse5.Location;
+    __original: parse5.Node;
+}
+
+export interface IRElement extends IRBaseNode {
     type: 'element';
     tag: string;
     namespace: string;
-
-    attrsList: parse5.AST.Default.Attribute[];
-
-    parent?: IRElement;
     children: IRNode[];
 
-    __original: HTMLElement;
+    __original: parse5.Element;
+    __attrsList: parse5.Attribute[];
+    location: parse5.ElementLocation;
 
     component?: string;
 
@@ -95,22 +95,16 @@ export interface IRElement {
     slotName?: string;
 }
 
-export interface IRText {
+export interface IRText extends IRBaseNode {
     type: 'text';
     value: string | TemplateExpression;
-
-    parent?: IRElement;
-
-    __original: HTMLText;
+    __original: parse5.TextNode;
 }
 
-export interface IRComment {
+export interface IRComment extends IRBaseNode {
     type: 'comment';
     value: string;
-
-    parent?: IRElement;
-
-    __original: HTMLComment;
+    __original: parse5.CommentNode;
 }
 
 export type IRNode = IRComment | IRElement | IRText;
@@ -123,7 +117,7 @@ export enum IRAttributeType {
 
 export interface IRBaseAttribute {
     name: string;
-    location: parse5.MarkupData.Location;
+    location: parse5.Location;
     type: IRAttributeType;
 }
 

--- a/packages/@lwc/template-compiler/typings/parse5.d.ts
+++ b/packages/@lwc/template-compiler/typings/parse5.d.ts
@@ -4,31 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import 'parse5-with-errors';
+import 'parse5';
 
-declare module 'parse5-with-errors' {
-    export namespace MarkupData {
-        export class StartTagLocation {
-            startLine: number;
-            startCol: number;
-        }
-
-        export class Location {
-            startLine: number;
-            startCol: number;
-        }
+declare module 'parse5' {
+    export interface ParsingError extends Location {
+        code: string;
     }
 
-    export namespace AST {
-        export interface TreeAdapter {
-            getTemplateContent(
-                templateElement: AST.Default.Element
-            ): AST.Default.DocumentFragment | undefined;
-            getChildNodes(node: AST.Default.ParentNode): AST.Default.Node[];
-            isTextNode(node: AST.Default.Node): node is AST.Default.TextNode;
-            isCommentNode(node: AST.Default.Node): node is AST.Default.CommentNode;
-            isDocumentTypeNode(node: AST.Default.Node): node is AST.Default.DocumentType;
-            isElementNode(node: AST.Default.Node): node is AST.Default.Element;
-        }
+    export interface ParserOptions {
+        onParseError?: (error: ParsingError) => void;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,11 +2828,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.2.tgz#6d7534ebb2e58af5e6379e95d79f1b96c44bc8d6"
   integrity sha512-d7oJSPzRZ1pN6z55wRpKuyOUXdUpNWAjxQ0g499bnnw9j9WmoeCcoD6POLVnYHLCrw+IK8/nyQDlUYeceu6QFg==
 
-"@types/node@^6.0.46":
-  version "6.14.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.14.13.tgz#b6649578fc0b5dac88c4ef48a46cab33c50a6c72"
-  integrity sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw==
-
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -2847,6 +2842,11 @@
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
+
+"@types/parse5@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.1.tgz#f8ae4fbcd2b9ba4ff934698e28778961f9cb22ca"
+  integrity sha512-ARATsLdrGPUnaBvxLhUlnltcMgn7pQG312S8ccdYlnyijabrX9RN/KN/iGj9Am96CoW8e/K9628BA7Bv4XHdrA==
 
 "@types/prettier@*", "@types/prettier@^2.1.5":
   version "2.3.2"
@@ -9607,14 +9607,7 @@ parse-url@^6.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parse5-with-errors@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/parse5-with-errors/-/parse5-with-errors-4.0.4.tgz#a35685d770994e50427364ba1804397860f71077"
-  integrity sha512-c9o3ucuboCcWfnfhMaOwUbj6ymACsKviD3P0K6ry0iETUK3nmasCncmFhBeyuRaLK4+aIEg4e0UXX3qdV7Byww==
-  dependencies:
-    "@types/node" "^6.0.46"
-
-parse5@6.0.1:
+parse5@6.0.1, parse5@~6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==


### PR DESCRIPTION
## Details

* Drops the template compiler depdency on our parse5 fork in favor of the latest version of parse5.
* Clean up all the warning collection logic to use the `IRNode` instead of the original parse5 AST nodes. 

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-8283257