### PR TITLE
fix(style-compiler): use postcss-selector-parser for serialization

### DIFF
--- a/packages/@lwc/style-compiler/src/@types/postcss-selector-parser/postcss-selector-parser.d.ts
+++ b/packages/@lwc/style-compiler/src/@types/postcss-selector-parser/postcss-selector-parser.d.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// This is an internal module from postcss-selector-parser, so it doesn't have any types.
+declare module 'postcss-selector-parser/dist/parser' {
+    export default class SelectorParser {
+        constructor(data: string);
+        tokens: number[][];
+    }
+}


### PR DESCRIPTION
## Details

Fixes #1288

This is a bit tricky because `postcss-selector-parser` doesn't directly expose its tokenizer, but the tokenizer is really the thing we want. We don't want a full AST because that's more overhead than we want to deal with. We're just outputting a flat array, so we'd rather operate directly on the tokens than on the AST.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9655080