### PR TITLE
chore: update observable-membrane

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -28,7 +28,7 @@
         "@lwc/shared": "2.3.6"
     },
     "devDependencies": {
-        "observable-membrane": "1.0.1"
+        "observable-membrane": "1.1.3"
     },
     "publishConfig": {
         "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,10 +9563,10 @@ object.values@^1.1.3:
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
 
-observable-membrane@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.0.1.tgz#1041074136d5d62b0fc488880bed1c3680674ec5"
-  integrity sha512-AlPC0ZuEuBYt9LSbsBGOz0rpIjkdbIH5JQMLHZrmCRkUedfVoNSFQXLYso+hXxWrRqwEhxEkQuYNg6Pch3hmqQ==
+observable-membrane@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.1.3.tgz#ad4441f8bae5d5b7f4b2035fa1f9dad2d514fb6c"
+  integrity sha512-UoMUGgGe7oLHCa0JZRPgrzQDkdOg+CxATra0m2uRNxhUapozafgv1qmssVsXnIkkuO2Q7UBycS0PBR2vwKVOjg==
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Details

Updates `observable-membrane` to the latest version (1.1.3). 1.0.1 is a year old, and there have been a few releases since then: https://github.com/salesforce/observable-membrane/releases

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`