### PR TITLE
perf: add benchmark for @track

### DIFF
--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.html
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.html
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
 <template>
   <ul>
     <template for:each={rows} for:item="row">

--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.html
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.html
@@ -1,0 +1,7 @@
+<template>
+  <ul>
+    <template for:each={rows} for:item="row">
+      <benchmark-tracked-component-row key={row.id} row={row}></benchmark-tracked-component-row>
+    </template>
+  </ul>
+</template>

--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.js
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponent/trackedComponent.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class TrackedComponent extends LightningElement {
+    @api rows = [];
+}

--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.html
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.html
@@ -1,0 +1,6 @@
+<template>
+  <li>
+    <div>Id: {trackedRow.id}</div>
+    <div>Label: {trackedRow.label}</div>
+  </li>
+</template>

--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.html
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.html
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
 <template>
   <li>
     <div>Id: {trackedRow.id}</div>

--- a/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.js
+++ b/packages/perf-benchmarks-components/src/benchmark/trackedComponentRow/trackedComponentRow.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, track, api } from 'lwc';
+
+export default class TrackedComponentRow extends LightningElement {
+    @track trackedRow = {}; // the whole point is to test @track
+    _row;
+
+    @api
+    set row(row) {
+        Object.assign(this.trackedRow, row);
+        this._row = row;
+    }
+
+    get row() {
+        return this._row;
+    }
+}

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tracked-component/trackedcmp-create-10k.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tracked-component/trackedcmp-create-10k.benchmark.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { createElement } from 'lwc';
+import TrackedComponent from 'perf-benchmarks-components/dist/dom/benchmark/trackedComponent/trackedComponent.js';
+import Store from 'perf-benchmarks-components/dist/dom/benchmark/store/store.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+import { benchmark, before, run, after } from '../../../utils/benchmark-framework.js';
+
+benchmark(`benchmark-tracked-component/create/10k`, () => {
+    let trackedComponent;
+
+    before(() => {
+        trackedComponent = createElement('benchmark-tracked-component', { is: TrackedComponent });
+        return insertComponent(trackedComponent);
+    });
+
+    run(() => {
+        const store = new Store();
+        store.runLots();
+        trackedComponent.rows = store.data;
+    });
+
+    after(() => {
+        destroyComponent(trackedComponent);
+    });
+});


### PR DESCRIPTION
## Details

As mentioned in https://github.com/salesforce/observable-membrane/pull/69, we don't currently have any benchmarks that exercise `@track`. It seems like it would be a good idea to at least have one benchmark using a component with `@track`.

This benchmark takes ~550ms to run on my machine, and I confirmed that it's exercising the `getProxy()` function in `observable-membrane`.

![Screen Shot 2021-10-29 at 3 23 50 PM](https://user-images.githubusercontent.com/283842/139507916-dcb4b9d7-7e5d-4521-99c2-387f2a85b0d6.png)


## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.