### PR TITLE
perf: optimize isHydrating

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -10,7 +10,7 @@ export type HostElement = any;
 
 export interface Renderer<N = HostNode, E = HostElement> {
     ssr: boolean;
-    readonly isHydrating: boolean;
+    isHydrating(): boolean;
     isNativeShadowDefined: boolean;
     isSyntheticShadowDefined: boolean;
     insert(node: N, parent: E, anchor: N | null): void;

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -194,7 +194,7 @@ export function createStylesheet(vm: VM, stylesheets: string[]): VNode | null {
         for (let i = 0; i < stylesheets.length; i++) {
             renderer.insertGlobalStylesheet(stylesheets[i]);
         }
-    } else if (renderer.ssr || renderer.isHydrating) {
+    } else if (renderer.ssr || renderer.isHydrating()) {
         // Note: We need to ensure that during hydration, the stylesheets method is the same as those in ssr.
         //       This works in the client, because the stylesheets are created, and cached in the VM
         //       the first time the VM renders.

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -151,7 +151,7 @@ export function setIsHydrating(v: boolean) {
 
 export const renderer: Renderer<Node, Element> = {
     ssr: false,
-    get isHydrating(): boolean {
+    isHydrating(): boolean {
         return isHydrating;
     },
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -61,7 +61,7 @@ class HTMLElement {
 
 export const renderer: Renderer<HostNode, HostElement> = {
     ssr: true,
-    get isHydrating(): boolean {
+    isHydrating(): boolean {
         return false;
     },
 


### PR DESCRIPTION
## Details

#2442 introduced a small performance regression, notably in the `dom-table-create-10k` benchmark. After [tracking it down](https://gus.lightning.force.com/lightning/r/0D5EE00000KKBVG0A5/view), most of the regression can be reduced to [this simple change](https://github.com/nolanlawson/lwc-1/commit/1cedb2f30b85c610cc82493c81ba8f728d673d3d).

My hunch is that adding the `get isHydrating` changes the object shape in such a way that V8 has a harder time optimizing the other functions on the object, which are frequently called. So switching from a getter to a regular function actually gives us a decent performance win across [most of the benchmarks](https://docs.google.com/spreadsheets/d/1KZx1eE5xGQs68klGLPvDN8Lb8NZAgVJXVL8LWTgDdXk/edit#gid=0):

![Screen Shot 2021-11-02 at 12 19 58 PM](https://user-images.githubusercontent.com/283842/139934942-de12f823-6ca1-42ea-b012-ecf24b1a3246.png)

(The above is comparing this PR versus current master – 100 sample size, 1% horizon, 20 minute timeout.)

Interestingly, the `dom-light-styled-component-create-1k-same` benchmark does indeed seem to be consistently regressed, by around ~2%. (I ran the test again to confirm.) But I'd say it's worth it, given it's small (~1ms) and the other benchmarks are mostly improved.

A further optimization would be to get rid of the `renderer` object entirely. It only exists so that we can have a nice TypeScript abstract class for the DOM/server renderers. Potentially, we could just hoist all of its properties into the top-level exports on a module.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

## GUS work item
W-10099550
