### PR TITLE
chore(build): properly handle worker errors

### DIFF
--- a/packages/lwc/scripts/build.js
+++ b/packages/lwc/scripts/build.js
@@ -89,4 +89,7 @@ function buildWireService(targets) {
     ];
     process.stdout.write('\n# Generating LWC artifacts...\n');
     await generateTargets(allTargets);
-})();
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/packages/lwc/scripts/utils/generate_targets.js
+++ b/packages/lwc/scripts/utils/generate_targets.js
@@ -21,15 +21,21 @@ module.exports = function generateTargets(targets, opts = {}) {
     let jobsCompleted = 0;
 
     return new Promise((resolve, reject) => {
+        let overallError;
         targets.forEach((config) => {
             workers(config, (err) => {
                 if (err) {
-                    return reject(err);
+                    console.error(err);
+                    overallError = err;
                 }
 
                 if (++jobsCompleted === jobs) {
                     workerFarm.end(workers);
-                    resolve();
+                    if (overallError) {
+                        reject(overallError);
+                    } else {
+                        resolve();
+                    }
                 }
             });
         });

--- a/packages/lwc/scripts/utils/generate_targets.js
+++ b/packages/lwc/scripts/utils/generate_targets.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+const { promisify } = require('util');
 const workerFarm = require('worker-farm');
 const isCI = require('is-ci');
 
@@ -12,32 +13,15 @@ const DEFAULT_FARM_OPTS = {
     maxConcurrentCallsPerWorker: 2,
 };
 
-module.exports = function generateTargets(targets, opts = {}) {
+module.exports = async function generateTargets(targets, opts = {}) {
     const workers = workerFarm(
         { ...DEFAULT_FARM_OPTS, ...opts },
         require.resolve('./child_worker')
     );
-    const jobs = targets.length;
-    let jobsCompleted = 0;
 
-    return new Promise((resolve, reject) => {
-        let overallError;
-        targets.forEach((config) => {
-            workers(config, (err) => {
-                if (err) {
-                    console.error(err);
-                    overallError = err;
-                }
-
-                if (++jobsCompleted === jobs) {
-                    workerFarm.end(workers);
-                    if (overallError) {
-                        reject(overallError);
-                    } else {
-                        resolve();
-                    }
-                }
-            });
-        });
-    });
+    try {
+        await Promise.all(targets.map((config) => promisify(workers)(config)));
+    } finally {
+        workerFarm.end(workers);
+    }
 };


### PR DESCRIPTION
## Details

In the `lwc` package, in the `build.js` script, if any of the worker processes throws an error, currently it will just hang forever with no output. This can be confusing. 🙂 

This PR fixes it so that if any worker throws an error, the process exits with a non-zero exit code and logs the error. I confirmed that this worked by throwing a deliberate `Error` in one of the build workers and confirming that it gave useful error output.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`