### PR TITLE
perf: use constructable stylesheets

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -46,6 +46,7 @@ export interface Renderer<N = HostNode, E = HostElement> {
     getElementsByClassName(element: E, names: string): HTMLCollection;
     isConnected(node: N): boolean;
     insertGlobalStylesheet(content: string): void;
+    insertStylesheet(content: string, target: N): void;
     assertInstanceOfHTMLElement?(elm: any, msg: string): void;
     defineCustomElement(
         name: string,

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -138,6 +138,9 @@ export function getStylesheetsContent(vm: VM, template: Template): string[] {
     return content;
 }
 
+// It might be worth caching this to avoid doing the lookup repeatedly, but
+// perf testing has not shown it to be a huge improvement yet:
+// https://github.com/salesforce/lwc/pull/2460#discussion_r691208892
 function getNearestNativeShadowComponent(vm: VM): VM | null {
     let owner: VM | null = vm;
     while (!isNull(owner)) {

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -299,6 +299,11 @@ export const renderer: Renderer<HostNode, HostElement> = {
         // synthetic shadow.
     },
 
+    insertStylesheet() {
+        // Noop on SSR (for now). This need to be reevaluated whenever we will implement support for
+        // synthetic shadow.
+    },
+
     addEventListener() {
         // Noop on SSR.
     },

--- a/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
@@ -23,7 +23,9 @@ describe('multiple templates', () => {
         element.next();
         return Promise.resolve().then(() => {
             expect(element.querySelector('div').textContent).toEqual('b');
-            expect(getComputedStyle(element.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
+            expect(getComputedStyle(element.querySelector('div')).color).toEqual(
+                'rgb(233, 150, 122)'
+            );
             expect(getComputedStyle(element.querySelector('div')).marginLeft).toEqual('10px');
             // element should not be dirty after template change
             expect(element.querySelector('div').hasAttribute('foo')).toEqual(false);

--- a/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -101,8 +101,14 @@ if (process.env.NATIVE_SHADOW) {
         document.body.appendChild(elm);
 
         return Promise.resolve().then(() => {
-            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map((xSimple) =>
-                xSimple.shadowRoot.querySelector('style')
+            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map(
+                (xSimple) => {
+                    // if constructable stylesheets are supported, return that rather than <style> tags
+                    return (
+                        xSimple.shadowRoot.adoptedStyleSheets ||
+                        xSimple.shadowRoot.querySelector('style')
+                    );
+                }
             );
 
             expect(styles[0]).toBeTruthy();

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
@@ -1,0 +1,41 @@
+import { createElement } from 'lwc';
+import Multi from 'x/multi';
+
+if (process.env.NATIVE_SHADOW) {
+    describe('Shadow DOM styling - multiple shadow DOM components', () => {
+        it('Does not duplicate styles if template is re-rendered', () => {
+            const element = createElement('x-multi', { is: Multi });
+
+            const getNumStyleSheets = () => {
+                if (element.shadowRoot.adoptedStyleSheets) {
+                    return element.shadowRoot.adoptedStyleSheets.length;
+                } else {
+                    return element.shadowRoot.querySelectorAll('style').length;
+                }
+            };
+
+            document.body.appendChild(element);
+            return Promise.resolve()
+                .then(() => {
+                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                        'rgb(0, 0, 255)'
+                    );
+                    expect(getNumStyleSheets()).toEqual(1);
+                    element.next();
+                })
+                .then(() => {
+                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                        'rgb(255, 0, 0)'
+                    );
+                    expect(getNumStyleSheets()).toEqual(2);
+                    element.next();
+                })
+                .then(() => {
+                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                        'rgb(0, 0, 255)'
+                    );
+                    expect(getNumStyleSheets()).toEqual(2);
+                });
+        });
+    });
+}

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/a.css
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/a.css
@@ -1,0 +1,3 @@
+.blue {
+    color: blue;
+}

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/a.html
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/a.html
@@ -1,0 +1,3 @@
+<template>
+  <div class="blue">a</div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/b.css
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/b.css
@@ -1,0 +1,3 @@
+.red {
+    color: red;
+}

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/b.html
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/b.html
@@ -1,0 +1,3 @@
+<template>
+  <div class="red">b</div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/multi.js
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multi/multi.js
@@ -1,0 +1,16 @@
+import { LightningElement, api } from 'lwc';
+import A from './a.html';
+import B from './b.html';
+
+export default class Multi extends LightningElement {
+    current = A;
+
+    @api
+    next() {
+        this.current = this.current === A ? B : A;
+    }
+
+    render() {
+        return this.current;
+    }
+}

--- a/packages/perf-benchmarks-components/scripts/generate-styled-components.js
+++ b/packages/perf-benchmarks-components/scripts/generate-styled-components.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import mkdirp from 'mkdirp';
+
+const NUM_COMPONENTS = 1000;
+
+// Generates some components with individual CSS for each one.
+// We could use @rollup/plugin-virtual for this, but @lwc/rollup-plugin deliberately
+// filters virtual modules, so it's simpler to just write to a temp dir.
+export function generateStyledComponents() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-'));
+
+    const components = Array(NUM_COMPONENTS)
+        .fill()
+        .map((_, i) =>
+            path.join(tmpDir, `src/benchmark/styledComponent${i}/styledComponent${i}.js`)
+        );
+
+    components.forEach((jsFilename, i) => {
+        const cssFilename = jsFilename.replace('.js', '.css');
+        const htmlFilename = jsFilename.replace('.js', '.html');
+
+        const js =
+            'import { LightningElement } from "lwc"; export default class extends LightningElement {}';
+        const css = `div { color: ${i.toString(16).padStart(6, '0')}}`;
+        const html = '<template><div></div></template>';
+
+        mkdirp.sync(path.dirname(jsFilename));
+        fs.writeFileSync(jsFilename, js, 'utf-8');
+        fs.writeFileSync(cssFilename, css, 'utf-8');
+        fs.writeFileSync(htmlFilename, html, 'utf-8');
+    });
+
+    const oneComponentFilename = path.join(tmpDir, 'src/benchmark/styledComponent.js');
+    const oneComponent = `export { default } from ${JSON.stringify(components[0])};`;
+    fs.writeFileSync(oneComponentFilename, oneComponent, 'utf-8');
+
+    const allComponentsFilename = path.join(tmpDir, 'src/benchmark/styledComponents.js');
+    const allComponents = `
+        ${components.map((mod, i) => `import cmp${i} from ${JSON.stringify(mod)}`).join(';')};
+        const modules = [${components.map((_, i) => `cmp${i}`).join(',')}];
+        export default modules;`;
+    fs.writeFileSync(allComponentsFilename, allComponents, 'utf-8');
+
+    return {
+        styledComponents: [oneComponentFilename, allComponentsFilename],
+        tmpDir,
+    };
+}

--- a/packages/perf-benchmarks-components/scripts/generate-styled-components.js
+++ b/packages/perf-benchmarks-components/scripts/generate-styled-components.js
@@ -46,8 +46,7 @@ export function generateStyledComponents() {
     const allComponentsFilename = path.join(tmpDir, 'src/benchmark/styledComponents.js');
     const allComponents = `
         ${components.map((mod, i) => `import cmp${i} from ${JSON.stringify(mod)}`).join(';')};
-        const modules = [${components.map((_, i) => `cmp${i}`).join(',')}];
-        export default modules;`;
+        export default [${components.map((_, i) => `cmp${i}`).join(',')}];
     fs.writeFileSync(allComponentsFilename, allComponents, 'utf-8');
 
     return {

--- a/packages/perf-benchmarks-components/scripts/generate-styled-components.js
+++ b/packages/perf-benchmarks-components/scripts/generate-styled-components.js
@@ -45,7 +45,7 @@ export function generateStyledComponents() {
     const allComponentsFilename = path.join(tmpDir, 'src/benchmark/styledComponents.js');
     const allComponents = `
         ${components.map((mod, i) => `import cmp${i} from ${JSON.stringify(mod)}`).join(';')};
-        export default [${components.map((_, i) => `cmp${i}`).join(',')}];
+        export default [${components.map((_, i) => `cmp${i}`).join(',')}];`;
     fs.writeFileSync(allComponentsFilename, allComponents, 'utf-8');
 
     return {

--- a/packages/perf-benchmarks-components/scripts/generate-styled-components.js
+++ b/packages/perf-benchmarks-components/scripts/generate-styled-components.js
@@ -8,7 +8,6 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import mkdirp from 'mkdirp';
 
 const NUM_COMPONENTS = 1000;
 
@@ -33,7 +32,7 @@ export function generateStyledComponents() {
         const css = `div { color: ${i.toString(16).padStart(6, '0')}}`;
         const html = '<template><div></div></template>';
 
-        mkdirp.sync(path.dirname(jsFilename));
+        fs.mkdirSync(path.dirname(jsFilename), { recursive: true });
         fs.writeFileSync(jsFilename, js, 'utf-8');
         fs.writeFileSync(cssFilename, css, 'utf-8');
         fs.writeFileSync(htmlFilename, html, 'utf-8');

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-different.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-different.benchmark.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import components from 'perf-benchmarks-components/dist/dom/benchmark/styledComponents.js';
+import { styledComponentBenchmark } from '../../../utils/styledComponentBenchmark';
+
+// Create 1k components with different CSS in each component
+styledComponentBenchmark(`ss-benchmark-styled-component/create/1k/different`, components);

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-same.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-same.benchmark.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import StyledComponent from 'perf-benchmarks-components/dist/dom/benchmark/styledComponent.js';
+import { styledComponentBenchmark } from '../../../utils/styledComponentBenchmark';
+
+// Create 1k components with the same CSS in each component
+styledComponentBenchmark(`ss-benchmark-styled-component/create/1k/same`, StyledComponent);

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-different.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-different.benchmark.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import components from 'perf-benchmarks-components/dist/dom/benchmark/styledComponents.js';
+import { styledComponentBenchmark } from '../../../utils/styledComponentBenchmark';
+
+// Create 1k components with different CSS in each component
+styledComponentBenchmark(`benchmark-styled-component/create/1k/different`, components);

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-same.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-same.benchmark.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import StyledComponent from 'perf-benchmarks-components/dist/dom/benchmark/styledComponent.js';
+import { styledComponentBenchmark } from '../../../utils/styledComponentBenchmark';
+
+// Create 1k components with the same CSS in each component
+styledComponentBenchmark(`benchmark-styled-component/create/1k/same`, StyledComponent);

--- a/packages/perf-benchmarks/src/utils/styledComponentBenchmark.js
+++ b/packages/perf-benchmarks/src/utils/styledComponentBenchmark.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { createElement } from 'lwc';
+import { destroyComponent } from './utils.js';
+import { benchmark, run, after } from './benchmark-framework.js';
+
+// Generic benchmark for styled components
+export function styledComponentBenchmark(name, componentOrComponents) {
+    benchmark(name, () => {
+        const elms = [];
+
+        const isArray = Array.isArray(componentOrComponents);
+
+        run(() => {
+            for (let i = 0; i < 1000; i++) {
+                const elm = createElement(isArray ? `styled-component${i}` : 'styled-component', {
+                    is: isArray ? componentOrComponents[i] : componentOrComponents,
+                });
+                document.body.appendChild(elm);
+                elms.push(elm);
+            }
+            return Promise.resolve();
+        });
+
+        after(() => {
+            for (const elm of elms) {
+                destroyComponent(elm);
+            }
+        });
+    });
+}

--- a/packages/perf-benchmarks/src/utils/styledComponentBenchmark.js
+++ b/packages/perf-benchmarks/src/utils/styledComponentBenchmark.js
@@ -16,7 +16,7 @@ export function styledComponentBenchmark(name, componentOrComponents) {
 
         const isArray = Array.isArray(componentOrComponents);
 
-        run(() => {
+        run(async () => {
             for (let i = 0; i < 1000; i++) {
                 const elm = createElement(isArray ? `styled-component${i}` : 'styled-component', {
                     is: isArray ? componentOrComponents[i] : componentOrComponents,
@@ -24,7 +24,6 @@ export function styledComponentBenchmark(name, componentOrComponents) {
                 document.body.appendChild(elm);
                 elms.push(elm);
             }
-            return Promise.resolve();
         });
 
         after(() => {


### PR DESCRIPTION
## Details

After looking into [the synthetic-to-native shadow migration](https://salesforce.quip.com/sYZaADXA4arY), it's clear to me that we need a performant solution for including the same stylesheet in multiple components (e.g. `@import 'shared.css'`). And through manual testing, I saw that constructable stylesheets really are a significant perf improvement in Chrome.

This PR is a revised version of #2290 that aims to be less invasive to the codebase while still bringing perf improvements. I also added some new Tachometer benchmarks to verify the perf gain.

My goal is to improve native shadow performance without regressing synthetic shadow performance. To achieve this, we're only using constructable stylesheets in the per-component level, not at the global level. (See [this doc](https://salesforce.quip.com/eUqbA9RVvBfs) for why that matters.)

<details><summary>Benchmark results</summary>

|Benchmark| Browser | Before | After | Delta |
| --- | --- | --- | --- | --- |
|dom-ss-styled-component-create-1k-different | chrome | 334ms-337ms | 335ms-338ms | -0.2% - 0.8% **(~same)** |
|dom-ss-styled-component-create-1k-different | firefox | 296ms-298ms | 297ms-299ms | -0.2% - 0.9% **(~same)** |
|dom-ss-styled-component-create-1k-different | safari | 161ms-163ms | 161ms-163ms | -0.8% - 0.9% **(~same)** |
|dom-ss-styled-component-create-1k-same | chrome | 105ms-107ms | 105ms-107ms | -0.6% - 1.0% **(~same)** |
|dom-ss-styled-component-create-1k-same | firefox | 87ms-89ms | 87ms-89ms | -1.0% - 0.9% **(~same)** |
|dom-ss-styled-component-create-1k-same | safari | 54ms-55ms | 54ms-54ms | -0.9% - 0.9% **(~same)** |
|dom-styled-component-create-1k-different | chrome | 330ms-332ms | 294ms-295ms | -11.5% - -10.6% **(faster)** |
|dom-styled-component-create-1k-different | firefox | 182ms-187ms | 173ms-177ms | -7.0% - -3.6% **(faster)** |
|dom-styled-component-create-1k-different | safari | 150ms-158ms | 146ms-149ms | -6.8% - -1.7% **(faster)** |
|dom-styled-component-create-1k-same | chrome | 148ms-150ms | 101ms-103ms | -32.0% - -30.9% **(faster)** |
|dom-styled-component-create-1k-same | firefox | 99ms-103ms | 83ms-87ms | -18.6% - -13.5% **(faster)** |
|dom-styled-component-create-1k-same | safari | 63ms-64ms | 55ms-56ms | -13.4% - -11.5% **(faster)** |

</details>

(The `ss-` ones use synthetic shadow.) Basically, the native shadow ones are massively improved (especially in Chrome), but the synthetic shadow ones are the same.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

There is a small change in how light DOM components work. Previously, if you switched templates on a light DOM component, then the old `<style>` would be removed from the DOM and replaced with the new `<style>`. Now the new `<style>` is merely added, while the old `<style>` remains. I don't think this will be a big problem in practice.

## GUS work item
W-9125079
