### PR TITLE
chore(compiler): Silent Babel codegen size error

### DIFF
--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -29,8 +29,17 @@ export default function scriptTransform(
     let result;
     try {
         result = babel.transformSync(code, {
+            filename,
+            sourceMaps: sourcemap,
+
+            // Prevent Babel from loading local configuration.
             babelrc: false,
             configFile: false,
+
+            // Force Babel to generate new line and whitespaces. This prevent Babel from generating
+            // an error when the generated code is over 500KB.
+            compact: false,
+
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
                 [babelClassPropertiesPlugin, { loose: true }],
@@ -39,8 +48,6 @@ export default function scriptTransform(
                 // already a stage 4 feature. The LWC compile should leave this syntax untouched.
                 babelObjectRestSpreadPlugin,
             ],
-            filename,
-            sourceMaps: sourcemap,
         })!;
     } catch (e) {
         throw normalizeToCompilerError(TransformerErrors.JS_TRANSFORMER_ERROR, e, { filename });


### PR DESCRIPTION
## Details

This PR forces Babel to run with `compact` turned off. This prevents the following error to print out in the console when compiling modules larger than 500 KB:

```
[BABEL] Note: The code generator has deoptimised the styling of <filename> as it exceeds the max of 500KB.
```

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
