### PR TITLE
test(template): add test for dynamic styles

### DIFF
--- a/packages/integration-karma/test/template/attribute-style/index.spec.js
+++ b/packages/integration-karma/test/template/attribute-style/index.spec.js
@@ -16,6 +16,20 @@ describe('static style attribute', () => {
             expect(target.style.getPropertyValue('--custom-property')).toBe('blue');
         }
     });
+
+    it('preserves manually added styles', () => {
+        const elm = createElement('x-static', { is: Static });
+        document.body.appendChild(elm);
+        const target = elm.shadowRoot.querySelector('div');
+
+        target.style.display = 'flex';
+        expect(target.style.display).toBe('flex');
+        expect(target.style.position).toBe('absolute');
+
+        target.style.display = 'inline-block';
+        expect(target.style.display).toBe('inline-block');
+        expect(target.style.position).toBe('absolute');
+    });
 });
 
 describe('dynamic style attribute', () => {


### PR DESCRIPTION
## Details

In [W-7186059](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000079dd3IAA/view) we consider replacing the current `styleMap`/`styleDecls` system with just setting the `style` attribute directly. We might also consider doing the same thing for `classMap`.

Unfortunately, these changes could break userland code if users are dynamically modifying the `elm.classList` or `elm.style`. We already have a test for this for `classMap`:

https://github.com/salesforce/lwc/blob/d93e2963d8d32b138ce9ed130d98e7bef84b3d74/packages/integration-karma/test/template/attribute-class/index.spec.js#L70-L79

But there is no equivalent test for `styleMap`/`styleDecls`. This PR adds a test.

Here is the issue we should be cognizant of (in a nutshell):

<img width="520" alt="Screen Shot 2021-08-12 at 9 49 11 AM" src="https://user-images.githubusercontent.com/283842/129236259-3f113b86-ff5c-4ee3-98fe-4c145df3513d.png">

So if we switch to setting the `style` attribute directly, we would clear out any styles that users set using `elm.style.foo = bar`.

Note I'm not trying to argue that we should never get rid of the current `style`/`class` system; just that we should be aware of any potential breaking changes.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`