### PR TITLE
perf: use const enum over enum

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -23,7 +23,7 @@ import {
     toString,
 } from '@lwc/shared';
 import { logError } from '../shared/logger';
-import { RenderMode } from './def';
+import { RenderMode } from './vm';
 import { invokeEventListener } from './invoker';
 import { getVMBeingRendered } from './template';
 import { EmptyArray, EmptyObject } from './utils';

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -25,11 +25,10 @@ import {
     setPrototypeOf,
 } from '@lwc/shared';
 import features from '@lwc/features';
-import { RenderMode } from './def';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
-import { associateVM, getAssociatedVM, ShadowMode, VM } from './vm';
+import { associateVM, getAssociatedVM, ShadowMode, VM, RenderMode } from './vm';
 import { componentValueMutated, componentValueObserved } from './mutation-tracker';
 import {
     patchComponentWithRestrictions,

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -32,7 +32,7 @@ type WireCompilerMeta = Record<string, WireCompilerDef>;
 type TrackCompilerMeta = Record<string, 1>;
 type MethodCompilerMeta = string[];
 type PropCompilerMeta = Record<string, PropCompilerDef>;
-export enum PropType {
+export const enum PropType {
     Field = 0,
     Set = 1,
     Get = 2,

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -35,6 +35,7 @@ import { LightningElement, LightningElementConstructor } from './base-lightning-
 import { lightningBasedDescriptors } from './base-lightning-element';
 import { PropType, getDecoratorsMeta } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
+import { RenderMode } from '../framework/vm';
 
 import {
     BaseBridgeElement,
@@ -46,11 +47,6 @@ import {
     resolveCircularModuleDependency,
 } from '../shared/circular-module-dependencies';
 import { getComponentOrSwappedComponent } from './hot-swaps';
-
-export enum RenderMode {
-    Light,
-    Shadow,
-}
 
 export interface ComponentDef {
     name: string;
@@ -283,7 +279,7 @@ const lightingElementDef: ComponentDef = {
     render: LightningElement.prototype.render,
 };
 
-enum PropDefType {
+const enum PropDefType {
     any = 'any',
 }
 

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -13,6 +13,7 @@ import {
     getAssociatedVMIfPresent,
     VM,
     ShadowMode,
+    RenderMode,
 } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
@@ -24,7 +25,7 @@ import modStaticClassName from './modules/static-class-attr';
 import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
-import { getComponentInternalDef, RenderMode } from './def';
+import { getComponentInternalDef } from './def';
 
 const noop = () => void 0;
 
@@ -91,7 +92,7 @@ export function createElmHook(vnode: VElement) {
     modComputedStyle.create(vnode);
 }
 
-enum LWCDOMMode {
+const enum LWCDOMMode {
     manual = 'manual',
 }
 

--- a/packages/@lwc/engine-core/src/framework/performance-timing.ts
+++ b/packages/@lwc/engine-core/src/framework/performance-timing.ts
@@ -18,7 +18,7 @@ export type MeasurementPhase =
     | 'renderedCallback'
     | 'errorCallback';
 
-export enum GlobalMeasurementPhase {
+export const enum GlobalMeasurementPhase {
     REHYDRATE = 'lwc-rehydrate',
     HYDRATE = 'lwc-hydrate',
 }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -11,7 +11,7 @@ function noop(_opId: number, _phase: number, _cmpName: string, _vm_idx: number) 
 
 let logOperation = noop;
 
-export enum OperationId {
+export const enum OperationId {
     constructor = 0,
     render = 1,
     patch = 2,
@@ -21,7 +21,7 @@ export enum OperationId {
     errorCallback = 6,
 }
 
-enum Phase {
+const enum Phase {
     Start = 0,
     Stop = 1,
 }

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -19,7 +19,6 @@ import { logError } from '../shared/logger';
 import { VNode, VNodes } from '../3rdparty/snabbdom/types';
 import * as api from './api';
 import { RenderAPI } from './api';
-import { RenderMode } from './def';
 import {
     resetComponentRoot,
     runWithBoundaryProtection,
@@ -27,6 +26,7 @@ import {
     SlotSet,
     TemplateCache,
     VM,
+    RenderMode,
 } from './vm';
 import { EmptyArray } from './utils';
 import { defaultEmptyTemplate, isTemplateRegistered } from './secure-template';

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -60,18 +60,18 @@ export interface SlotSet {
     [key: string]: VNodes;
 }
 
-export enum VMState {
+export const enum VMState {
     created,
     connected,
     disconnected,
 }
 
-export enum RenderMode {
+export const enum RenderMode {
     Light,
     Shadow,
 }
 
-export enum ShadowMode {
+export const enum ShadowMode {
     Native,
     Synthetic,
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -56,7 +56,7 @@ import { arrayFromCollection, isGlobalPatchingSkipped } from '../shared/utils';
 import { assignedSlotGetterPatched } from './slot';
 import { getNonPatchedFilteredArrayOfNodes } from './no-patch-utils';
 
-enum ShadowDomSemantic {
+const enum ShadowDomSemantic {
     Disabled,
     Enabled,
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -31,7 +31,7 @@ import { compareDocumentPosition, DOCUMENT_POSITION_CONTAINED_BY } from '../env/
 import { isInstanceOfNativeShadowRoot } from '../env/shadow-root';
 import { shouldInvokeListener } from '../shared/event-target';
 
-export enum EventListenerContext {
+export const enum EventListenerContext {
     CUSTOM_ELEMENT_LISTENER,
     SHADOW_ROOT_LISTENER,
     UNKNOWN_LISTENER,

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -115,7 +115,7 @@ export interface IRComment {
 
 export type IRNode = IRComment | IRElement | IRText;
 
-export enum IRAttributeType {
+export const enum IRAttributeType {
     Expression,
     String,
     Boolean,


### PR DESCRIPTION
## Details

This modestly reduces the bundle size by using `const enum` instead of `enum` for client-side code ([details](https://github.com/salesforce/lwc/pull/2400#discussion_r670447568)). `engine-dom.js` drops from 223.1kB to 221.5kB (-1.6kB), and `synthetic-shadow.js` drops from 186.0kB to 185.4kB (-0.6kB).

The PR won't pass CI until #2427 is merged.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9611979
