### PR TITLE
feat: add API to detect synthetic shadow

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -178,6 +178,7 @@ const SyntheticShadowRootDescriptors = {
     },
     synthetic: {
         writable: false,
+        enumerable: false,
         configurable: false,
         value: true,
     },

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -176,6 +176,11 @@ const SyntheticShadowRootDescriptors = {
             return `[object ShadowRoot]`;
         },
     },
+    synthetic: {
+        writable: false,
+        configurable: false,
+        value: true,
+    },
 };
 
 const ShadowRootDescriptors = {

--- a/packages/integration-karma/helpers/test-utils.js
+++ b/packages/integration-karma/helpers/test-utils.js
@@ -346,11 +346,11 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     }
 
     function isSyntheticShadowRootInstance(sr) {
-        return Boolean(sr && /function SyntheticShadowRoot/.test(sr.constructor.toString()));
+        return Boolean(sr && sr.synthetic);
     }
 
     function isNativeShadowRootInstance(sr) {
-        return Boolean(sr && /function ShadowRoot/.test(sr.constructor.toString()));
+        return Boolean(sr && !sr.synthetic);
     }
 
     // Providing overridable hooks for tests

--- a/packages/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/integration-karma/test/api/createElement/index.spec.js
@@ -52,6 +52,7 @@ if (!process.env.NATIVE_SHADOW) {
     it('should create an element with a synthetic shadow root by default', () => {
         const elm = createElement('x-component', { is: Test });
         expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
+        expect(elm.isSynthetic()).toBeTrue();
     });
 }
 
@@ -69,6 +70,7 @@ if (process.env.NATIVE_SHADOW) {
     it('should create an element with a native shadow root if fallback is false', () => {
         const elm = createElement('x-component', { is: Test });
         expect(isNativeShadowRootInstance(elm.shadowRoot)).toBeTrue();
+        expect(elm.isSynthetic()).toBeFalse();
     });
 
     it('should create a shadowRoot in open mode when mode in not specified', () => {

--- a/packages/integration-karma/test/api/createElement/x/test/test.js
+++ b/packages/integration-karma/test/api/createElement/x/test/test.js
@@ -1,3 +1,7 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 
-export default class Test extends LightningElement {}
+export default class Test extends LightningElement {
+    @api isSynthetic() {
+        return typeof this.template.synthetic === 'undefined' ? false : this.template.synthetic;
+    }
+}


### PR DESCRIPTION
## Details

Component authors have been asking for a way to detect synthetic shadow. You can do it today by inspecting the `this.template.constructor.toString()`, but it's fragile because the value may differ across Jest and the browser, or in minified vs unminified code.

This PR adds a `synthetic` boolean property to `SyntheticShadowRoot` so that developers can do:

```js
export default class extends LightningElement {
  renderedCallback() {
    console.log('Synthetic?', !!this.template.synthetic)
  }
}
```

I'm happy to bikeshed on the name (`synthetic`? `lwcSynthetic`? `__synthetic__`?), but I seem to recall @pmdartus already suggested something like this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

The `SyntheticShadowRoot` class exposes a new boolean property.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-10277423
