### PR TITLE
feat: add observability for renderMode/shadowMode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -6,7 +6,7 @@
  */
 import { isUndefined, noop } from '@lwc/shared';
 
-import { VM } from './vm';
+import { RenderMode, ShadowMode, VM } from './vm';
 import { getComponentTag } from '../shared/format';
 
 export const enum OperationId {
@@ -28,7 +28,14 @@ const enum Phase {
     Stop = 1,
 }
 
-type LogDispatcher = (opId: OperationId, phase: Phase, cmpName?: string, vmIndex?: number) => void;
+type LogDispatcher = (
+    opId: OperationId,
+    phase: Phase,
+    cmpName?: string,
+    vmIndex?: number,
+    renderMode?: RenderMode,
+    shadowMode?: ShadowMode
+) => void;
 
 const operationIdNameMapping = [
     'constructor',
@@ -120,7 +127,7 @@ export function logOperationStart(opId: OperationId, vm: VM) {
     }
 
     if (isProfilerEnabled) {
-        currentDispatcher(opId, Phase.Start, vm.tagName, vm.idx);
+        currentDispatcher(opId, Phase.Start, vm.tagName, vm.idx, vm.renderMode, vm.shadowMode);
     }
 }
 
@@ -132,7 +139,7 @@ export function logOperationEnd(opId: OperationId, vm: VM) {
     }
 
     if (isProfilerEnabled) {
-        currentDispatcher(opId, Phase.Stop, vm.tagName, vm.idx);
+        currentDispatcher(opId, Phase.Stop, vm.tagName, vm.idx, vm.renderMode, vm.shadowMode);
     }
 }
 
@@ -144,7 +151,7 @@ export function logGlobalOperationStart(opId: GlobalOperationId, vm?: VM) {
     }
 
     if (isProfilerEnabled) {
-        currentDispatcher(opId, Phase.Start, vm?.tagName, vm?.idx);
+        currentDispatcher(opId, Phase.Start, vm?.tagName, vm?.idx, vm?.renderMode, vm?.shadowMode);
     }
 }
 
@@ -156,6 +163,6 @@ export function logGlobalOperationEnd(opId: GlobalOperationId, vm?: VM) {
     }
 
     if (isProfilerEnabled) {
-        currentDispatcher(opId, Phase.Stop, vm?.tagName, vm?.idx);
+        currentDispatcher(opId, Phase.Stop, vm?.tagName, vm?.idx, vm?.renderMode, vm?.shadowMode);
     }
 }

--- a/packages/integration-karma/test/profiler/sanity/x/container/container.html
+++ b/packages/integration-karma/test/profiler/sanity/x/container/container.html
@@ -15,4 +15,5 @@
             </li>
         </template>
     </ul>
+    <x-light></x-light>
 </template>

--- a/packages/integration-karma/test/profiler/sanity/x/light/light.html
+++ b/packages/integration-karma/test/profiler/sanity/x/light/light.html
@@ -1,0 +1,1 @@
+<template lwc:render-mode="light"></template>

--- a/packages/integration-karma/test/profiler/sanity/x/light/light.js
+++ b/packages/integration-karma/test/profiler/sanity/x/light/light.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Light extends LightningElement {
+    static renderMode = 'light';
+}


### PR DESCRIPTION
## Details

This adds observability to the profiler API for renderMode (light vs shadow) and shadowMode (synthetic vs native). It does so in a [performant](https://gus.lightning.force.com/lightning/r/0D5EE000008jsE90AI/view) and backwards-compatible way with the existing API.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->
## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

Someone using the experimental profiler API can notice that the callback is being passed additional arguments.

## GUS work item
W-9923052
