### PR TITLE
refactor(engine-core): Simplify profiler logic

### DIFF
--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -49,7 +49,7 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
     const vmBeingConstructedInception = vmBeingConstructed;
     let error;
     if (profilerEnabled) {
-        logOperationStart(OperationId.constructor, vm);
+        logOperationStart(OperationId.Constructor, vm);
     }
     vmBeingConstructed = vm;
     /**
@@ -74,7 +74,7 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         error = Object(e);
     } finally {
         if (profilerEnabled) {
-            logOperationEnd(OperationId.constructor, vm);
+            logOperationEnd(OperationId.Constructor, vm);
         }
         vmBeingConstructed = vmBeingConstructedInception;
         if (!isUndefined(error)) {
@@ -137,7 +137,7 @@ export function invokeComponentRenderedCallback(vm: VM): void {
                 vmInvokingRenderedCallback = vm;
                 // pre
                 if (profilerEnabled) {
-                    logOperationStart(OperationId.renderedCallback, vm);
+                    logOperationStart(OperationId.RenderedCallback, vm);
                 }
             },
             () => {
@@ -147,7 +147,7 @@ export function invokeComponentRenderedCallback(vm: VM): void {
             () => {
                 // post
                 if (profilerEnabled) {
-                    logOperationEnd(OperationId.renderedCallback, vm);
+                    logOperationEnd(OperationId.RenderedCallback, vm);
                 }
                 vmInvokingRenderedCallback = vmInvokingRenderedCallbackInception;
             }

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -9,7 +9,7 @@ import { assert, isFunction, isUndefined, noop } from '@lwc/shared';
 import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
 import { VM, runWithBoundaryProtection } from './vm';
 import { LightningElement, LightningElementConstructor } from './base-lightning-element';
-import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
+import { logOperationStart, logOperationEnd, OperationId } from './profiler';
 
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
@@ -25,9 +25,6 @@ let vmInvokingRenderedCallback: VM | null = null;
 export function isInvokingRenderedCallback(vm: VM): boolean {
     return vmInvokingRenderedCallback === vm;
 }
-
-let profilerEnabled = false;
-trackProfilerState((t) => (profilerEnabled = t));
 
 export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, args?: any[]): any {
     const { component, callHook, owner } = vm;
@@ -48,9 +45,9 @@ export function invokeComponentCallback(vm: VM, fn: (...args: any[]) => any, arg
 export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstructor) {
     const vmBeingConstructedInception = vmBeingConstructed;
     let error;
-    if (profilerEnabled) {
-        logOperationStart(OperationId.Constructor, vm);
-    }
+
+    logOperationStart(OperationId.Constructor, vm);
+
     vmBeingConstructed = vm;
     /**
      * Constructors don't need to be wrapped with a boundary because for root elements
@@ -73,9 +70,8 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
     } catch (e) {
         error = Object(e);
     } finally {
-        if (profilerEnabled) {
-            logOperationEnd(OperationId.Constructor, vm);
-        }
+        logOperationEnd(OperationId.Constructor, vm);
+
         vmBeingConstructed = vmBeingConstructedInception;
         if (!isUndefined(error)) {
             addErrorComponentStack(vm, error);
@@ -134,11 +130,9 @@ export function invokeComponentRenderedCallback(vm: VM): void {
             vm,
             owner,
             () => {
-                vmInvokingRenderedCallback = vm;
                 // pre
-                if (profilerEnabled) {
-                    logOperationStart(OperationId.RenderedCallback, vm);
-                }
+                vmInvokingRenderedCallback = vm;
+                logOperationStart(OperationId.RenderedCallback, vm);
             },
             () => {
                 // job
@@ -146,9 +140,7 @@ export function invokeComponentRenderedCallback(vm: VM): void {
             },
             () => {
                 // post
-                if (profilerEnabled) {
-                    logOperationEnd(OperationId.RenderedCallback, vm);
-                }
+                logOperationEnd(OperationId.RenderedCallback, vm);
                 vmInvokingRenderedCallback = vmInvokingRenderedCallbackInception;
             }
         );

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -74,13 +74,13 @@ type LogDispatcher = (opId: OperationId, phase: Phase, cmpName?: string, vmIndex
 
 let logOperation: LogDispatcher = noop;
 
-export const startMeasure = !isUserTimingSupported
+const startMeasure = !isUserTimingSupported
     ? noop
     : function (phase: MeasurementPhase, vm: VM) {
           const markName = getMarkName(phase, vm);
           start(markName);
       };
-export const endMeasure = !isUserTimingSupported
+const endMeasure = !isUserTimingSupported
     ? noop
     : function (phase: MeasurementPhase, vm: VM) {
           const markName = getMarkName(phase, vm);
@@ -88,13 +88,13 @@ export const endMeasure = !isUserTimingSupported
           end(measureName, markName);
       };
 
-export const startGlobalMeasure = !isUserTimingSupported
+const startGlobalMeasure = !isUserTimingSupported
     ? noop
     : function (phase: GlobalMeasurementPhase, vm?: VM) {
           const markName = isUndefined(vm) ? phase : getMarkName(phase, vm);
           start(markName);
       };
-export const endGlobalMeasure = !isUserTimingSupported
+const endGlobalMeasure = !isUserTimingSupported
     ? noop
     : function (phase: GlobalMeasurementPhase, vm?: VM) {
           const markName = isUndefined(vm) ? phase : getMarkName(phase, vm);
@@ -122,29 +122,6 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 const profilerStateCallbacks: ((arg0: boolean) => void)[] = [];
-
-function trackProfilerState(callback: (arg0: boolean) => void) {
-    callback(profilerEnabled);
-    profilerStateCallbacks.push(callback);
-}
-
-function logOperationStart(opId: OperationId, vm: VM) {
-    if (logMarks) {
-        startMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
-    }
-    if (bufferLogging) {
-        logOperation(opId, Phase.Start, vm.tagName, vm.idx);
-    }
-}
-
-function logOperationEnd(opId: OperationId, vm: VM) {
-    if (logMarks) {
-        endMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
-    }
-    if (bufferLogging) {
-        logOperation(opId, Phase.Stop, vm.tagName, vm.idx);
-    }
-}
 
 function enableProfiler() {
     profilerEnabled = true;
@@ -184,20 +161,43 @@ function detachDispatcher() {
     return currentLogOperation;
 }
 
-const profilerControl = {
-    enableProfiler,
-    disableProfiler,
-    attachDispatcher,
-    detachDispatcher,
-};
-
 function opIdForGlobalMeasurementPhase(phase: GlobalMeasurementPhase) {
     return phase === GlobalMeasurementPhase.HYDRATE
         ? OperationId.GlobalHydrate
         : OperationId.GlobalRehydrate;
 }
 
-function logGlobalOperationStart(phase: GlobalMeasurementPhase, vm?: VM) {
+export const profilerControl = {
+    enableProfiler,
+    disableProfiler,
+    attachDispatcher,
+    detachDispatcher,
+};
+
+export function trackProfilerState(callback: (arg0: boolean) => void) {
+    callback(profilerEnabled);
+    profilerStateCallbacks.push(callback);
+}
+
+export function logOperationStart(opId: OperationId, vm: VM) {
+    if (logMarks) {
+        startMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
+    }
+    if (bufferLogging) {
+        logOperation(opId, Phase.Start, vm.tagName, vm.idx);
+    }
+}
+
+export function logOperationEnd(opId: OperationId, vm: VM) {
+    if (logMarks) {
+        endMeasure(opIdToMeasurementPhaseMappingArray[opId], vm);
+    }
+    if (bufferLogging) {
+        logOperation(opId, Phase.Stop, vm.tagName, vm.idx);
+    }
+}
+
+export function logGlobalOperationStart(phase: GlobalMeasurementPhase, vm?: VM) {
     if (logMarks) {
         startGlobalMeasure(phase, vm);
     }
@@ -206,7 +206,7 @@ function logGlobalOperationStart(phase: GlobalMeasurementPhase, vm?: VM) {
     }
 }
 
-function logGlobalOperationEnd(phase: GlobalMeasurementPhase, vm?: VM) {
+export function logGlobalOperationEnd(phase: GlobalMeasurementPhase, vm?: VM) {
     if (logMarks) {
         endGlobalMeasure(phase, vm);
     }
@@ -214,12 +214,3 @@ function logGlobalOperationEnd(phase: GlobalMeasurementPhase, vm?: VM) {
         logOperation(opIdForGlobalMeasurementPhase(phase), Phase.Stop, vm?.tagName, vm?.idx);
     }
 }
-
-export {
-    logOperationStart,
-    logOperationEnd,
-    trackProfilerState,
-    profilerControl,
-    logGlobalOperationStart,
-    logGlobalOperationEnd,
-};

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -23,15 +23,15 @@ export const enum GlobalMeasurementPhase {
 }
 
 export const enum OperationId {
-    constructor = 0,
-    render = 1,
-    patch = 2,
-    connectedCallback = 3,
-    renderedCallback = 4,
-    disconnectedCallback = 5,
-    errorCallback = 6,
-    globalHydrate = 7,
-    globalRehydrate = 8,
+    Constructor = 0,
+    Render = 1,
+    Patch = 2,
+    ConnectedCallback = 3,
+    RenderedCallback = 4,
+    DisconnectedCallback = 5,
+    ErrorCallback = 6,
+    GlobalHydrate = 7,
+    GlobalRehydrate = 8,
 }
 
 const enum Phase {
@@ -193,8 +193,8 @@ const profilerControl = {
 
 function opIdForGlobalMeasurementPhase(phase: GlobalMeasurementPhase) {
     return phase === GlobalMeasurementPhase.HYDRATE
-        ? OperationId.globalHydrate
-        : OperationId.globalRehydrate;
+        ? OperationId.GlobalHydrate
+        : OperationId.GlobalRehydrate;
 }
 
 function logGlobalOperationStart(phase: GlobalMeasurementPhase, vm?: VM) {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -36,7 +36,7 @@ import {
     getStylesheetsContent,
     updateSyntheticShadowAttributes,
 } from './stylesheet';
-import { logOperationStart, logOperationEnd, OperationId, trackProfilerState } from './profiler';
+import { logOperationStart, logOperationEnd, OperationId } from './profiler';
 import { getTemplateOrSwappedTemplate, setActiveVM } from './hot-swaps';
 
 export interface TemplateStylesheetTokens {
@@ -71,9 +71,6 @@ export function getVMBeingRendered(): VM | null {
 export function setVMBeingRendered(vm: VM | null) {
     vmBeingRendered = vm;
 }
-
-let profilerEnabled = false;
-trackProfilerState((t) => (profilerEnabled = t));
 
 function validateSlots(vm: VM, html: Template) {
     if (process.env.NODE_ENV === 'production') {
@@ -142,9 +139,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
         () => {
             // pre
             vmBeingRendered = vm;
-            if (profilerEnabled) {
-                logOperationStart(OperationId.Render, vm);
-            }
+            logOperationStart(OperationId.Render, vm);
         },
         () => {
             // job
@@ -217,9 +212,8 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
             // post
             isUpdatingTemplate = isUpdatingTemplateInception;
             vmBeingRendered = vmOfTemplateBeingUpdatedInception;
-            if (profilerEnabled) {
-                logOperationEnd(OperationId.Render, vm);
-            }
+
+            logOperationEnd(OperationId.Render, vm);
         }
     );
 

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -143,7 +143,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
             // pre
             vmBeingRendered = vm;
             if (profilerEnabled) {
-                logOperationStart(OperationId.render, vm);
+                logOperationStart(OperationId.Render, vm);
             }
         },
         () => {
@@ -218,7 +218,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
             isUpdatingTemplate = isUpdatingTemplateInception;
             vmBeingRendered = vmOfTemplateBeingUpdatedInception;
             if (profilerEnabled) {
-                logOperationEnd(OperationId.render, vm);
+                logOperationEnd(OperationId.Render, vm);
             }
         }
     );

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -39,7 +39,6 @@ import {
     logOperationStart,
     logOperationEnd,
     OperationId,
-    trackProfilerState,
     logGlobalOperationEnd,
     logGlobalOperationStart,
     GlobalMeasurementPhase,
@@ -161,9 +160,6 @@ export interface VM<N = HostNode, E = HostElement> {
     callHook: (cmp: LightningElement | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
 }
 
-let profilerEnabled = false;
-trackProfilerState((t) => (profilerEnabled = t));
-
 type VMAssociable = HostNode | LightningElement;
 
 let idx: number = 0;
@@ -194,9 +190,7 @@ export function rerenderVM(vm: VM) {
 export function connectRootElement(elm: any) {
     const vm = getAssociatedVM(elm);
 
-    if (profilerEnabled) {
-        logGlobalOperationStart(GlobalMeasurementPhase.HYDRATE, vm);
-    }
+    logGlobalOperationStart(GlobalMeasurementPhase.HYDRATE, vm);
 
     // Usually means moving the element from one place to another, which is observable via
     // life-cycle hooks.
@@ -207,9 +201,7 @@ export function connectRootElement(elm: any) {
     runConnectedCallback(vm);
     rehydrate(vm);
 
-    if (profilerEnabled) {
-        logGlobalOperationEnd(GlobalMeasurementPhase.HYDRATE, vm);
-    }
+    logGlobalOperationEnd(GlobalMeasurementPhase.HYDRATE, vm);
 }
 
 export function disconnectRootElement(elm: any) {
@@ -423,9 +415,7 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 vm,
                 () => {
                     // pre
-                    if (profilerEnabled) {
-                        logOperationStart(OperationId.Patch, vm);
-                    }
+                    logOperationStart(OperationId.Patch, vm);
                 },
                 () => {
                     // job
@@ -434,9 +424,7 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 },
                 () => {
                     // post
-                    if (profilerEnabled) {
-                        logOperationEnd(OperationId.Patch, vm);
-                    }
+                    logOperationEnd(OperationId.Patch, vm);
                 }
             );
         }
@@ -466,9 +454,7 @@ function runRenderedCallback(vm: VM) {
 let rehydrateQueue: VM[] = [];
 
 function flushRehydrationQueue() {
-    if (profilerEnabled) {
-        logGlobalOperationStart(GlobalMeasurementPhase.REHYDRATE);
-    }
+    logGlobalOperationStart(GlobalMeasurementPhase.REHYDRATE);
 
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
@@ -491,9 +477,7 @@ function flushRehydrationQueue() {
                 ArrayUnshift.apply(rehydrateQueue, ArraySlice.call(vms, i + 1));
             }
             // we need to end the measure before throwing.
-            if (profilerEnabled) {
-                logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
-            }
+            logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
 
             // re-throwing the original error will break the current tick, but since the next tick is
             // already scheduled, it should continue patching the rest.
@@ -501,9 +485,7 @@ function flushRehydrationQueue() {
         }
     }
 
-    if (profilerEnabled) {
-        logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
-    }
+    logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
 }
 
 export function runConnectedCallback(vm: VM) {
@@ -522,15 +504,11 @@ export function runConnectedCallback(vm: VM) {
     }
     const { connectedCallback } = vm.def;
     if (!isUndefined(connectedCallback)) {
-        if (profilerEnabled) {
-            logOperationStart(OperationId.ConnectedCallback, vm);
-        }
+        logOperationStart(OperationId.ConnectedCallback, vm);
 
         invokeComponentCallback(vm, connectedCallback);
 
-        if (profilerEnabled) {
-            logOperationEnd(OperationId.ConnectedCallback, vm);
-        }
+        logOperationEnd(OperationId.ConnectedCallback, vm);
     }
 }
 
@@ -560,15 +538,11 @@ function runDisconnectedCallback(vm: VM) {
     }
     const { disconnectedCallback } = vm.def;
     if (!isUndefined(disconnectedCallback)) {
-        if (profilerEnabled) {
-            logOperationStart(OperationId.DisconnectedCallback, vm);
-        }
+        logOperationStart(OperationId.DisconnectedCallback, vm);
 
         invokeComponentCallback(vm, disconnectedCallback);
 
-        if (profilerEnabled) {
-            logOperationEnd(OperationId.DisconnectedCallback, vm);
-        }
+        logOperationEnd(OperationId.DisconnectedCallback, vm);
     }
 }
 
@@ -748,17 +722,13 @@ export function runWithBoundaryProtection(
             }
             resetComponentRoot(vm); // remove offenders
 
-            if (profilerEnabled) {
-                logOperationStart(OperationId.ErrorCallback, vm);
-            }
+            logOperationStart(OperationId.ErrorCallback, vm);
 
             // error boundaries must have an ErrorCallback
             const errorCallback = errorBoundaryVm.def.errorCallback!;
             invokeComponentCallback(errorBoundaryVm, errorCallback, [error, error.wcStack]);
 
-            if (profilerEnabled) {
-                logOperationEnd(OperationId.ErrorCallback, vm);
-            }
+            logOperationEnd(OperationId.ErrorCallback, vm);
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -41,7 +41,6 @@ import {
     OperationId,
     logGlobalOperationEnd,
     logGlobalOperationStart,
-    GlobalMeasurementPhase,
 } from './profiler';
 import { hasDynamicChildren } from './hooks';
 import { ReactiveObserver } from './mutation-tracker';
@@ -190,7 +189,7 @@ export function rerenderVM(vm: VM) {
 export function connectRootElement(elm: any) {
     const vm = getAssociatedVM(elm);
 
-    logGlobalOperationStart(GlobalMeasurementPhase.HYDRATE, vm);
+    logGlobalOperationStart(OperationId.GlobalHydrate, vm);
 
     // Usually means moving the element from one place to another, which is observable via
     // life-cycle hooks.
@@ -201,7 +200,7 @@ export function connectRootElement(elm: any) {
     runConnectedCallback(vm);
     rehydrate(vm);
 
-    logGlobalOperationEnd(GlobalMeasurementPhase.HYDRATE, vm);
+    logGlobalOperationEnd(OperationId.GlobalHydrate, vm);
 }
 
 export function disconnectRootElement(elm: any) {
@@ -454,7 +453,7 @@ function runRenderedCallback(vm: VM) {
 let rehydrateQueue: VM[] = [];
 
 function flushRehydrationQueue() {
-    logGlobalOperationStart(GlobalMeasurementPhase.REHYDRATE);
+    logGlobalOperationStart(OperationId.GlobalRehydrate);
 
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
@@ -477,7 +476,7 @@ function flushRehydrationQueue() {
                 ArrayUnshift.apply(rehydrateQueue, ArraySlice.call(vms, i + 1));
             }
             // we need to end the measure before throwing.
-            logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
+            logGlobalOperationEnd(OperationId.GlobalRehydrate);
 
             // re-throwing the original error will break the current tick, but since the next tick is
             // already scheduled, it should continue patching the rest.
@@ -485,7 +484,7 @@ function flushRehydrationQueue() {
         }
     }
 
-    logGlobalOperationEnd(GlobalMeasurementPhase.REHYDRATE);
+    logGlobalOperationEnd(OperationId.GlobalRehydrate);
 }
 
 export function runConnectedCallback(vm: VM) {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -424,7 +424,7 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 () => {
                     // pre
                     if (profilerEnabled) {
-                        logOperationStart(OperationId.patch, vm);
+                        logOperationStart(OperationId.Patch, vm);
                     }
                 },
                 () => {
@@ -435,7 +435,7 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 () => {
                     // post
                     if (profilerEnabled) {
-                        logOperationEnd(OperationId.patch, vm);
+                        logOperationEnd(OperationId.Patch, vm);
                     }
                 }
             );
@@ -523,13 +523,13 @@ export function runConnectedCallback(vm: VM) {
     const { connectedCallback } = vm.def;
     if (!isUndefined(connectedCallback)) {
         if (profilerEnabled) {
-            logOperationStart(OperationId.connectedCallback, vm);
+            logOperationStart(OperationId.ConnectedCallback, vm);
         }
 
         invokeComponentCallback(vm, connectedCallback);
 
         if (profilerEnabled) {
-            logOperationEnd(OperationId.connectedCallback, vm);
+            logOperationEnd(OperationId.ConnectedCallback, vm);
         }
     }
 }
@@ -561,13 +561,13 @@ function runDisconnectedCallback(vm: VM) {
     const { disconnectedCallback } = vm.def;
     if (!isUndefined(disconnectedCallback)) {
         if (profilerEnabled) {
-            logOperationStart(OperationId.disconnectedCallback, vm);
+            logOperationStart(OperationId.DisconnectedCallback, vm);
         }
 
         invokeComponentCallback(vm, disconnectedCallback);
 
         if (profilerEnabled) {
-            logOperationEnd(OperationId.disconnectedCallback, vm);
+            logOperationEnd(OperationId.DisconnectedCallback, vm);
         }
     }
 }
@@ -749,7 +749,7 @@ export function runWithBoundaryProtection(
             resetComponentRoot(vm); // remove offenders
 
             if (profilerEnabled) {
-                logOperationStart(OperationId.errorCallback, vm);
+                logOperationStart(OperationId.ErrorCallback, vm);
             }
 
             // error boundaries must have an ErrorCallback
@@ -757,7 +757,7 @@ export function runWithBoundaryProtection(
             invokeComponentCallback(errorBoundaryVm, errorCallback, [error, error.wcStack]);
 
             if (profilerEnabled) {
-                logOperationEnd(OperationId.errorCallback, vm);
+                logOperationEnd(OperationId.ErrorCallback, vm);
             }
         }
     }


### PR DESCRIPTION
## Details

This PR simplifies the LWC engine profiler logic:
- Remove the necessity to wrap profiler call in a `if (profilerEnabled) {}` block
- Unify `logOperation*` and `logGlobalOperation*` function signature

Since this PR is a complete rewrite of the `profiler.ts` I made sure to create a clean commit history with incremental changes. I would recommend reviewing this change by looking at each commit in isolation.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 