### PR TITLE
chore(nucleus): remove LCT/lightning-container-testing

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -8,7 +8,6 @@ branches:
       auto-start: true
       auto-start-from-forks: false
       required-downstream-deps:
-        - LCT/Lightning-container-testing
         - automation-platform/ui-interaction-explorer-components
         - communities/microsite-template-marketing
         - communities/shared-experience-components


### PR DESCRIPTION
## Details

This downstream [has flapped](https://salesforce-internal.slack.com/archives/C02C1PTVB1N/p1638923299105500?thread_ts=1638922616.104200&cid=C02C1PTVB1N), so let's remove it for now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
