### PR TITLE
refactor(integration-karma): add env variable NATIVE_SHADOW_ROOT_DEFINED

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
           name: Run karma integration tests
           working_directory: packages/integration-karma
           command: >
-              <<# parameters.native_shadow >> NATIVE_SHADOW=1 <</ parameters.native_shadow >>
+              <<# parameters.native_shadow >> DISABLE_SYNTHETIC=1 <</ parameters.native_shadow >>
               <<# parameters.compat >> COMPAT=1 <</ parameters.compat >>
               <<# parameters.coverage >> COVERAGE=1 <</ parameters.coverage >>
               yarn sauce
@@ -128,7 +128,7 @@ jobs:
           name: Install dependencies and build
           command: yarn install --frozen-lockfile
       - run:
-          name: Check missing file headers 
+          name: Check missing file headers
           command: node ./scripts/tasks/check-license-headers.js
       - run:
           name: Check formatting

--- a/packages/integration-karma/README.md
+++ b/packages/integration-karma/README.md
@@ -23,15 +23,16 @@ Every time the test suite runs with the `COVERAGE=1` environment variable it pro
 This set of environment variables applies to the `start` and `test` commands:
 
 -   **`COMPAT=1`:** Compile and deliver tests in COMPAT mode.
--   **`NATIVE_SHADOW=1`:** Force the components to be created with native shadow enabled.
+-   **`DISABLE_SYNTHETIC=1`:** Run without any synthetic shadow polyfill patches.
 -   **`COVERAGE=1`:** Gather engine code coverage, and store it in the `coverage` folder.
 -   **`GREP="pattern"`:** Filter the spec to run based on the pattern.
 
 ## Examples
 
 ```sh
-NATIVE_SHADOW=1 GREP=ShadowRoot yarn start          # Run in watch mode the "ShadowRoot" related tests with native shadow enable
-COVERAGE=1 yarn test                                # Run all the test once and compute coverage
+DISABLE_SYNTHETIC=1 yarn test  # Run tests without any synthetic shadow polyfills
+GREP=ShadowRoot yarn start     # Run "ShadowRoot" related tests in watch mode
+COVERAGE=1 yarn test           # Compute coverage after a single test run
 ```
 
 ## Contributing
@@ -40,8 +41,9 @@ COVERAGE=1 yarn test                                # Run all the test once and 
 -   On top of the standard [jasmine matchers](https://jasmine.github.io/api/edge/matchers.html), the test suite also register custom matchers:
     -   `toLogErrorDev(message)`: `expect` a function to log an error with a specific message in DEV only.
     -   `toThrowErrorDev(Error, message)`: `expect` a function to throw an error with a specific Error constructor and a specific message.
--   You should rather import `createElement` from `test-utils` instead of `lwc`. The `createElement` element from `test-utils` set `fallback` to false if the `--native-shadow` flag is passed to the command.
 -   Some of the test command options are available in the test suite on the global `process.env` object:
-    -   `process.env.COMPAT`: is set to `false` by default and `true` if the `--compat` flag is passed
-    -   `process.env.NATIVE_SHADOW`: is set to `false` by default and `true` if the `--native-shadow` flag is passed
+    -   `process.env.COMPAT`: is set to `false` by default and `true` if the `COMPAT` environment
+        variable is set.
+    -   `process.env.DISABLE_SYNTHETIC`: is set to `false` by default and `true` if the
+        `DISABLE_SYNTHETIC` environment variable is set.
 -   The test setup file (`test-setup.js`) will automatically clean up the DOM before and after each test. So you don't have to do anything to clean up. However, you should use `beforeEach()` rather than `beforeAll()` to add DOM elements for your test, so that the cleanup code can properly clean up the DOM.

--- a/packages/integration-karma/package.json
+++ b/packages/integration-karma/package.json
@@ -6,7 +6,7 @@
         "start": "karma start ./scripts/karma-configs/local.js",
         "test": "karma start ./scripts/karma-configs/local.js --single-run --browsers Chrome",
         "test:compat": "COMPAT=1 yarn test",
-        "test:native": "NATIVE_SHADOW=1 yarn test",
+        "test:native": "DISABLE_SYNTHETIC=1 yarn test",
         "sauce": "karma start ./scripts/karma-configs/sauce.js --single-run",
         "coverage": "node ./scripts/merge-coverage.js"
     },

--- a/packages/integration-karma/scripts/karma-configs/base.js
+++ b/packages/integration-karma/scripts/karma-configs/base.js
@@ -12,7 +12,7 @@ const { getModulePath } = require('lwc');
 
 const karmaPluginLwc = require('../karma-plugins/lwc');
 const karmaPluginEnv = require('../karma-plugins/env');
-const { COMPAT, NATIVE_SHADOW, TAGS, GREP, COVERAGE } = require('../shared/options');
+const { COMPAT, DISABLE_SYNTHETIC, TAGS, GREP, COVERAGE } = require('../shared/options');
 
 const BASE_DIR = path.resolve(__dirname, '../../test');
 const COVERAGE_DIR = path.resolve(__dirname, '../../coverage');
@@ -45,7 +45,7 @@ function getFiles() {
         frameworkFiles.push(createPattern(LWC_ENGINE_COMPAT));
         frameworkFiles.push(createPattern(WIRE_SERVICE_COMPAT));
     } else {
-        if (!NATIVE_SHADOW) {
+        if (!DISABLE_SYNTHETIC) {
             frameworkFiles.push(createPattern(SYNTHETIC_SHADOW));
         }
         frameworkFiles.push(createPattern(LWC_ENGINE));

--- a/packages/integration-karma/scripts/karma-configs/sauce.js
+++ b/packages/integration-karma/scripts/karma-configs/sauce.js
@@ -10,7 +10,7 @@
 const localConfig = require('./base');
 const {
     COMPAT,
-    NATIVE_SHADOW,
+    DISABLE_SYNTHETIC,
     TAGS,
     SAUCE_USERNAME,
     SAUCE_ACCESS_KEY,
@@ -106,7 +106,7 @@ function getSauceConfig() {
         customData: {
             lwc: {
                 COMPAT,
-                NATIVE_SHADOW,
+                DISABLE_SYNTHETIC,
             },
 
             ci: IS_CI,
@@ -127,7 +127,7 @@ function getMatchingBrowsers() {
     return SAUCE_BROWSERS.filter((browser) => {
         return (
             browser.compat === COMPAT &&
-            (!NATIVE_SHADOW || browser.nativeShadowCompatible === NATIVE_SHADOW)
+            (!DISABLE_SYNTHETIC || browser.nativeShadowCompatible === DISABLE_SYNTHETIC)
         );
     });
 }

--- a/packages/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/integration-karma/scripts/karma-plugins/env.js
@@ -15,7 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { COMPAT, NATIVE_SHADOW } = require('../shared/options');
+const { COMPAT, DISABLE_SYNTHETIC } = require('../shared/options');
 
 const DIST_DIR = path.resolve(__dirname, '../../dist');
 const ENV_FILENAME = path.resolve(DIST_DIR, 'env.js');
@@ -30,7 +30,7 @@ function createEnvFile() {
         `    env: {`,
         `        NODE_ENV: "development",`,
         `        COMPAT: ${COMPAT},`,
-        `        NATIVE_SHADOW: ${NATIVE_SHADOW}`,
+        `        DISABLE_SYNTHETIC: ${DISABLE_SYNTHETIC}`,
         `    }`,
         `};`,
     ];

--- a/packages/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/integration-karma/scripts/karma-plugins/env.js
@@ -31,7 +31,7 @@ function createEnvFile() {
         `        NODE_ENV: "development",`,
         `        COMPAT: ${COMPAT},`,
         `        DISABLE_SYNTHETIC: ${DISABLE_SYNTHETIC},`,
-        `        NATIVE_SHADOW_ROOT_DEFINED: ${typeof ShadowRoot !== undefined}`,
+        `        NATIVE_SHADOW_ROOT_DEFINED: typeof ShadowRoot !== "undefined"`,
         `    }`,
         `};`,
     ];

--- a/packages/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/integration-karma/scripts/karma-plugins/env.js
@@ -30,7 +30,8 @@ function createEnvFile() {
         `    env: {`,
         `        NODE_ENV: "development",`,
         `        COMPAT: ${COMPAT},`,
-        `        DISABLE_SYNTHETIC: ${DISABLE_SYNTHETIC}`,
+        `        DISABLE_SYNTHETIC: ${DISABLE_SYNTHETIC},`,
+        `        NATIVE_SHADOW_ROOT_DEFINED: ${typeof ShadowRoot !== undefined}`,
         `    }`,
         `};`,
     ];

--- a/packages/integration-karma/scripts/shared/options.js
+++ b/packages/integration-karma/scripts/shared/options.js
@@ -7,6 +7,11 @@
 
 'use strict';
 
+// Helpful error. Remove after a few months.
+if (process.env.NATIVE_SHADOW) {
+    throw new Error('NATIVE_SHADOW is deprecated. Use DISABLE_SYNTHETIC instead!');
+}
+
 const COMPAT = Boolean(process.env.COMPAT);
 const DISABLE_SYNTHETIC = Boolean(process.env.DISABLE_SYNTHETIC);
 const TAGS = [`${DISABLE_SYNTHETIC ? 'native' : 'synthetic'}-shadow`, COMPAT && 'compat'].filter(

--- a/packages/integration-karma/scripts/shared/options.js
+++ b/packages/integration-karma/scripts/shared/options.js
@@ -8,15 +8,15 @@
 'use strict';
 
 const COMPAT = Boolean(process.env.COMPAT);
-const NATIVE_SHADOW = Boolean(process.env.NATIVE_SHADOW);
-const TAGS = [`${NATIVE_SHADOW ? 'native' : 'synthetic'}-shadow`, COMPAT && 'compat'].filter((v) =>
-    Boolean(v)
+const DISABLE_SYNTHETIC = Boolean(process.env.DISABLE_SYNTHETIC);
+const TAGS = [`${DISABLE_SYNTHETIC ? 'native' : 'synthetic'}-shadow`, COMPAT && 'compat'].filter(
+    (v) => Boolean(v)
 );
 
 module.exports = {
     // Test configuration
     COMPAT,
-    NATIVE_SHADOW,
+    DISABLE_SYNTHETIC,
     TAGS,
     GREP: process.env.GREP,
     COVERAGE: Boolean(process.env.COVERAGE),

--- a/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
+++ b/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 // TODO [#985]: Firefox does not implement delegatesFocus
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     describe('host.focus() when { delegatesFocus: true }', () => {
         it('should focus the host element', () => {
             const elm = createElement('x-focus', { is: DelegatesFocusTrue });

--- a/packages/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/integration-karma/test/api/createElement/index.spec.js
@@ -47,7 +47,7 @@ it('returns an HTMLElement', () => {
     expect(elm instanceof HTMLElement).toBe(true);
 });
 
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     it('should create an element with a synthetic shadow root by default', () => {
         const elm = createElement('x-component', { is: Test });
         expect(elm.shadowRoot.constructor.name).toBe('SyntheticShadowRoot');
@@ -64,7 +64,7 @@ it('supports component constructors in circular dependency', () => {
     expect(elm instanceof HTMLElement).toBe(true);
 });
 
-if (process.env.NATIVE_SHADOW) {
+if (process.env.DISABLE_SYNTHETIC) {
     it('should create an element with a native shadow root if fallback is false', () => {
         const elm = createElement('x-component', {
             is: Test,

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -51,7 +51,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     // TODO [#1253]: optimization to synchronously adopt new child nodes added
     // to this elm, we can do that by patching the most common operations
     // on the node itself
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         expect(isNodeFromTemplate(div)).toBe(false); // it is false sync because MO hasn't pick up the element yet
     }
     return new Promise((resolve) => {
@@ -63,7 +63,7 @@ it('should return true on elements manually inserted in the DOM inside an elemen
 
 // TODO [#1252]: old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     it('should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -142,7 +142,7 @@ orderings. For any given component, the invariants are:
 
 It's ok to update the orderings below after a refactor, as long as these invariants hold!
 */
-if (process.env.NATIVE_SHADOW) {
+if (process.env.DISABLE_SYNTHETIC) {
     it(`should invoke connectedCallback and renderedCallback in the expected order (native shadow)`, () => {
         const elm = createElement('order-container', { is: Container });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/host-element/index.spec.js
+++ b/packages/integration-karma/test/host-element/index.spec.js
@@ -5,7 +5,7 @@ describe('host element', () => {
     it('should accept children being appended to it', () => {
         const element = createElement('x-container', { is: Shadow });
         document.body.appendChild(element);
-        if (process.env.NATIVE_SHADOW) {
+        if (process.env.DISABLE_SYNTHETIC) {
             // synthetic shadow returns null here even though it successfully inserts the div
             expect(element.firstChild.tagName).toEqual('DIV');
         }

--- a/packages/integration-karma/test/light-dom/ids/index.spec.js
+++ b/packages/integration-karma/test/light-dom/ids/index.spec.js
@@ -42,7 +42,7 @@ describe('Light DOM IDs and fragment links', () => {
         expect(light.querySelector('.go-to-bar').href).toMatch(/#bar$/);
         expect(light.querySelector('.go-to-quux').href).toMatch(/#quux$/);
 
-        if (process.env.NATIVE_SHADOW) {
+        if (process.env.DISABLE_SYNTHETIC) {
             expect(shadow.shadowRoot.querySelector('.foo').id).toEqual('foo');
             expect(shadow.shadowRoot.querySelector('.quux').id).toEqual('quux');
             expect(shadow.shadowRoot.querySelector('.go-to-foo').href).toMatch(/#foo$/);

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -61,7 +61,7 @@ describe('Slotting', () => {
     it('shadow container, light consumer', () => {
         const nodes = createTestElement('x-light-consumer', LightConsumer);
 
-        const expected = process.env.NATIVE_SHADOW // native shadow doesn't output slots in innerHTML
+        const expected = process.env.DISABLE_SYNTHETIC // native shadow doesn't output slots in innerHTML
             ? '<x-shadow-container><p data-id="light-consumer-text">Hello from Light DOM</p></x-shadow-container>'
             : '<x-shadow-container><slot><p data-id="light-consumer-text">Hello from Light DOM</p></slot></x-shadow-container>';
         expect(nodes['x-light-consumer'].innerHTML).toEqual(expected);

--- a/packages/integration-karma/test/light-dom/style-global/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style-global/index.spec.js
@@ -21,7 +21,7 @@ describe('Light DOM styling at the global level', () => {
         expect(getColor(elm.querySelector('x-one .globally-styled'))).toEqual('rgb(0, 0, 255)');
         expect(getColor(elm.querySelector('x-two .globally-styled'))).toEqual('rgb(0, 0, 255)');
         // synthetic shadow can't do this kind of style encapsulation
-        if (process.env.NATIVE_SHADOW === true) {
+        if (process.env.DISABLE_SYNTHETIC === true) {
             expect(
                 getColor(elm.querySelector('x-shadow').shadowRoot.querySelector('.globally-styled'))
             ).toEqual('rgb(0, 0, 0)');
@@ -36,7 +36,7 @@ describe('Light DOM styling at the global level', () => {
 
         expect(getColor(two.querySelector('.globally-styled'))).toEqual('rgb(0, 0, 255)');
         // synthetic shadow can't do this kind of style encapsulation
-        if (process.env.NATIVE_SHADOW === true) {
+        if (process.env.DISABLE_SYNTHETIC === true) {
             expect(getColor(shadow.shadowRoot.querySelector('.globally-styled'))).toEqual(
                 'rgb(0, 0, 0)'
             );

--- a/packages/integration-karma/test/light-dom/style-with-host/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style-with-host/index.spec.js
@@ -2,7 +2,7 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
 
 // synthetic shadow can't do this kind of style encapsulation
-if (process.env.NATIVE_SHADOW === true) {
+if (process.env.DISABLE_SYNTHETIC === true) {
     describe('Light DOM styling with :host', () => {
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);

--- a/packages/integration-karma/test/light-dom/style/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style/index.spec.js
@@ -25,7 +25,7 @@ describe('Light DOM styling', () => {
             'rgb(255, 0, 0)'
         );
         // synthetic shadow can't do this kind of style encapsulation
-        if (process.env.NATIVE_SHADOW === true) {
+        if (process.env.DISABLE_SYNTHETIC === true) {
             expect(
                 getColor(
                     elm.shadowRoot
@@ -36,7 +36,7 @@ describe('Light DOM styling', () => {
         }
 
         // synthetic shadow can't do this kind of style encapsulation
-        if (process.env.NATIVE_SHADOW === true) {
+        if (process.env.DISABLE_SYNTHETIC === true) {
             // sibling elements should be unaffected
             const two = createElement('x-two', { is: Two });
             const shadow = createElement('x-shadow', { is: Shadow });

--- a/packages/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -2,7 +2,7 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     describe('Light DOM and synthetic shadow', () => {
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);

--- a/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/composition/index.spec.js
@@ -5,7 +5,7 @@ import SyntheticContainer from 'x/syntheticContainer';
 import NativeContainer from 'x/nativeContainer';
 import NativeLightSynthetic from 'x/nativeLightSynthetic';
 
-if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
+if (!process.env.DISABLE_SYNTHETIC && !process.env.COMPAT) {
     describe('composition', () => {
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);

--- a/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -99,7 +99,7 @@ if (process.env.COMPAT !== true) {
             document.body.appendChild(synthetic);
 
             let expected;
-            if (process.env.NATIVE_SHADOW) {
+            if (process.env.DISABLE_SYNTHETIC) {
                 expected = [
                     div.shadowRoot,
                     div,

--- a/packages/integration-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/integration-karma/test/polyfills/document-properties/index.spec.js
@@ -51,7 +51,7 @@ describe('dynamic nodes', () => {
             expect(document.querySelector('span.manual-span')).toBe(null);
         });
     });
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         // TODO [#1252]: old behavior that is still used by some pieces of the platform
         // that is only useful in synthetic mode where elements inserted manually without lwc:dom="manual"
         // are still considered global elements

--- a/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -29,7 +29,7 @@ describe('custom elements', () => {
                 expect(xSimple.assignedSlot).not.toBeNull();
                 expect(elm.shadowRoot.querySelector('.mark')).not.toBeNull();
 
-                if (!process.env.NATIVE_SHADOW) {
+                if (!process.env.DISABLE_SYNTHETIC) {
                     expect(xSimple).not.toBe(firstRenderCustomElement);
                 }
             });
@@ -37,7 +37,7 @@ describe('custom elements', () => {
 });
 
 describe('elements', () => {
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         it('should not be reused when slotted', function () {
             const elm = createElement('x-container', { is: Container });
             elm.isElement = true;
@@ -94,7 +94,7 @@ describe('elements', () => {
     });
 });
 
-if (process.env.NATIVE_SHADOW) {
+if (process.env.DISABLE_SYNTHETIC) {
     it('should render same styles for custom element instances', function () {
         const elm = createElement('x-container', { is: Container });
         elm.isStyleCheck = true;

--- a/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -74,7 +74,7 @@ describe('Event.target', () => {
         div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
     });
 
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         describe('legacy behavior', () => {
             beforeAll(() => {
                 // Suppress error logging

--- a/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -425,7 +425,7 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
     });
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         describe('References to mutation observers are not leaked', () => {
             let container;
             beforeEach(() => {

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.childNodes.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.childNodes.spec.js
@@ -48,13 +48,13 @@ describe('Node.childNodes', () => {
         // While with synthetic shadow, the fallback slot content is only rendered only when the slot has no assigned
         // nodes.
         expect(container.shadowRoot.querySelector('slot').childNodes.length).toBe(
-            process.env.NATIVE_SHADOW ? 1 : 0
+            process.env.DISABLE_SYNTHETIC ? 1 : 0
         );
     });
 
     // TODO [#1761]: Difference in behavior of slot.childNodes in native and synthetic-shadow
     // enable this test in synthetic-shadow mode once the bug is fixed
-    if (process.env.NATIVE_SHADOW) {
+    if (process.env.DISABLE_SYNTHETIC) {
         it('should always return an default content for slots not rendering default content', () => {
             const elm = createElement('x-slotted-parent', { is: SlottedParent });
             document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
@@ -314,7 +314,7 @@ describe('Node.getRootNode', () => {
             expect(processingInstruction.getRootNode(composedTrueConfig)).toBe(fragment);
         });
 
-        if (process.env.NATIVE_SHADOW) {
+        if (process.env.DISABLE_SYNTHETIC) {
             it('native shadow dom', () => {
                 const shadowHost = document.createElement('div');
                 document.body.appendChild(shadowHost);

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.hasChildNodes.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.hasChildNodes.spec.js
@@ -26,7 +26,7 @@ describe('Node.hasChildNodes', () => {
 
         expect(container.shadowRoot.querySelector('.container').hasChildNodes()).toBe(true);
         expect(container.shadowRoot.querySelector('slot').hasChildNodes()).toBe(
-            process.env.NATIVE_SHADOW
+            process.env.DISABLE_SYNTHETIC
         );
     });
 });

--- a/packages/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
+++ b/packages/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
@@ -19,10 +19,10 @@ describe('Node.textContent - getter', () => {
 
         const container = elm.shadowRoot.querySelector('x-container');
         expect(container.shadowRoot.textContent).toBe(
-            process.env.NATIVE_SHADOW ? 'Before[default-slotted]After' : 'Before[]After'
+            process.env.DISABLE_SYNTHETIC ? 'Before[default-slotted]After' : 'Before[]After'
         );
         expect(container.shadowRoot.querySelector('slot').textContent).toBe(
-            process.env.NATIVE_SHADOW ? 'default-slotted' : ''
+            process.env.DISABLE_SYNTHETIC ? 'default-slotted' : ''
         );
     });
 });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
@@ -3,7 +3,7 @@ import { createElement } from 'lwc';
 
 describe('ShadowRoot.delegatesFocus', () => {
     // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
-    if (!process.env.NATIVE_SHADOW) {
+    if (!process.env.DISABLE_SYNTHETIC) {
         it('ShadowRoot.delegatesFocus should be false by default', () => {
             class NoDelegatesFocus extends LightningElement {}
 

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -66,7 +66,7 @@ describe('Properties overrides', () => {
     });
 });
 
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     describe('synthetic-shadow restrictions', () => {
         let elm;
 

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -20,7 +20,7 @@ describe('elementsFromPoint', () => {
     // https://crbug.com/1207863#c4
     const onlyIncludesElementsInImmediateShadowRoot = (() => {
         function detect() {
-            if (!process.env.NATIVE_SHADOW) {
+            if (!process.env.DISABLE_SYNTHETIC) {
                 return false; // in synthetic shadow we control the behavior, so we match Chrome/Safari
             }
             // detect the Firefox behavior

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -35,7 +35,7 @@ describe('post-dispatch event state', () => {
 
         // WebKit bug - https://bugs.webkit.org/show_bug.cgi?id=206374
         // In Safari, the event target is not null.
-        if (process.env.NATIVE_SHADOW !== true) {
+        if (process.env.DISABLE_SYNTHETIC !== true) {
             it('{ bubbles: true, composed: false }', () => {
                 const nodes = createComponent();
                 const event = new CustomEvent('test', { bubbles: true, composed: false });
@@ -62,7 +62,7 @@ describe('post-dispatch event state', () => {
 
         // WebKit bug - https://bugs.webkit.org/show_bug.cgi?id=206374
         // In Safari, the event target is not null.
-        if (process.env.NATIVE_SHADOW !== true) {
+        if (process.env.DISABLE_SYNTHETIC !== true) {
             it('{ bubbles: true, composed: false }', () => {
                 const nodes = createComponent();
                 const event = new CustomEvent('test', { bubbles: true, composed: false });

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -133,7 +133,7 @@ describe('event propagation', () => {
             ];
 
             let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
+            if (process.env.DISABLE_SYNTHETIC) {
                 expectedLogs = [
                     [nodes.button, nodes.button, composedPath],
                     [nodes['x-button'], nodes['x-button'], composedPath],
@@ -158,7 +158,7 @@ describe('event propagation', () => {
             expect(actualLogs).toEqual(expectedLogs);
         });
 
-        if (!process.env.NATIVE_SHADOW) {
+        if (!process.env.DISABLE_SYNTHETIC) {
             describe('when the ENABLE_NON_COMPOSED_EVENTS_LEAKAGE flag is enabled', () => {
                 beforeEach(() => {
                     setFeatureFlagForTest('ENABLE_NON_COMPOSED_EVENTS_LEAKAGE', true);
@@ -299,7 +299,7 @@ describe('event propagation', () => {
             ];
 
             let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
+            if (process.env.DISABLE_SYNTHETIC) {
                 expectedLogs = [
                     [nodes['x-button'], nodes['x-button'], composedPath],
                     [nodes['x-container'], nodes['x-container'], composedPath],
@@ -333,7 +333,7 @@ describe('event propagation', () => {
             expect(actualLogs).toEqual(expectedLogs);
         });
 
-        if (!process.env.NATIVE_SHADOW) {
+        if (!process.env.DISABLE_SYNTHETIC) {
             describe('when the ENABLE_NON_COMPOSED_EVENTS_LEAKAGE flag is enabled', () => {
                 beforeEach(() => {
                     setFeatureFlagForTest('ENABLE_NON_COMPOSED_EVENTS_LEAKAGE', true);
@@ -471,7 +471,7 @@ describe('event propagation', () => {
             ];
 
             let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
+            if (process.env.DISABLE_SYNTHETIC) {
                 expectedLogs = [
                     [nodes['x-button'].shadowRoot, nodes['x-button'].shadowRoot, composedPath],
                     [nodes['x-button'], nodes['x-button'], composedPath],
@@ -502,7 +502,7 @@ describe('event propagation', () => {
     });
 
     describe('dispatched on lwc:dom="manual" node', () => {
-        if (!process.env.NATIVE_SHADOW) {
+        if (!process.env.DISABLE_SYNTHETIC) {
             describe('when the ENABLE_NON_COMPOSED_EVENTS_LEAKAGE flag is enabled', () => {
                 beforeEach(() => {
                     setFeatureFlagForTest('ENABLE_NON_COMPOSED_EVENTS_LEAKAGE', true);
@@ -614,7 +614,7 @@ describe('event propagation', () => {
             ];
 
             let expectedLogs;
-            if (process.env.NATIVE_SHADOW) {
+            if (process.env.DISABLE_SYNTHETIC) {
                 expectedLogs = [
                     [nodes.container_span_manual, nodes.container_span_manual, composedPath],
                     [nodes['x-container'], nodes['x-container'], composedPath],
@@ -701,7 +701,7 @@ describe('event propagation', () => {
                 ];
 
                 let expectedLogs;
-                if (process.env.NATIVE_SHADOW) {
+                if (process.env.DISABLE_SYNTHETIC) {
                     expectedLogs = [
                         [nodes.container_div, nodes.container_div, composedPath],
                         [nodes['x-container'], nodes['x-container'], composedPath],

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -37,7 +37,7 @@ import ParentSpecialized from 'x/parentSpecialized';
      </x-container>
  </div>
  */
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     describe('synthetic shadow with patch flags OFF', () => {
         let lwcElementInsideShadow,
             divManuallyApendedToShadow,

--- a/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -1,7 +1,7 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
 
-if (!process.env.NATIVE_SHADOW) {
+if (!process.env.DISABLE_SYNTHETIC) {
     beforeAll(() => {
         setFeatureFlagForTest('ENABLE_INNER_OUTER_TEXT_PATCH', true);
     });

--- a/packages/integration-karma/test/synthetic-shadow/scoped-id/multiple-idrefs.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/scoped-id/multiple-idrefs.spec.js
@@ -10,7 +10,7 @@ it('should handle multiple idrefs when set dynamically', () => {
     const hokkaido = elm.shadowRoot.querySelector('.hokkaido');
     const input = elm.shadowRoot.querySelector('.dynamic');
 
-    if (process.env.NATIVE_SHADOW) {
+    if (process.env.DISABLE_SYNTHETIC) {
         expect(aomori.id).toMatch(/^aomori$/);
         expect(hokkaido.id).toMatch(/^hokkaido$/);
     } else {
@@ -30,7 +30,7 @@ it('should handle multiple idrefs when set statically', () => {
     const iwate = elm.shadowRoot.querySelector('.iwate');
     const input = elm.shadowRoot.querySelector('.static');
 
-    if (process.env.NATIVE_SHADOW) {
+    if (process.env.DISABLE_SYNTHETIC) {
         expect(aomori.id).toMatch(/^aomori$/);
         expect(iwate.id).toMatch(/^iwate$/);
     } else {

--- a/packages/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/integration-karma/test/template/directive-if/index.spec.js
@@ -69,7 +69,7 @@ describe('if:true directive', () => {
                 expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
             });
     });
-    if (process.env.NATIVE_SHADOW) {
+    if (process.env.DISABLE_SYNTHETIC) {
         // In native shadow, the slotted content from parent is always queriable, its only the
         // child's <slot> that is rendered/unrendered based on the directive
         it('should update child with slot content if value changes', () => {


### PR DESCRIPTION
## Details

Changes to facilitate mixed shadow mode tests. Renamed `NATIVE_SHADOW` to the more suitable `DISABLE_SYNTHETIC` since it's more about whether the polyfill is applied or not. Added `NATIVE_SHADOW_ROOT_DEFINED` to add support for testing mixed shadow mode fallback in browsers that don't implement `ShadowRoot`.

## Does this PR introduce breaking changes?

No

## GUS work item

W-9726385 
