### PR TITLE
chore: simplify how benchmarks load components

### DIFF
--- a/packages/perf-benchmarks/README.md
+++ b/packages/perf-benchmarks/README.md
@@ -40,14 +40,6 @@ When analyzing with the Chrome DevTools Performance tab, pay special attention t
 
 `benchmark-run` is what's actually measured, whereas the `-before` and `-after` measures are just the setup and teardown code.
 
-## Modifying the benchmark components locally
-
-If you're adding new benchmarks with new benchmark components and you want to test those against the tip-of-tree branch, then add this to your `.bashrc` to ensure that the tip-of-tree is overwritten with your local components:
-
-```shell
-export CIRCLE_WORKING_DIRECTORY=/path/to/lwc
-```
-
 ## Testing other branches
 
 By default, the benchmark will compare the local code against the latest `master` branch from the `salesforce/lwc` repo. To test against another branch or commit, use the following environment variables when running `yarn build:performance`:


### PR DESCRIPTION
## Details

I have no idea how I didn't notice this before, but there's no reason to require setting a `CIRCLE_WORKING_DIRECTORY` when running the benchmarks. We already know what the working directory is, because we can find it relative to the location of the script.

This makes the benchmark build script a lot simpler.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`