### PR TITLE
fix: throw error if Rollup version is too old

### DIFF
--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -22,10 +22,11 @@
     },
     "dependencies": {
         "@lwc/module-resolver": "2.5.1",
-        "@rollup/pluginutils": "~4.1.1"
+        "@rollup/pluginutils": "~4.1.1",
+        "semver": "^7.3.5"
     },
     "peerDependencies": {
-        "rollup": "^1.2.0||^2.0.0"
+        "rollup": "^2.29.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -9,6 +9,8 @@ const path = require('path');
 const pluginUtils = require('@rollup/pluginutils');
 const compiler = require('@lwc/compiler');
 const { resolveModule } = require('@lwc/module-resolver');
+const semver = require('semver');
+const pkg = require('../package.json');
 
 const DEFAULT_MODULES = [
     { npm: '@lwc/engine-dom' },
@@ -53,6 +55,14 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
 
             customRootDir = rootDir ? path.resolve(rootDir) : path.dirname(path.resolve(input));
             customResolvedModules = [...userModules, ...DEFAULT_MODULES, { dir: customRootDir }];
+        },
+
+        buildStart() {
+            if (!semver.satisfies(this.meta.rollupVersion, pkg.peerDependencies.rollup)) {
+                throw new Error(
+                    `@lwc/rollup-plugin requires Rollup version ${pkg.peerDependencies.rollup} (found: ${this.meta.rollupVersion}). Please update Rollup.`
+                );
+            }
         },
 
         resolveId(importee, importer) {


### PR DESCRIPTION
## Details

Fixes #2505

This PR updates the min semver in the `peerDependencies` Rollup version for `@lwc/rollup-plugin`, and improves the error message if the Rollup version is too old.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`