### PR TITLE
fix(synthetic-shadow): invoke native composedPath() for native shadow dom

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/env/dom.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/dom.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { getOwnPropertyDescriptor } from '@lwc/shared';
+import { getOwnPropertyDescriptor, hasOwnProperty } from '@lwc/shared';
 
 const eventTargetGetter: (this: Event) => EventTarget = getOwnPropertyDescriptor(
     Event.prototype,
@@ -19,4 +19,11 @@ const eventCurrentTargetGetter: (this: Event) => EventTarget | null = getOwnProp
 const focusEventRelatedTargetGetter: (this: FocusEvent) => EventTarget | null =
     getOwnPropertyDescriptor(FocusEvent.prototype, 'relatedTarget')!.get!;
 
-export { eventTargetGetter, eventCurrentTargetGetter, focusEventRelatedTargetGetter };
+// IE does not implement composedPath() but that's ok because we only use this instead of our
+// composedPath() polyfill when dealing with native shadow DOM components in mixed mode. Defaulting
+// to a NOOP just to be safe, even though this is almost guaranteed to be defined such a scenario.
+const composedPath: () => EventTarget[] = hasOwnProperty.call(Event.prototype, 'composedPath')
+    ? Event.prototype.composedPath
+    : () => [];
+
+export { composedPath, eventTargetGetter, eventCurrentTargetGetter, focusEventRelatedTargetGetter };

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -65,6 +65,10 @@ interface ShadowRootRecord {
     shadowRoot: SyntheticShadowRootInterface;
 }
 
+export function hasInternalSlot(root: unknown): boolean {
+    return Boolean(InternalSlot.get(root));
+}
+
 function getInternalSlot(root: SyntheticShadowRootInterface | Element): ShadowRootRecord {
     const record = InternalSlot.get(root);
     if (isUndefined(record)) {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -90,8 +90,12 @@ function patchedComposedPathValue(this: Event): EventTarget[] {
         return [];
     }
 
-    // Invokes the native composedPath() method if the target has a native shadow root attached.
-    // Workaround specifically for W-9846457. Mixed mode solution will likely be more involved.
+    // If the original target is inside a native shadow root, then just call the native
+    // composePath() method. The event is already retargeted and this causes our composedPath()
+    // polyfill to compute the wrong value. This is only an issue when you have a native web
+    // component inside an LWC component (see test in same commit) but this scenario is unlikely
+    // because we don't yet support that. Workaround specifically for W-9846457. Mixed mode solution
+    // will likely be more involved.
     const hasShadowRoot = Boolean((originalTarget as any).shadowRoot);
     const hasSyntheticShadowRootAttached = hasInternalSlot(originalTarget);
     if (hasShadowRoot && !hasSyntheticShadowRootAttached) {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event/polyfill.ts
@@ -90,6 +90,8 @@ function patchedComposedPathValue(this: Event): EventTarget[] {
         return [];
     }
 
+    // Invokes the native composedPath() method if the target has a native shadow root attached.
+    // Workaround specifically for W-9846457. Mixed mode solution will likely be more involved.
     const hasShadowRoot = Boolean((originalTarget as any).shadowRoot);
     const hasSyntheticShadowRootAttached = hasInternalSlot(originalTarget);
     if (hasShadowRoot && !hasSyntheticShadowRootAttached) {

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,5 +1,5 @@
 if (process.env.COMPAT !== true) {
-    describe('[W-9846457]', () => {
+    describe('[W-9846457] event access when using native shadow dom', () => {
         let nativeParent;
         let nativeChild;
         const noop = () => {};
@@ -61,6 +61,30 @@ if (process.env.COMPAT !== true) {
             nativeChild.shadowRoot.dispatchEvent(
                 new CustomEvent('test', { composed: true, bubbles: true })
             );
+        });
+
+        it('should handle composed bubbling events (native element)', (done) => {
+            const div = document.createElement('div');
+            const span = document.createElement('span');
+
+            const shadowRoot = div.attachShadow({ mode: 'open' });
+            shadowRoot.appendChild(span);
+            document.body.appendChild(div);
+
+            div.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual([
+                    span,
+                    div.shadowRoot,
+                    div,
+                    document.body,
+                    document.documentElement,
+                    document,
+                    window,
+                ]);
+                done();
+            });
+
+            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
     });
 

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -98,11 +98,23 @@ if (process.env.COMPAT !== true) {
             synthetic.shadowRoot.appendChild(div);
             document.body.appendChild(synthetic);
 
-            // The synthetic shadow root is transparent to the native composedPath() because it's
-            // not actually rendered in the DOM. This is not an issue because LWC doesn't yet
-            // support native web components.
-            synthetic.addEventListener('test', (event) => {
-                expect(event.composedPath()).toEqual([
+            let expected;
+            if (process.env.NATIVE_SHADOW) {
+                expected = [
+                    div.shadowRoot,
+                    div,
+                    synthetic.shadowRoot,
+                    synthetic,
+                    document.body,
+                    document.documentElement,
+                    document,
+                    window,
+                ];
+            } else {
+                // The synthetic shadow root is transparent to the native composedPath() because
+                // it's not actually rendered in the DOM. This is not an issue because LWC doesn't
+                // yet support native web components.
+                expected = [
                     div.shadowRoot,
                     div,
                     /* synthetic.shadowRoot, */
@@ -111,7 +123,11 @@ if (process.env.COMPAT !== true) {
                     document.documentElement,
                     document,
                     window,
-                ]);
+                ];
+            }
+
+            synthetic.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual(expected);
                 done();
             });
 

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -99,7 +99,8 @@ if (process.env.COMPAT !== true) {
             document.body.appendChild(synthetic);
 
             // The synthetic shadow root is transparent to the native composedPath() because it's
-            // not actually rendered in the DOM.
+            // not actually rendered in the DOM. This is not an issue because LWC doesn't yet
+            // support native web components.
             synthetic.addEventListener('test', (event) => {
                 expect(event.composedPath()).toEqual([
                     div.shadowRoot,

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,4 +1,69 @@
 if (process.env.COMPAT !== true) {
+    describe('[W-9846457]', () => {
+        let nativeParent;
+        let nativeChild;
+        const noop = () => {};
+
+        beforeEach(() => {
+            nativeParent = document.createElement('x-native-parent');
+            nativeParent.attachShadow({ mode: 'open' });
+            nativeChild = document.createElement('x-native-child');
+            nativeChild.attachShadow({ mode: 'open' });
+
+            nativeParent.shadowRoot.appendChild(nativeChild);
+            document.body.appendChild(nativeParent);
+
+            // Internally computes composed path and adds to cache
+            document.addEventListener('test', noop, true);
+        });
+
+        afterEach(() => {
+            nativeParent = null;
+            nativeChild = null;
+            document.removeEventListener('test', noop, true);
+        });
+
+        it('should handle composed bubbling events (nested child)', (done) => {
+            nativeChild.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual([
+                    nativeChild.shadowRoot,
+                    nativeChild,
+                    nativeParent.shadowRoot,
+                    nativeParent,
+                    document.body,
+                    document.documentElement,
+                    document,
+                    window,
+                ]);
+                done();
+            });
+
+            nativeChild.shadowRoot.dispatchEvent(
+                new CustomEvent('test', { composed: true, bubbles: true })
+            );
+        });
+
+        it('should handle composed bubbling events (root parent)', (done) => {
+            nativeParent.addEventListener('test', (event) => {
+                expect(event.composedPath()).toEqual([
+                    nativeChild.shadowRoot,
+                    nativeChild,
+                    nativeParent.shadowRoot,
+                    nativeParent,
+                    document.body,
+                    document.documentElement,
+                    document,
+                    window,
+                ]);
+                done();
+            });
+
+            nativeChild.shadowRoot.dispatchEvent(
+                new CustomEvent('test', { composed: true, bubbles: true })
+            );
+        });
+    });
+
     describe('Event.composedPath() method', () => {
         describe('dispatched on shadow root', () => {
             it('{bubbles: true, composed: true}', (done) => {

--- a/packages/integration-karma/test/native-shadow/Event-methods/x/synthetic/synthetic.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/x/synthetic/synthetic.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Our `composedPath()` polyfill returns an incorrect path when a component is using native Shadow DOM. This is because the polyfill requires the original target to work correctly and the target we pass it has been natively retargeted.

Fixes #2379

## Does this PR introduce breaking changes?

No

## GUS work item

W-9493000