### PR TITLE
fix(integration-karma): disable_synthetic is not an exported option

### DIFF
--- a/packages/integration-karma/scripts/karma-configs/sauce.js
+++ b/packages/integration-karma/scripts/karma-configs/sauce.js
@@ -9,7 +9,7 @@
 
 const {
     COMPAT,
-    DISABLE_SYNTHETIC,
+    SYNTHETIC_SHADOW_ENABLED,
     TEST_HYDRATION,
     TAGS,
     SAUCE_USERNAME,
@@ -111,7 +111,7 @@ function getSauceConfig() {
         customData: {
             lwc: {
                 COMPAT,
-                DISABLE_SYNTHETIC,
+                DISABLE_SYNTHETIC: !SYNTHETIC_SHADOW_ENABLED,
             },
 
             ci: IS_CI,
@@ -133,7 +133,8 @@ function getMatchingBrowsers() {
         return (
             (!TEST_HYDRATION || browser.test_hydration === TEST_HYDRATION) &&
             browser.compat === COMPAT &&
-            (!DISABLE_SYNTHETIC || browser.nativeShadowCompatible === DISABLE_SYNTHETIC)
+            (SYNTHETIC_SHADOW_ENABLED ||
+                browser.nativeShadowCompatible !== SYNTHETIC_SHADOW_ENABLED)
         );
     });
 }


### PR DESCRIPTION
## Details
Fixes an issue introduced in #2496:`DISABLE_SYNTHETIC` was removed in favor of `SYNTHETIC_SHADOW_ENABLED ` and is no longer an exported option.

Note: The effect of `DISABLE_SYNTHETIC` being always `undefined` was not observable because `compat` and  `nativeShadowCompatible` are opposed (if `compat=true` then `nativeShadowCompatible=false`, and vice versa), at least for the configured browsers.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.