### PR TITLE
fix(rollup-plugin): fix scoped style loading

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -1,0 +1,36 @@
+(function (lwc) {
+  'use strict';
+
+  function stylesheet(useActualHostSelector, token) {
+    var shadowSelector = token ? ("." + token) : "";
+    return ["div", shadowSelector, " {color: blue;}"].join('');
+  }
+  stylesheet.$scoped$ = true;
+  var _implicitScopedStylesheets = [stylesheet];
+
+  function tmpl($api, $cmp, $slotset, $ctx) {
+    const {h: api_element} = $api;
+    return [api_element("div", {
+      key: 0
+    }, [])];
+  }
+  var _tmpl = lwc.registerTemplate(tmpl);
+  tmpl.stylesheets = [];
+  if (_implicitScopedStylesheets) {
+    tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+  }
+  tmpl.stylesheetToken = "x-app_app";
+
+  class App extends lwc.LightningElement {}
+
+  var App$1 = lwc.registerComponent(App, {
+    tmpl: _tmpl
+  });
+
+  const container = document.getElementById('main');
+  const element = lwc.createElement('x-app', {
+    is: App$1
+  });
+  container.appendChild(element);
+
+})(LWC);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/main.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/main.js
@@ -1,0 +1,5 @@
+import { createElement } from "lwc";
+import App from "x/app";
+const container = document.getElementById('main');
+const element = createElement('x-app', { is: App });
+container.appendChild(element);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.html
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.js
@@ -1,0 +1,3 @@
+import { LightningElement } from "lwc";
+
+export default class App extends LightningElement {}

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.scoped.css
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/simple_app_with_scoped_styles/src/x/app/app.scoped.css
@@ -1,0 +1,3 @@
+div {
+  color: blue;
+}


### PR DESCRIPTION
## Details

In some cases it is possible for another Rollup plugin to resolve scoped styles, meaning its `resolveId` will apply but not the `resolveId` of `@lwc/rollup-plugin`. This means that we effectively have to figure out the `lwcScopedStyles` Rollup `meta`-data (i.e. whether to process styles as scoped or not) in the `load` phase.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`

This _shouldn't_ break anything, but I think it's a somewhat risky change, because it's hard to predict how other Rollup pipelines/plugins will react now that we are no longer stripping the query param in the `resolveId` phase. But I think this behavior is best, because it's what `@rollup/plugin-node-resolve` already does.

## The PR fulfills these requirements:
* Have tests for the proposed changes been added? ✅ 
* Have you followed [these instructions](../CONTRIBUTING.md#-commit-message-conventions) to clearly describe the issue being fixed or feature enhanced? ✅ 

## GUS work item
W-9966469
