### PR TITLE
fix(synthetic-shadow): convert getRootNode test into regression test

### DIFF
--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -39,9 +39,12 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.p.parentElement).toEqual(nodes.consumer);
             expect(nodes.consumer.parentElement).toEqual(elm);
         });
-        // TODO [#2424]: Fails because the <p> doesn't have an owner key.
-        xit('getRootNode', () => {
-            expect(nodes.p.getRootNode()).toEqual(document);
+        // Issue [#2424]: Fails because the <p> doesn't have an owner key.
+        // Synthetic shadow is no longer being changed. This test now verifies
+        // that the existing behavior does not regress.
+        it('getRootNode', () => {
+            // expect(nodes.p.getRootNode()).toEqual(document); // correct behavior
+            expect(nodes.p.getRootNode()).toEqual(nodes['consumer.shadowRoot']); // incorrect, existing behavior
             expect(nodes.consumer.getRootNode()).toEqual(document);
         });
         // TODO [#2425]: Incorrect serialization

--- a/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -39,12 +39,16 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.p.parentElement).toEqual(nodes.consumer);
             expect(nodes.consumer.parentElement).toEqual(elm);
         });
-        // Issue [#2424]: Fails because the <p> doesn't have an owner key.
-        // Synthetic shadow is no longer being changed. This test now verifies
-        // that the existing behavior does not regress.
+
+        // Issue [#2424]: Synthetic shadow returns an incorrect root node because the <p>
+        // doesn't have an owner key. However, synthetic shadow is no longer being changed.
+        // This test verifies that the existing behavior in synthetic shadow does not regress.
         it('getRootNode', () => {
-            // expect(nodes.p.getRootNode()).toEqual(document); // correct behavior
-            expect(nodes.p.getRootNode()).toEqual(nodes['consumer.shadowRoot']); // incorrect, existing behavior
+            const expectedRootNode = process.env.NATIVE_SHADOW
+                ? document // native, correct behavior
+                : nodes['consumer.shadowRoot']; // incorrect, existing behavior
+
+            expect(nodes.p.getRootNode()).toEqual(expectedRootNode);
             expect(nodes.consumer.getRootNode()).toEqual(document);
         });
         // TODO [#2425]: Incorrect serialization


### PR DESCRIPTION
## Details
Since we decided to maintain the existing behavior and not to drop https://github.com/salesforce/lwc/pull/2455, this PR adds a test to ensure the existing behavior does not regress.

## Does this pull request introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.

## GUS work item
W-9630161
