### PR TITLE
fix: clean up light DOM scoped styles in compiler

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -69,10 +69,11 @@ export interface TransformOptions {
     scopedStyles?: boolean;
 }
 
-type RequiredTransformOptions = Omit<TransformOptions, 'name' | 'namespace'>;
+type RequiredTransformOptions = Omit<TransformOptions, 'name' | 'namespace' | 'scopedStyles'>;
 export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTransformOptions> {
     name?: string;
     namespace?: string;
+    scopedStyles?: boolean;
 }
 
 export function validateTransformOptions(options: TransformOptions): NormalizedTransformOptions {
@@ -156,5 +157,5 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         stylesheetConfig,
         outputConfig,
         experimentalDynamicComponent,
-    } as NormalizedTransformOptions;
+    };
 }


### PR DESCRIPTION
## Details

This is a follow-up to address some PR comments in #2332.

- Use Rollup `meta` data for `scoped` property (https://github.com/salesforce/lwc/pull/2332#discussion_r709142064)
- Clean up TypeScript `NormalizedTransformOptions` interface (https://github.com/salesforce/lwc/pull/2332#discussion_r703300444)

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`