### PR TITLE
refactor: move isNativeShadowDefined to renderer

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -10,6 +10,7 @@ export type HostElement = any;
 
 export interface Renderer<N = HostNode, E = HostElement> {
     ssr: boolean;
+    isNativeShadowDefined: boolean;
     isSyntheticShadowDefined: boolean;
     insert(node: N, parent: E, anchor: N | null): void;
     remove(node: N, parent: E): void;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -11,14 +11,12 @@ import {
     assert,
     create,
     getOwnPropertyNames,
-    globalThis,
     isArray,
     isFalse,
     isNull,
     isObject,
     isTrue,
     isUndefined,
-    KEY__IS_NATIVE_SHADOW_ROOT_DEFINED,
     keys,
 } from '@lwc/shared';
 import { getComponentTag } from '../shared/format';
@@ -48,8 +46,6 @@ import { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
 
 type ShadowRootMode = 'open' | 'closed';
-
-const isNativeShadowRootDefined = globalThis[KEY__IS_NATIVE_SHADOW_ROOT_DEFINED];
 
 export interface TemplateCache {
     [key: string]: any;
@@ -293,7 +289,7 @@ export function createVM<HostNode, HostElement>(
             shadowMode = ShadowMode.Native;
         } else {
             shadowMode =
-                def.shadowSupportMode === ShadowSupportMode.Any && isNativeShadowRootDefined
+                def.shadowSupportMode === ShadowSupportMode.Any && renderer.isNativeShadowDefined
                     ? ShadowMode.Native
                     : ShadowMode.Synthetic;
         }

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -10,8 +10,10 @@ import {
     create,
     hasOwnProperty,
     htmlPropertyToAttribute,
+    globalThis,
     isFunction,
     isUndefined,
+    KEY__IS_NATIVE_SHADOW_ROOT_DEFINED,
     KEY__SHADOW_TOKEN,
     setPrototypeOf,
     StringToLowerCase,
@@ -138,6 +140,7 @@ if (isCustomElementRegistryAvailable()) {
 export const renderer: Renderer<Node, Element> = {
     ssr: false,
 
+    isNativeShadowDefined: globalThis[KEY__IS_NATIVE_SHADOW_ROOT_DEFINED],
     isSyntheticShadowDefined: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
 
     createElement(tagName: string, namespace: string): Element {

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -62,6 +62,7 @@ class HTMLElement {
 export const renderer: Renderer<HostNode, HostElement> = {
     ssr: true,
 
+    isNativeShadowDefined: false,
     isSyntheticShadowDefined: false,
 
     insert(node, parent, anchor) {


### PR DESCRIPTION
## Details

This PR moves the `isNativeShadowRootDefined` check from the `globalThis` to the `Renderer` interface. Both `isNativeShadowDefined` and `isSyntheticShadowDefined` flags are now present on now directly accessible via the `Renderer` interface.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 