### PR TITLE
refactor(template-compiler): Remove parent AST references

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/parser.spec.ts
@@ -65,7 +65,6 @@ describe('parsing', () => {
         expect(root.children[0].tag).toBe('ul');
         expect(root.children[0].children[0].tag).toBe('li');
         expect(root.children[0].children[0].children[0].value).toBe('hello');
-        expect(root.children[0].parent).toBe(root);
     });
 });
 

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -75,12 +75,13 @@ export function hasIdAttribute(element: IRElement): boolean {
 export function memorizeHandler(
     codeGen: CodeGen,
     element: IRElement,
+    parentStack: IRNode[],
     componentHandler: t.Expression,
     handler: t.Expression
 ): t.Expression {
     // #439 - The handler can only be memorized if it is bound to component instance
     const id = getMemberExpressionRoot(componentHandler as t.MemberExpression);
-    const shouldMemorizeHandler = isComponentProp(id, element);
+    const shouldMemorizeHandler = isComponentProp(id, element, parentStack);
 
     // Apply memorization if the handler is memorizable.
     //   $cmp.handlePress -> _m1 || ($ctx._m1 = b($cmp.handlePress))

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -57,15 +57,19 @@ import {
 import { SVG_NAMESPACE_URI } from '../parser/constants';
 
 function transform(codeGen: CodeGen): t.Expression {
+    const parentStack: IRNode[] = [];
+
     function transformElement(element: IRElement): t.Expression {
         const databag = elementDataBag(element);
         let res: t.Expression;
 
+        parentStack.push(element);
         const children = transformChildren(element.children);
+        parentStack.pop();
 
         // Check wether it has the special directive lwc:dynamic
         if (element.lwc && element.lwc.dynamic) {
-            const expression = bindExpression(element.lwc.dynamic, element);
+            const expression = bindExpression(element.lwc.dynamic, element, parentStack);
             res = codeGen.genDynamicElement(element.tag, expression, databag, children);
         } else if (isCustomElement(element)) {
             // Make sure to register the component
@@ -92,7 +96,9 @@ function transform(codeGen: CodeGen): t.Expression {
     }
 
     function transformTemplate(element: IRElement): t.Expression | t.Expression[] {
+        parentStack.push(element);
         const children = transformChildren(element.children);
+        parentStack.pop();
 
         let res = applyTemplateIf(element, children);
 
@@ -116,7 +122,7 @@ function transform(codeGen: CodeGen): t.Expression {
             consecutiveText.map((text) => {
                 const { value } = text;
 
-                return typeof value === 'string' ? value : bindExpression(value, text);
+                return typeof value === 'string' ? value : bindExpression(value, text, parentStack);
             })
         );
     }
@@ -189,7 +195,7 @@ function transform(codeGen: CodeGen): t.Expression {
         }
 
         if (!testExpression) {
-            testExpression = bindExpression(element.if!, element);
+            testExpression = bindExpression(element.if!, element, parentStack);
         }
 
         let leftExpression: t.Expression;
@@ -220,7 +226,7 @@ function transform(codeGen: CodeGen): t.Expression {
             params.push(index);
         }
 
-        const iterable = bindExpression(expression, element);
+        const iterable = bindExpression(expression, element, parentStack);
         const iterationFunction = t.functionExpression(
             null,
             params,
@@ -252,7 +258,7 @@ function transform(codeGen: CodeGen): t.Expression {
             )
         );
 
-        const iterable = bindExpression(expression, element);
+        const iterable = bindExpression(expression, element, parentStack);
         const iterationFunction = t.functionExpression(
             null,
             iteratorArgs,
@@ -292,7 +298,7 @@ function transform(codeGen: CodeGen): t.Expression {
 
         if (t.isArrayExpression(fragmentNodes)) {
             // Bind the expression once for all the template children
-            const testExpression = bindExpression(element.if!, element);
+            const testExpression = bindExpression(element.if!, element, parentStack);
 
             return t.arrayExpression(
                 fragmentNodes.elements.map((child) =>
@@ -313,7 +319,7 @@ function transform(codeGen: CodeGen): t.Expression {
 
         switch (attr.type) {
             case IRAttributeType.Expression: {
-                const expression = bindExpression(attr.value, element);
+                const expression = bindExpression(attr.value, element, parentStack);
 
                 // TODO [#2012]: Normalize global boolean attrs values passed to custom elements as props
                 if (isUsedAsAttribute && isBooleanAttribute(attr.name, tag)) {
@@ -410,7 +416,7 @@ function transform(codeGen: CodeGen): t.Expression {
                     // - string values are parsed and turned into a `classMap` object associating
                     //   each individual class name with a `true` boolean.
                     if (value.type === IRAttributeType.Expression) {
-                        const classExpression = bindExpression(value.value, element);
+                        const classExpression = bindExpression(value.value, element, parentStack);
                         data.push(t.property(t.identifier('className'), classExpression));
                     } else if (value.type === IRAttributeType.String) {
                         const classNames = parseClassNames(value.value);
@@ -425,7 +431,7 @@ function transform(codeGen: CodeGen): t.Expression {
                     // - string values are parsed and turned into a `styles` array
                     // containing triples of [name, value, important (optional)]
                     if (value.type === IRAttributeType.Expression) {
-                        const styleExpression = bindExpression(value.value, element);
+                        const styleExpression = bindExpression(value.value, element, parentStack);
                         data.push(t.property(t.identifier('style'), styleExpression));
                     } else if (value.type === IRAttributeType.String) {
                         const styleMap = parseStyleText(value.value);
@@ -465,7 +471,7 @@ function transform(codeGen: CodeGen): t.Expression {
         // Key property on VNode
         if (forKey) {
             // If element has user-supplied `key` or is in iterator, call `api.k`
-            const forKeyExpression = bindExpression(forKey, element);
+            const forKeyExpression = bindExpression(forKey, element, parentStack);
             const generatedKey = codeGen.genKey(t.literal(codeGen.generateKey()), forKeyExpression);
             data.push(t.property(t.identifier('key'), generatedKey));
         } else {
@@ -477,10 +483,10 @@ function transform(codeGen: CodeGen): t.Expression {
         // Event handler
         if (on) {
             const onObj = objectToAST(on, (key) => {
-                const componentHandler = bindExpression(on[key], element);
+                const componentHandler = bindExpression(on[key], element, parentStack);
                 const handler = codeGen.genBind(componentHandler);
 
-                return memorizeHandler(codeGen, element, componentHandler, handler);
+                return memorizeHandler(codeGen, element, parentStack, componentHandler, handler);
             });
             data.push(t.property(t.identifier('on'), onObj));
         }
@@ -493,6 +499,7 @@ function transform(codeGen: CodeGen): t.Expression {
         return t.objectExpression(data);
     }
 
+    parentStack.push(codeGen.root);
     return transformChildren(codeGen.root.children);
 }
 

--- a/packages/@lwc/template-compiler/src/codegen/scope.ts
+++ b/packages/@lwc/template-compiler/src/codegen/scope.ts
@@ -16,9 +16,13 @@ import { IRNode, TemplateExpression } from '../shared/types';
  * - {value} --> {$cmp.value}
  * - {value[index]} --> {$cmp.value[$cmp.index]}
  */
-export function bindExpression(expression: TemplateExpression, irNode: IRNode): t.Expression {
+export function bindExpression(
+    expression: TemplateExpression,
+    irNode: IRNode,
+    parentStack: IRNode[]
+): t.Expression {
     if (t.isIdentifier(expression)) {
-        if (isComponentProp(expression, irNode)) {
+        if (isComponentProp(expression, irNode, parentStack)) {
             return t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), expression);
         } else {
             return expression;
@@ -32,7 +36,7 @@ export function bindExpression(expression: TemplateExpression, irNode: IRNode): 
                 t.isIdentifier(node) &&
                 t.isMemberExpression(parent) &&
                 parent.object === node &&
-                isComponentProp(node, irNode)
+                isComponentProp(node, irNode, parentStack)
             ) {
                 this.replace(t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), node));
             }

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -124,7 +124,7 @@ export function getForOfParent(parentStack: IRElement[]): IRElement | null {
             return parent;
         }
 
-        parent = parent.tag.toLowerCase() === 'template' ? parentStack[--size] : undefined;
+        parent = parent.tag === 'template' ? parentStack[--size] : undefined;
     }
 
     return null;
@@ -140,7 +140,7 @@ export function getForEachParent(element: IRElement, parentStack: IRElement[]): 
         }
 
         const parent = parentStack[--size];
-        current = parent?.tag.toLowerCase() === 'template' ? parent : undefined;
+        current = parent?.tag === 'template' ? parent : undefined;
     }
 
     return null;

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -117,15 +117,14 @@ export function parseIdentifier(source: string): TemplateIdentifier | never {
 // a non-template element without a forOf.
 export function getForOfParent(parentStack: IRElement[]): IRElement | null {
     let size = parentStack.length;
-    let parent: IRElement | undefined = getParent(parentStack, --size);
+    let parent: IRElement | undefined = parentStack[--size];
 
     while (parent) {
         if (parent.forOf) {
             return parent;
         }
 
-        parent =
-            parent.tag.toLowerCase() === 'template' ? getParent(parentStack, --size) : undefined;
+        parent = parent.tag.toLowerCase() === 'template' ? parentStack[--size] : undefined;
     }
 
     return null;
@@ -140,10 +139,8 @@ export function getForEachParent(element: IRElement, parentStack: IRElement[]): 
             return current;
         }
 
-        current = getParent(parentStack, --size);
-        if (current?.tag.toLowerCase() !== 'template') {
-            current = undefined;
-        }
+        const parent = parentStack[--size];
+        current = parent?.tag.toLowerCase() === 'template' ? parent : undefined;
     }
 
     return null;
@@ -151,8 +148,4 @@ export function getForEachParent(element: IRElement, parentStack: IRElement[]): 
 
 export function isIteratorElement(element: IRElement, parentStack: IRElement[]): boolean {
     return !!(getForOfParent(parentStack) || getForEachParent(element, parentStack));
-}
-
-export function getParent(parentStack: IRElement[], size: number): IRElement | undefined {
-    return size > 0 ? parentStack[size] : undefined;
 }

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -115,33 +115,44 @@ export function parseIdentifier(source: string): TemplateIdentifier | never {
 // Returns the immediate iterator parent if it exists.
 // Traverses up until it finds an element with forOf, or
 // a non-template element without a forOf.
-export function getForOfParent(element: IRElement): IRElement | null {
-    const parent = element.parent;
-    if (!parent) {
-        return null;
-    }
+export function getForOfParent(parentStack: IRElement[]): IRElement | null {
+    let size = parentStack.length;
+    let parent: IRElement | undefined = getParent(parentStack, --size);
 
-    if (parent.forOf) {
-        return parent;
-    } else if (parent.tag.toLowerCase() === 'template') {
-        return getForOfParent(parent);
-    }
-    return null;
-}
+    while (parent) {
+        if (parent.forOf) {
+            return parent;
+        }
 
-export function getForEachParent(element: IRElement): IRElement | null {
-    if (element.forEach) {
-        return element;
-    }
-
-    const parent = element.parent;
-    if (parent && parent.tag.toLowerCase() === 'template') {
-        return getForEachParent(parent);
+        parent =
+            parent.tag.toLowerCase() === 'template' ? getParent(parentStack, --size) : undefined;
     }
 
     return null;
 }
 
-export function isIteratorElement(element: IRElement): boolean {
-    return !!(getForOfParent(element) || getForEachParent(element));
+export function getForEachParent(element: IRElement, parentStack: IRElement[]): IRElement | null {
+    let current: IRElement | undefined = element;
+    let size = parentStack.length;
+
+    while (current) {
+        if (current.forEach) {
+            return current;
+        }
+
+        current = getParent(parentStack, --size);
+        if (current?.tag.toLowerCase() !== 'template') {
+            current = undefined;
+        }
+    }
+
+    return null;
+}
+
+export function isIteratorElement(element: IRElement, parentStack: IRElement[]): boolean {
+    return !!(getForOfParent(parentStack) || getForEachParent(element, parentStack));
+}
+
+export function getParent(parentStack: IRElement[], size: number): IRElement | undefined {
+    return size > 0 ? parentStack[size] : undefined;
 }

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -36,7 +36,6 @@ import {
     isIteratorElement,
     parseExpression,
     parseIdentifier,
-    getParent,
 } from './expression';
 
 import * as t from '../shared/estree';
@@ -666,15 +665,15 @@ export default function parse(source: string, state: State): TemplateParseResult
 
     function isInIteration(element: IRElement): boolean {
         let current: IRElement | undefined = element;
-        let size = parentStack.length;
 
-        while (current) {
+        for (let i = parentStack.length; i >= 0; i--) {
             if (current.tag === 'template') {
                 if (current.forEach || current.forOf) {
                     return true;
                 }
             }
-            current = getParent(parentStack, --size);
+
+            current = parentStack[i - 1];
         }
 
         return false;
@@ -772,7 +771,7 @@ export default function parse(source: string, state: State): TemplateParseResult
 
     function validateElement(element: IRElement) {
         const { tag, namespace, location, __original: node } = element;
-        const isRoot = !(parentStack.length > 0);
+        const isRoot = parentStack.length === 0;
 
         if (isRoot) {
             if (tag !== 'template') {
@@ -980,7 +979,7 @@ export default function parse(source: string, state: State): TemplateParseResult
     }
 
     function getRoot(element: IRElement): IRElement {
-        return parentStack.length > 0 ? parentStack[0] : element;
+        return parentStack[0] || element;
     }
 
     function getRenderMode(element: IRElement): LWCDirectiveRenderMode {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -378,7 +378,10 @@ export default function parse(source: string, state: State): TemplateParseResult
             return;
         }
 
-        if (parentStack.length > 0 || lwcPreserveCommentAttribute.type !== IRAttributeType.Boolean) {
+        if (
+            parentStack.length > 0 ||
+            lwcPreserveCommentAttribute.type !== IRAttributeType.Boolean
+        ) {
             return warnOnIRNode(ParserDiagnostics.UNKNOWN_LWC_DIRECTIVE, element, [
                 ROOT_TEMPLATE_DIRECTIVES.RENDER_MODE,
                 `<${element.tag}>`,

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -48,10 +48,7 @@ export function createElement(original: parse5.Element): IRElement {
     };
 }
 
-export function createText(
-    original: parse5.TextNode,
-    value: string | TemplateExpression
-): IRText {
+export function createText(original: parse5.TextNode, value: string | TemplateExpression): IRText {
     if (!original.sourceCodeLocation) {
         throw new Error('Invalid text AST node. Missing source code location.');
     }
@@ -64,10 +61,7 @@ export function createText(
     };
 }
 
-export function createComment(
-    original: parse5.CommentNode,
-    value: string
-): IRComment {
+export function createComment(original: parse5.CommentNode, value: string): IRComment {
     if (!original.sourceCodeLocation) {
         throw new Error('Invalid comment AST node. Missing source code location.');
     }

--- a/packages/@lwc/template-compiler/src/shared/ir.ts
+++ b/packages/@lwc/template-compiler/src/shared/ir.ts
@@ -111,11 +111,10 @@ export function isComponentProp(
 ): boolean {
     const { name } = identifier;
     let current: IRNode | undefined = root;
-    let size = parentStack.length;
 
     // Walking up the AST and checking for each node to find if the identifer name is identical to
     // an iteration variable.
-    while (current !== undefined) {
+    for (let i = parentStack.length; i >= 0; i--) {
         if (isElement(current)) {
             const { forEach, forOf } = current;
 
@@ -128,7 +127,7 @@ export function isComponentProp(
             }
         }
 
-        current = size > 0 ? parentStack[--size] : undefined;
+        current = parentStack[i - 1];
     }
 
     // The identifier is bound to a component property if no match is found after reaching to AST

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -62,7 +62,6 @@ export interface LWCDirectives {
 
 export interface IRBaseNode<N extends parse5.Node> {
     type: string;
-    parent?: IRElement;
     location: parse5.Location;
 
     // TODO [#2432]: Remove `__original` property on the `IRBaseNode`.


### PR DESCRIPTION
## Details
This PR covers the following two tasks from the [Github issue](https://github.com/salesforce/lwc/issues/2432):

- Remove parent field from IRNodes: The future AST nodes won't have parent back pointers (because it introduces circular dependencies). We can take a head start by changing the compiler code to keep track of the parent chain instead of relying on the information stored on the AST node.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9698817