### PR TITLE
refactor(engine-core): Remove duplicate dev assertions

### DIFF
--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -4,13 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isArray, isFalse, isFunction, isUndefined } from '@lwc/shared';
-import {
-    invokeComponentConstructor,
-    invokeComponentRenderMethod,
-    isInvokingRender,
-    invokeEventListener,
-} from './invoker';
+import { assert, isFalse, isFunction, isUndefined } from '@lwc/shared';
+import { invokeComponentRenderMethod, isInvokingRender, invokeEventListener } from './invoker';
 import { VM, scheduleRehydration } from './vm';
 import { VNodes } from '../3rdparty/snabbdom/types';
 import { ReactiveObserver } from '../libs/mutation-tracker';
@@ -39,17 +34,6 @@ export function getComponentRegisteredTemplate(
     return signedTemplateMap.get(Ctor);
 }
 
-export function createComponent(vm: VM, Ctor: LightningElementConstructor) {
-    // create the component instance
-    invokeComponentConstructor(vm, Ctor);
-
-    if (isUndefined(vm.component)) {
-        throw new ReferenceError(
-            `Invalid construction for ${Ctor}, you must extend LightningElement.`
-        );
-    }
-}
-
 export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
     return new ReactiveObserver(() => {
         const { isDirty } = vm;
@@ -70,12 +54,6 @@ export function renderComponent(vm: VM): VNodes {
     vm.isDirty = false;
     vm.isScheduled = false;
 
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            isArray(vnodes),
-            `${vm}.render() should always return an array of vnodes instead of ${vnodes}`
-        );
-    }
     return vnodes;
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -22,15 +22,14 @@ import {
     keys,
 } from '@lwc/shared';
 import { getComponentTag } from '../shared/format';
-import {
-    createComponent,
-    renderComponent,
-    markComponentAsDirty,
-    getTemplateReactiveObserver,
-} from './component';
+import { renderComponent, markComponentAsDirty, getTemplateReactiveObserver } from './component';
 import { addCallbackToNextTick, EmptyArray, EmptyObject } from './utils';
 import { invokeServiceHook, Services } from './services';
-import { invokeComponentCallback, invokeComponentRenderedCallback } from './invoker';
+import {
+    invokeComponentCallback,
+    invokeComponentConstructor,
+    invokeComponentRenderedCallback,
+} from './invoker';
 
 import { Template } from './template';
 import { ComponentDef } from './def';
@@ -354,7 +353,7 @@ export function createVM<HostNode, HostElement>(
     }
 
     // Create component instance associated to the vm and the element.
-    createComponent(vm, def.ctor);
+    invokeComponentConstructor(vm, def.ctor);
 
     // Initializing the wire decorator per instance only when really needed
     if (isFalse(renderer.ssr) && hasWireAdapters(vm)) {


### PR DESCRIPTION
## Details

This PR removes the following dev only assertions:
- asserting if the returned object from the constructor invocation is a LightningElement in `createComponent` is already done in `invokeComponentConstructor`
- asserting if the returned value from invoking the template is an array in `renderComponent` is already done in `invokeComponentRenderMethod`

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
