### PR TITLE
chore: update release script to avoid git tags

### DIFF
--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -18,6 +18,8 @@ const ARGS = [
     '--force-publish',
     // Skip git commit and tag push
     '--no-push',
+    // Don't add a git tag
+    '--no-git-tag-version',
 ];
 
 const { stderr, stdin, stdout } = process;


### PR DESCRIPTION
## Details

For the new Nucleus release process, we're going to need to open a PR bumping the version numbers, rather than directly committing to `master` and then pushing the branch and the tag to git. This means that the release script should not automatically add a git tag – we will need to add it manually after the PR is merged.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-10179839
