### PR TITLE
chore(nucleus): use nucleus to publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,6 @@ only_forks: &only_forks
     # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
     only: /pull\/[0-9]+/
 
-deploy_filters: &deploy_filters
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      # Trigger on tags that begin with `v`
-      only: /^v.*/
-
 # Jobs definition
 version: 2.1
 
@@ -144,18 +136,6 @@ jobs:
           command: yarn bundlesize
       - save_yarn_cache
       - save_workspace
-
-
-  deploy:
-    executor: node
-    steps:
-      - load_workspace
-      - run:
-          name: Configure NPM authentication
-          command: npm config set "//registry.npmjs.org/:_authToken" "$NPM_AUTOMATION_TOKEN"
-      - run:
-          name: Publish package
-          command: yarn release:publish:ci
 
 
   test_unit:
@@ -309,36 +289,3 @@ workflows:
           requires:
             - test_unit
             - test_karma
-
-  build_and_test_and_deploy:
-    jobs:
-      - build:
-          <<: *deploy_filters
-
-      - test_unit:
-          <<: *deploy_filters
-          requires:
-            - build
-
-      - test_karma:
-          <<: *deploy_filters
-          requires:
-            - build
-
-      - test_integration:
-          <<: *deploy_filters
-          requires:
-            - test_unit
-            - test_karma
-
-      - test_integration_compat:
-          <<: *deploy_filters
-          requires:
-            - test_unit
-            - test_karma
-
-      - deploy:
-          <<: *deploy_filters
-          requires:
-            - test_integration
-            - test_integration_compat

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -3,10 +3,35 @@ core-deploy:
   project-modules:
     lwc: lwc.version
 branches:
+  release:
+    pull-request:
+      workflow: release
+      auto-start: true
+      auto-start-from-forks: false
+      # release branch should always be exactly in sync with master branch (linear history)
+      merge-method: force-push
+      required-downstream-deps:
+        # sadly these need to be repeated for every branch
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
+        - salesforce/luvio
+        - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
   ~DEFAULT~:
     pull-request:
       auto-start: true
       auto-start-from-forks: false
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
       required-downstream-deps:
         - automation-platform/ui-interaction-explorer-components
         - communities/microsite-template-marketing
@@ -23,4 +48,65 @@ branches:
         - salesforce/utam-docs
         - salesforcedevs/developer-website
         - uiplatform/nucleus
-
+  winter22:
+    pull-request:
+      auto-start: true
+      auto-start-from-forks: false
+      merge-method: disabled
+      required-downstream-deps:
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
+        - salesforce/luvio
+        - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
+  spring22:
+    pull-request:
+      auto-start: true
+      auto-start-from-forks: false
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
+      required-downstream-deps:
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
+        - salesforce/luvio
+        - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
+steps:
+  node-conformance:
+    run:
+      command: yarn run lint
+    after: node-build
+  node-unit-tests:
+    run:
+      command: yarn test
+  # this project runs yarn build after yarn install so skip explicit build step
+  node-build: &node-build
+    skip: true
+  node-pre-release-tests:
+    params:
+      command: yarn test
+  npm-configure:
+    params:
+      registry-url: https://registry.yarnpkg.com
+  npm-configure-for-publish:
+    params:
+      registry-url: https://registry.npmjs.org

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -1,29 +1,32 @@
+# shared config. The `__shared-branch-config__` name isn't meaningful.
+__shared-branch-config__: &branch-definition
+  auto-start: true
+  auto-start-from-forks: false
+  required-downstream-deps:
+    - automation-platform/ui-interaction-explorer-components
+    - communities/microsite-template-marketing
+    - communities/shared-experience-components
+    - communities/ui-b2b-components
+    - communities/ui-cms-components
+    - communities/ui-feeds-components
+    - communities/ui-lightning-community
+    - lwc/lwc-platform
+    - salesforce/lds-lightning-platform
+    - salesforce/luvio
+    - salesforce/lwr
+    - salesforce/lwr-recipes
+    - salesforce/utam-docs
+    - salesforcedevs/developer-website
+    - uiplatform/nucleus
 core-deploy:
   enabled: true
   project-modules:
     lwc: lwc.version
 branches:
   ~DEFAULT~:
-    pull-request: &branch-definition
-      auto-start: true
-      auto-start-from-forks: false
+    pull-request:
+      <<: *branch-definition
       merge-method: disabled # do not auto-merge; we'll do it ourselves
-      required-downstream-deps:
-        - automation-platform/ui-interaction-explorer-components
-        - communities/microsite-template-marketing
-        - communities/shared-experience-components
-        - communities/ui-b2b-components
-        - communities/ui-cms-components
-        - communities/ui-feeds-components
-        - communities/ui-lightning-community
-        - lwc/lwc-platform
-        - salesforce/lds-lightning-platform
-        - salesforce/luvio
-        - salesforce/lwr
-        - salesforce/lwr-recipes
-        - salesforce/utam-docs
-        - salesforcedevs/developer-website
-        - uiplatform/nucleus
   release:
     pull-request:
       <<: *branch-definition
@@ -31,9 +34,11 @@ branches:
   winter22:
     pull-request:
       <<: *branch-definition
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
   spring22:
     pull-request:
       <<: *branch-definition
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
 steps:
   node-conformance:
     run:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -52,7 +52,7 @@ branches:
     pull-request:
       auto-start: true
       auto-start-from-forks: false
-      merge-method: disabled
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
       required-downstream-deps:
         - automation-platform/ui-interaction-explorer-components
         - communities/microsite-template-marketing

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -18,6 +18,7 @@ __shared_config__: &branch-definition
     - salesforce/utam-docs
     - salesforcedevs/developer-website
     - uiplatform/nucleus
+
 core-deploy:
   enabled: true
   project-modules:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -1,33 +1,29 @@
-# shared config. The `__shared_config__` name isn't meaningful.
-__shared_config__: &branch-definition
-  auto-start: true
-  auto-start-from-forks: false
-  required-downstream-deps:
-    - automation-platform/ui-interaction-explorer-components
-    - communities/microsite-template-marketing
-    - communities/shared-experience-components
-    - communities/ui-b2b-components
-    - communities/ui-cms-components
-    - communities/ui-feeds-components
-    - communities/ui-lightning-community
-    - lwc/lwc-platform
-    - salesforce/lds-lightning-platform
-    - salesforce/luvio
-    - salesforce/lwr
-    - salesforce/lwr-recipes
-    - salesforce/utam-docs
-    - salesforcedevs/developer-website
-    - uiplatform/nucleus
-
 core-deploy:
   enabled: true
   project-modules:
     lwc: lwc.version
 branches:
   ~DEFAULT~:
-    pull-request:
-      <<: *branch-definition
+    pull-request: &branch-definition
+      auto-start: true
+      auto-start-from-forks: false
       merge-method: disabled # do not auto-merge; we'll do it ourselves
+      required-downstream-deps:
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
+        - salesforce/luvio
+        - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
   release:
     pull-request:
       <<: *branch-definition
@@ -35,11 +31,9 @@ branches:
   winter22:
     pull-request:
       <<: *branch-definition
-      merge-method: disabled # do not auto-merge; we'll do it ourselves
   spring22:
     pull-request:
       <<: *branch-definition
-      merge-method: disabled # do not auto-merge; we'll do it ourselves
 steps:
   node-conformance:
     run:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -1,5 +1,5 @@
-# shared config. The `__shared-branch-config__` name isn't meaningful.
-__shared-branch-config__: &branch-definition
+# shared config. The `__shared_config__` name isn't meaningful.
+__shared_config__: &branch-definition
   auto-start: true
   auto-start-from-forks: false
   required-downstream-deps:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -3,93 +3,37 @@ core-deploy:
   project-modules:
     lwc: lwc.version
 branches:
+  ~DEFAULT~:
+    pull-request: &branch-definition
+      auto-start: true
+      auto-start-from-forks: false
+      merge-method: disabled # do not auto-merge; we'll do it ourselves
+      required-downstream-deps:
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
+        - communities/shared-experience-components
+        - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-feeds-components
+        - communities/ui-lightning-community
+        - lwc/lwc-platform
+        - salesforce/lds-lightning-platform
+        - salesforce/luvio
+        - salesforce/lwr
+        - salesforce/lwr-recipes
+        - salesforce/utam-docs
+        - salesforcedevs/developer-website
+        - uiplatform/nucleus
   release:
     pull-request:
-      workflow: release
-      auto-start: true
-      auto-start-from-forks: false
-      # release branch should always be exactly in sync with master branch (linear history)
-      merge-method: force-push
-      required-downstream-deps:
-        # sadly these need to be repeated for every branch
-        - automation-platform/ui-interaction-explorer-components
-        - communities/microsite-template-marketing
-        - communities/shared-experience-components
-        - communities/ui-b2b-components
-        - communities/ui-cms-components
-        - communities/ui-feeds-components
-        - communities/ui-lightning-community
-        - lwc/lwc-platform
-        - salesforce/lds-lightning-platform
-        - salesforce/luvio
-        - salesforce/lwr
-        - salesforce/lwr-recipes
-        - salesforce/utam-docs
-        - salesforcedevs/developer-website
-        - uiplatform/nucleus
-  ~DEFAULT~:
-    pull-request:
-      auto-start: true
-      auto-start-from-forks: false
-      merge-method: disabled # do not auto-merge; we'll do it ourselves
-      required-downstream-deps:
-        - automation-platform/ui-interaction-explorer-components
-        - communities/microsite-template-marketing
-        - communities/shared-experience-components
-        - communities/ui-b2b-components
-        - communities/ui-cms-components
-        - communities/ui-feeds-components
-        - communities/ui-lightning-community
-        - lwc/lwc-platform
-        - salesforce/lds-lightning-platform
-        - salesforce/luvio
-        - salesforce/lwr
-        - salesforce/lwr-recipes
-        - salesforce/utam-docs
-        - salesforcedevs/developer-website
-        - uiplatform/nucleus
+      <<: *branch-definition
+      merge-method: force-push # release branch should always be in sync with master branch (linear history)
   winter22:
     pull-request:
-      auto-start: true
-      auto-start-from-forks: false
-      merge-method: disabled # do not auto-merge; we'll do it ourselves
-      required-downstream-deps:
-        - automation-platform/ui-interaction-explorer-components
-        - communities/microsite-template-marketing
-        - communities/shared-experience-components
-        - communities/ui-b2b-components
-        - communities/ui-cms-components
-        - communities/ui-feeds-components
-        - communities/ui-lightning-community
-        - lwc/lwc-platform
-        - salesforce/lds-lightning-platform
-        - salesforce/luvio
-        - salesforce/lwr
-        - salesforce/lwr-recipes
-        - salesforce/utam-docs
-        - salesforcedevs/developer-website
-        - uiplatform/nucleus
+      <<: *branch-definition
   spring22:
     pull-request:
-      auto-start: true
-      auto-start-from-forks: false
-      merge-method: disabled # do not auto-merge; we'll do it ourselves
-      required-downstream-deps:
-        - automation-platform/ui-interaction-explorer-components
-        - communities/microsite-template-marketing
-        - communities/shared-experience-components
-        - communities/ui-b2b-components
-        - communities/ui-cms-components
-        - communities/ui-feeds-components
-        - communities/ui-lightning-community
-        - lwc/lwc-platform
-        - salesforce/lds-lightning-platform
-        - salesforce/luvio
-        - salesforce/lwr
-        - salesforce/lwr-recipes
-        - salesforce/utam-docs
-        - salesforcedevs/developer-website
-        - uiplatform/nucleus
+      <<: *branch-definition
 steps:
   node-conformance:
     run:


### PR DESCRIPTION
## Details

Disables Circle CI publishing and enables Nucleus publishing. Based on my reading of the Nucleus docs (and looking at [other `.nucleus.yaml` implementations](https://github.com/search?l=YAML&q=filename%3A.nucleus.yaml+org%3Asalesforce&type=Code)), this should be correct.

Basically our workflow becomes:

- `release` branch represents the latest OSS release
- Open a PR on `master` with the version bump
- Merge it
- Open a PR to `release` from `master`
- Nucleus will auto-merge when the tests pass.

What this _doesn't_ do:

- Run code coverage in Nucleus (or publish it to Gus)
- Run Circle CI karma/integration tests in Nucleus
- Publish Slack notifications for releases

Those are all TODOs for a future PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10179858
