### PR TITLE
perf: Remove unnecessary boundary protection in children diffing

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -4,21 +4,11 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    ArrayFilter,
-    ArrayJoin,
-    assert,
-    isArray,
-    isNull,
-    isUndefined,
-    keys,
-    noop,
-} from '@lwc/shared';
+import { ArrayFilter, ArrayJoin, assert, isArray, isNull, isUndefined, keys } from '@lwc/shared';
 import { EmptyArray, parseStyleText } from './utils';
 import {
     createVM,
     allocateInSlot,
-    runWithBoundaryProtection,
     getAssociatedVMIfPresent,
     VM,
     ShadowMode,
@@ -169,17 +159,12 @@ export function updateElmHook(oldVnode: VElement, vnode: VElement) {
 }
 
 export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
-    const { children, owner } = vnode;
-    const fn = hasDynamicChildren(children) ? updateDynamicChildren : updateStaticChildren;
-    runWithBoundaryProtection(
-        owner,
-        owner.owner,
-        noop,
-        () => {
-            fn(vnode.elm!, oldVnode.children, children);
-        },
-        noop
-    );
+    const { elm, children } = vnode;
+    if (hasDynamicChildren(children)) {
+        updateDynamicChildren(elm!, oldVnode.children, children);
+    } else {
+        updateStaticChildren(elm!, oldVnode.children, children);
+    }
 }
 
 export function allocateChildrenHook(vnode: VCustomElement, vm: VM) {


### PR DESCRIPTION
## Details

This PR removes the `runWithBoundaryProtection` in `updateChildrenHook`. 

For context, the `runWithBoundaryProtection` method is used to catch and report user errors and recover from them. This method should wrap all the userland code invocation from the framework code. In the diffing algo the boundary protection is invoked in: 
- `patchShadowRoot`: root method to trigger the diffing algo.
- and `updateChildrenHook`: method used to diff children VNodes. This method is called recursively for each VNode with children. 

This is no need to `runWithBoundaryProtection` from within `updateChildrenHook` as it is always guarded by another boundary protection at `patchShadowRoot`. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
