### PR TITLE
refactor: use a single noop function

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isArray, isNull, isUndefined } from '@lwc/shared';
+import { assert, isArray, isNull, isUndefined, noop } from '@lwc/shared';
 import { EmptyArray } from './utils';
 import {
     createVM,
@@ -25,8 +25,6 @@ import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef, RenderMode } from './def';
-
-const noop = () => void 0;
 
 function observeElementChildNodes(elm: Element) {
     (elm as any).$domManual$ = true;

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFunction, isUndefined } from '@lwc/shared';
+import { assert, isFunction, isUndefined, noop } from '@lwc/shared';
 
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
 import { VM, runWithBoundaryProtection } from './vm';
@@ -28,8 +28,6 @@ export function isInvokingRenderedCallback(vm: VM): boolean {
 
 let profilerEnabled = false;
 trackProfilerState((t) => (profilerEnabled = t));
-
-const noop = () => void 0;
 
 export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, args?: any[]): any {
     const { component, callHook, owner } = vm;

--- a/packages/@lwc/engine-core/src/framework/performance-timing.ts
+++ b/packages/@lwc/engine-core/src/framework/performance-timing.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined } from '@lwc/shared';
+import { isUndefined, noop } from '@lwc/shared';
 
 import { VM } from './vm';
 import { getComponentTag } from '../shared/format';
@@ -53,10 +53,6 @@ function end(measureName: string, markName: string) {
     // Note: Even if the entries get deleted, existing PerformanceObservers preserve a copy of those entries.
     performance.clearMarks(markName);
     performance.clearMeasures(measureName);
-}
-
-function noop() {
-    /* do nothing */
 }
 
 export const startMeasure = !isUserTimingSupported

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { noop } from '@lwc/shared';
 import { startMeasure, endMeasure, MeasurementPhase } from './performance-timing';
 import { VM } from './vm';
 
-function noop(_opId: number, _phase: number, _cmpName: string, _vm_idx: number) {}
-
-let logOperation = noop;
+type LogOperationFunc = (_opId: number, _phase: number, _cmpName: string, _vm_idx: number) => void;
+let logOperation: LogOperationFunc = noop;
 
 export enum OperationId {
     constructor = 0,

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isUndefined, ArrayPush, defineProperty, defineProperties } from '@lwc/shared';
+import {
+    assert,
+    isUndefined,
+    ArrayPush,
+    defineProperty,
+    defineProperties,
+    noop,
+} from '@lwc/shared';
 import { LightningElement } from './base-lightning-element';
 import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
 import { runWithBoundaryProtection, VMState, VM } from './vm';
@@ -13,7 +20,6 @@ const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
 
 const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
-function noop(): void {}
 
 interface WireContextInternalEventPayload {
     setNewContext(newContext: ContextValue): void;

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -115,6 +115,10 @@ export function isNumber(obj: any): obj is number {
     return typeof obj === 'number';
 }
 
+export function noop(): void {
+    /* Do nothing */
+}
+
 const OtS = {}.toString;
 export function toString(obj: any): string {
     if (obj && obj.toString) {


### PR DESCRIPTION
## Details

We had 5 different `noop` functions throughout the code. This gets us down to one, exported from `@lwc/shared`.

I won't claim this is a perf improvement, because it only reduced the minified size of `engine-dom.js` by 92 bytes. 🙂  But I figure hey, we might as well.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`