### PR TITLE
docs(rollup-plugin): add docs on "modules" option

### DIFF
--- a/packages/@lwc/rollup-plugin/README.md
+++ b/packages/@lwc/rollup-plugin/README.md
@@ -24,6 +24,6 @@ export default {
 
 -   `rootDir` (string, optional, default: `input directory`) - set the LWC module directory
 -   `sourcemap` (boolean, optional, default: `false`) - make the LWC compiler produce source maps
--   `modules` Mapping of module specifiers.
+-   `modules` Mapping of module specifiers (for details, see [Module Resolution](https://lwc.dev/guide/es_modules#module-resolution))
 -   `stylesheetConfig` (object, optional, default: `{}`) - the configuration to pass to the `@lwc/style-compiler`
 -   `preserveHtmlComments` (boolean, optional, default: `false`) - the configuration to pass to the `@lwc/template-compiler`


### PR DESCRIPTION
## Details

Adds a link to the documentation for the `modules` option for `@lwc/rollup-plugin`.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
