### PR TITLE
chore: Cleanup unused types

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -15,14 +15,6 @@
 
 import { VM } from '../../framework/vm';
 
-export type VNodeStyleDecls = Array<[string, string, boolean]>;
-export interface On {
-    [event: string]: EventListener;
-}
-export type Attrs = Record<string, string | number | boolean>;
-export type Classes = Record<string, boolean>;
-export type Props = Record<string, any>;
-
 export type Key = string | number;
 
 export type VNodes = Array<VNode | null>;
@@ -70,17 +62,15 @@ export interface VComment extends VNode {
     key: undefined;
 }
 
-export type CustomElementContext = Record<string, Record<string, any>>;
-
 export interface VNodeData {
-    props?: Props;
-    attrs?: Attrs;
-    className?: any;
-    style?: any;
-    classMap?: Classes;
-    styleDecls?: VNodeStyleDecls;
-    context?: CustomElementContext;
-    on?: On;
+    props?: Record<string, any>;
+    attrs?: Record<string, string | number | boolean>;
+    className?: string;
+    style?: string;
+    classMap?: Record<string, boolean>;
+    styleDecls?: Array<[string, string, boolean]>;
+    context?: Record<string, Record<string, any>>;
+    on?: Record<string, Function>;
     svg?: boolean;
 }
 
@@ -95,9 +85,4 @@ export interface Hooks<N extends VNode> {
     update: (oldVNode: N, vNode: N) => void;
     remove: (vNode: N, parentNode: Node) => void;
     hydrate: (vNode: N, node: Node) => void;
-}
-
-export interface Module<N extends VNode> {
-    create?: (vNode: N) => void;
-    update?: (oldVNode: N, vNode: N) => void;
 }

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -222,7 +222,7 @@ export function evaluateTemplate(vm: VM, html: Template): Array<VNode | null> {
     return vnodes;
 }
 
-export function computeHasScopedStyles(template: Template): boolean {
+function computeHasScopedStyles(template: Template): boolean {
     const { stylesheets } = template;
     if (!isUndefined(stylesheets)) {
         for (let i = 0; i < stylesheets.length; i++) {

--- a/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
+++ b/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
@@ -30,11 +30,7 @@ function selectorProcessorFactory(transformConfig: SelectorScopingConfig) {
     });
 }
 
-export interface PostCssLwcPluginOptions {
-    scoped: boolean;
-}
-
-export default function postCssLwcPlugin(options: PostCssLwcPluginOptions): TransformCallback {
+export default function postCssLwcPlugin(options: { scoped: boolean }): TransformCallback {
     // We need 2 types of selectors processors, since transforming the :host selector make the selector
     // unusable when used in the context of the native shadow and vice-versa.
     const nativeShadowSelectorProcessor = selectorProcessorFactory({

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -69,11 +69,3 @@ export function getNodeKey(node: Node): number | undefined {
 export function isNodeShadowed(node: Node): boolean {
     return !isUndefined(getNodeOwnerKey(node));
 }
-
-/**
- * This function verifies if a node (with or without owner key) is contained in a shadow root.
- * Use with care since has high computational cost.
- */
-export function isNodeDeepShadowed(node: Node): boolean {
-    return !isUndefined(getNodeNearestOwnerKey(node));
-}


### PR DESCRIPTION
## Details

This PR removes all the unused types and code present in the repository.

This code was flagged by [`ts-prune`](https://www.npmjs.com/package/ts-prune) as exported but unused or exported but only used locally. This package is not bug-free, but I would encourage running this one in a while on our projects.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

