### PR TITLE
fix(engine-core): Preserve old duplicate public property behavior

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/api-decorator.spec.js
@@ -735,6 +735,90 @@ describe('Transform property', () => {
             },
         }
     );
+
+    pluginTest(
+        '[W-9927596] - public property with duplicate getter/setter',
+        `
+        import { api } from 'lwc';
+        export default class Text {
+            @api foo = 1;
+            
+            get foo() {}
+            set foo(value) {}
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+                import _tmpl from "./test.html";
+
+                class Text {
+                    foo = 1;
+
+                    get foo() {}
+
+                    set foo(value) {}
+                }
+                
+                _registerDecorators(Text, {
+                    publicProps: {
+                        foo: {
+                            config: 0,
+                        },
+                    },
+                });
+
+                export default _registerComponent(Text, {
+                    tmpl: _tmpl,
+                });
+              `,
+            },
+        }
+    );
+
+    pluginTest(
+        '[W-9927596] - public getter/setter with duplicate property',
+        `
+        import { api } from 'lwc';
+        export default class Text {
+            foo = 1;
+            
+            @api
+            get foo() {}
+            set foo(value) {}
+        }
+    `,
+        {
+            output: {
+                code: `
+                import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+                import _tmpl from "./test.html";
+
+                class Text {
+                    foo = 1;
+
+                    get foo() {}
+
+                    set foo(value) {}
+                }
+                
+                _registerDecorators(Text, {
+                    publicProps: {
+                        foo: {
+                            config: 3,
+                        },
+                    },
+                    fields: ["foo"]
+                });
+
+                export default _registerComponent(Text, {
+                    tmpl: _tmpl,
+                });
+              `,
+            },
+        }
+    );
 });
 
 describe('Transform method', () => {

--- a/packages/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/integration-karma/test/component/decorators/api/index.spec.js
@@ -9,6 +9,8 @@ import Methods from 'x/methods';
 import Inheritance from 'x/inheritance';
 import NullInitialValue from 'x/nullInitialValue';
 
+import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
+
 describe('properties', () => {
     it('should expose class properties with the api decorator', () => {
         const elm = createElement('x-properties', { is: Properties });
@@ -125,5 +127,156 @@ describe('restrictions', () => {
         }).toThrowError(
             'Invalid @api showFeatures field. Found a duplicate method with the same name.'
         );
+    });
+});
+
+describe('regression [W-9927596]', () => {
+    describe('public property with duplicate observed field', () => {
+        it('log errors when evaluated and preserve the public property', () => {
+            let Ctor;
+
+            expect(() => {
+                class DuplicateProperty extends LightningElement {
+                    foo = 'observed';
+                    @api foo = 'public';
+
+                    render() {
+                        return duplicatePropertyTemplate;
+                    }
+                }
+
+                Ctor = DuplicateProperty;
+            }).toLogErrorDev(
+                /Invalid observed foo field\. Found a duplicate accessor with the same name\./
+            );
+
+            const elm = createElement('x-duplicate-property', { is: Ctor });
+            document.body.appendChild(elm);
+
+            expect(elm.shadowRoot.querySelector('p').textContent).toBe('public');
+
+            elm.foo = 'updated';
+            return Promise.resolve().then(() => {
+                expect(elm.shadowRoot.querySelector('p').textContent).toBe('updated');
+            });
+        });
+    });
+
+    describe('public property with duplicate accessor', () => {
+        it('log errors when evaluated and treat accessors as public', () => {
+            let Ctor;
+            const accessors = [];
+
+            expect(() => {
+                class DuplicateProperty extends LightningElement {
+                    @api foo = 'default';
+
+                    get foo() {
+                        accessors.push('getter');
+                        return this._foo;
+                    }
+                    set foo(value) {
+                        accessors.push(`setter ${value}`);
+                        this._foo = value;
+                    }
+
+                    render() {
+                        return duplicatePropertyTemplate;
+                    }
+                }
+
+                Ctor = DuplicateProperty;
+            }).toLogErrorDev(
+                /Invalid @api foo field\. Found a duplicate accessor with the same name\./
+            );
+
+            const elm = createElement('x-duplicate-property', { is: Ctor });
+            elm.foo = 'test';
+
+            document.body.appendChild(elm);
+
+            expect(accessors).toEqual(['setter default', 'setter test', 'getter']);
+            expect(elm.shadowRoot.querySelector('p').textContent).toBe('test');
+        });
+    });
+
+    describe('public accessor with duplicate observed field', () => {
+        describe('@api on the getter', () => {
+            it('log errors when evaluated and preserve the public accessors', () => {
+                let Ctor;
+                const accessors = [];
+
+                expect(() => {
+                    class DuplicateAccessor extends LightningElement {
+                        foo = 'default';
+
+                        @api
+                        get foo() {
+                            accessors.push('getter');
+                            return this._foo;
+                        }
+                        set foo(value) {
+                            accessors.push(`setter ${value}`);
+                            this._foo = value;
+                        }
+
+                        render() {
+                            return duplicatePropertyTemplate;
+                        }
+                    }
+
+                    Ctor = DuplicateAccessor;
+                }).toLogErrorDev(
+                    /Invalid observed foo field\. Found a duplicate accessor with the same name\./
+                );
+
+                const elm = createElement('x-duplicate-accessor', { is: Ctor });
+                elm.foo = 'test';
+
+                document.body.appendChild(elm);
+
+                expect(accessors).toEqual(['setter default', 'setter test', 'getter']);
+                expect(elm.shadowRoot.querySelector('p').textContent).toBe('test');
+            });
+        });
+
+        describe('@api on the setter', () => {
+            it('log errors when evaluated and invokes accessors', () => {
+                let Ctor;
+                const accessors = [];
+
+                expect(() => {
+                    class DuplicateAccessor extends LightningElement {
+                        foo = 'default';
+
+                        @api
+                        set foo(value) {
+                            accessors.push(`setter ${value}`);
+                            this._foo = value;
+                        }
+                        get foo() {
+                            accessors.push('getter');
+                            return this._foo;
+                        }
+
+                        render() {
+                            return duplicatePropertyTemplate;
+                        }
+                    }
+
+                    Ctor = DuplicateAccessor;
+                }).toLogErrorDev(
+                    /Invalid observed foo field\. Found a duplicate accessor with the same name\./
+                );
+
+                const elm = createElement('x-duplicate-accessor', { is: Ctor });
+                elm.foo = 'test';
+
+                document.body.appendChild(elm);
+
+                expect(accessors).toEqual(['setter default', 'setter test', 'getter']);
+                expect(elm.shadowRoot.querySelector('p').textContent).toBe('test');
+            });
+        });
     });
 });

--- a/packages/integration-karma/test/component/decorators/api/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
+++ b/packages/integration-karma/test/component/decorators/api/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{foo}</p>
+</template>

--- a/packages/integration-karma/test/component/decorators/api/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
+++ b/packages/integration-karma/test/component/decorators/api/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
@@ -1,0 +1,1 @@
+export { default } from './duplicatePropertyTemplate.html';

--- a/packages/integration-karma/test/component/decorators/track/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
+++ b/packages/integration-karma/test/component/decorators/track/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{foo.name}</p>
+</template>

--- a/packages/integration-karma/test/component/decorators/track/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
+++ b/packages/integration-karma/test/component/decorators/track/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
@@ -1,0 +1,1 @@
+export { default } from './duplicatePropertyTemplate.html';

--- a/packages/integration-karma/test/component/decorators/wire/x/adapter/adapter.js
+++ b/packages/integration-karma/test/component/decorators/wire/x/adapter/adapter.js
@@ -1,1 +1,5 @@
-export function adapter() {}
+export const adapter = class Adapter {
+    connect() {}
+    update() {}
+    disconnect() {}
+};

--- a/packages/integration-karma/test/component/decorators/wire/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
+++ b/packages/integration-karma/test/component/decorators/wire/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{foo}</p>
+</template>

--- a/packages/integration-karma/test/component/decorators/wire/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
+++ b/packages/integration-karma/test/component/decorators/wire/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
@@ -1,0 +1,1 @@
+export { default } from './duplicatePropertyTemplate.html';

--- a/packages/integration-karma/test/component/observed-fields/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
+++ b/packages/integration-karma/test/component/observed-fields/x/duplicatePropertyTemplate/duplicatePropertyTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{foo}</p>
+</template>

--- a/packages/integration-karma/test/component/observed-fields/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
+++ b/packages/integration-karma/test/component/observed-fields/x/duplicatePropertyTemplate/duplicatePropertyTemplate.js
@@ -1,0 +1,1 @@
+export { default } from './duplicatePropertyTemplate.html';


### PR DESCRIPTION
## Details

This is a backport of https://github.com/salesforce/lwc/pull/2501 to `winter22` branch.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9927596
