### PR TITLE
test: fix test for Firefox 94 delegatesFocus

### DIFF
--- a/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
+++ b/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
@@ -4,12 +4,11 @@ import DelegatesFocusTrue from 'x/delegatesFocusTrue';
 import DelegatesFocusFalse from 'x/delegatesFocusFalse';
 import Container from 'x/container';
 
-beforeEach(() => {
-    document.body.focus();
-});
+describe('LightningElement.focus', () => {
+    beforeEach(() => {
+        document.body.focus();
+    });
 
-// TODO [#985]: Firefox does not implement delegatesFocus
-if (!process.env.NATIVE_SHADOW) {
     describe('host.focus() when { delegatesFocus: true }', () => {
         it('should focus the host element', () => {
             const elm = createElement('x-focus', { is: DelegatesFocusTrue });
@@ -28,70 +27,73 @@ if (!process.env.NATIVE_SHADOW) {
             expect(elm.shadowRoot.activeElement).toEqual(input);
         });
     });
-}
 
-it('should not focus the first internally focusable element (delegatesFocus=false)', () => {
-    const elm = createElement('x-focus', { is: DelegatesFocusFalse });
-    document.body.appendChild(elm);
-
-    elm.focus();
-    expect(elm.shadowRoot.activeElement).toBeNull();
-});
-
-it('should focus the host element (delegatesFocus=false, tabIndex=-1)', () => {
-    const container = createElement('x-container', { is: Container });
-    document.body.appendChild(container);
-
-    const elm = container.shadowRoot.querySelector('x-delegates-focus-false[tabindex="-1"]');
-    elm.focus();
-    expect(container.shadowRoot.activeElement).toBe(elm);
-    expect(elm.shadowRoot.activeElement).toBeNull();
-});
-
-it('should focus the host element (delegatesFocus=false, tabIndex=0)', () => {
-    const container = createElement('x-container', { is: Container });
-    document.body.appendChild(container);
-
-    const elm = container.shadowRoot.querySelector('x-delegates-focus-false[tabindex="0"]');
-    elm.focus();
-    expect(container.shadowRoot.activeElement).toBe(elm);
-    expect(elm.shadowRoot.activeElement).toBeNull();
-});
-
-// Tests that apply regardless of whether focus is being delegated
-function runFocusTests({ delegatesFocus }) {
-    const category = `(delegatesFocus=${delegatesFocus})`;
-    const Ctor = delegatesFocus ? DelegatesFocusTrue : DelegatesFocusFalse;
-
-    it(`should focus the internal element when invoking the focus method directly on the internal element ${category}`, () => {
-        const elm = createElement('x-focus', { is: Ctor });
+    it('should not focus the first internally focusable element (delegatesFocus=false)', () => {
+        const elm = createElement('x-focus', { is: DelegatesFocusFalse });
         document.body.appendChild(elm);
 
-        const input = elm.shadowRoot.querySelector('.second');
-        input.focus();
-        expect(elm.shadowRoot.activeElement).toBe(input);
-    });
-
-    it(`should blur the internal element when invoking the blur method directly on the internal element ${category}`, () => {
-        const elm = createElement('x-focus', { is: Ctor });
-        document.body.appendChild(elm);
-
-        const input = elm.shadowRoot.querySelector('.second');
-        input.focus();
-        input.blur();
+        elm.focus();
         expect(elm.shadowRoot.activeElement).toBeNull();
     });
 
-    it(`should not move focus if an internal element is already focused ${category}`, () => {
-        const elm = createElement('x-focus', { is: Ctor });
-        document.body.appendChild(elm);
+    it('should focus the host element (delegatesFocus=false, tabIndex=-1)', () => {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
 
-        const input = elm.shadowRoot.querySelector('.second');
-        input.focus();
+        const elm = container.shadowRoot.querySelector('x-delegates-focus-false[tabindex="-1"]');
         elm.focus();
-        expect(elm.shadowRoot.activeElement).toBe(input);
+        expect(container.shadowRoot.activeElement).toBe(elm);
+        expect(elm.shadowRoot.activeElement).toBeNull();
     });
-}
 
-runFocusTests({ delegatesFocus: true });
-runFocusTests({ delegatesFocus: false });
+    it('should focus the host element (delegatesFocus=false, tabIndex=0)', () => {
+        const container = createElement('x-container', { is: Container });
+        document.body.appendChild(container);
+
+        const elm = container.shadowRoot.querySelector('x-delegates-focus-false[tabindex="0"]');
+        elm.focus();
+        expect(container.shadowRoot.activeElement).toBe(elm);
+        expect(elm.shadowRoot.activeElement).toBeNull();
+    });
+
+    // Tests that apply regardless of whether focus is being delegated
+    function runFocusTests({ delegatesFocus }) {
+        const category = `(delegatesFocus=${delegatesFocus})`;
+        const Ctor = delegatesFocus ? DelegatesFocusTrue : DelegatesFocusFalse;
+
+        it(`should focus the internal element when invoking the focus method directly on the internal element ${category}`, () => {
+            const elm = createElement('x-focus', { is: Ctor });
+            document.body.appendChild(elm);
+
+            const input = elm.shadowRoot.querySelector('.second');
+            input.focus();
+            expect(elm.shadowRoot.activeElement).toBe(input);
+        });
+
+        it(`should blur the internal element when invoking the blur method directly on the internal element ${category}`, () => {
+            const elm = createElement('x-focus', { is: Ctor });
+            document.body.appendChild(elm);
+
+            const input = elm.shadowRoot.querySelector('.second');
+            input.focus();
+            input.blur();
+            expect(elm.shadowRoot.activeElement).toBeNull();
+        });
+
+        // TODO [#2566]: Firefox behaves differently from Chrome/Safari in this test
+        if (!(process.env.NATIVE_SHADOW && delegatesFocus && window.mozInnerScreenX)) {
+            it(`should not move focus if an internal element is already focused ${category}`, () => {
+                const elm = createElement('x-focus', { is: Ctor });
+                document.body.appendChild(elm);
+
+                const input = elm.shadowRoot.querySelector('.second');
+                input.focus();
+                elm.focus();
+                expect(elm.shadowRoot.activeElement).toBe(input);
+            });
+        }
+    }
+
+    runFocusTests({ delegatesFocus: true });
+    runFocusTests({ delegatesFocus: false });
+});

--- a/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
+++ b/packages/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
@@ -81,7 +81,7 @@ describe('LightningElement.focus', () => {
         });
 
         // TODO [#2566]: Firefox behaves differently from Chrome/Safari in this test
-        if (!(process.env.NATIVE_SHADOW && delegatesFocus && window.mozInnerScreenX)) {
+        if (!(process.env.NATIVE_SHADOW && delegatesFocus)) {
             it(`should not move focus if an internal element is already focused ${category}`, () => {
                 const elm = createElement('x-focus', { is: Ctor });
                 document.body.appendChild(elm);

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
@@ -2,25 +2,22 @@ import { LightningElement } from 'lwc';
 import { createElement } from 'lwc';
 
 describe('ShadowRoot.delegatesFocus', () => {
-    // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
-    if (!process.env.NATIVE_SHADOW) {
-        it('ShadowRoot.delegatesFocus should be false by default', () => {
-            class NoDelegatesFocus extends LightningElement {}
+    it('ShadowRoot.delegatesFocus should be false by default', () => {
+        class NoDelegatesFocus extends LightningElement {}
 
-            const elm = createElement('x-test', { is: NoDelegatesFocus });
-            document.body.appendChild(elm);
+        const elm = createElement('x-test', { is: NoDelegatesFocus });
+        document.body.appendChild(elm);
 
-            expect(elm.shadowRoot.delegatesFocus).toBe(false);
-        });
-        it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
-            class DelegatesFocus extends LightningElement {
-                static delegatesFocus = true;
-            }
+        expect(elm.shadowRoot.delegatesFocus).toBe(false);
+    });
+    it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
+        class DelegatesFocus extends LightningElement {
+            static delegatesFocus = true;
+        }
 
-            const elm = createElement('x-test', { is: DelegatesFocus });
-            document.body.appendChild(elm);
+        const elm = createElement('x-test', { is: DelegatesFocus });
+        document.body.appendChild(elm);
 
-            expect(elm.shadowRoot.delegatesFocus).toBe(true);
-        });
-    }
+        expect(elm.shadowRoot.delegatesFocus).toBe(true);
+    });
 });

--- a/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
+++ b/packages/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
@@ -2,22 +2,25 @@ import { LightningElement } from 'lwc';
 import { createElement } from 'lwc';
 
 describe('ShadowRoot.delegatesFocus', () => {
-    it('ShadowRoot.delegatesFocus should be false by default', () => {
-        class NoDelegatesFocus extends LightningElement {}
+    // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
+    if (!process.env.NATIVE_SHADOW) {
+        it('ShadowRoot.delegatesFocus should be false by default', () => {
+            class NoDelegatesFocus extends LightningElement {}
 
-        const elm = createElement('x-test', { is: NoDelegatesFocus });
-        document.body.appendChild(elm);
+            const elm = createElement('x-test', { is: NoDelegatesFocus });
+            document.body.appendChild(elm);
 
-        expect(elm.shadowRoot.delegatesFocus).toBe(false);
-    });
-    it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
-        class DelegatesFocus extends LightningElement {
-            static delegatesFocus = true;
-        }
+            expect(elm.shadowRoot.delegatesFocus).toBe(false);
+        });
+        it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
+            class DelegatesFocus extends LightningElement {
+                static delegatesFocus = true;
+            }
 
-        const elm = createElement('x-test', { is: DelegatesFocus });
-        document.body.appendChild(elm);
+            const elm = createElement('x-test', { is: DelegatesFocus });
+            document.body.appendChild(elm);
 
-        expect(elm.shadowRoot.delegatesFocus).toBe(true);
-    });
+            expect(elm.shadowRoot.delegatesFocus).toBe(true);
+        });
+    }
 });


### PR DESCRIPTION
## Details

Fixes #2565

We may have to file a bug on Firefox, but for now this should get rid of the CI test failures.

Tip: [hide whitespace changes](https://github.com/salesforce/lwc/pull/2567/files?diff=split&w=1) when looking at the diff for this PR.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.