### PR TITLE
chore: update observable-membrane to 1.1.5

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -28,7 +28,7 @@
         "@lwc/shared": "2.5.8"
     },
     "devDependencies": {
-        "observable-membrane": "1.1.3"
+        "observable-membrane": "1.1.4"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -28,7 +28,7 @@
         "@lwc/shared": "2.5.8"
     },
     "devDependencies": {
-        "observable-membrane": "1.1.4"
+        "observable-membrane": "1.1.5"
     },
     "publishConfig": {
         "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9295,10 +9295,10 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-observable-membrane@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.1.4.tgz#f4e1a120623e754f314f0c573875c4f0ed7505cd"
-  integrity sha512-kd5YeQKTT4l8DTkNI4AeSvUtp/RL42rkyUVYB9IbJ9UW5w4EjYGHJ4kRuZY57y5H2kpx5ME+ApjzlvF9MQwXeA==
+observable-membrane@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.1.5.tgz#7db964f8f948ed44946f3a9885ea2e9b53f7b119"
+  integrity sha512-C7kZClqHPyujOKA+/qjnvZDV+i3wVY3IMJJ68tvELNj90vzs7LtiHIp8jaJD0M5OOU4J3Lx69yh2huaWo8o+gg==
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9295,10 +9295,10 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-observable-membrane@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.1.3.tgz#ad4441f8bae5d5b7f4b2035fa1f9dad2d514fb6c"
-  integrity sha512-UoMUGgGe7oLHCa0JZRPgrzQDkdOg+CxATra0m2uRNxhUapozafgv1qmssVsXnIkkuO2Q7UBycS0PBR2vwKVOjg==
+observable-membrane@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/observable-membrane/-/observable-membrane-1.1.4.tgz#f4e1a120623e754f314f0c573875c4f0ed7505cd"
+  integrity sha512-kd5YeQKTT4l8DTkNI4AeSvUtp/RL42rkyUVYB9IbJ9UW5w4EjYGHJ4kRuZY57y5H2kpx5ME+ApjzlvF9MQwXeA==
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Details

1.1.5 includes a performance improvement: https://github.com/salesforce/observable-membrane/pull/69

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

## GUS work item

W-10099550