### PR TITLE
chore(synthetic-shadow): use cached Node reference for instanceof test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,9 +91,10 @@
         "template-curly-spacing": "error",
         "yoda": "error",
 
+        "lwc-internal/no-instanceof-uncached-node": "error",
         "lwc-internal/no-invalid-todo": "error",
         "import/order": [
-            "error", 
+            "error",
             { "groups": [["builtin", "external", "internal"]] }
         ]
     },

--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -14,6 +14,7 @@ import { renderer } from '../renderer';
  * API is subject to change or being removed.
  */
 export function isNodeFromTemplate(node: Node): boolean {
+    // eslint-disable-next-line lwc-internal/no-instanceof-uncached-node
     if (isFalse(node instanceof Node)) {
         return false;
     }

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
-import { DOMNodeInterface as Node } from '../../env/dom';
+import { Node } from '../../env/dom';
 import { isInstanceOfNativeShadowRoot } from '../../env/shadow-root';
 import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';
+import { DOMNodeInterface as Node } from '../../env/dom';
 import { isInstanceOfNativeShadowRoot } from '../../env/shadow-root';
 import { SyntheticShadowRoot } from '../../faux-shadow/shadow-root';
 

--- a/packages/@lwc/synthetic-shadow/src/env/dom.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/dom.ts
@@ -19,11 +19,12 @@ const eventCurrentTargetGetter: (this: Event) => EventTarget | null = getOwnProp
 const focusEventRelatedTargetGetter: (this: FocusEvent) => EventTarget | null =
     getOwnPropertyDescriptor(FocusEvent.prototype, 'relatedTarget')!.get!;
 
-const DOMNodeInterface = Node;
+// Cached reference to the DOM Node interface
+const _Node = Node;
 
 export {
     eventTargetGetter,
     eventCurrentTargetGetter,
     focusEventRelatedTargetGetter,
-    DOMNodeInterface,
+    _Node as Node,
 };

--- a/packages/@lwc/synthetic-shadow/src/env/dom.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/dom.ts
@@ -19,4 +19,11 @@ const eventCurrentTargetGetter: (this: Event) => EventTarget | null = getOwnProp
 const focusEventRelatedTargetGetter: (this: FocusEvent) => EventTarget | null =
     getOwnPropertyDescriptor(FocusEvent.prototype, 'relatedTarget')!.get!;
 
-export { eventTargetGetter, eventCurrentTargetGetter, focusEventRelatedTargetGetter };
+const DOMNodeInterface = Node;
+
+export {
+    eventTargetGetter,
+    eventCurrentTargetGetter,
+    focusEventRelatedTargetGetter,
+    DOMNodeInterface,
+};

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -12,7 +12,7 @@ import {
     getShadowRootResolver,
     getShadowRoot,
 } from './shadow-root';
-import { DOMNodeInterface as Node } from '../env/dom';
+import { Node } from '../env/dom';
 import { querySelectorAll } from '../env/element';
 import {
     childNodesGetter,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -12,6 +12,7 @@ import {
     getShadowRootResolver,
     getShadowRoot,
 } from './shadow-root';
+import { DOMNodeInterface as Node } from '../env/dom';
 import { querySelectorAll } from '../env/element';
 import {
     childNodesGetter,

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -8,7 +8,11 @@ import { defineProperties, isNull, isUndefined } from '@lwc/shared';
 
 import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { retarget } from '../../3rdparty/polymer/retarget';
-import { eventTargetGetter, eventCurrentTargetGetter } from '../../env/dom';
+import {
+    eventTargetGetter,
+    eventCurrentTargetGetter,
+    DOMNodeInterface as Node,
+} from '../../env/dom';
 import { eventToShadowRootMap, getShadowRoot, isHostElement } from '../../faux-shadow/shadow-root';
 import { EventListenerContext, eventToContextMap } from '../../faux-shadow/events';
 import { getNodeOwnerKey } from '../../shared/node-ownership';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -8,11 +8,7 @@ import { defineProperties, isNull, isUndefined } from '@lwc/shared';
 
 import { pathComposer } from '../../3rdparty/polymer/path-composer';
 import { retarget } from '../../3rdparty/polymer/retarget';
-import {
-    eventTargetGetter,
-    eventCurrentTargetGetter,
-    DOMNodeInterface as Node,
-} from '../../env/dom';
+import { eventTargetGetter, eventCurrentTargetGetter, Node } from '../../env/dom';
 import { eventToShadowRootMap, getShadowRoot, isHostElement } from '../../faux-shadow/shadow-root';
 import { EventListenerContext, eventToContextMap } from '../../faux-shadow/events';
 import { getNodeOwnerKey } from '../../shared/node-ownership';

--- a/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
@@ -8,7 +8,7 @@ import { defineProperty, getOwnPropertyDescriptor, isNull } from '@lwc/shared';
 
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { retarget } from '../3rdparty/polymer/retarget';
-import { eventCurrentTargetGetter, DOMNodeInterface as Node } from '../env/dom';
+import { eventCurrentTargetGetter, Node } from '../env/dom';
 import { isNodeShadowed } from '../shared/node-ownership';
 import { getOwnerDocument } from '../shared/utils';
 

--- a/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/retarget-related-target.ts
@@ -8,7 +8,7 @@ import { defineProperty, getOwnPropertyDescriptor, isNull } from '@lwc/shared';
 
 import { pathComposer } from '../3rdparty/polymer/path-composer';
 import { retarget } from '../3rdparty/polymer/retarget';
-import { eventCurrentTargetGetter } from '../env/dom';
+import { eventCurrentTargetGetter, DOMNodeInterface as Node } from '../env/dom';
 import { isNodeShadowed } from '../shared/node-ownership';
 import { getOwnerDocument } from '../shared/utils';
 

--- a/scripts/eslint-plugin/index.js
+++ b/scripts/eslint-plugin/index.js
@@ -9,11 +9,13 @@
 const noExtendGlobalConstructor = require('./rules/no-extend-global-constructor');
 const noProductionAssert = require('./rules/no-production-assert');
 const noInvalidTodo = require('./rules/no-invalid-todo');
+const noInstanceofUncachedNode = require('./rules/no-instanceof-uncached-node');
 
 module.exports = {
     rules: {
         'no-extend-global-constructor': noExtendGlobalConstructor,
-        'no-production-assert': noProductionAssert,
+        'no-instanceof-uncached-node': noInstanceofUncachedNode,
         'no-invalid-todo': noInvalidTodo,
+        'no-production-assert': noProductionAssert,
     },
 };

--- a/scripts/eslint-plugin/rules/no-instanceof-uncached-node.js
+++ b/scripts/eslint-plugin/rules/no-instanceof-uncached-node.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Avoid using uncached Node reference for instanceof test',
+        },
+    },
+
+    create(context) {
+        return {
+            'Identifier[name="Node"]': function (node) {
+                const parent = node.parent;
+                if (parent.type === 'BinaryExpression' && parent.operator === 'instanceof') {
+                    const scope = context.getScope();
+                    scope.references.forEach((ref) => {
+                        if (ref.identifier.name === 'Node' && ref.resolved === null) {
+                            context.report({
+                                node,
+                                message: `Avoid using uncached Node reference for instanceof test`,
+                            });
+                        }
+                    });
+                }
+            },
+        };
+    },
+};


### PR DESCRIPTION
## Details

Avoids exceptions from being thrown when external scripts set `window.Node` to `null`.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-7663143, W-9478958
