### PR TITLE
fix(synthetic-shadow): elementsFromPoint returns invisible hosts

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
@@ -32,11 +32,11 @@ export function fauxElementsFromPoint(
 
     const findAppropriateHost = (rootNode: Node) => {
         // Keep searching up the host tree until we find an element that is within the context node's
-        // shadow root and isn't already in the elements or result arrays
+        // immediate shadow root and isn't already in the elements or result arrays
         let host;
         while (!isUndefined((host = (rootNode as any).host))) {
             if (
-                rootNodes.indexOf(host.getRootNode()) !== -1 &&
+                rootNodes[0] === host.getRootNode() &&
                 elements.indexOf(host) === -1 &&
                 result.indexOf(host) === -1
             ) {

--- a/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isNull, isUndefined } from '@lwc/shared';
+import { ArrayIndexOf, ArrayPush, isNull, isUndefined } from '@lwc/shared';
 import { elementsFromPoint } from '../env/document';
 import { isSyntheticSlotElement } from '../faux-shadow/traverse';
 
@@ -55,8 +55,8 @@ export function fauxElementsFromPoint(
             }
             const elementRootNode = element.getRootNode();
 
-            if (rootNodes.indexOf(elementRootNode) !== -1) {
-                result.push(element);
+            if (ArrayIndexOf.call(rootNodes, elementRootNode) !== -1) {
+                ArrayPush.call(result, element);
                 continue;
             }
             // In cases where the host element is not visible but its shadow descendants are, then
@@ -69,10 +69,10 @@ export function fauxElementsFromPoint(
             const ancestorHost = findAncestorHostInImmediateShadowRoot(elementRootNode);
             if (
                 !isUndefined(ancestorHost) &&
-                elements.indexOf(ancestorHost) === -1 &&
-                result.indexOf(ancestorHost) === -1
+                ArrayIndexOf.call(elements, ancestorHost) === -1 &&
+                ArrayIndexOf.call(result, ancestorHost) === -1
             ) {
-                result.push(ancestorHost);
+                ArrayPush.call(result, ancestorHost);
             }
         }
     }

--- a/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
@@ -26,9 +26,25 @@ export function fauxElementsFromPoint(
     top: number
 ): Element[] {
     const elements: Element[] | null = elementsFromPoint.call(doc, left, top);
-    const result = [];
+    const result: Element[] = [];
 
     const rootNodes = getAllRootNodes(context);
+
+    const findAppropriateHost = (rootNode: Node) => {
+        // Keep searching up the host tree until we find an element that is within the context node's
+        // shadow root and isn't already in the elements or result arrays
+        let host;
+        while (!isUndefined((host = (rootNode as any).host))) {
+            if (
+                rootNodes.indexOf(host.getRootNode()) !== -1 &&
+                elements.indexOf(host) === -1 &&
+                result.indexOf(host) === -1
+            ) {
+                return host;
+            }
+            rootNode = host.getRootNode();
+        }
+    };
 
     // Filter the elements array to only include those elements that are in this shadow root or in one of its
     // ancestor roots. This matches Chrome and Safari's implementation (but not Firefox's, which only includes
@@ -37,11 +53,25 @@ export function fauxElementsFromPoint(
         // can be null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint#browser_compatibility
         for (let i = 0; i < elements.length; i++) {
             const element = elements[i];
-            if (
-                rootNodes.indexOf(element.getRootNode()) !== -1 &&
-                !isSyntheticSlotElement(element)
-            ) {
+            if (isSyntheticSlotElement(element)) {
+                continue;
+            }
+            const elementRootNode = element.getRootNode();
+
+            if (rootNodes.indexOf(elementRootNode) !== -1) {
                 result.push(element);
+                continue;
+            }
+            // In cases where the host element is not visible but its shadow descendants are, then
+            // we may get the shadow descendant instead of the host element here. (The
+            // browser doesn't know the difference in synthetic shadow DOM.)
+            // In native shadow DOM, however, elementsFromPoint would return the host but not
+            // the child. So we need to detect if this shadow element's host is accessible from
+            // the context's shadow root. Note we also need to be careful not to add the host
+            // multiple times.
+            const appropriateHost = findAppropriateHost(elementRootNode);
+            if (!isUndefined(appropriateHost)) {
+                result.push(appropriateHost);
             }
         }
     }

--- a/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/faux-elements-from-point.ts
@@ -30,19 +30,16 @@ export function fauxElementsFromPoint(
 
     const rootNodes = getAllRootNodes(context);
 
-    const findAppropriateHost = (rootNode: Node) => {
-        // Keep searching up the host tree until we find an element that is within the context node's
-        // immediate shadow root and isn't already in the elements or result arrays
+    // Keep searching up the host tree until we find an element that is within the context node's
+    // immediate shadow root
+    const findAncestorHostInImmediateShadowRoot = (rootNode: Node) => {
         let host;
         while (!isUndefined((host = (rootNode as any).host))) {
-            if (
-                rootNodes[0] === host.getRootNode() &&
-                elements.indexOf(host) === -1 &&
-                result.indexOf(host) === -1
-            ) {
+            const thisRootNode = host.getRootNode();
+            if (thisRootNode === rootNodes[0]) {
                 return host;
             }
-            rootNode = host.getRootNode();
+            rootNode = thisRootNode;
         }
     };
 
@@ -69,9 +66,13 @@ export function fauxElementsFromPoint(
             // the child. So we need to detect if this shadow element's host is accessible from
             // the context's shadow root. Note we also need to be careful not to add the host
             // multiple times.
-            const appropriateHost = findAppropriateHost(elementRootNode);
-            if (!isUndefined(appropriateHost)) {
-                result.push(appropriateHost);
+            const ancestorHost = findAncestorHostInImmediateShadowRoot(elementRootNode);
+            if (
+                !isUndefined(ancestorHost) &&
+                elements.indexOf(ancestorHost) === -1 &&
+                result.indexOf(ancestorHost) === -1
+            ) {
+                result.push(ancestorHost);
             }
         }
     }

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -146,10 +146,14 @@ describe('elementsFromPoint', () => {
 
         it('host elements are not all visible', () => {
             const grandparent = createElement('x-grandparent', { is: Grandparent });
-            document.body.appendChild(grandparent);
+            const container = document.createElement('div');
+            container.style = 'position: relative; width: 100px; height: 100px;';
+            document.body.appendChild(container);
+            container.appendChild(grandparent);
             const nodes = extractShadowDataIds(grandparent.shadowRoot);
             const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
             const html = document.documentElement;
+            const { body } = document;
 
             const resetStyles = () => {
                 [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
@@ -158,56 +162,61 @@ describe('elementsFromPoint', () => {
             };
 
             function test(element, expectedElements) {
-                testElementsFromPoint(element.getRootNode(), 50, 50, expectedElements);
+                testElementsFromPoint(element.getRootNode(), 50, 50, [
+                    ...expectedElements,
+                    container,
+                    body,
+                    html,
+                ]);
             }
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
+            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             grandparent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, html]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, html]);
-            test(grandparentDiv, [parent, grandparentDiv, html]);
+            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
+            test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
+            test(grandparentDiv, [parent, grandparentDiv]);
 
             resetStyles();
             parent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
+            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             resetStyles();
             child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
+            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             resetStyles();
             parent.style = 'width: 0px; height: 0px;';
             parentDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
+            test(parentDiv, [child, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             resetStyles();
             parent.style = 'width: 0px; height: 0px;';
             parentDiv.style = 'width: 0px; height: 0px;';
             child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, grandparentDiv, grandparent]);
+            test(parentDiv, [child, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             resetStyles();
             parent.style = 'width: 0px; height: 0px;';
             child.style = 'width: 0px; height: 0px;';
-            test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
+            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
             resetStyles();
             parent.style = 'width: 0px; height: 0px;';
@@ -215,17 +224,17 @@ describe('elementsFromPoint', () => {
             child.style = 'width: 0px; height: 0px;';
             childDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [grandparentDiv, grandparent, html]);
-            test(parentDiv, [grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [grandparentDiv, grandparent, html]);
+            test(childDiv, [grandparentDiv, grandparent]);
+            test(parentDiv, [grandparentDiv, grandparent]);
+            test(grandparentDiv, [grandparentDiv, grandparent]);
 
             resetStyles();
             parentDiv.style = 'width: 0px; height: 0px;';
             child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parent, grandparentDiv, grandparent, html]);
-            test(parentDiv, [child, parent, grandparentDiv, grandparent, html]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent, html]);
+            test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
+            test(parentDiv, [child, parent, grandparentDiv, grandparent]);
+            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
         });
     }
 });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -95,53 +95,19 @@ describe('elementsFromPoint', () => {
                 const rootNode = element.getRootNode();
                 const x = left + width / 2;
                 const y = top + height / 2;
-                testElementsFromPoint(rootNode, x, y, expectedElements);
+                testElementsFromPoint(rootNode, x, y, [...expectedElements, elm, body, html]);
             }
 
-            test(elm, [elm, body, html]);
-            test(aboveContainer, [aboveContainer, elm, body, html]);
-            test(inContainer, [slottable, inContainer, elm, body, html]);
-            test(slottable, [slottable, inContainer, elm, body, html]);
-            test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer, elm, body, html]);
-            test(slotted, [slotted, aroundSlotted, slottable, inContainer, elm, body, html]);
-            test(inSlotted, [
-                inSlotted,
-                slotted,
-                aroundSlotted,
-                slottable,
-                inContainer,
-                elm,
-                body,
-                html,
-            ]);
-            test(slotWrapper, [
-                slotted,
-                aroundSlotted,
-                slotWrapper,
-                slottable,
-                inContainer,
-                elm,
-                body,
-                html,
-            ]);
-            test(inSlottable, [
-                inSlottableInner,
-                inSlottable,
-                slottable,
-                inContainer,
-                elm,
-                body,
-                html,
-            ]);
-            test(inSlottableInner, [
-                inSlottableInner,
-                inSlottable,
-                slottable,
-                inContainer,
-                elm,
-                body,
-                html,
-            ]);
+            test(elm, []);
+            test(aboveContainer, [aboveContainer]);
+            test(inContainer, [slottable, inContainer]);
+            test(slottable, [slottable, inContainer]);
+            test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer]);
+            test(slotted, [slotted, aroundSlotted, slottable, inContainer]);
+            test(inSlotted, [inSlotted, slotted, aroundSlotted, slottable, inContainer]);
+            test(slotWrapper, [slotted, aroundSlotted, slotWrapper, slottable, inContainer]);
+            test(inSlottable, [inSlottableInner, inSlottable, slottable, inContainer]);
+            test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
         });
 
         it('host elements are not all visible', () => {

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -110,97 +110,96 @@ describe('elementsFromPoint', () => {
             test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
         });
 
-        it('host elements are not all visible', () => {
-            const grandparent = createElement('x-grandparent', { is: Grandparent });
-            const container = document.createElement('div');
-            container.style = 'position: relative; width: 100px; height: 100px;';
-            document.body.appendChild(container);
-            container.appendChild(grandparent);
-            const nodes = extractShadowDataIds(grandparent.shadowRoot);
-            const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
-            const html = document.documentElement;
-            const { body } = document;
+        // IE11 sometimes includes <html> in the elements array, sometimes not. It's not worth testing
+        if (!process.env.COMPAT) {
+            it('host elements are not all visible', () => {
+                const grandparent = createElement('x-grandparent', { is: Grandparent });
+                document.body.appendChild(grandparent);
+                const nodes = extractShadowDataIds(grandparent.shadowRoot);
+                const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
+                const html = document.documentElement;
 
-            const resetStyles = () => {
-                [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
-                    el.style = '';
-                });
-            };
+                const resetStyles = () => {
+                    [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach(
+                        (el) => {
+                            el.style = '';
+                        }
+                    );
+                };
 
-            function test(element, expectedElements) {
-                testElementsFromPoint(element.getRootNode(), 50, 50, [
-                    ...expectedElements,
-                    container,
-                    body,
-                    html,
-                ]);
-            }
+                function test(element, expectedElements) {
+                    testElementsFromPoint(element.getRootNode(), 50, 50, [
+                        ...expectedElements,
+                        html,
+                    ]);
+                }
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
+                test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            grandparent.style = 'width: 0px; height: 0px;';
+                grandparent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
-            test(grandparentDiv, [parent, grandparentDiv]);
+                test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
+                test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
+                test(grandparentDiv, [parent, grandparentDiv]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                parent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
+                test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            child.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
+                test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                parent.style = 'width: 0px; height: 0px;';
+                parentDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
-            test(parentDiv, [child, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
+                test(parentDiv, [child, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                parent.style = 'width: 0px; height: 0px;';
+                parentDiv.style = 'width: 0px; height: 0px;';
+                child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                test(childDiv, [childDiv, grandparentDiv, grandparent]);
+                test(parentDiv, [child, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
-            test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+                resetStyles();
+                parent.style = 'width: 0px; height: 0px;';
+                child.style = 'width: 0px; height: 0px;';
+                test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
+                test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
-            childDiv.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                parent.style = 'width: 0px; height: 0px;';
+                parentDiv.style = 'width: 0px; height: 0px;';
+                child.style = 'width: 0px; height: 0px;';
+                childDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [grandparentDiv, grandparent]);
-            test(parentDiv, [grandparentDiv, grandparent]);
-            test(grandparentDiv, [grandparentDiv, grandparent]);
+                test(childDiv, [grandparentDiv, grandparent]);
+                test(parentDiv, [grandparentDiv, grandparent]);
+                test(grandparentDiv, [grandparentDiv, grandparent]);
 
-            resetStyles();
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
+                resetStyles();
+                parentDiv.style = 'width: 0px; height: 0px;';
+                child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
-        });
+                test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
+                test(parentDiv, [child, parent, grandparentDiv, grandparent]);
+                test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+            });
+        }
     }
 });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.css
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.css
@@ -1,0 +1,5 @@
+:host, div {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+}

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.html
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+  <div data-id="childDiv"></div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.css
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.css
@@ -1,0 +1,5 @@
+:host, div {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+}

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.html
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.html
@@ -1,0 +1,5 @@
+<template>
+  <div data-id="grandparentDiv">
+    <x-parent data-id="parent"></x-parent>
+  </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/grandparent/grandparent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.css
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.css
@@ -1,0 +1,5 @@
+:host, div {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+}

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.html
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+  <div data-id="parentDiv">
+    <x-child data-id="child"></x-child>
+  </div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Fixes #2495

Here's a basic example of what's happening:

```html
<x-outer>
  #shadow-root
    <x-inner>
      #shadow-root
        <div></div>
    </x-inner>
</x-outer>
```

Let's say we call `outer.shadowRoot.elementsFromPoint()`. And let's say `<x-inner>` is invisible (width and height = 0) whereas `<div>` is visible.

In _native_ shadow, we get these elements:

    [<x-inner>, <x-outer>, <html>]

In synthetic shadow, the native `elementsFromPoint` returns these:

    [<div>, <x-outer>, <html>]

The current (wrong) behavior returns:

    [<x-outer>, <html>]

The problem is that the current code ignores the `<div>` because it's not visible in `<x-outer>`'s shadow root.

In this PR, we take the `<div>` and find an ancestor host that is accessible to `<x-outer>`'s shadow root. This host can be added to the resulting array.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

* ⚠️ Yes, it does include an observable change.

Anyone using `elementsFromPoint` in synthetic shadow could observe this change. We are aligning more closely with Chrome's and Safari's native behavior.

I don't anticipate this would cause breakages because we would be exposing _more_ elements, not fewer.

## GUS work item

W-9904840