### PR TITLE
feat(engine-core): Enable light DOM by default

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -24,7 +24,6 @@ import {
     KEY__SYNTHETIC_MODE,
     setPrototypeOf,
 } from '@lwc/shared';
-import features from '@lwc/features';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
@@ -218,15 +217,6 @@ export const LightningElement: LightningElementConstructor = function (
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);
     associateVM(elm, vm);
-
-    if (!features.ENABLE_LIGHT_DOM_COMPONENTS) {
-        assert.isTrue(
-            def.renderMode !== RenderMode.Light,
-            `${
-                def.name || 'Anonymous class'
-            } is an invalid LWC component. Light DOM components are not available in this environment.`
-        );
-    }
 
     if (vm.renderMode === RenderMode.Shadow) {
         attachShadow(vm);

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-multiple/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-multiple/index.js
@@ -1,3 +1,2 @@
 export const tagName = 'x-parent';
 export { default } from 'x/parent';
-export const features = ['ENABLE_LIGHT_DOM_COMPONENTS'];

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom/index.js
@@ -1,3 +1,2 @@
 export const tagName = 'x-basic';
 export { default } from 'x/basic';
-export const features = ['ENABLE_LIGHT_DOM_COMPONENTS'];

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -16,7 +16,6 @@ const features: FeatureFlagMap = {
     ENABLE_HTML_COLLECTIONS_PATCH: null,
     ENABLE_NODE_PATCH: null,
     ENABLE_NON_COMPOSED_EVENTS_LEAKAGE: null,
-    ENABLE_LIGHT_DOM_COMPONENTS: null,
     ENABLE_MIXED_SHADOW_MODE: null,
     ENABLE_WIRE_SYNC_EMIT: null,
 };

--- a/packages/integration-karma/test/light-dom/basic/index.spec.js
+++ b/packages/integration-karma/test/light-dom/basic/index.spec.js
@@ -1,28 +1,15 @@
-import { createElement, setFeatureFlagForTest, LightningElement } from 'lwc';
+import { createElement, LightningElement } from 'lwc';
 
 import Test from 'x/test';
 import InvalidRenderMode from 'x/invalidRenderMode';
 
 describe('Basic Light DOM', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should render properly', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot).toBeNull();
         expect(elm.firstChild.innerText).toEqual('Hello, Light DOM');
-    });
-    it('should throw error when feature is disabled', () => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-        expect(() => createElement('x-test', { is: Test })).toThrowErrorDev(
-            Error,
-            'Assert Violation: Test is an invalid LWC component. Light DOM components are not available in this environment.'
-        );
     });
 
     it('should return null for template', () => {

--- a/packages/integration-karma/test/light-dom/events/index.spec.js
+++ b/packages/integration-karma/test/light-dom/events/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
 import LightChild from 'x/lightChild';
@@ -43,12 +43,9 @@ function dispatchEventWithLog(target, nodes, event) {
 describe('single light child', () => {
     let nodes;
     beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
         nodes = createTestElement('x-light-child', LightChild);
     });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
+
     it('{ bubbles: true, composed: false }', () => {
         const log = dispatchEventWithLog(
             nodes.button,
@@ -98,11 +95,7 @@ describe('single light child', () => {
 describe('shadow container, light child', () => {
     let nodes;
     beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
         nodes = createTestElement('x-shadow-container', ShadowContainer);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
     });
 
     it('{ bubbles: true, composed: true }', () => {
@@ -159,11 +152,7 @@ describe('shadow container, light child', () => {
 describe('light container, shadow child', () => {
     let nodes;
     beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
         nodes = createTestElement('x-light-container', LightContainer);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
     });
 
     it('{ bubbles: true, composed: true }', () => {

--- a/packages/integration-karma/test/light-dom/ids/index.spec.js
+++ b/packages/integration-karma/test/light-dom/ids/index.spec.js
@@ -1,16 +1,10 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import One from 'x/one';
 import Two from 'x/two';
 import Shadow from 'x/shadow';
 
 describe('Light DOM IDs and fragment links', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should not mangle IDs or hrefs in light DOM', () => {
         document.body.appendChild(createElement('x-one', { is: One }));
         document.body.appendChild(createElement('x-two', { is: Two }));

--- a/packages/integration-karma/test/light-dom/inheritance/index.spec.js
+++ b/packages/integration-karma/test/light-dom/inheritance/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import ShadowExtendsLight from 'x/shadowExtendsLight';
 import DefaultExtendsLight from 'x/defaultExtendsLight';
@@ -6,13 +6,6 @@ import LightExtendsShadow from 'x/lightExtendsShadow';
 import DefaultExtendsShadow from 'x/defaultExtendsShadow';
 
 describe('light/shadow inheritance from base classes', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
-
     const testCases = [
         { tag: 'x-shadow-extends-light', is: ShadowExtendsLight, shadow: true },
         { tag: 'x-default-extends-light', is: DefaultExtendsLight, shadow: false },

--- a/packages/integration-karma/test/light-dom/light-parent-shadow-child/index.spec.js
+++ b/packages/integration-karma/test/light-dom/light-parent-shadow-child/index.spec.js
@@ -1,16 +1,9 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
+
 import LightParent from 'x/lightParent';
 
 describe('light parent with shadow child', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
-
     it('should render properly', () => {
         const element = createElement('x-light-parent', { is: LightParent });
         element.setAttribute('data-id', 'x-light-parent');

--- a/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
@@ -1,16 +1,8 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import Multi from 'x/multi';
 
 describe('multiple templates', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
-
     it('can render multiple templates with different styles', () => {
         const element = createElement('x-multi', { is: Multi });
 

--- a/packages/integration-karma/test/light-dom/restriction/index.spec.js
+++ b/packages/integration-karma/test/light-dom/restriction/index.spec.js
@@ -1,15 +1,8 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import Component from 'x/component';
 
 describe('restriction', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should not restrict setting innerHTML on non-portaled light DOM component', () => {
         const elm = createElement('x-component', { is: Component });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/light-dom/shadow-getter/index.spec.js
+++ b/packages/integration-karma/test/light-dom/shadow-getter/index.spec.js
@@ -1,16 +1,14 @@
-import { createElement, setFeatureFlagForTest, LightningElement } from 'lwc';
+import { createElement, LightningElement } from 'lwc';
 
 import Test from 'x/test';
 
 describe('Light DOM shadow getter', () => {
     it('should render properly', () => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot).toBeNull();
         expect(elm.firstChild.innerText).toEqual('Hello, Light DOM');
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
     });
 
     it('renderMode should be undefined for LightningElement', () => {

--- a/packages/integration-karma/test/light-dom/shadow-parent-light-child/index.spec.js
+++ b/packages/integration-karma/test/light-dom/shadow-parent-light-child/index.spec.js
@@ -1,16 +1,9 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
 import Container from 'x/container';
 
 describe('shadow parent with light child', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should render properly', () => {
         const element = createElement('x-container', { is: Container });
         element.setAttribute('data-id', 'x-container');

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
 import BasicSlot from 'x/basicSlot';
@@ -16,12 +16,6 @@ function createTestElement(tag, component) {
 }
 
 describe('Slotting', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should render properly', () => {
         const nodes = createTestElement('x-default-slot', BasicSlot);
 

--- a/packages/integration-karma/test/light-dom/style-global/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style-global/index.spec.js
@@ -1,15 +1,10 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
+
 import Container from 'x/container';
 import Two from 'x/two';
 import Shadow from 'x/shadow';
 
 describe('Light DOM styling at the global level', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('styles bleed into other light DOM but not shadow DOM components in root context', () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/light-dom/style-multiple/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style-multiple/index.spec.js
@@ -1,13 +1,8 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
+
 import Container from 'x/container';
 
 describe('Light DOM styling - multiple light DOM components', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('styles bleed mutually across light DOM components', () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/light-dom/style-with-host/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style-with-host/index.spec.js
@@ -1,15 +1,9 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import Container from 'x/container';
 
 // synthetic shadow can't do this kind of style encapsulation
 if (process.env.DISABLE_SYNTHETIC === true) {
     describe('Light DOM styling with :host', () => {
-        beforeEach(() => {
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-        });
-        afterEach(() => {
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-        });
         it(':host can style a containing shadow component', () => {
             const elm = createElement('x-container', { is: Container });
             document.body.appendChild(elm);

--- a/packages/integration-karma/test/light-dom/style/index.spec.js
+++ b/packages/integration-karma/test/light-dom/style/index.spec.js
@@ -1,15 +1,10 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
+
 import Container from 'x/container';
 import Two from 'x/two';
 import Shadow from 'x/shadow';
 
 describe('Light DOM styling', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('styles bleed into other light DOM but not shadow DOM components', () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);

--- a/packages/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -1,15 +1,9 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
 if (!process.env.DISABLE_SYNTHETIC) {
     describe('Light DOM and synthetic shadow', () => {
-        beforeEach(() => {
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-        });
-        afterEach(() => {
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-        });
         it('shadow scoping tokens are not set for light DOM components', () => {
             // shadow grandparent, light child, shadow grandchild
             const elm = createElement('x-container', { is: Container });

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -1,17 +1,10 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
 import LightContainer from 'x/lightContainer';
 import ShadowContainer from 'x/shadowContainer';
 
 describe('Light DOM + Synthetic Shadow DOM', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
-
     describe('light -> shadow', () => {
         let elm, nodes;
         beforeEach(() => {

--- a/packages/integration-karma/test/template/directive-lwc-render-mode/index.spec.js
+++ b/packages/integration-karma/test/template/directive-lwc-render-mode/index.spec.js
@@ -1,15 +1,9 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import Shadow from 'x/shadow';
 import Light from 'x/light';
 
 describe('lwc:render-mode', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
-    });
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
-    });
     it('should throw error if shadow template is passed to light component', () => {
         expect(() => {
             const root = createElement('x-test', { is: Light });


### PR DESCRIPTION
## Details

This PR enables LWC light DOM by default by removing the associated feature flag.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 
