### PR TITLE
chore: add more required downstream deps to nucleus

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -17,7 +17,6 @@ branches:
         - communities/ui-dxp-components
         - communities/ui-feeds-components
         - communities/ui-lightning-community
-        - lds/lds-container-tests
         - lwc/lwc-platform
         - salesforce/lds-lightning-platform
         - salesforce/luvio

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -8,6 +8,22 @@ branches:
       auto-start: true
       auto-start-from-forks: false
       required-downstream-deps:
+        - LCT/Lightning-container-testing
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-dxp-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lds/lds-container-tests
         - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
         - salesforce/luvio
         - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
+


### PR DESCRIPTION
## Details

In #2586, we enabled Nucleus for two downstream deps. This PR adds more downstreams, based on which ones were green in [a recent run](https://nucleus.data.sfdc.net/workflows/37689).

This may increase our test flappiness, so we may have to remove certain downstreams in the future if they end up being flappy.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10179854
