### PR TITLE
fix(synthetic-shadow): fix light DOM serialization

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -17,7 +17,7 @@ import {
     KEY__SYNTHETIC_MODE,
 } from '@lwc/shared';
 import featureFlags from '@lwc/features';
-import { attachShadow, getShadowRoot, hasHostChild, isHostElement } from './shadow-root';
+import { attachShadow, getShadowRoot, containsHost, isHostElement } from './shadow-root';
 import {
     getNodeOwner,
     getAllMatches,
@@ -124,7 +124,7 @@ defineProperties(Element.prototype, {
                 // use the native innerHTML because it would expose private node internals.
                 // (Note that innerHTMLGetterPatched calls innerHTML on all children, so we only need to check
                 // one level deep.)
-                if (isNodeShadowed(this) || isHostElement(this) || hasHostChild(this)) {
+                if (isNodeShadowed(this) || isHostElement(this) || containsHost(this)) {
                     return innerHTMLGetterPatched.call(this);
                 }
 
@@ -147,7 +147,7 @@ defineProperties(Element.prototype, {
         get(this: Element): string {
             if (!featureFlags.ENABLE_ELEMENT_PATCH) {
                 // See notes above on get innerHTML
-                if (isNodeShadowed(this) || isHostElement(this) || hasHostChild(this)) {
+                if (isNodeShadowed(this) || isHostElement(this) || containsHost(this)) {
                     return outerHTMLGetterPatched.call(this);
                 }
                 return outerHTMLGetter.call(this);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -48,7 +48,7 @@ import {
     getShadowRoot,
     isHostElement,
     getIE11FakeShadowRootPlaceholder,
-    hasHostChild,
+    containsHost,
 } from './shadow-root';
 import { getNodeNearestOwnerKey, getNodeOwnerKey, isNodeShadowed } from '../shared/node-ownership';
 import { createStaticNodeList } from '../shared/static-node-list';
@@ -287,7 +287,7 @@ defineProperties(Node.prototype, {
         get(this: Node): string {
             if (!featureFlags.ENABLE_NODE_PATCH) {
                 // See note on get innerHTML in faux-shadow/element.ts
-                if (isNodeShadowed(this) || isHostElement(this) || hasHostChild(this)) {
+                if (isNodeShadowed(this) || isHostElement(this) || containsHost(this)) {
                     return textContentGetterPatched.call(this);
                 }
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -127,6 +127,17 @@ export function isHostElement(node: unknown): node is HTMLElement {
     return !isUndefined(InternalSlot.get(node));
 }
 
+// Return true if any immediate child is a host
+export function hasHostChild(node: Node) {
+    const { childNodes } = node;
+    for (let i = 0, length = childNodes.length; i < length; i++) {
+        if (isHostElement(childNodes[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
 let uid = 0;
 
 export function attachShadow(elm: Element, options: ShadowRootInit): SyntheticShadowRootInterface {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -127,11 +127,12 @@ export function isHostElement(node: unknown): node is HTMLElement {
     return !isUndefined(InternalSlot.get(node));
 }
 
-// Return true if any immediate child is a host
-export function hasHostChild(node: Node) {
-    const { childNodes } = node;
-    for (let i = 0, length = childNodes.length; i < length; i++) {
-        if (isHostElement(childNodes[i])) {
+// Return true if any descendant is a host element
+export function containsHost(node: Node) {
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+    let descendantNode;
+    while ((descendantNode = walker.nextNode())) {
+        if (isHostElement(descendantNode)) {
             return true;
         }
     }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -20,6 +20,7 @@ import {
     setPrototypeOf,
     getPrototypeOf,
     isObject,
+    ArrayPush,
 } from '@lwc/shared';
 import { addShadowRootEventListener, removeShadowRootEventListener } from './events';
 import { dispatchEvent } from '../env/event-target';
@@ -53,7 +54,7 @@ import { getOuterHTML } from '../3rdparty/polymer/outer-html';
 import { getInternalChildNodes } from './node';
 import { innerHTMLSetter } from '../env/element';
 import { setNodeKey, setNodeOwnerKey } from '../shared/node-ownership';
-import { getOwnerDocument } from '../shared/utils';
+import { arrayFromCollection, getOwnerDocument } from '../shared/utils';
 import { fauxElementsFromPoint } from '../shared/faux-elements-from-point';
 
 const InternalSlot = new WeakMap<any, ShadowRootRecord>();
@@ -129,12 +130,15 @@ export function isHostElement(node: unknown): node is HTMLElement {
 
 // Return true if any descendant is a host element
 export function containsHost(node: Node) {
-    const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
-    let descendantNode;
-    while ((descendantNode = walker.nextNode())) {
-        if (isHostElement(descendantNode)) {
+    const descendants = arrayFromCollection(node.childNodes);
+    let descendant;
+    while (!isUndefined((descendant = descendants.shift()))) {
+        if (isHostElement(descendant)) {
             return true;
         }
+        // TypeScript does not like passing an array-like in as an array
+        // @ts-ignore
+        ArrayPush.apply(descendants, descendant.childNodes);
     }
     return false;
 }

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -55,10 +55,9 @@ describe('Slotting', () => {
     it('shadow container, light consumer', () => {
         const nodes = createTestElement('x-light-consumer', LightConsumer);
 
-        const expected = process.env.DISABLE_SYNTHETIC // native shadow doesn't output slots in innerHTML
-            ? '<x-shadow-container><p data-id="light-consumer-text">Hello from Light DOM</p></x-shadow-container>'
-            : '<x-shadow-container><slot><p data-id="light-consumer-text">Hello from Light DOM</p></slot></x-shadow-container>';
-        expect(nodes['x-light-consumer'].innerHTML).toEqual(expected);
+        expect(nodes['x-light-consumer'].innerHTML).toEqual(
+            '<x-shadow-container><p data-id="light-consumer-text">Hello from Light DOM</p></x-shadow-container>'
+        );
     });
 
     it('light container, shadow consumer', () => {

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -3,6 +3,7 @@ import { extractDataIds } from 'test-utils';
 
 import LightContainer from 'x/lightContainer';
 import ShadowContainer from 'x/shadowContainer';
+import LightContainerDeepShadow from 'x/lightContainerDeepShadow';
 
 describe('Light DOM + Synthetic Shadow DOM', () => {
     describe('light -> shadow', () => {
@@ -83,6 +84,46 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             );
             expect(elm.outerHTML).toEqual(
                 '<x-light-container><x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer></x-light-container>'
+            );
+        });
+    });
+
+    describe('light -> deep shadow', () => {
+        let elm, nodes;
+        beforeEach(() => {
+            elm = createElement('x-light-container-deep-shadow', {
+                is: LightContainerDeepShadow,
+            });
+            document.body.appendChild(elm);
+            nodes = extractDataIds(elm);
+        });
+        it('childNodes', () => {
+            expect(Array.from(elm.childNodes)).toEqual([nodes.wrapper]);
+            expect(Array.from(nodes.wrapper.childNodes)).toEqual([nodes.consumer]);
+        });
+        it('textContent', () => {
+            expect(nodes.p.textContent).toEqual('I am an assigned element.');
+            expect(nodes.consumer.textContent).toEqual(
+                'I am an assigned element.I am an assigned text.'
+            );
+            expect(elm.textContent).toEqual('I am an assigned element.I am an assigned text.');
+        });
+        it('innerHTML', () => {
+            expect(nodes.p.innerHTML).toEqual('I am an assigned element.');
+            expect(nodes.consumer.innerHTML).toEqual(
+                '<p data-id="p">I am an assigned element.</p>I am an assigned text.'
+            );
+            expect(elm.innerHTML).toEqual(
+                '<div data-id="wrapper"><x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer></div>'
+            );
+        });
+        it('outerHTML', () => {
+            expect(nodes.p.outerHTML).toEqual('<p data-id="p">I am an assigned element.</p>');
+            expect(nodes.consumer.outerHTML).toEqual(
+                '<x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer>'
+            );
+            expect(elm.outerHTML).toEqual(
+                '<x-light-container-deep-shadow><div data-id="wrapper"><x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer></div></x-light-container-deep-shadow>'
             );
         });
     });

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -25,7 +25,27 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.p.assignedSlot).toEqual(nodes.slot);
         });
         it('childNodes', () => {
+            // TreeWalker is just a convenient way of getting text nodes without using childNodes
+            const textNodes = {};
+            const walker = document.createTreeWalker(elm, NodeFilter.SHOW_TEXT);
+            let node;
+            while ((node = walker.nextNode())) {
+                textNodes[node.wholeText] = node;
+            }
             expect(Array.from(nodes.slot.childNodes)).toEqual([]);
+            expect(Array.from(nodes.p.childNodes)).toEqual([
+                textNodes['I am an assigned element.'],
+            ]);
+            expect(Array.from(nodes.consumer.childNodes)).toEqual([
+                nodes.p,
+                textNodes['I am an assigned text.'],
+            ]);
+            expect(Array.from(elm.childNodes)).toEqual([nodes.consumer]);
+            expect(Array.from(nodes['consumer.shadowRoot'].childNodes)).toEqual([
+                nodes.pInShadow,
+                nodes.slot,
+            ]);
+            expect(Array.from(nodes.slot)).toEqual([]);
         });
         it('parentNode', () => {
             expect(nodes.p.parentNode).toEqual(nodes.consumer);
@@ -40,16 +60,14 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.p.getRootNode()).toEqual(document);
             expect(nodes.consumer.getRootNode()).toEqual(document);
         });
-        // TODO [#2425]: Incorrect serialization
-        xit('textContent', () => {
+        it('textContent', () => {
             expect(nodes.p.textContent).toEqual('I am an assigned element.');
             expect(nodes.consumer.textContent).toEqual(
                 'I am an assigned element.I am an assigned text.'
             );
             expect(elm.textContent).toEqual('I am an assigned element.I am an assigned text.');
         });
-        // TODO [#2425]: Incorrect serialization
-        xit('innerHTML', () => {
+        it('innerHTML', () => {
             expect(nodes.p.innerHTML).toEqual('I am an assigned element.');
             expect(nodes.consumer.innerHTML).toEqual(
                 '<p data-id="p">I am an assigned element.</p>I am an assigned text.'
@@ -58,8 +76,7 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
                 '<x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer>'
             );
         });
-        // TODO [#2425]: Incorrect serialization
-        xit('outerHTML', () => {
+        it('outerHTML', () => {
             expect(nodes.p.outerHTML).toEqual('<p data-id="p">I am an assigned element.</p>');
             expect(nodes.consumer.outerHTML).toEqual(
                 '<x-consumer data-id="consumer"><p data-id="p">I am an assigned element.</p>I am an assigned text.</x-consumer>'

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -26,21 +26,7 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.p.assignedSlot).toEqual(nodes.slot);
         });
         it('childNodes', () => {
-            // TreeWalker is just a convenient way of getting text nodes without using childNodes
-            const textNodes = {};
-            const walker = document.createTreeWalker(elm, NodeFilter.SHOW_TEXT);
-            let node;
-            while ((node = walker.nextNode())) {
-                textNodes[node.wholeText] = node;
-            }
             expect(Array.from(nodes.slot.childNodes)).toEqual([]);
-            expect(Array.from(nodes.p.childNodes)).toEqual([
-                textNodes['I am an assigned element.'],
-            ]);
-            expect(Array.from(nodes.consumer.childNodes)).toEqual([
-                nodes.p,
-                textNodes['I am an assigned text.'],
-            ]);
             expect(Array.from(elm.childNodes)).toEqual([nodes.consumer]);
             expect(Array.from(nodes['consumer.shadowRoot'].childNodes)).toEqual([
                 nodes.pInShadow,
@@ -48,6 +34,25 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             ]);
             expect(Array.from(nodes.slot)).toEqual([]);
         });
+        if (!process.env.COMPAT) {
+            it('childNodes - text nodes', () => {
+                // TreeWalker is just a convenient way of getting text nodes without using childNodes
+                // Sadly it throws errors in IE11 (even when adding arguments to `createTreeWalker()`)
+                const textNodes = {};
+                const walker = document.createTreeWalker(elm, NodeFilter.SHOW_TEXT);
+                let node;
+                while ((node = walker.nextNode())) {
+                    textNodes[node.wholeText] = node;
+                }
+                expect(Array.from(nodes.p.childNodes)).toEqual([
+                    textNodes['I am an assigned element.'],
+                ]);
+                expect(Array.from(nodes.consumer.childNodes)).toEqual([
+                    nodes.p,
+                    textNodes['I am an assigned text.'],
+                ]);
+            });
+        }
         it('parentNode', () => {
             expect(nodes.p.parentNode).toEqual(nodes.consumer);
             expect(nodes.consumer.parentNode).toEqual(elm);

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/x/consumer/consumer.html
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/x/consumer/consumer.html
@@ -1,4 +1,4 @@
 <template>
-    <p>I am in the shadow</p>
+    <p data-id="pInShadow">I am in the shadow</p>
     <slot data-id="slot"></slot>
 </template>

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/x/lightContainerDeepShadow/lightContainerDeepShadow.html
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/x/lightContainerDeepShadow/lightContainerDeepShadow.html
@@ -1,0 +1,8 @@
+<template lwc:render-mode="light">
+    <div data-id="wrapper">
+        <x-consumer data-id="consumer">
+            <p data-id="p">I am an assigned element.</p>
+            I am an assigned text.
+        </x-consumer>
+    </div>
+</template>

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/x/lightContainerDeepShadow/lightContainerDeepShadow.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/x/lightContainerDeepShadow/lightContainerDeepShadow.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class LightContainerDeepShadow extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -67,11 +67,11 @@ if (!process.env.DISABLE_SYNTHETIC) {
 
         describe('Element.prototype API', () => {
             it('should keep behavior for innerHTML', () => {
-                expect(elementOutsideLWC.innerHTML.length).toBe(455);
+                expect(elementOutsideLWC.innerHTML.length).toBe(27);
                 expect(rootLwcElement.innerHTML.length).toBe(0);
                 expect(lwcElementInsideShadow.innerHTML.length).toBe(0);
 
-                expect(divManuallyApendedToShadow.innerHTML.length).toBe(176); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
+                expect(divManuallyApendedToShadow.innerHTML.length).toBe(43); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
 
                 expect(cmpShadow.innerHTML.length).toBe(99);
 
@@ -80,11 +80,11 @@ if (!process.env.DISABLE_SYNTHETIC) {
             });
 
             it('should keep behavior for outerHTML', () => {
-                expect(elementOutsideLWC.outerHTML.length).toBe(466);
+                expect(elementOutsideLWC.outerHTML.length).toBe(38);
                 expect(rootLwcElement.outerHTML.length).toBe(27);
                 expect(lwcElementInsideShadow.outerHTML.length).toBe(27);
 
-                expect(divManuallyApendedToShadow.outerHTML.length).toBe(206); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
+                expect(divManuallyApendedToShadow.outerHTML.length).toBe(73); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
 
                 expect(cmpShadow.outerHTML).toBe(undefined);
 
@@ -257,12 +257,12 @@ if (!process.env.DISABLE_SYNTHETIC) {
             });
 
             it('should preserve behaviour for textContent', () => {
-                expect(elementOutsideLWC.textContent.length).toBe(117);
+                expect(elementOutsideLWC.textContent.length).toBe(0);
                 expect(rootLwcElement.textContent.length).toBe(0);
                 expect(lwcElementInsideShadow.textContent.length).toBe(0);
 
                 expect(elementInShadow.textContent.length).toBe(0);
-                expect(divManuallyApendedToShadow.textContent.length).toBe(45);
+                expect(divManuallyApendedToShadow.textContent.length).toBe(0);
 
                 expect(cmpShadow.textContent.length).toBe(31);
 


### PR DESCRIPTION
## Details

Fixes #2425

The root causes of the `innerHTML`/`outerHTML`/`textContent` issues were very similar:

1. The implementations relied on `childNodes`, e.g. calling `outerHTML` on every child node to get the `innerHTML`
2. `childNodes` was returning an empty array for light DOM elements
3. `innerHTML`/`outerHTML`/`textContent` needed to check if any immediate children were shadowed/hosts for the cast of light DOM root elements

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item

W-9630160