### PR TITLE
fix(engine-core): just warn on qS/qSA/etc in constructor

### DIFF
--- a/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.getBoundingClientRect/index.spec.js
@@ -21,9 +21,8 @@ if (supportCallingGetBoundingClientRect) {
     it('should throw when accessing during construction', () => {
         expect(() => {
             createElement('x-constructor-invocation', { is: ConstructorInvocation });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this\.getBoundingClientRect\(\) should not be called during the construction of the custom element for <x-constructor-invocation> because the element is not yet in the DOM, instead, you can use it in one of the available life-cycle hooks\./
+        }).toLogErrorDev(
+            /Error: \[LWC error]: this\.getBoundingClientRect\(\) should not be called during the construction of the custom element for <x-constructor-invocation> because the element is not yet in the DOM or has no children yet\./
         );
     });
 }

--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByClassName.spec.js
@@ -8,9 +8,8 @@ describe('LightningElement.getElementsByClassName', () => {
             createElement('x-constructor-get-elements-by-class-name', {
                 is: ConstructorGetElementsByClassName,
             });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this.getElementsByClassName\(\) cannot be called during the construction of the custom element for <x-constructor-get-elements-by-class-name> because no children has been added to this element yet\./
+        }).toLogErrorDev(
+            /Error: \[LWC error]: this.getElementsByClassName\(\) should not be called during the construction of the custom element for <x-constructor-get-elements-by-class-name> because the element is not yet in the DOM or has no children yet\./
         );
     });
 });

--- a/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.getElementsByTagName.spec.js
@@ -8,9 +8,8 @@ describe('LightningElement.getElementsByTagName', () => {
             createElement('x-constructor-get-elements-by-tag-name', {
                 is: ConstructorGetElementsByTagName,
             });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this.getElementsByTagName\(\) cannot be called during the construction of the custom element for <x-constructor-get-elements-by-tag-name> because no children has been added to this element yet\./
+        }).toLogErrorDev(
+            /Error: \[LWC error]: this.getElementsByTagName\(\) should not be called during the construction of the custom element for <x-constructor-get-elements-by-tag-name> because the element is not yet in the DOM or has no children yet\./
         );
     });
 });

--- a/packages/integration-karma/test/component/dom-query/LightningElement.querySelector.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.querySelector.spec.js
@@ -7,9 +7,8 @@ describe('LightningElement.querySelector', () => {
     it('should throw when invoked in the constructor', () => {
         expect(() => {
             createElement('x-constructor-query-selector', { is: ConstructorQuerySelector });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this.querySelector\(\) cannot be called during the construction of the custom element for <x-constructor-query-selector> because no children has been added to this element yet\./
+        }).toLogErrorDev(
+            /Error: \[LWC error]: this.querySelector\(\) should not be called during the construction of the custom element for <x-constructor-query-selector> because the element is not yet in the DOM or has no children yet\./
         );
     });
 

--- a/packages/integration-karma/test/component/dom-query/LightningElement.querySelectorAll.spec.js
+++ b/packages/integration-karma/test/component/dom-query/LightningElement.querySelectorAll.spec.js
@@ -7,9 +7,8 @@ describe('LightningElement.querySelectorAll', () => {
     it('should throw when invoked in the constructor', () => {
         expect(() => {
             createElement('x-constructor-query-selector-all', { is: ConstructorQuerySelectorAll });
-        }).toThrowErrorDev(
-            Error,
-            /Assert Violation: this.querySelectorAll\(\) cannot be called during the construction of the custom element for <x-constructor-query-selector-all> because no children has been added to this element yet\./
+        }).toLogErrorDev(
+            /Error: \[LWC error]: this.querySelectorAll\(\) should not be called during the construction of the custom element for <x-constructor-query-selector-all> because the element is not yet in the DOM or has no children yet\./
         );
     });
 


### PR DESCRIPTION
## Details

Rather than throw an error when `querySelector`/`querySelectorAll`/etc are called in the `constructor` phase, log a warning instead. There are some valid use cases for doing this, and the browser doesn't treat it as an error, so we probably shouldn't.

**Future work**: currently we're only doing this for a few APIs, but arguably we should be consistent and do it for more APIs. (If `getElementsByTagName`, then why not `getElementsByTagNameTS`? If `getBoundingClientRect`, then why not `getClientRects`?)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9833099
