### PR TITLE
Remove object spread transpilation plugin

### DIFF
--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -34,10 +34,6 @@ export default function scriptTransform(
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
                 [babelClassPropertiesPlugin, { loose: true }],
-
-                // This plugin should be removed in a future version. The object-rest-spread is
-                // already a stage 4 feature. The LWC compile should leave this syntax untouched.
-                babelObjectRestSpreadPlugin,
             ],
             filename,
             sourceMaps: sourcemap,


### PR DESCRIPTION
We have 0% of non-IE11 traffic that requires object spread.
Moreover this is duplicated plugin in platform compiler


## Details
Remove unnecessary transpilation plugin

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`