### PR TITLE
test: add test for snabbdom mutating old children

### DIFF
--- a/packages/integration-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/table-diffing/index.spec.js
@@ -74,16 +74,17 @@ describe('Table diffing', () => {
             );
         };
 
-        const [, e2, e3] = elm.shadowRoot.querySelectorAll('x-row');
+        const [, e2, e3, e4] = elm.shadowRoot.querySelectorAll('x-row');
         expect(getRowContents()).toEqual([0, 1, 2, 3]);
         elm.rows = [{ id: 3 }, { id: 1 }, { id: 2 }, { id: 4 }];
 
         return Promise.resolve().then(() => {
             expect(getRowContents()).toEqual([3, 1, 2, 4]);
             expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(4);
-            const [, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
+            const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
             expect(r2).toBe(e2);
             expect(r3).toBe(e3);
+            expect(r1).toBe(e4);
         });
     });
 });

--- a/packages/integration-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/table-diffing/index.spec.js
@@ -62,4 +62,28 @@ describe('Table diffing', () => {
             expect(r2).toBe(e2);
         });
     });
+
+    it('should reuse the elements when moving the end to the start and adding new to the end', () => {
+        const elm = createElement('x-table', { is: Table });
+        elm.rows = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
+        document.body.appendChild(elm);
+
+        const getRowContents = () => {
+            return [...elm.shadowRoot.querySelectorAll('x-row')].map((row) =>
+                parseInt(row.shadowRoot.querySelector('span').textContent, 10)
+            );
+        };
+
+        const [, e2, e3] = elm.shadowRoot.querySelectorAll('x-row');
+        expect(getRowContents()).toEqual([0, 1, 2, 3]);
+        elm.rows = [{ id: 3 }, { id: 1 }, { id: 2 }, { id: 4 }];
+
+        return Promise.resolve().then(() => {
+            expect(getRowContents()).toEqual([3, 1, 2, 4]);
+            expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(4);
+            const [, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
+            expect(r2).toBe(e2);
+            expect(r3).toBe(e3);
+        });
+    });
 });


### PR DESCRIPTION
## Details

See discussion here: https://github.com/salesforce/lwc/pull/2589#discussion_r766070386

Prior to this PR, we didn't have any Jest or Karma tests to exercise the `else` block in this code path (line 133):

https://github.com/salesforce/lwc/blob/d93e2963d8d32b138ce9ed130d98e7bef84b3d74/packages/%40lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts#L127-L146

This PR adds a test that does hit this line of code:

![Screen Shot 2021-12-09 at 11 53 19 AM](https://user-images.githubusercontent.com/283842/145466463-7fed617c-8285-443f-9350-6d22c96c9c30.png)

Interestingly, the `if` block here seems completely unreachable:

https://github.com/salesforce/lwc/blob/d93e2963d8d32b138ce9ed130d98e7bef84b3d74/packages/%40lwc/engine-core/src/3rdparty/snabbdom/snabbdom.ts#L136

The only way it could be reached is if two VNodes with two different tags (e.g. `x-foo` and `x-bar`) occupy the same positions in the children array. I tried to repro this using both:

1. `lwc:dynamic` and
2. `<template if:true>` inside of a `<template for:each>`

…but neither seem to work. In the case of (1), the dynamic component has the same tag name (e.g. `x-dynamic`) regardless of whether it's actually `x-foo` or `x-bar` under the hood, and in the case of (2) there are holes in the array for the `<template if:true>` and `<template if:false>`, so two different element types cannot occupy the same index in the array.

We can probably remove that part of the code, but I'd prefer not to, because maybe someday we will refactor our templates to avoid creating holes for if/else blocks?

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
