### PR TITLE
fix: fix !important in inline styles

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -15,7 +15,7 @@
 
 import { VM } from '../../framework/vm';
 
-export type VNodeStyle = Record<string, string>;
+export type VNodeStyle = Array<[string, string] | [string, string, boolean]>;
 export interface On {
     [event: string]: EventListener;
 }
@@ -77,7 +77,7 @@ export interface VNodeData {
     className?: any;
     style?: any;
     classMap?: Classes;
-    styleMap?: VNodeStyle;
+    styles?: VNodeStyle;
     context?: CustomElementContext;
     on?: On;
     svg?: boolean;

--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -15,7 +15,7 @@
 
 import { VM } from '../../framework/vm';
 
-export type VNodeStyleDecls = Array<[string, string] | [string, string, boolean]>;
+export type VNodeStyleDecls = Array<[string, string, boolean]>;
 export interface On {
     [event: string]: EventListener;
 }

--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -15,7 +15,7 @@
 
 import { VM } from '../../framework/vm';
 
-export type VNodeStyle = Array<[string, string] | [string, string, boolean]>;
+export type VNodeStyleDecls = Array<[string, string] | [string, string, boolean]>;
 export interface On {
     [event: string]: EventListener;
 }
@@ -77,7 +77,7 @@ export interface VNodeData {
     className?: any;
     style?: any;
     classMap?: Classes;
-    styles?: VNodeStyle;
+    styleDecls?: VNodeStyleDecls;
     context?: CustomElementContext;
     on?: On;
     svg?: boolean;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -282,8 +282,8 @@ export function h(sel: string, data: ElementCompilerData, children: VNodes): VEl
             `vnode.data.className and vnode.data.classMap ambiguous declaration.`
         );
         assert.isFalse(
-            data.styleMap && data.style,
-            `vnode.data.styleMap and vnode.data.style ambiguous declaration.`
+            data.styles && data.style,
+            `vnode.data.styles and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
             logError(
@@ -397,8 +397,8 @@ export function c(
             `vnode.data.className and vnode.data.classMap ambiguous declaration.`
         );
         assert.isFalse(
-            data.styleMap && data.style,
-            `vnode.data.styleMap and vnode.data.style ambiguous declaration.`
+            data.styles && data.style,
+            `vnode.data.styles and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
             logError(

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -282,8 +282,8 @@ export function h(sel: string, data: ElementCompilerData, children: VNodes): VEl
             `vnode.data.className and vnode.data.classMap ambiguous declaration.`
         );
         assert.isFalse(
-            data.styles && data.style,
-            `vnode.data.styles and vnode.data.style ambiguous declaration.`
+            data.styleDecls && data.style,
+            `vnode.data.styleDecls and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
             logError(
@@ -397,8 +397,8 @@ export function c(
             `vnode.data.className and vnode.data.classMap ambiguous declaration.`
         );
         assert.isFalse(
-            data.styles && data.style,
-            `vnode.data.styles and vnode.data.style ambiguous declaration.`
+            data.styleDecls && data.style,
+            `vnode.data.styleDecls and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
             logError(

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -23,7 +23,7 @@ function createStyleAttribute(vnode: VNode) {
 
     for (let i = 0; i < styleDecls.length; i++) {
         const [prop, value, important] = styleDecls[i];
-        renderer.setCSSStyleProperty(elm, prop, value, !!important);
+        renderer.setCSSStyleProperty(elm, prop, value, important);
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -7,22 +7,22 @@
 import { isUndefined } from '@lwc/shared';
 import { VNode } from '../../3rdparty/snabbdom/types';
 
-// The HTML style property becomes the vnode.data.styles object when defined as a string in the template.
+// The HTML style property becomes the vnode.data.styleDecls object when defined as a string in the template.
 // The compiler takes care of transforming the inline style into an object. It's faster to set the
 // different style properties individually instead of via a string.
 function createStyleAttribute(vnode: VNode) {
     const {
         elm,
-        data: { styles },
+        data: { styleDecls },
         owner: { renderer },
     } = vnode;
 
-    if (isUndefined(styles)) {
+    if (isUndefined(styleDecls)) {
         return;
     }
 
-    for (let i = 0; i < styles.length; i++) {
-        const [prop, value, important] = styles[i];
+    for (let i = 0; i < styleDecls.length; i++) {
+        const [prop, value, important] = styleDecls[i];
         renderer.setCSSStyleProperty(elm, prop, value, !!important);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -7,22 +7,23 @@
 import { isUndefined } from '@lwc/shared';
 import { VNode } from '../../3rdparty/snabbdom/types';
 
-// The HTML style property becomes the vnode.data.styleMap object when defined as a string in the template.
+// The HTML style property becomes the vnode.data.styles object when defined as a string in the template.
 // The compiler takes care of transforming the inline style into an object. It's faster to set the
 // different style properties individually instead of via a string.
 function createStyleAttribute(vnode: VNode) {
     const {
         elm,
-        data: { styleMap },
+        data: { styles },
         owner: { renderer },
     } = vnode;
 
-    if (isUndefined(styleMap)) {
+    if (isUndefined(styles)) {
         return;
     }
 
-    for (const name in styleMap) {
-        renderer.setCSSStyleProperty(elm, name, styleMap[name]);
+    for (let i = 0; i < styles.length; i++) {
+        const [prop, value, important] = styles[i];
+        renderer.setCSSStyleProperty(elm, prop, value, !!important);
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -38,7 +38,7 @@ export interface Renderer<N = HostNode, E = HostElement> {
     ): void;
     dispatchEvent(target: N, event: Event): boolean;
     getClassList(element: E): DOMTokenList;
-    setCSSStyleProperty(element: E, name: string, value: string): void;
+    setCSSStyleProperty(element: E, name: string, value: string, important: boolean): void;
     getBoundingClientRect(element: E): ClientRect;
     querySelector(element: E, selectors: string): E | null;
     querySelectorAll(element: E, selectors: string): NodeList;

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -196,10 +196,14 @@ export const renderer: Renderer<Node, Element> = {
         return element.classList;
     },
 
-    setCSSStyleProperty(element: Element, name: string, value: string): void {
+    setCSSStyleProperty(element: Element, name: string, value: string, important: boolean): void {
         // TODO [#0]: How to avoid this type casting? Shall we use a different type interface to
         // represent elements in the engine?
-        (element as HTMLElement | SVGElement).style.setProperty(name, value);
+        (element as HTMLElement | SVGElement).style.setProperty(
+            name,
+            value,
+            important ? 'important' : ''
+        );
     },
 
     getBoundingClientRect(element: Element): DOMRect {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
@@ -5,6 +5,13 @@
     <div
       style="border-width: 1px; border-style: solid; border-color: red"
     ></div>
+    <div
+      style="
+        border-width: 1px !important;
+        border-style: solid;
+        border-color: red !important;
+      "
+    ></div>
     <div style="color: salmon; background-color: chocolate"></div>
     <x-child style="color: red">
       <template shadowroot="open"></template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/modules/x/attribute-style/attribute-style.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/modules/x/attribute-style/attribute-style.html
@@ -8,6 +8,9 @@
     <!-- Standard element, complex values -->
     <div style="border-width: 1px; border-style: solid; border-color: red;"></div>
 
+    <!-- Standard element, !important style -->
+    <div style="border-width: 1px !important; border-style: solid; border-color: red    !important;"></div>
+
     <!-- Standard element, dynamic value -->
     <div style={dynamicStyle}></div>
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -270,7 +270,7 @@ export const renderer: Renderer<HostNode, HostElement> = {
         } as DOMTokenList;
     },
 
-    setCSSStyleProperty(element, name, value) {
+    setCSSStyleProperty(element, name, value, important) {
         let styleAttribute = element.attributes.find(
             (attr) => attr.name === 'style' && isNull(attr.namespace)
         );
@@ -285,7 +285,9 @@ export const renderer: Renderer<HostNode, HostElement> = {
             element.attributes.push(styleAttribute);
         }
 
-        styleAttribute.value = `${styleAttribute.value}; ${name}: ${value}`;
+        styleAttribute.value = `${styleAttribute.value}; ${name}: ${value}${
+            important ? ' !important' : ''
+        }`;
     },
 
     isConnected(node: HostNode) {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -5,7 +5,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleDecls: [["color", "blue"]],
+        styleDecls: [["color", "blue", false]],
         key: 0,
       },
       []
@@ -13,7 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleDecls: [["color", "blue"]],
+        styleDecls: [["color", "blue", false]],
         key: 1,
       },
       []
@@ -21,7 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleDecls: [["color", "blue"]],
+        styleDecls: [["color", "blue", false]],
         key: 2,
       },
       []
@@ -29,7 +29,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleDecls: [["box-shadow", "10px 5px 5px black"]],
+        styleDecls: [["box-shadow", "10px 5px 5px black", false]],
         key: 3,
       },
       []
@@ -38,9 +38,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "div",
       {
         styleDecls: [
-          ["font-size", "12px"],
-          ["background", "blue"],
-          ["color", "red"],
+          ["font-size", "12px", false],
+          ["background", "blue", false],
+          ["color", "red", false],
         ],
         key: 4,
       },
@@ -50,9 +50,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "div",
       {
         styleDecls: [
-          ["font-size", "12px"],
-          ["background", "blue"],
-          ["color", "red"],
+          ["font-size", "12px", false],
+          ["background", "blue", false],
+          ["color", "red", false],
         ],
         key: 5,
       },
@@ -61,7 +61,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleDecls: [["background-color", "rgba(255,0,0,0.3)"]],
+        styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
         key: 6,
       },
       []

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -5,9 +5,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          color: "blue",
-        },
+        styles: [["color", "blue"]],
         key: 0,
       },
       []
@@ -15,9 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          color: "blue",
-        },
+        styles: [["color", "blue"]],
         key: 1,
       },
       []
@@ -25,9 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          color: "blue",
-        },
+        styles: [["color", "blue"]],
         key: 2,
       },
       []
@@ -35,9 +29,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          "box-shadow": "10px 5px 5px black",
-        },
+        styles: [["box-shadow", "10px 5px 5px black"]],
         key: 3,
       },
       []
@@ -45,11 +37,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          "font-size": "12px",
-          background: "blue",
-          color: "red",
-        },
+        styles: [
+          ["font-size", "12px"],
+          ["background", "blue"],
+          ["color", "red"],
+        ],
         key: 4,
       },
       []
@@ -57,11 +49,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          "font-size": "12px",
-          background: "blue",
-          color: "red",
-        },
+        styles: [
+          ["font-size", "12px"],
+          ["background", "blue"],
+          ["color", "red"],
+        ],
         key: 5,
       },
       []
@@ -69,9 +61,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styleMap: {
-          "background-color": "rgba(255,0,0,0.3)",
-        },
+        styles: [["background-color", "rgba(255,0,0,0.3)"]],
         key: 6,
       },
       []

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -5,7 +5,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [["color", "blue"]],
+        styleDecls: [["color", "blue"]],
         key: 0,
       },
       []
@@ -13,7 +13,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [["color", "blue"]],
+        styleDecls: [["color", "blue"]],
         key: 1,
       },
       []
@@ -21,7 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [["color", "blue"]],
+        styleDecls: [["color", "blue"]],
         key: 2,
       },
       []
@@ -29,7 +29,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [["box-shadow", "10px 5px 5px black"]],
+        styleDecls: [["box-shadow", "10px 5px 5px black"]],
         key: 3,
       },
       []
@@ -37,7 +37,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [
+        styleDecls: [
           ["font-size", "12px"],
           ["background", "blue"],
           ["color", "red"],
@@ -49,7 +49,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [
+        styleDecls: [
           ["font-size", "12px"],
           ["background", "blue"],
           ["color", "red"],
@@ -61,7 +61,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "div",
       {
-        styles: [["background-color", "rgba(255,0,0,0.3)"]],
+        styleDecls: [["background-color", "rgba(255,0,0,0.3)"]],
         key: 6,
       },
       []

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -5,11 +5,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "section",
       {
-        styleMap: {
-          "font-size": "12px",
-          color: "red",
-          margin: "10px 5px 10px",
-        },
+        styles: [
+          ["font-size", "12px"],
+          ["color", "red"],
+          ["margin", "10px 5px 10px"],
+        ],
         key: 0,
       },
       []
@@ -17,10 +17,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "section",
       {
-        styleMap: {
-          "--my-color": "blue",
-          color: "var(--my-color)",
-        },
+        styles: [
+          ["--my-color", "blue"],
+          ["color", "var(--my-color)"],
+        ],
         key: 1,
       },
       []

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -6,9 +6,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "section",
       {
         styleDecls: [
-          ["font-size", "12px"],
-          ["color", "red"],
-          ["margin", "10px 5px 10px"],
+          ["font-size", "12px", false],
+          ["color", "red", false],
+          ["margin", "10px 5px 10px", false],
         ],
         key: 0,
       },
@@ -18,8 +18,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "section",
       {
         styleDecls: [
-          ["--my-color", "blue"],
-          ["color", "var(--my-color)"],
+          ["--my-color", "blue", false],
+          ["color", "var(--my-color)", false],
         ],
         key: 1,
       },

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -5,7 +5,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "section",
       {
-        styles: [
+        styleDecls: [
           ["font-size", "12px"],
           ["color", "red"],
           ["margin", "10px 5px 10px"],
@@ -17,7 +17,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_element(
       "section",
       {
-        styles: [
+        styleDecls: [
           ["--my-color", "blue"],
           ["color", "var(--my-color)"],
         ],

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -38,8 +38,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   "stop",
                   {
                     styleDecls: [
-                      ["stop-color", "rgb(255,255,0)"],
-                      ["stop-opacity", "1"],
+                      ["stop-color", "rgb(255,255,0)", false],
+                      ["stop-opacity", "1", false],
                     ],
                     attrs: {
                       offset: "0%",
@@ -53,8 +53,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   "stop",
                   {
                     styleDecls: [
-                      ["stop-color", "rgb(255,0,0)"],
-                      ["stop-opacity", "1"],
+                      ["stop-color", "rgb(255,0,0)", false],
+                      ["stop-opacity", "1", false],
                     ],
                     attrs: {
                       offset: "100%",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -37,10 +37,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 api_element(
                   "stop",
                   {
-                    styleMap: {
-                      "stop-color": "rgb(255,255,0)",
-                      "stop-opacity": "1",
-                    },
+                    styles: [
+                      ["stop-color", "rgb(255,255,0)"],
+                      ["stop-opacity", "1"],
+                    ],
                     attrs: {
                       offset: "0%",
                     },
@@ -52,10 +52,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 api_element(
                   "stop",
                   {
-                    styleMap: {
-                      "stop-color": "rgb(255,0,0)",
-                      "stop-opacity": "1",
-                    },
+                    styles: [
+                      ["stop-color", "rgb(255,0,0)"],
+                      ["stop-opacity", "1"],
+                    ],
                     attrs: {
                       offset: "100%",
                     },

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -37,7 +37,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 api_element(
                   "stop",
                   {
-                    styles: [
+                    styleDecls: [
                       ["stop-color", "rgb(255,255,0)"],
                       ["stop-opacity", "1"],
                     ],
@@ -52,7 +52,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 api_element(
                   "stop",
                   {
-                    styles: [
+                    styleDecls: [
                       ["stop-color", "rgb(255,0,0)"],
                       ["stop-opacity", "1"],
                     ],

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -159,17 +159,18 @@ export function parseStyleText(cssText: string): { [name: string]: string } {
 }
 
 // Given a map of CSS property keys to values, return an array AST like:
-// ['color', 'blue']           // { color: 'blue' }
+// ['color', 'blue', false]    // { color: 'blue' }
 // ['background', 'red', true] // { background: 'red !important' }
 export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t.ArrayExpression {
     const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
         styleMap
     ).map(([key, value]) => {
-        if (value.endsWith('!important')) {
+        const important = value.endsWith('!important');
+        if (important) {
             // trim off the trailing "!important" (10 chars)
-            return [key, value.substring(0, value.length - 10).trim(), true];
+            value = value.substring(0, value.length - 10).trim();
         }
-        return [key, value];
+        return [key, value, important];
     });
     return t.arrayExpression(
         styles.map((arr) => t.arrayExpression(arr.map((val) => t.literal(val))))

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -158,6 +158,24 @@ export function parseStyleText(cssText: string): { [name: string]: string } {
     return styleMap;
 }
 
+// Given a map of CSS property keys to values, return an array AST like:
+// ['color', 'blue']           // { color: 'blue' }
+// ['background', 'red', true] // { background: 'red !important' }
+export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t.ArrayExpression {
+    const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
+        styleMap
+    ).map(([key, value]) => {
+        if (value.endsWith('!important')) {
+            // trim off the trailing "!important" (10 chars)
+            return [key, value.substring(0, value.length - 10).trim(), true];
+        }
+        return [key, value];
+    });
+    return t.arrayExpression(
+        styles.map((arr) => t.arrayExpression(arr.map((val) => t.literal(val))))
+    );
+}
+
 const CLASSNAME_DELIMITER = /\s+/;
 
 export function parseClassNames(classNames: string): string[] {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -40,6 +40,7 @@ import {
     parseClassNames,
     parseStyleText,
     hasIdAttribute,
+    styleMapToStyleDeclsAST,
 } from './helpers';
 
 import { format as formatModule } from './formatters/module';
@@ -428,22 +429,8 @@ function transform(codeGen: CodeGen): t.Expression {
                         data.push(t.property(t.identifier('style'), styleExpression));
                     } else if (value.type === IRAttributeType.String) {
                         const styleMap = parseStyleText(value.value);
-                        const styles: Array<[string, string] | [string, string, boolean]> =
-                            Object.entries(styleMap).map(([key, value]) => {
-                                if (value.endsWith('!important')) {
-                                    // trim off the trailing "!important" (10 chars)
-                                    return [
-                                        key,
-                                        value.substring(0, value.length - 10).trim(),
-                                        true,
-                                    ];
-                                }
-                                return [key, value];
-                            });
-                        const styleAST = t.arrayExpression(
-                            styles.map((arr) => t.arrayExpression(arr.map((val) => t.literal(val))))
-                        );
-                        data.push(t.property(t.identifier('styles'), styleAST));
+                        const styleAST = styleMapToStyleDeclsAST(styleMap);
+                        data.push(t.property(t.identifier('styleDecls'), styleAST));
                     }
                 } else {
                     rest[name] = computeAttrValue(attrs[name], element);

--- a/packages/integration-karma/test/template/attribute-style-important/index.spec.js
+++ b/packages/integration-karma/test/template/attribute-style-important/index.spec.js
@@ -1,0 +1,16 @@
+import { createElement } from 'lwc';
+
+import Component from 'x/component';
+
+describe('important style attribute', () => {
+    it('renders important styles correctly', () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        const target = elm.shadowRoot.querySelector('div');
+
+        expect(getComputedStyle(target).color).toEqual('rgb(0, 0, 255)');
+        expect(getComputedStyle(target).opacity).toEqual('0.5');
+        expect(getComputedStyle(target).backgroundColor).toEqual('rgb(255, 0, 0)');
+    });
+});

--- a/packages/integration-karma/test/template/attribute-style-important/x/component/component.css
+++ b/packages/integration-karma/test/template/attribute-style-important/x/component/component.css
@@ -1,0 +1,4 @@
+div {
+    color: goldenrod;
+    background-color: salmon;
+}

--- a/packages/integration-karma/test/template/attribute-style-important/x/component/component.html
+++ b/packages/integration-karma/test/template/attribute-style-important/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <div style="color: blue !important; opacity: 0.5; background-color: red        !important;">Static style attribute</div>
+</template>

--- a/packages/integration-karma/test/template/attribute-style-important/x/component/component.js
+++ b/packages/integration-karma/test/template/attribute-style-important/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Component extends LightningElement {}


### PR DESCRIPTION
Fixes #2443

## Details

Converts `styleMap` to a `styleDecls` array containing triples of `[name, value, important?]`. E.g.:

```html
<div style="background: blue !important; color: red; opacity: 0.5 !important"></div>
```

becomes:

```js
{
  /* ... */
  styleDecls: [
    ['background', 'blue', true],
    ['color', 'red'],
    ['opacity', '0.5', true]
  ]
}  
```

So the compiler output has changed.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9682301
