### PR TITLE
feat: add support for `config` in `lwc:dynamic`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -766,7 +766,7 @@ type LightningElementConfig = {
     constructor: LightningElementConstructor;
     props: Record<string, any>;
 };
-function isConfig(obj: any): obj is LightningElementConfig {
+function isLightningElementConfig(obj: any): obj is LightningElementConfig {
     return !!obj.props;
 }
 export function dc(
@@ -788,9 +788,10 @@ export function dc(
         return null;
     }
     let props = {};
-    if (isConfig(Ctor)) {
+    if (isLightningElementConfig(Ctor)) {
         props = Ctor.props;
         Ctor = Ctor.constructor;
+        data.props = { ...data.props, ...props };
     }
     if (!isComponentConstructor(Ctor)) {
         throw new Error(`Invalid LWC Constructor ${toString(Ctor)} for custom element <${sel}>.`);
@@ -804,7 +805,6 @@ export function dc(
     // to identify different constructors as vnodes with different keys to avoid reusing the
     // element used for previous constructors.
     data.key = `dc:${idx}:${data.key}`;
-    data.props = { ...data.props, ...props };
     return c(sel, Ctor, data, children);
 }
 

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isUndefined, keys } from '@lwc/shared';
+import { isUndefined } from '@lwc/shared';
 import { VElement } from '../../3rdparty/snabbdom/types';
 
 function isLiveBindingProp(sel: string, key: string): boolean {
@@ -22,13 +22,6 @@ function update(oldVnode: VElement, vnode: VElement) {
     const oldProps = oldVnode.data.props;
     if (oldProps === props) {
         return;
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            isUndefined(oldProps) || keys(oldProps).join(',') === keys(props).join(','),
-            'vnode.data.props cannot change shape.'
-        );
     }
 
     const isFirstPatch = isUndefined(oldProps);

--- a/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
+++ b/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
@@ -1,22 +1,10 @@
 import { createElement } from 'lwc';
-import { registerForLoad, clearRegister } from 'test-utils';
-import ConfigOne from 'x/configone';
-import ConfigTwo from 'x/configtwo';
 
 import PropContainer from 'x/props';
-
-beforeEach(() => {
-    clearRegister();
-});
 
 const macroTask = () => new Promise((resolve) => setTimeout(resolve));
 
 it('should pass props passed as config', async () => {
-    // note, using `x-` prefix instead of `x/` because these are
-    // handled by `registerForLoad`
-    registerForLoad('x-configone', ConfigOne);
-    registerForLoad('x-configtwo', ConfigTwo);
-
     const elm = createElement('x-dynamic', { is: PropContainer });
     document.body.appendChild(elm);
 

--- a/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
+++ b/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 
 import PropContainer from 'x/props';
 
-const macroTask = () => new Promise((resolve) => setTimeout(resolve));
+const macroTask = () => new Promise(setTimeout);
 
 it('should pass props passed as config', async () => {
     const elm = createElement('x-dynamic', { is: PropContainer });
@@ -33,4 +33,29 @@ it('should pass props passed as config', async () => {
     const span = twoElm.shadowRoot.querySelector('span');
     expect(span).not.toBeNull();
     expect(span.textContent).toBe('prop2 value');
+});
+
+it("should render the same custom element when constructor doesn't change", async () => {
+    const elm = createElement('x-dynamic', { is: PropContainer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    const child = elm.shadowRoot.querySelector('x-ctor');
+    expect(child).toBeNull();
+    // first rendered with ctor set to undefined (nothing)
+
+    elm.enableOne();
+    await macroTask();
+    const oneElm = elm.shadowRoot.querySelector('x-ctor');
+    elm.enableOneAlternateProps();
+    await macroTask();
+
+    // second rendered with ctor set to x-configone
+    const oneElmAlternate = elm.shadowRoot.querySelector('x-ctor');
+    expect(oneElmAlternate).not.toBeNull();
+    const prop1 = oneElmAlternate.shadowRoot.querySelector('span');
+    expect(prop1).not.toBeNull();
+    expect(prop1.textContent).toBe('prop1 alternate value');
+    expect(oneElm).toBe(oneElmAlternate);
 });

--- a/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
+++ b/packages/integration-karma/test/component/dynamic-imports/import-config.spec.js
@@ -1,0 +1,48 @@
+import { createElement } from 'lwc';
+import { registerForLoad, clearRegister } from 'test-utils';
+import ConfigOne from 'x/configone';
+import ConfigTwo from 'x/configtwo';
+
+import PropContainer from 'x/props';
+
+beforeEach(() => {
+    clearRegister();
+});
+
+const macroTask = () => new Promise((resolve) => setTimeout(resolve));
+
+it('should pass props passed as config', async () => {
+    // note, using `x-` prefix instead of `x/` because these are
+    // handled by `registerForLoad`
+    registerForLoad('x-configone', ConfigOne);
+    registerForLoad('x-configtwo', ConfigTwo);
+
+    const elm = createElement('x-dynamic', { is: PropContainer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    const child = elm.shadowRoot.querySelector('x-ctor');
+    expect(child).toBeNull();
+    // first rendered with ctor set to undefined (nothing)
+
+    elm.enableOne();
+    await macroTask();
+
+    // second rendered with ctor set to x-configone
+    const oneElm = elm.shadowRoot.querySelector('x-ctor');
+    expect(oneElm).not.toBeNull();
+    const prop1 = oneElm.shadowRoot.querySelector('span');
+    expect(prop1).not.toBeNull();
+    expect(prop1.textContent).toBe('prop1 value');
+
+    elm.enableTwo();
+    await macroTask();
+
+    // third rendered with ctor set to x-configtwo
+    const twoElm = elm.shadowRoot.querySelector('x-ctor');
+    expect(twoElm).not.toBeNull();
+    const span = twoElm.shadowRoot.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('prop2 value');
+});

--- a/packages/integration-karma/test/component/dynamic-imports/x/configone/configone.html
+++ b/packages/integration-karma/test/component/dynamic-imports/x/configone/configone.html
@@ -1,0 +1,3 @@
+<template>
+    <span>{prop1}</span>
+</template>

--- a/packages/integration-karma/test/component/dynamic-imports/x/configone/configone.js
+++ b/packages/integration-karma/test/component/dynamic-imports/x/configone/configone.js
@@ -1,0 +1,5 @@
+import { api, LightningElement } from 'lwc';
+
+export default class ConfigOne extends LightningElement {
+    @api prop1;
+}

--- a/packages/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.html
+++ b/packages/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.html
@@ -1,0 +1,3 @@
+<template>
+    <span>{prop2}</span>
+</template>

--- a/packages/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.js
+++ b/packages/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.js
@@ -1,0 +1,5 @@
+import { api, LightningElement } from 'lwc';
+
+export default class Configtwo extends LightningElement {
+    @api prop2;
+}

--- a/packages/integration-karma/test/component/dynamic-imports/x/props/props.html
+++ b/packages/integration-karma/test/component/dynamic-imports/x/props/props.html
@@ -1,0 +1,3 @@
+<template>
+    <x-ctor lwc:dynamic={config}></x-ctor>
+</template>

--- a/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
+++ b/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
@@ -1,16 +1,20 @@
-import { api, LightningElement, track } from 'lwc';
+import { api, LightningElement } from 'lwc';
 import ConfigOne from 'x/configone';
 import ConfigTwo from 'x/configtwo';
 
 export default class Props extends LightningElement {
-    @track config = undefined;
+    config = undefined;
 
     @api enableOne() {
-        this.config = { constructor: ConfigOne, props: { prop1: 'prop1 value' } };
+        this.config = { ctor: ConfigOne, props: { prop1: 'prop1 value' } };
     }
 
     @api enableTwo() {
-        this.config = { constructor: ConfigTwo, props: { prop2: 'prop2 value' } };
+        this.config = { ctor: ConfigTwo, props: { prop2: 'prop2 value' } };
+    }
+
+    @api enableOneAlternateProps() {
+        this.config = { ctor: ConfigOne, props: { prop1: 'prop1 alternate value' } };
     }
 
     @api disableAll() {

--- a/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
+++ b/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
@@ -1,0 +1,27 @@
+import { LightningElement, track, api } from 'lwc';
+export default class Props extends LightningElement {
+    @track config = undefined;
+
+    async loadOne() {
+        // note, using `x-` prefix instead of `x/` because these are
+        // handled by `registerForLoad`
+        const one = await import('x-configone');
+        this.config = { constructor: one, props: { prop1: 'prop1 value' } };
+    }
+    async loadTwo() {
+        // note, using `x-` prefix instead of `x/` because these are
+        // handled by `registerForLoad`
+        const two = await import('x-configtwo');
+        this.config = { constructor: two, props: { prop2: 'prop2 value' } };
+    }
+
+    @api enableOne() {
+        this.loadOne();
+    }
+    @api enableTwo() {
+        this.loadTwo();
+    }
+    @api disableAll() {
+        this.config = null;
+    }
+}

--- a/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
+++ b/packages/integration-karma/test/component/dynamic-imports/x/props/props.js
@@ -1,26 +1,18 @@
-import { LightningElement, track, api } from 'lwc';
+import { api, LightningElement, track } from 'lwc';
+import ConfigOne from 'x/configone';
+import ConfigTwo from 'x/configtwo';
+
 export default class Props extends LightningElement {
     @track config = undefined;
 
-    async loadOne() {
-        // note, using `x-` prefix instead of `x/` because these are
-        // handled by `registerForLoad`
-        const one = await import('x-configone');
-        this.config = { constructor: one, props: { prop1: 'prop1 value' } };
-    }
-    async loadTwo() {
-        // note, using `x-` prefix instead of `x/` because these are
-        // handled by `registerForLoad`
-        const two = await import('x-configtwo');
-        this.config = { constructor: two, props: { prop2: 'prop2 value' } };
+    @api enableOne() {
+        this.config = { constructor: ConfigOne, props: { prop1: 'prop1 value' } };
     }
 
-    @api enableOne() {
-        this.loadOne();
-    }
     @api enableTwo() {
-        this.loadTwo();
+        this.config = { constructor: ConfigTwo, props: { prop2: 'prop2 value' } };
     }
+
     @api disableAll() {
         this.config = null;
     }


### PR DESCRIPTION
## Details
`lwc:dynamic` after this change accepts an object `{props: Record<string, any>, constructor: LightningElementConstructor}`. We're doing only props for now, since the ask is only for props. We'll enable attrs, event listeners if required.

RFC: https://github.com/salesforce/lwc-rfcs/pull/57

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
