### PR TITLE
fix: remove ENABLE_LIGHT_DOM_COMPONENTS flag entirely

### DIFF
--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -29,11 +29,6 @@ export interface FeatureFlagMap {
     ENABLE_HMR: FeatureFlagValue;
 
     /**
-     * LWC engine flag to toggle LWC light DOM support.
-     */
-    ENABLE_LIGHT_DOM_COMPONENTS: FeatureFlagValue;
-
-    /**
      * LWC engine flag to toggle LWC mixed shadow DOM support.
      */
     ENABLE_MIXED_SHADOW_MODE: FeatureFlagValue;

--- a/packages/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
@@ -28,14 +28,12 @@ if (SYNTHETIC_SHADOW_DEFINED) {
 
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
             elm = createElement('x-native-container', { is: NativeContainer });
             document.body.appendChild(elm);
         });
 
         afterEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
         });
 
         it('should attach a native shadow root when possible', () => {
@@ -71,14 +69,12 @@ if (SYNTHETIC_SHADOW_DEFINED) {
 
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
             elm = createElement('x-light-container', { is: LightContainer });
             document.body.appendChild(elm);
         });
 
         afterEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
         });
 
         it('should not attach shadow root', () => {
@@ -106,7 +102,6 @@ if (SYNTHETIC_SHADOW_DEFINED) {
 
         beforeEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', true);
             elm = createElement('x-default-extends-native', {
                 is: DefaultExtendsNative,
             });
@@ -115,7 +110,6 @@ if (SYNTHETIC_SHADOW_DEFINED) {
 
         afterEach(() => {
             setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-            setFeatureFlagForTest('ENABLE_LIGHT_DOM_COMPONENTS', false);
         });
 
         it('should attach a synthetic shadow root', () => {


### PR DESCRIPTION
## Details

I think #2487 was supposed to remove this flag entirely, but it looks like we may have missed a few references.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`