### PR TITLE
fix(rollup-plugin): revert rollup peerDep check

### DIFF
--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -22,11 +22,10 @@
     },
     "dependencies": {
         "@lwc/module-resolver": "2.5.8",
-        "@rollup/pluginutils": "~4.1.1",
-        "semver": "^7.3.5"
+        "@rollup/pluginutils": "~4.1.1"
     },
     "peerDependencies": {
-        "rollup": "^2.29.0"
+        "rollup": "^1.2.0||^2.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/rollup-plugin/src/index.js
+++ b/packages/@lwc/rollup-plugin/src/index.js
@@ -9,8 +9,6 @@ const path = require('path');
 const pluginUtils = require('@rollup/pluginutils');
 const compiler = require('@lwc/compiler');
 const { resolveModule } = require('@lwc/module-resolver');
-const semver = require('semver');
-const pkg = require('../package.json');
 
 const DEFAULT_MODULES = [
     { npm: '@lwc/engine-dom' },
@@ -55,14 +53,6 @@ module.exports = function rollupLwcCompiler(pluginOptions = {}) {
 
             customRootDir = rootDir ? path.resolve(rootDir) : path.dirname(path.resolve(input));
             customResolvedModules = [...userModules, ...DEFAULT_MODULES, { dir: customRootDir }];
-        },
-
-        buildStart() {
-            if (!semver.satisfies(this.meta.rollupVersion, pkg.peerDependencies.rollup)) {
-                throw new Error(
-                    `@lwc/rollup-plugin requires Rollup version ${pkg.peerDependencies.rollup} (found: ${this.meta.rollupVersion}). Please update Rollup.`
-                );
-            }
         },
 
         resolveId(importee, importer) {


### PR DESCRIPTION
## Details

Reverts a6d45efd6ee82e6a2a62dcc8fc5557d7baefbc48.

As of 13661ae4ab6e00f7a049fcc62562dcc77b8e209a, we actually don't use Rolup's `meta` feature anymore, so we don't strictly need Rollup `2.29.0`+. I ran a quick sanity check with `lwc-barebone` and it works fine in Rollup `1.2.0`. (In fact it works in `1.1.2`, but for safety's sake I just reverted to the old peerDep version of `^1.2.0||^2.0.0`.)

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

It won't throw an error anymore if you use an old version of Rollup.