### PR TITLE
refactor(template-compiler): Remove original and attrsList references

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-invalid/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-invalid/metadata.json
@@ -35,28 +35,6 @@
         },
         {
             "code": 1055,
-            "message": "LWC1055: onZ={handleClick} is not valid attribute for div. All attributes name should be all lowercase.",
-            "level": 1,
-            "location": {
-                "line": 4,
-                "column": 10,
-                "start": 103,
-                "length": 17
-            }
-        },
-        {
-            "code": 1055,
-            "message": "LWC1055: onfooBar={handleClick} is not valid attribute for div. All attributes name should be all lowercase.",
-            "level": 1,
-            "location": {
-                "line": 5,
-                "column": 10,
-                "start": 142,
-                "length": 22
-            }
-        },
-        {
-            "code": 1055,
             "message": "LWC1055: onfooBar={handleClick} is not valid attribute for div. All attributes name should be all lowercase.",
             "level": 1,
             "location": {

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -242,7 +242,7 @@ export class ParsedAttribute {
     }
 
     get(pattern: string | RegExp): IRAttribute | undefined {
-        const key = this._getKey(pattern);
+        const key = this.getKey(pattern);
         if (key) {
             return this.attributes.get(key);
         }
@@ -256,7 +256,7 @@ export class ParsedAttribute {
         return attr;
     }
 
-    private _getKey(pattern: string | RegExp): string | undefined {
+    private getKey(pattern: string | RegExp): string | undefined {
         let match: string | undefined;
         if (typeof pattern === 'string') {
             match = pattern;

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -169,11 +169,14 @@ export function getAttribute(
     );
 }
 
-export function removeAttribute(el: parse5.Element, pattern: string | RegExp): void {
-    el.attrs = el.attrs.filter((attr) =>
+export function filterAttributes(
+    attrs: parse5.Attribute[],
+    pattern: string | RegExp
+): parse5.Attribute[] {
+    return attrs.filter((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) !== pattern
-            : !attributeName(attr).match(pattern)
+            : !!attributeName(attr).match(pattern)
     );
 }
 

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -159,18 +159,18 @@ export function attributeName(attr: parse5.Attribute): string {
 }
 
 export function getAttribute(
-    el: IRElement,
+    el: parse5.Element,
     pattern: string | RegExp
 ): parse5.Attribute | undefined {
-    return el.attrsList.find((attr) =>
+    return el.attrs.find((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) === pattern
             : !!attributeName(attr).match(pattern)
     );
 }
 
-export function removeAttribute(el: IRElement, pattern: string | RegExp): void {
-    el.attrsList = el.attrsList.filter((attr) =>
+export function removeAttribute(el: parse5.Element, pattern: string | RegExp): void {
+    el.attrs = el.attrs.filter((attr) =>
         typeof pattern === 'string'
             ? attributeName(attr) !== pattern
             : !attributeName(attr).match(pattern)

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -27,6 +27,12 @@ export const LWC_DIRECTIVES = {
 
 export const LWC_DIRECTIVE_SET: Set<string> = new Set(Object.values(LWC_DIRECTIVES));
 
+export const FOR_DIRECTIVES = {
+    FOR_EACH: 'for:each',
+    FOR_ITEM: 'for:item',
+    FOR_INDEX: 'for:index',
+};
+
 export const ROOT_TEMPLATE_DIRECTIVES = {
     PRESERVE_COMMENTS: 'lwc:preserve-comments',
     RENDER_MODE: 'lwc:render-mode',

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -141,8 +141,7 @@ export default function parse(source: string, state: State): TemplateParseResult
 
     function parseElement(elementNode: parse5.Element): IRElement {
         const element = createElement(elementNode);
-        const parsedAttr = new ParsedAttribute();
-        mapTemplateAttribute(element, elementNode, parsedAttr);
+        const parsedAttr = parseAttributes(element, elementNode);
 
         applyForEach(element, parsedAttr);
         applyIterator(element, parsedAttr);
@@ -682,8 +681,9 @@ export default function parse(source: string, state: State): TemplateParseResult
 
     function applyAttributes(element: IRElement, parsedAttr: ParsedAttribute) {
         const { tag } = element;
+        const attributes = parsedAttr.getAttributes();
 
-        parsedAttr.getAttributes().forEach((attr) => {
+        for (const attr of attributes) {
             const name = attr.name;
 
             if (!isValidHTMLAttribute(tag, name)) {
@@ -762,7 +762,7 @@ export default function parse(source: string, state: State): TemplateParseResult
 
                 parsedAttr.pick(name);
             }
-        });
+        }
     }
 
     function validateElement(element: IRElement, node: parse5.Element) {
@@ -856,8 +856,9 @@ export default function parse(source: string, state: State): TemplateParseResult
 
     function validateAttributes(element: IRElement, parsedAttr: ParsedAttribute) {
         const { tag } = element;
+        const attributes = parsedAttr.getAttributes();
 
-        parsedAttr.getAttributes().forEach((attr) => {
+        for (const attr of attributes) {
             const { name: attrName } = attr;
 
             if (isProhibitedIsAttribute(attrName)) {
@@ -882,7 +883,7 @@ export default function parse(source: string, state: State): TemplateParseResult
             if (tag === 'iframe' && attrName === 'srcdoc') {
                 warnOnIRNode(ParserDiagnostics.FORBIDDEN_IFRAME_SRCDOC_ATTRIBUTE, element);
             }
-        });
+        }
     }
 
     function validateProperties(element: IRElement) {
@@ -910,17 +911,18 @@ export default function parse(source: string, state: State): TemplateParseResult
         }
     }
 
-    function mapTemplateAttribute(
-        element: IRElement,
-        node: parse5.Element,
-        parsedAttrs: ParsedAttribute
-    ) {
-        node.attrs.forEach((rawAttr) => {
-            const irAttr = getTemplateAttribute(element, rawAttr);
+    function parseAttributes(element: IRElement, node: parse5.Element): ParsedAttribute {
+        const parsedAttrs = new ParsedAttribute();
+        const { attrs: attributes } = node;
+
+        for (const attr of attributes) {
+            const irAttr = getTemplateAttribute(element, attr);
             if (irAttr) {
                 parsedAttrs.append(irAttr);
             }
-        });
+        }
+
+        return parsedAttrs;
     }
 
     function getTemplateAttribute(

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -43,7 +43,6 @@ export function createElement(original: parse5.Element): IRElement {
         namespace: original.namespaceURI,
         children: [],
         location,
-        attrsList: original.attrs,
         __original: original,
     };
 }
@@ -57,7 +56,6 @@ export function createText(original: parse5.TextNode, value: string | TemplateEx
         type: 'text',
         value,
         location: original.sourceCodeLocation,
-        __original: original,
     };
 }
 
@@ -70,7 +68,6 @@ export function createComment(original: parse5.CommentNode, value: string): IRCo
         type: 'comment',
         value,
         location: original.sourceCodeLocation,
-        __original: original,
     };
 }
 

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -65,7 +65,7 @@ export interface IRBaseNode<N extends parse5.Node> {
     location: parse5.Location;
 
     // TODO [#2432]: Remove `__original` property on the `IRBaseNode`.
-    __original: N;
+    __original?: N;
 }
 
 export interface IRElement extends IRBaseNode<parse5.Element> {
@@ -74,11 +74,6 @@ export interface IRElement extends IRBaseNode<parse5.Element> {
     namespace: string;
     children: IRNode[];
     location: parse5.ElementLocation;
-
-    // TODO [#2432]: Remove `attrsList` property from `IRElement`. Instead of storing the original
-    // list of attributes produced by parse5 the attribute list should be passed around in the
-    // parser.
-    attrsList: parse5.Attribute[];
 
     component?: string;
 


### PR DESCRIPTION
## Details
This PR covers the following two tasks from the [Github issue](https://github.com/salesforce/lwc/issues/2432):

- Remove the following fields from the IRNodes: original, attrsList: Those properties won't be present in the new AST shape and are only used for internal bookkeeping. Instead of storing parse5 AST nodes on the LWC compiler AST nodes, those should be passed around in the parser.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9698810
