### PR TITLE
chore: show proper TypeScript error messages

### DIFF
--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -52,6 +52,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
+            noEmitOnError: true,
         }),
         writeDistAndTypes(),
         rollupFeaturesPlugin(),

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -37,6 +37,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
+            noEmitOnError: true,
         }),
         writeDistAndTypes(),
     ],

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -35,6 +35,7 @@ module.exports = {
         typescriptPlugin({
             target: 'es2017',
             tsconfig: path.join(__dirname, '../tsconfig.json'),
+            noEmitOnError: true,
         }),
         writeDistAndTypes(),
     ],

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -35,6 +35,7 @@ function rollupConfig({ format }) {
             typescript({
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
+                noEmitOnError: true,
             }),
             writeDistAndTypes(),
         ],

--- a/packages/@lwc/shared/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/shared/scripts/rollup/rollup.config.js
@@ -30,6 +30,7 @@ function rollupConfig({ format }) {
             typescript({
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
+                noEmitOnError: true,
             }),
             writeDistAndTypes(),
         ],

--- a/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
@@ -54,6 +54,7 @@ function rollupConfig({ wrap } = {}) {
             rollupTypescript({
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
+                noEmitOnError: true,
             }),
             rollupFeaturesPlugin(),
         ].filter(Boolean),

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { defineProperty, isNull, isUndefined } from '@lwc/shared';
-import { Node, parentNodeGetter } from '../env/node';
+import { parentNodeGetter } from '../env/node';
 
 // Used as a back reference to identify the host element
 const HostElementKey = '$$HostElementKey$$';

--- a/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
@@ -34,6 +34,7 @@ function rollupConfig({ format }) {
             typescript({
                 target: 'es2017',
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
+                noEmitOnError: true,
             }),
             writeDistAndTypes(),
         ],


### PR DESCRIPTION
## Details

Currently, if there's a TypeScript error in the code, we won't see the full error information (the filename, the line of code, etc.) in `yarn build`. That's because by default it's just a warning, and we have our own `onwarn` handler that throws its own Error:

https://github.com/salesforce/lwc/blob/9675ae066cce503e4bd50a21bb094bf727b9a11d/packages/%40lwc/engine-dom/scripts/rollup.config.js#L44-L47

This PR uses the (somewhat awkwardly-named) [`noEmitOnError`](https://github.com/rollup/plugins/tree/master/packages/typescript#noemitonerror) option to throw a proper TypeScript error message during the build.

**Before**

![Screen Shot 2021-12-06 at 1 25 43 PM](https://user-images.githubusercontent.com/283842/144925433-52449cdb-ab05-4b17-93c5-f0543f12f1ca.png)

**After**

![Screen Shot 2021-12-06 at 1 25 54 PM](https://user-images.githubusercontent.com/283842/144925457-6b4d3ff5-d731-4160-a269-fdd079c33339.png)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

