### PR TITLE
fix: ensure synthetic shadow IDs are random

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -155,7 +155,9 @@ export interface VM<N = HostNode, E = HostElement> {
 
 type VMAssociable = HostNode | LightningElement;
 
-let idx: number = 0;
+// Start with a random number to discourage taking a dependency on anything downstream from the idx,
+// such as globally-scoped IDs in synthetic shadow DOM. These are not supposed to be predictable.
+let idx: number = Math.floor(Math.random() * 1000);
 
 /** The internal slot used to associate different objects the engine manipulates with the VM */
 const ViewModelReflection = new WeakMap<any, VM>();


### PR DESCRIPTION
## Details

The cow is already out of the barn (so to speak), but making the synthetic shadow IDs more random could help avoid future breakages where folks take a dependency on the ID being `foo-0`, `foo-1`, etc. This would also help in a native shadow world, as the ID would be `foo` rather than `foo-0`.

I'm not aware of a way to write a Karma test for this, since `idx` is a global variable so it maintains its state between tests.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`