### PR TITLE
fix(template-compiler): fix event listeners on light DOM slots

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1139
+ * Next error code: 1140
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -525,4 +525,11 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Warning,
         url: '',
     },
+    LWC_LIGHT_SLOT_INVALID_EVENT_LISTENER: {
+        code: 1139,
+        message:
+            "Invalid event listener '{0}' on slot. Slots in Light DOM templates cannot have event listeners.",
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-event-listeners/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-event-listeners/actual.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <slot onslotchange={onSlotChange}></slot>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-event-listeners/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-event-listeners/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1139,
+            "message": "LWC1139: Invalid event listener 'onslotchange' on slot. Slots in Light DOM templates cannot have event listeners.",
+            "level": 1,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 39,
+                "length": 41
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -263,6 +263,13 @@ function applyHandlers(ctx: ParserCtx, element: IRElement, parsedAttr: ParsedAtt
             ctx.throwOnIRNode(ParserDiagnostics.INVALID_EVENT_NAME, eventHandlerAttribute, [name]);
         }
 
+        // Light DOM slots cannot have events because there's no actual `<slot>` element
+        if (element.tag === 'slot' && ctx.getRenderMode(element) === LWCDirectiveRenderMode.light) {
+            ctx.throwOnIRNode(ParserDiagnostics.LWC_LIGHT_SLOT_INVALID_EVENT_LISTENER, element, [
+                name,
+            ]);
+        }
+
         // Strip the `on` prefix from the event handler name
         const eventName = name.slice(2);
 


### PR DESCRIPTION
## Details

Fixes #2507

I also added a test to confirm that `onslotchange` throws the error for a `<slot>` in light DOM mode.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## GUS work item
W-9947075