### PR TITLE
fix(engine-core): light dom shadow mode should be ShadowMode.Native

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -253,10 +253,10 @@ const CustomElementHook: Hooks<VCustomElement> = {
 };
 
 function linkNodeToShadow(elm: Node, owner: VM) {
-    const { shadowMode } = owner;
+    const { renderMode, shadowMode } = owner;
 
     // TODO [#1164]: this should eventually be done by the polyfill directly
-    if (shadowMode === ShadowMode.Synthetic) {
+    if (shadowMode === ShadowMode.Synthetic || renderMode === RenderMode.Light) {
         (elm as any)[KEY__SHADOW_RESOLVER] = getRenderRoot(owner)[KEY__SHADOW_RESOLVER];
     }
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -289,10 +289,14 @@ export function createVM<HostNode, HostElement>(
 
     let shadowMode;
     if (renderer.syntheticShadow) {
-        shadowMode =
-            def.shadowSupportMode === ShadowSupportMode.Any && isNativeShadowRootDefined
-                ? ShadowMode.Native
-                : ShadowMode.Synthetic;
+        if (def.renderMode === RenderMode.Light) {
+            shadowMode = ShadowMode.Native;
+        } else {
+            shadowMode =
+                def.shadowSupportMode === ShadowSupportMode.Any && isNativeShadowRootDefined
+                    ? ShadowMode.Native
+                    : ShadowMode.Synthetic;
+        }
     } else {
         shadowMode = ShadowMode.Native;
     }


### PR DESCRIPTION
## Details

I noticed this issue when working on a related task and pulled the fix out into its own PR.

The original implementation of `ShadowMode` assumed that `ShadowMode.Native` means "not synthetic". This is admittedly confusing but made the most sense at the time. These changes align with those semantics.

## Does this PR introduce breaking changes?

No

## GUS work item

W-9726335