### PR TITLE
chore: fix publish script after `execa` update

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -8,7 +8,7 @@
  */
 
 import isCI from 'is-ci';
-import { execaSync } from 'execa';
+import { execaSync, execaCommandSync } from 'execa';
 
 const ARGS = [
     // https://github.com/lerna/lerna/tree/master/commands/publish
@@ -37,14 +37,14 @@ try {
     // All branches that contain the current commit. Since we only deal with release commits, the
     // only scenario where this might be an issue is if we try to publish a release commit from
     // master after CLCO because the commit will show up in two branches.
-    const branches = execaSync('git branch --all --contains').stdout;
+    const branches = execaCommandSync('git branch --all --contains').stdout;
 
     // Restrict the regex to remote branches to avoid assumptions about local branches.
     const REMOTE_RELEASE_BRANCH_RE = /origin\/(master|((winter|spring|summer)\d+))/;
 
     const result = REMOTE_RELEASE_BRANCH_RE.exec(branches);
     if (result === null) {
-        const tag = execaSync('git tag --points-at HEAD').stdout;
+        const tag = execaCommandSync('git tag --points-at HEAD').stdout;
         console.error(`The commit referenced by "${tag}" is not contained by any release branch.`);
         process.exit(1);
     }


### PR DESCRIPTION
## Details

Fix `publish.mjs` script after the upgrade to `execa@6`. In #2581, I missed that all the `git` commands in this script were using `execa.commandSync` and not `execa.sync`. This PR rectifies this issue.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-7258582
