### PR TITLE
feat: enable wire protocol in SSR

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -351,7 +351,7 @@ export function createVM<HostNode, HostElement>(
     invokeComponentConstructor(vm, def.ctor);
 
     // Initializing the wire decorator per instance only when really needed
-    if (isFalse(renderer.ssr) && hasWireAdapters(vm)) {
+    if (hasWireAdapters(vm)) {
         installWireAdapters(vm);
     }
 

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -340,7 +340,7 @@ export function installWireAdapters(vm: VM) {
             const hasDynamicParams = wireDef.dynamic.length > 0;
             ArrayPush.call(wiredConnecting, () => {
                 connector.connect();
-                if (featureFlags.ENABLE_WIRE_DEFERRED_FIRST_UPDATE) {
+                if (!featureFlags.ENABLE_WIRE_SYNC_EMIT) {
                     if (hasDynamicParams) {
                         Promise.resolve().then(computeConfigAndUpdate);
                         return;

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/expected.html
@@ -1,3 +1,3 @@
 <x-wire>
-  <template shadowroot="open">Wire adapter invoked: false</template>
+  <template shadowroot="open">Wire adapter invoked: true</template>
 </x-wire>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/modules/x/wire/adapter.js
@@ -1,5 +1,16 @@
 export let isAdapterInvoked = false;
 
-export function adapter() {
-    isAdapterInvoked = true;
+export class adapter {
+    constructor(dataCallback) {
+        this.dc = dataCallback;
+    }
+
+    connect() {}
+
+    update() {
+        isAdapterInvoked = true;
+        this.dc(true);
+    }
+
+    disconnect() {}
 }

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -22,9 +22,9 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
     ENABLE_LIGHT_DOM_COMPONENTS: null,
     ENABLE_MIXED_SHADOW_MODE: null,
-    // Flag to defer (on/off) the first call to the wire adapter update method until the next tick after the component
-    // is connected. It only applies to wire configurations that depend on component values.
-    ENABLE_WIRE_DEFERRED_FIRST_UPDATE: null,
+    // Flag to make (on/off) the first call to the wire adapter update method right after the component
+    // is connected (instead of next tick). It only affects wire configurations that depend on component values.
+    ENABLE_WIRE_SYNC_EMIT: null,
 };
 export default featureFlagLookup;
 

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -22,7 +22,7 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
     ENABLE_LIGHT_DOM_COMPONENTS: null,
     ENABLE_MIXED_SHADOW_MODE: null,
-    // Flag to make (on/off) the first call to the wire adapter update method right after the component
+    // Flag to make the first call to the wire adapter update method right after the component
     // is connected (instead of next tick). It only affects wire configurations that depend on component values.
     ENABLE_WIRE_SYNC_EMIT: null,
 };

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -22,6 +22,9 @@ const featureFlagLookup: FeatureFlagLookup = {
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
     ENABLE_LIGHT_DOM_COMPONENTS: null,
     ENABLE_MIXED_SHADOW_MODE: null,
+    // Flag to defer (on/off) the first call to the wire adapter update method until the next tick after the component
+    // is connected. It only applies to wire configurations that depend on component values.
+    ENABLE_WIRE_DEFERRED_FIRST_UPDATE: null,
 };
 export default featureFlagLookup;
 

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -79,7 +79,7 @@ describe('wiring', () => {
                 setFeatureFlagForTest('ENABLE_WIRE_SYNC_EMIT', false);
             });
 
-            it('should be called after connect (in same tick) when a component with wire that has dynamic params is created', () => {
+            it('should be called synchronously after connect when a component with wire that has dynamic params is created', () => {
                 const spy = [];
                 AdapterId.setSpy(spy);
                 expect(spy.length).toBe(0);

--- a/packages/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/integration-karma/test/wire/wiring/index.spec.js
@@ -92,7 +92,7 @@ describe('wiring', () => {
                 expect(spy[1].method).toBe('update');
             });
 
-            it('should call update only once (in same tick) when the component is created and a wire dynamic param is modified', () => {
+            it('should call synchronously update only once when the component is created and a wire dynamic param is modified', () => {
                 const spy = [];
                 AdapterId.setSpy(spy);
                 expect(spy.length).toBe(0);


### PR DESCRIPTION
## Summary

This PR enables the wire adapters on SSR and modifies the timing of invoking the wire adapter `update` method for a wire adapter instance configuration which depends on a component value. This PR also adds a flag to enable (disabled by default) the invocation timing, as we don't know the blast radius for the existing components today.

## Details

Currently, SSR rendering is governed by a set of principles ([SSR RFC](https://rfcs.lwc.dev/rfcs/lwc/0112-server-engine#constraints)) to make the LWC SSR predictable and performant.

(a) As of today, wire adapters are not invoked in SSR because of two main reasons:

1. The current protocol doesn't define a way today to indicate that the stream is done emitting new data.
2. In cases where a wire adapter instance configuration depends on a component value, the wire adapter update method is not invoked until the [next tick/render cycle](https://github.com/salesforce/lwc/blob/master/packages/@lwc/engine-core/src/framework/wiring.ts#L341-L345), even if it’s known. This makes it impossible for wire adapters to provide synchronous data depending on the config.

## Proposed modification to the Wire Protocol (This PR)

1. Always invoke the wire adapter update after the component is connected, passing the known configuration at the moment.

Doing so will provide a one-time-only opportunity for wire adapter authors to push data synchronously to components, explicitly solving impediments (a.2). In the case of impediment (a.1), the SSR logic already dismisses all async/reactive behavior so that it will have no consequences.

### Consequences of proposed modification:

1. It may affect components using the `@wire`, because now the data may be available on the first render, or if it modifies the config value on the `renderedCallback` , there may be 2 trips to the server. 

<details>
  <summary>Example</summary>
  
 ```js
import { LightningElement, @wire } from 'lwc';

export default class Foo extends LightningElement {
   page = 0;
   @wire(getRecords, { page: '$page' }) records;

   renderedCallback() {
        // (only example) When setting this value, the adapter is already
        // fetching page 0. Before the proposed modification, it will only fetch page 3
        this.page = 3; // compute the actual page.
   }
}
```
</details>

### Alternatives

Introduce a new Wire Adapter lifecycle, for example: `once`.  The LWC engine will optionally (otherwise, a breaking change for existing wire adapters) call right after `connect` with the existing config. This may present challenges of their own, and mainly, in the case of wire adapter authors, the `update` will be called with the same config in most cases, but given that this is a new API, they will need to consider that.

### Limitations of using the Wire Protocol on SSR

* Only config values that are computed before or during the `connectedCallback` will be present when the `update` method is called on the wire adapter.
* Because the LWC engine does not have any order (or ensures order) when executing the wire adapters, “Cascade wire adapters” are not ensured to work as expected on the server, and therefore should not be used on the server.

In the following example (assuming wire adapters provide the data synchronously), the rendered component will be correct if `getRecord` is processed before `getAccount`, but not otherwise.

```js
import { LightningElement, api, wire } from 'lwc';
import { getRecord, getAccount } from 'wire/adapters';

export default class RecordView extends from LightningElement {
   @api recordId;
   
   @wire(getRecord, { id: '$recordId' }) record;
   
   @wire(getAccount, { id: '$record.accountId' }) account;
}
```


## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.` 

**NOTE: When the flag is active, it does introduce a breaking change.**
