### PR TITLE
fix(synthetic-shadow): ie11 error accesing walker.nextNode

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -135,6 +135,12 @@ export function isSyntheticShadowRoot(node: unknown): node is ShadowRoot {
 
 // Return true if any descendant is a host element
 export function containsHost(node: Node) {
+    // IE11 complains with "Unexpected call to method or property access." when calling walker.nextNode().
+    // The fix for this is to only walk trees for nodes that are Node.ELEMENT_NODE.
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+        return false;
+    }
+
     // IE requires all arguments
     // https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker#browser_compatibility
     const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, null, false);


### PR DESCRIPTION
## Details

Fixes an issue in IE11 introduced with #2502. detected with [template directive-lwc-inner-html renders the content as HTML](https://github.com/salesforce/lwc/blob/52e0a2b3a0463df42baa161cfd369aa069d96303/packages/integration-karma/test/template/directive-lwc-inner-html/index.spec.js#L23-L35) test.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
