### PR TITLE
fix(engine-dom): better detection for constructable stylesheets

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -33,6 +33,9 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 const globalStylesheetsParentElement: Element = document.head || document.body || document;
+// This check for constructable stylesheets is similar to Fast's:
+// https://github.com/microsoft/fast/blob/d49d1ec/packages/web-components/fast-element/src/dom.ts#L51-L53
+// See also: https://github.com/whatwg/webidl/issues/1027#issuecomment-934510070
 const supportsConstructableStyleSheets =
     isFunction((CSSStyleSheet.prototype as any).replaceSync) &&
     isArray((document as any).adoptedStyleSheets);


### PR DESCRIPTION
## Details

I thought about it, and it makes me nervous to only check for `CSSStyleSheet.replaceSync` as a test for whether the browser supports constructable stylesheets. Technically, there are two changes to the CSS spec, one for `DocumentOrShadowRoot.adoptedStyleSheets` (https://github.com/w3c/csswg-drafts/commit/3664d57f7f2265f82f99c2c0cfb56a344c5431d0) and another for `CSSStyleSheet.replaceSync` (https://github.com/w3c/csswg-drafts/commit/0aca629bc2ff93d364eb363fa751c065187153fe).

I don't see why a browser would implement `replaceSync` without implementing `adoptedStyleSheets`, but potentially it could. And our implementation relies on both, so in that case, it would break. This seems like a "better safe than sorry" kind of situation – let's just check for both.

I verified manually that constructable stylesheets are still working correctly in Chrome and are disabled in Firefox.

## Does this PR introduce breaking changes?

* ✅ `No, it does not introduce breaking changes.`