### PR TITLE
refactor(template-compiler): Add AST traversal helper to ParserCtx and updated error handling

### DIFF
--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -82,10 +82,10 @@ export function isFragmentOnlyUrl(url: string): boolean {
 }
 
 export function normalizeAttributeValue(
-    attr: parse5.Attribute,
+    ctx: ParserCtx,
     raw: string,
     tag: string,
-    ctx: ParserCtx,
+    attr: parse5.Attribute,
     location: parse5.Location
 ): {
     value: string;

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -10,12 +10,11 @@ import { Location } from 'parse5';
 import { ParserDiagnostics, invariant } from '@lwc/errors';
 
 import * as t from '../shared/estree';
-import { TemplateExpression, TemplateIdentifier, IRElement } from '../shared/types';
+import { TemplateExpression, TemplateIdentifier } from '../shared/types';
 
 import ParserCtx from './parser';
 
 import { ResolvedConfig } from '../config';
-import { isTemplate } from '../shared/ir';
 
 export const EXPRESSION_SYMBOL_START = '{';
 export const EXPRESSION_SYMBOL_END = '}';
@@ -96,10 +95,10 @@ function validateSourceIsParsedExpression(source: string, parsedExpression: Node
 }
 
 export function parseExpression(
-    source: string,
     ctx: ParserCtx,
+    source: string,
     location: Location
-): TemplateExpression | never {
+): TemplateExpression {
     return ctx.withErrorWrapping(
         () => {
             const parsed = parseExpressionAt(source, 1, { ecmaVersion: 2020 });
@@ -116,35 +115,13 @@ export function parseExpression(
 }
 
 export function parseIdentifier(
-    source: string,
     ctx: ParserCtx,
+    source: string,
     location: Location
-): TemplateIdentifier | never {
+): TemplateIdentifier {
     if (esutils.keyword.isIdentifierES6(source)) {
         return t.identifier(source);
     } else {
         ctx.throwAtLocation(ParserDiagnostics.INVALID_IDENTIFIER, location, [source]);
     }
-}
-
-// Returns the immediate iterator parent if it exists.
-// Traverses up until it finds an element with forOf, or
-// a non-template element without a forOf.
-export function getForOfParent(ctx: ParserCtx): IRElement | null {
-    return ctx.findAncestor({
-        predicate: (element) => element.forOf,
-        traversalCond: ({ current }) => isTemplate(current),
-    });
-}
-
-export function getForEachParent(ctx: ParserCtx, element: IRElement): IRElement | null {
-    return ctx.findAncestor({
-        element,
-        predicate: (element) => element.forEach,
-        traversalCond: ({ parent }) => parent && isTemplate(parent),
-    });
-}
-
-export function isIteratorElement(ctx: ParserCtx, element: IRElement): boolean {
-    return !!(getForOfParent(ctx) || getForEachParent(ctx, element));
 }

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -901,14 +901,14 @@ function isInIteration(element: IRElement, ctx: ParserCtx) {
     });
 }
 
-export function getForOfParent(ctx: ParserCtx): IRElement | null {
+function getForOfParent(ctx: ParserCtx): IRElement | null {
     return ctx.findAncestor({
         predicate: (element) => element.forOf,
         traversalCond: ({ current }) => isTemplate(current),
     });
 }
 
-export function getForEachParent(ctx: ParserCtx, element: IRElement): IRElement | null {
+function getForEachParent(ctx: ParserCtx, element: IRElement): IRElement | null {
     return ctx.findAncestor({
         element,
         predicate: (element) => element.forEach,
@@ -916,6 +916,6 @@ export function getForEachParent(ctx: ParserCtx, element: IRElement): IRElement 
     });
 }
 
-export function isInIteratorElement(ctx: ParserCtx, element: IRElement): boolean {
+function isInIteratorElement(ctx: ParserCtx, element: IRElement): boolean {
     return !!(getForOfParent(ctx) || getForEachParent(ctx, element));
 }

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -601,7 +601,7 @@ function applySlot(ctx: ParserCtx, element: IRElement, parsedAttr: ParsedAttribu
         return ctx.warnOnIRNode(ParserDiagnostics.NO_DUPLICATE_SLOTS, element, [
             name === '' ? 'default' : `name="${name}"`,
         ]);
-    } else if (isInIteration(element, ctx)) {
+    } else if (isInIteration(ctx, element)) {
         return ctx.warnOnIRNode(ParserDiagnostics.NO_SLOTS_IN_ITERATOR, element, [
             name === '' ? 'default' : `name="${name}"`,
         ]);
@@ -653,7 +653,7 @@ function applyAttributes(ctx: ParserCtx, element: IRElement, parsedAttr: ParsedA
                     ctx.throwOnIRNode(ParserDiagnostics.INVALID_ID_ATTRIBUTE, attr, [value]);
                 }
 
-                if (isInIteration(element, ctx)) {
+                if (isInIteration(ctx, element)) {
                     ctx.throwOnIRNode(ParserDiagnostics.INVALID_STATIC_ID_IN_ITERATION, attr, [
                         value,
                     ]);
@@ -894,7 +894,7 @@ function getTemplateAttribute(
     }
 }
 
-function isInIteration(element: IRElement, ctx: ParserCtx) {
+function isInIteration(ctx: ParserCtx, element: IRElement) {
     return ctx.findAncestor({
         predicate: (element) => isTemplate(element) && (element.forOf || element.forEach),
         element,

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -54,6 +54,30 @@ export default class ParserCtx {
         return this.source.slice(start, end);
     }
 
+    *ancestorGenerator(element?: IRElement) {
+        const ancestors = element ? [...this.parentStack, element] : this.parentStack;
+        for (let index = ancestors.length - 1; index > 0; index--) {
+            yield { current: ancestors[index], index };
+        }
+    }
+
+    findAncestor(args: {
+        element?: IRElement;
+        predicate: (elm: IRElement) => unknown;
+        traversalCond?: (nodes: { current: IRElement; parent: IRElement | undefined }) => unknown;
+    }): IRElement | null {
+        const { element, predicate, traversalCond = () => true } = args;
+        for (const { current, index } of this.ancestorGenerator(element)) {
+            if (predicate(current)) {
+                return current;
+            }
+            if (!traversalCond({ current, parent: this.parentStack[index - 1] })) {
+                break;
+            }
+        }
+        return null;
+    }
+
     withErrorRecovery<T>(fn: () => T): T | undefined {
         try {
             return fn();

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -54,7 +54,7 @@ export default class ParserCtx {
         return this.source.slice(start, end);
     }
 
-    *ancestorGenerator(element?: IRElement) {
+    *ancestors(element?: IRElement) {
         const ancestors = element ? [...this.parentStack, element] : this.parentStack;
         for (let index = ancestors.length - 1; index > 0; index--) {
             yield { current: ancestors[index], index };
@@ -67,7 +67,7 @@ export default class ParserCtx {
         traversalCond?: (nodes: { current: IRElement; parent: IRElement | null }) => unknown;
     }): IRElement | null {
         const { element, predicate, traversalCond = () => true } = args;
-        for (const { current, index } of this.ancestorGenerator(element)) {
+        for (const { current, index } of this.ancestors(element)) {
             if (predicate(current)) {
                 return current;
             }
@@ -153,7 +153,7 @@ export default class ParserCtx {
         );
     }
 
-    addDiagnostic(diagnostic: CompilerDiagnostic): void {
+    private addDiagnostic(diagnostic: CompilerDiagnostic): void {
         this.warnings.push(diagnostic);
     }
 


### PR DESCRIPTION
## Details
Refactor AST traversal in the parser to use new helper method findAncestor on ParserCtx and updated error handling for parseExpression, parseIdentifier and normalizeAttribute to use ParserCtx's helper methods.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

If yes, please describe the impact and migration path for existing applications.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9698836
