### PR TITLE
test: add more tests for light DOM inheritance

### DIFF
--- a/packages/integration-karma/test/light-dom/inheritance/index.spec.js
+++ b/packages/integration-karma/test/light-dom/inheritance/index.spec.js
@@ -1,16 +1,34 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
 
-import Test from 'x/test';
+import ShadowExtendsLight from 'x/shadowExtendsLight';
+import DefaultExtendsLight from 'x/defaultExtendsLight';
+import LightExtendsShadow from 'x/lightExtendsShadow';
+import DefaultExtendsShadow from 'x/defaultExtendsShadow';
 
-describe('with base class light and subclass shadow', () => {
+describe('light/shadow inheritance from base classes', () => {
     beforeEach(() => {
         setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
     });
     afterEach(() => {
         setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
     });
-    it('should render properly', () => {
-        const elm = createElement('x-test', { is: Test });
-        expect(elm.shadowRoot).not.toBeNull();
-    });
+
+    const testCases = [
+        { tag: 'x-shadow-extends-light', is: ShadowExtendsLight, shadow: true },
+        { tag: 'x-default-extends-light', is: DefaultExtendsLight, shadow: false },
+        { tag: 'x-light-extends-shadow', is: LightExtendsShadow, shadow: false },
+        { tag: 'x-default-extends-shadow', is: DefaultExtendsShadow, shadow: true },
+    ];
+
+    for (const { tag, is, shadow } of testCases) {
+        it(`renders ${is.name}`, () => {
+            const elm = createElement(tag, { is });
+            document.body.appendChild(elm);
+            if (shadow) {
+                expect(elm.shadowRoot).not.toBeNull();
+            } else {
+                expect(elm.shadowRoot).toBeNull();
+            }
+        });
+    }
 });

--- a/packages/integration-karma/test/light-dom/inheritance/x/baseLight/baseLight.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/baseLight/baseLight.html
@@ -1,0 +1,1 @@
+<template lwc:render-mode="light"></template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/baseLight/baseLight.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/baseLight/baseLight.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
-export default class Base extends LightningElement {
+export default class BaseLight extends LightningElement {
     static renderMode = 'light';
 }

--- a/packages/integration-karma/test/light-dom/inheritance/x/baseShadow/baseShadow.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/baseShadow/baseShadow.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/baseShadow/baseShadow.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/baseShadow/baseShadow.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class BaseShadow extends LightningElement {}

--- a/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsLight/defaultExtendsLight.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsLight/defaultExtendsLight.html
@@ -1,0 +1,1 @@
+<template lwc:render-mode="light"></template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsLight/defaultExtendsLight.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsLight/defaultExtendsLight.js
@@ -1,0 +1,3 @@
+import BaseLight from 'x/baseLight';
+
+export default class DefaultExtendsLight extends BaseLight {}

--- a/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsShadow/defaultExtendsShadow.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsShadow/defaultExtendsShadow.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsShadow/defaultExtendsShadow.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/defaultExtendsShadow/defaultExtendsShadow.js
@@ -1,0 +1,3 @@
+import BaseShadow from 'x/baseShadow';
+
+export default class DefaultExtendsShadow extends BaseShadow {}

--- a/packages/integration-karma/test/light-dom/inheritance/x/lightExtendsShadow/lightExtendsShadow.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/lightExtendsShadow/lightExtendsShadow.html
@@ -1,3 +1,3 @@
 <template lwc:render-mode="light">
-    <x-test data-id="x-test"></x-test>
+    <p></p>
 </template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/lightExtendsShadow/lightExtendsShadow.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/lightExtendsShadow/lightExtendsShadow.js
@@ -1,0 +1,5 @@
+import BaseShadow from 'x/baseShadow';
+
+export default class LightExtendsShadow extends BaseShadow {
+    static renderMode = 'light';
+}

--- a/packages/integration-karma/test/light-dom/inheritance/x/shadowExtendsLight/shadowExtendsLight.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/shadowExtendsLight/shadowExtendsLight.html
@@ -1,0 +1,3 @@
+<template>
+    <p></p>
+</template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/shadowExtendsLight/shadowExtendsLight.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/shadowExtendsLight/shadowExtendsLight.js
@@ -1,0 +1,5 @@
+import BaseLight from 'x/baseLight';
+
+export default class ShadowExtendsLight extends BaseLight {
+    static renderMode = 'shadow';
+}

--- a/packages/integration-karma/test/light-dom/inheritance/x/test/test.html
+++ b/packages/integration-karma/test/light-dom/inheritance/x/test/test.html
@@ -1,3 +1,0 @@
-<template lwc:render-mode="light">
-    <p data-id="text">Hello, Light DOM</p>
-</template>

--- a/packages/integration-karma/test/light-dom/inheritance/x/test/test.js
+++ b/packages/integration-karma/test/light-dom/inheritance/x/test/test.js
@@ -1,5 +1,0 @@
-import Base from 'x/base';
-
-export default class Test extends Base {
-    static renderMode = 'shadow';
-}


### PR DESCRIPTION
## Details

Adds a Karma test to verify that light DOM inheritance works as expected:

- shadow can override light
- light can override shadow
- undefined inherits light
- undefined inherits shadow

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`