### PR TITLE
fix(engine-dom): hydration errors due type mismatch

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -100,7 +100,7 @@ const TextHook: Hooks<VText> = {
                 assert.fail('Hydration mismatch: incorrect node type received.');
             }
 
-            if (node.nodeValue !== String(vNode.text)) {
+            if (node.nodeValue !== vNode.text) {
                 logWarn(
                     'Hydration mismatch: text values do not match, will recover from the difference',
                     vNode.owner
@@ -671,8 +671,8 @@ function co(text: string): VComment {
 }
 
 // [d]ynamic text
-function d(value: any): string | any {
-    return value == null ? '' : value;
+function d(value: any): string {
+    return value == null ? '' : String(value);
 }
 
 // [b]ind function

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -100,7 +100,7 @@ const TextHook: Hooks<VText> = {
                 assert.fail('Hydration mismatch: incorrect node type received.');
             }
 
-            if (node.nodeValue !== vNode.text) {
+            if (node.nodeValue !== String(vNode.text)) {
                 logWarn(
                     'Hydration mismatch: text values do not match, will recover from the difference',
                     vNode.owner

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -279,7 +279,7 @@ function vnodesAndElementHaveCompatibleAttrs(vnode: VNode, elm: Element): boolea
     // Note: intentionally ONLY matching vnodes.attrs to elm.attrs, in case SSR is adding extra attributes.
     for (const [attrName, attrValue] of Object.entries(attrs)) {
         const elmAttrValue = renderer.getAttribute(elm, attrName);
-        if (attrValue !== elmAttrValue) {
+        if (String(attrValue) !== elmAttrValue) {
             logError(
                 `Mismatch hydrating element <${elm.tagName.toLowerCase()}>: attribute "${attrName}" has different values, expected "${attrValue}" but found "${elmAttrValue}"`,
                 vnode.owner
@@ -300,7 +300,7 @@ function vnodesAndElementHaveCompatibleClass(vnode: VNode, elm: Element): boolea
     let nodesAreCompatible = true;
     let vnodeClassName;
 
-    if (!isUndefined(className) && className !== elm.className) {
+    if (!isUndefined(className) && String(className) !== elm.className) {
         // className is used when class is bound to an expr.
         nodesAreCompatible = false;
         vnodeClassName = className;

--- a/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/index.spec.js
+++ b/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/index.spec.js
@@ -1,0 +1,21 @@
+export default {
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            text: p.firstChild,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        expect(consoleCalls.warn).toHaveSize(0);
+        expect(consoleCalls.error).toHaveSize(0);
+
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.firstChild).toBe(snapshots.text);
+
+        expect(p.textContent).toBe('123');
+        expect(p.getAttribute('class')).toBe('123');
+        expect(p.getAttribute('data-attr')).toBe('123');
+    },
+};

--- a/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/x/main/main.html
+++ b/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/x/main/main.html
@@ -1,0 +1,4 @@
+<template>
+    <!-- style attr is validated at compile time -->
+    <p class={num} data-attr={num}>{num}</p>
+</template>

--- a/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/x/main/main.js
+++ b/packages/integration-karma/test-hydration/mismatches/type-coercion-to-string/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    num = 123;
+}


### PR DESCRIPTION
## Details
This PR fixes a validation issue while hydrating an element. The problem is visible when setting attributes/text to a non-string value.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
