### PR TITLE
refactor(engine-core): Simplify props and attrs patching

### DIFF
--- a/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
+++ b/packages/@lwc/engine-core/src/3rdparty/snabbdom/types.ts
@@ -70,7 +70,7 @@ export interface VNodeData {
     classMap?: Record<string, boolean>;
     styleDecls?: Array<[string, string, boolean]>;
     context?: Record<string, Record<string, any>>;
-    on?: Record<string, Function>;
+    on?: Record<string, (event: Event) => any>;
     svg?: boolean;
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -64,7 +64,7 @@ import {
     insertNodeHook,
     removeNodeHook,
     patchChildren,
-    patchElementPropsAndAttributes,
+    patchElementPropsAndAttrs,
     allocateChildrenHook,
     markAsDynamicChildren,
     hydrateChildrenHook,
@@ -165,10 +165,10 @@ const ElementHook: Hooks<VElement> = {
         fallbackElmHook(elm, vnode);
         vnode.elm = elm;
 
-        patchElementPropsAndAttributes(null, vnode);
+        patchElementPropsAndAttrs(null, vnode);
     },
     update: (oldVnode, vnode) => {
-        patchElementPropsAndAttributes(oldVnode, vnode);
+        patchElementPropsAndAttrs(oldVnode, vnode);
         patchChildren(vnode.elm!, oldVnode.children, vnode.children);
     },
     insert: (vnode, parentNode, referenceNode) => {
@@ -241,10 +241,10 @@ const CustomElementHook: Hooks<VCustomElement> = {
         } else if (vnode.ctor !== UpgradableConstructor) {
             throw new TypeError(`Incorrect Component Constructor`);
         }
-        patchElementPropsAndAttributes(null, vnode);
+        patchElementPropsAndAttrs(null, vnode);
     },
     update: (oldVnode, vnode) => {
-        patchElementPropsAndAttributes(oldVnode, vnode);
+        patchElementPropsAndAttrs(oldVnode, vnode);
         const vm = getAssociatedVMIfPresent(vnode.elm);
         if (vm) {
             // in fallback mode, the allocation will always set children to

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -65,8 +65,6 @@ import {
     removeNodeHook,
     createElmHook,
     updateElmHook,
-    createCustomElmHook,
-    updateCustomElmHook,
     patchChildren,
     allocateChildrenHook,
     markAsDynamicChildren,
@@ -244,10 +242,10 @@ const CustomElementHook: Hooks<VCustomElement> = {
         } else if (vnode.ctor !== UpgradableConstructor) {
             throw new TypeError(`Incorrect Component Constructor`);
         }
-        createCustomElmHook(vnode);
+        createElmHook(vnode);
     },
     update: (oldVnode, vnode) => {
-        updateCustomElmHook(oldVnode, vnode);
+        updateElmHook(oldVnode, vnode);
         const vm = getAssociatedVMIfPresent(vnode.elm);
         if (vm) {
             // in fallback mode, the allocation will always set children to

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -63,9 +63,8 @@ import {
     updateNodeHook,
     insertNodeHook,
     removeNodeHook,
-    createElmHook,
-    updateElmHook,
     patchChildren,
+    patchElementPropsAndAttributes,
     allocateChildrenHook,
     markAsDynamicChildren,
     hydrateChildrenHook,
@@ -166,10 +165,10 @@ const ElementHook: Hooks<VElement> = {
         fallbackElmHook(elm, vnode);
         vnode.elm = elm;
 
-        createElmHook(vnode);
+        patchElementPropsAndAttributes(null, vnode);
     },
     update: (oldVnode, vnode) => {
-        updateElmHook(oldVnode, vnode);
+        patchElementPropsAndAttributes(oldVnode, vnode);
         patchChildren(vnode.elm!, oldVnode.children, vnode.children);
     },
     insert: (vnode, parentNode, referenceNode) => {
@@ -242,10 +241,10 @@ const CustomElementHook: Hooks<VCustomElement> = {
         } else if (vnode.ctor !== UpgradableConstructor) {
             throw new TypeError(`Incorrect Component Constructor`);
         }
-        createElmHook(vnode);
+        patchElementPropsAndAttributes(null, vnode);
     },
     update: (oldVnode, vnode) => {
-        updateElmHook(oldVnode, vnode);
+        patchElementPropsAndAttributes(oldVnode, vnode);
         const vm = getAssociatedVMIfPresent(vnode.elm);
         if (vm) {
             // in fallback mode, the allocation will always set children to

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -85,7 +85,7 @@ export function removeNodeHook(vnode: VNode, parentNode: Node) {
     }
 }
 
-export function patchElementPropsAndAttributes(oldVnode: VElement | null, vnode: VElement) {
+export function patchElementPropsAndAttrs(oldVnode: VElement | null, vnode: VElement) {
     if (isNull(oldVnode)) {
         applyEventListeners(vnode);
         applyStaticClassAttribute(vnode);

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -214,20 +214,6 @@ export function createViewModelHook(elm: HTMLElement, vnode: VCustomElement) {
     }
 }
 
-export function createCustomElmHook(vnode: VCustomElement) {
-    applyEventListeners(vnode);
-
-    // Attrs need to be applied to element before props
-    // IE11 will wipe out value on radio inputs if value
-    // is set before type=radio.
-    patchAttributes(null, vnode);
-    patchProps(null, vnode);
-    applyStaticClassAttribute(vnode);
-    patchClassAttribute(null, vnode);
-    applyStaticStyleAttribute(vnode);
-    patchStyleAttribute(null, vnode);
-}
-
 export function createChildrenHook(vnode: VElement) {
     const { elm, children } = vnode;
     for (let j = 0; j < children.length; ++j) {
@@ -411,16 +397,6 @@ export function hydrateChildrenHook(elmChildren: NodeListOf<ChildNode>, children
             elmCurrentChildIdx++;
         }
     }
-}
-
-export function updateCustomElmHook(oldVnode: VCustomElement, vnode: VCustomElement) {
-    // Attrs need to be applied to element before props
-    // IE11 will wipe out value on radio inputs if value
-    // is set before type=radio.
-    patchAttributes(oldVnode, vnode);
-    patchProps(oldVnode, vnode);
-    patchClassAttribute(oldVnode, vnode);
-    patchStyleAttribute(oldVnode, vnode);
 }
 
 export function removeElmHook(vnode: VElement) {

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -20,18 +20,19 @@ import { getClassList, setText, getAttribute, remove, insert } from '../renderer
 import { EmptyArray, parseStyleText } from './utils';
 import { createVM, getAssociatedVMIfPresent, VM, ShadowMode, RenderMode } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
-import modEvents from './modules/events';
-import modAttrs from './modules/attrs';
-import modProps from './modules/props';
-import modComputedClassName from './modules/computed-class-attr';
-import modComputedStyle from './modules/computed-style-attr';
-import modStaticClassName from './modules/static-class-attr';
-import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef } from './def';
 import { markComponentAsDirty } from './component';
 import { logError } from '../shared/logger';
+
+import { patchAttributes } from './modules/attrs';
+import { patchProps } from './modules/props';
+import { patchClassAttribute } from './modules/computed-class-attr';
+import { patchStyleAttribute } from './modules/computed-style-attr';
+import { applyEventListeners } from './modules/events';
+import { applyStaticClassAttribute } from './modules/static-class-attr';
+import { applyStaticStyleAttribute } from './modules/static-style-attr';
 
 function observeElementChildNodes(elm: Element) {
     (elm as any).$domManual$ = true;
@@ -85,16 +86,17 @@ export function removeNodeHook(vnode: VNode, parentNode: Node) {
 }
 
 export function createElmHook(vnode: VElement) {
-    modEvents.create(vnode);
+    applyEventListeners(vnode);
+
     // Attrs need to be applied to element before props
     // IE11 will wipe out value on radio inputs if value
     // is set before type=radio.
-    modAttrs.create(vnode);
-    modProps.create(vnode);
-    modStaticClassName.create(vnode);
-    modStaticStyle.create(vnode);
-    modComputedClassName.create(vnode);
-    modComputedStyle.create(vnode);
+    patchAttributes(null, vnode);
+    patchProps(null, vnode);
+    applyStaticClassAttribute(vnode);
+    patchClassAttribute(null, vnode);
+    applyStaticStyleAttribute(vnode);
+    patchStyleAttribute(null, vnode);
 }
 
 export const enum LWCDOMMode {
@@ -102,15 +104,8 @@ export const enum LWCDOMMode {
 }
 
 export function hydrateElmHook(vnode: VElement) {
-    modEvents.create(vnode);
-    // Attrs are already on the element.
-    // modAttrs.create(vnode);
-    modProps.create(vnode);
-    // Already set.
-    // modStaticClassName.create(vnode);
-    // modStaticStyle.create(vnode);
-    // modComputedClassName.create(vnode);
-    // modComputedStyle.create(vnode);
+    applyEventListeners(vnode);
+    patchProps(null, vnode);
 }
 
 export function fallbackElmHook(elm: Element, vnode: VElement) {
@@ -150,10 +145,10 @@ export function updateElmHook(oldVnode: VElement, vnode: VElement) {
     // Attrs need to be applied to element before props
     // IE11 will wipe out value on radio inputs if value
     // is set before type=radio.
-    modAttrs.update(oldVnode, vnode);
-    modProps.update(oldVnode, vnode);
-    modComputedClassName.update(oldVnode, vnode);
-    modComputedStyle.update(oldVnode, vnode);
+    patchAttributes(oldVnode, vnode);
+    patchProps(oldVnode, vnode);
+    patchClassAttribute(oldVnode, vnode);
+    patchStyleAttribute(oldVnode, vnode);
 }
 
 export function patchChildren(parent: ParentNode, oldCh: VNodes, newCh: VNodes) {
@@ -220,16 +215,17 @@ export function createViewModelHook(elm: HTMLElement, vnode: VCustomElement) {
 }
 
 export function createCustomElmHook(vnode: VCustomElement) {
-    modEvents.create(vnode);
+    applyEventListeners(vnode);
+
     // Attrs need to be applied to element before props
     // IE11 will wipe out value on radio inputs if value
     // is set before type=radio.
-    modAttrs.create(vnode);
-    modProps.create(vnode);
-    modStaticClassName.create(vnode);
-    modStaticStyle.create(vnode);
-    modComputedClassName.create(vnode);
-    modComputedStyle.create(vnode);
+    patchAttributes(null, vnode);
+    patchProps(null, vnode);
+    applyStaticClassAttribute(vnode);
+    patchClassAttribute(null, vnode);
+    applyStaticStyleAttribute(vnode);
+    patchStyleAttribute(null, vnode);
 }
 
 export function createChildrenHook(vnode: VElement) {
@@ -421,10 +417,10 @@ export function updateCustomElmHook(oldVnode: VCustomElement, vnode: VCustomElem
     // Attrs need to be applied to element before props
     // IE11 will wipe out value on radio inputs if value
     // is set before type=radio.
-    modAttrs.update(oldVnode, vnode);
-    modProps.update(oldVnode, vnode);
-    modComputedClassName.update(oldVnode, vnode);
-    modComputedStyle.update(oldVnode, vnode);
+    patchAttributes(oldVnode, vnode);
+    patchProps(oldVnode, vnode);
+    patchClassAttribute(oldVnode, vnode);
+    patchStyleAttribute(oldVnode, vnode);
 }
 
 export function removeElmHook(vnode: VElement) {

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -85,18 +85,19 @@ export function removeNodeHook(vnode: VNode, parentNode: Node) {
     }
 }
 
-export function createElmHook(vnode: VElement) {
-    applyEventListeners(vnode);
+export function patchElementPropsAndAttributes(oldVnode: VElement | null, vnode: VElement) {
+    if (isNull(oldVnode)) {
+        applyEventListeners(vnode);
+        applyStaticClassAttribute(vnode);
+        applyStaticStyleAttribute(vnode);
+    }
 
-    // Attrs need to be applied to element before props
-    // IE11 will wipe out value on radio inputs if value
-    // is set before type=radio.
-    patchAttributes(null, vnode);
-    patchProps(null, vnode);
-    applyStaticClassAttribute(vnode);
-    patchClassAttribute(null, vnode);
-    applyStaticStyleAttribute(vnode);
-    patchStyleAttribute(null, vnode);
+    // Attrs need to be applied to element before props IE11 will wipe out value on radio inputs if
+    // value is set before type=radio.
+    patchClassAttribute(oldVnode, vnode);
+    patchStyleAttribute(oldVnode, vnode);
+    patchAttributes(oldVnode, vnode);
+    patchProps(oldVnode, vnode);
 }
 
 export const enum LWCDOMMode {
@@ -139,16 +140,6 @@ export function fallbackElmHook(elm: Element, vnode: VElement) {
         const isLight = owner.renderMode === RenderMode.Light;
         patchElementWithRestrictions(elm, { isPortal, isLight });
     }
-}
-
-export function updateElmHook(oldVnode: VElement, vnode: VElement) {
-    // Attrs need to be applied to element before props
-    // IE11 will wipe out value on radio inputs if value
-    // is set before type=radio.
-    patchAttributes(oldVnode, vnode);
-    patchProps(oldVnode, vnode);
-    patchClassAttribute(oldVnode, vnode);
-    patchStyleAttribute(oldVnode, vnode);
 }
 
 export function patchChildren(parent: ParentNode, oldCh: VNodes, newCh: VNodes) {

--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -5,16 +5,18 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isNull, isUndefined, keys, StringCharCodeAt } from '@lwc/shared';
+
 import { setAttribute, removeAttribute } from '../../renderer';
+import { VElement } from '../../3rdparty/snabbdom/types';
+
 import { unlockAttribute, lockAttribute } from '../attributes';
 import { EmptyObject } from '../utils';
-import { VElement } from '../../3rdparty/snabbdom/types';
 
 const xlinkNS = 'http://www.w3.org/1999/xlink';
 const xmlNS = 'http://www.w3.org/XML/1998/namespace';
 const ColonCharCode = 58;
 
-function updateAttrs(oldVnode: VElement, vnode: VElement) {
+export function patchAttributes(oldVnode: VElement | null, vnode: VElement) {
     const {
         data: { attrs },
     } = vnode;
@@ -22,9 +24,9 @@ function updateAttrs(oldVnode: VElement, vnode: VElement) {
     if (isUndefined(attrs)) {
         return;
     }
-    let {
-        data: { attrs: oldAttrs },
-    } = oldVnode;
+
+    let oldAttrs = isNull(oldVnode) ? undefined : oldVnode.data.attrs;
+
     if (oldAttrs === attrs) {
         return;
     }
@@ -64,10 +66,3 @@ function updateAttrs(oldVnode: VElement, vnode: VElement) {
         }
     }
 }
-
-const emptyVNode = { data: {} } as VElement;
-
-export default {
-    create: (vnode: VElement) => updateAttrs(emptyVNode, vnode),
-    update: updateAttrs,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -17,40 +17,30 @@ const xmlNS = 'http://www.w3.org/XML/1998/namespace';
 const ColonCharCode = 58;
 
 export function patchAttributes(oldVnode: VElement | null, vnode: VElement) {
-    const {
-        data: { attrs },
-    } = vnode;
-
+    const { attrs } = vnode.data;
     if (isUndefined(attrs)) {
         return;
     }
 
-    let oldAttrs = isNull(oldVnode) ? undefined : oldVnode.data.attrs;
-
+    const oldAttrs = isNull(oldVnode) ? EmptyObject : oldVnode.data.attrs;
     if (oldAttrs === attrs) {
         return;
     }
 
     if (process.env.NODE_ENV !== 'production') {
         assert.invariant(
-            isUndefined(oldAttrs) || keys(oldAttrs).join(',') === keys(attrs).join(','),
+            oldAttrs === EmptyObject || keys(oldAttrs).join(',') === keys(attrs).join(','),
             `vnode.data.attrs cannot change shape.`
         );
     }
 
-    const elm = vnode.elm!;
-
-    let key: string;
-    oldAttrs = isUndefined(oldAttrs) ? EmptyObject : oldAttrs;
-
-    // update modified attributes, add new attributes
-    // this routine is only useful for data-* attributes in all kind of elements
-    // and aria-* in standard elements (custom elements will use props for these)
-    for (key in attrs) {
+    const { elm } = vnode;
+    for (const key in attrs) {
         const cur = attrs[key];
-        const old = (oldAttrs as any)[key];
+        const old = oldAttrs[key];
+
         if (old !== cur) {
-            unlockAttribute(elm, key);
+            unlockAttribute(elm!, key);
             if (StringCharCodeAt.call(key, 3) === ColonCharCode) {
                 // Assume xml namespace
                 setAttribute(elm, key, cur as string, xmlNS);
@@ -62,7 +52,7 @@ export function patchAttributes(oldVnode: VElement | null, vnode: VElement) {
             } else {
                 setAttribute(elm, key, cur as string);
             }
-            lockAttribute(elm, key);
+            lockAttribute(elm!, key);
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -4,10 +4,20 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { create, freeze, isString, isUndefined, StringCharCodeAt, StringSlice } from '@lwc/shared';
+import {
+    create,
+    freeze,
+    isNull,
+    isString,
+    isUndefined,
+    StringCharCodeAt,
+    StringSlice,
+} from '@lwc/shared';
+
 import { getClassList } from '../../renderer';
-import { EmptyObject, SPACE_CHAR } from '../utils';
 import { VElement } from '../../3rdparty/snabbdom/types';
+
+import { EmptyObject, SPACE_CHAR } from '../utils';
 
 const classNameToClassMap = create(null);
 
@@ -47,14 +57,13 @@ function getMapFromClassName(className: string | undefined): Record<string, bool
     return map;
 }
 
-function updateClassAttribute(oldVnode: VElement, vnode: VElement) {
+export function patchClassAttribute(oldVnode: VElement | null, vnode: VElement) {
     const {
         elm,
         data: { className: newClass },
     } = vnode;
-    const {
-        data: { className: oldClass },
-    } = oldVnode;
+
+    const oldClass = isNull(oldVnode) ? undefined : oldVnode.data.className;
     if (oldClass === newClass) {
         return;
     }
@@ -76,10 +85,3 @@ function updateClassAttribute(oldVnode: VElement, vnode: VElement) {
         }
     }
 }
-
-const emptyVNode = { data: {} } as VElement;
-
-export default {
-    create: (vnode: VElement) => updateClassAttribute(emptyVNode, vnode),
-    update: updateClassAttribute,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
@@ -4,17 +4,20 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isString } from '@lwc/shared';
+import { isNull, isString } from '@lwc/shared';
+
 import { setAttribute, removeAttribute } from '../../renderer';
-import { VNode } from '../../3rdparty/snabbdom/types';
+import { VElement } from '../../3rdparty/snabbdom/types';
 
 // The style property is a string when defined via an expression in the template.
-function updateStyleAttribute(oldVnode: VNode, vnode: VNode) {
+export function patchStyleAttribute(oldVnode: VElement | null, vnode: VElement) {
     const {
         elm,
         data: { style: newStyle },
     } = vnode;
-    if (oldVnode.data.style === newStyle) {
+
+    const oldStyle = isNull(oldVnode) ? undefined : oldVnode.data.style;
+    if (oldStyle === newStyle) {
         return;
     }
 
@@ -24,10 +27,3 @@ function updateStyleAttribute(oldVnode: VNode, vnode: VNode) {
         setAttribute(elm, 'style', newStyle);
     }
 }
-
-const emptyVNode = { data: {} } as VNode;
-
-export default {
-    create: (vnode: VNode) => updateStyleAttribute(emptyVNode, vnode),
-    update: updateStyleAttribute,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/events.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/events.ts
@@ -5,45 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
+
 import { addEventListener } from '../../renderer';
-import { VNode } from '../../3rdparty/snabbdom/types';
+import { VElement } from '../../3rdparty/snabbdom/types';
 
-function handleEvent(event: Event, vnode: VNode) {
-    const { type } = event;
-    const {
-        data: { on },
-    } = vnode;
-    const handler = on && on[type];
-    // call event handler if exists
-    if (handler) {
-        handler.call(undefined, event);
-    }
-}
-
-interface VNodeEventListener extends EventListener {
-    vnode?: VNode;
-}
-
-interface InteractiveVNode extends VNode {
-    listener: VNodeEventListener | undefined;
-}
-
-function createListener(): EventListener {
-    return function handler(event: Event) {
-        handleEvent(event, (handler as VNodeEventListener).vnode as VNode);
-    };
-}
-
-function updateAllEventListeners(oldVnode: InteractiveVNode, vnode: InteractiveVNode) {
-    if (isUndefined(oldVnode.listener)) {
-        createAllEventListeners(vnode);
-    } else {
-        vnode.listener = oldVnode.listener;
-        vnode.listener.vnode = vnode;
-    }
-}
-
-function createAllEventListeners(vnode: VNode) {
+export function applyEventListeners(vnode: VElement) {
     const {
         elm,
         data: { on },
@@ -53,16 +19,10 @@ function createAllEventListeners(vnode: VNode) {
         return;
     }
 
-    const listener: VNodeEventListener = ((vnode as InteractiveVNode).listener = createListener());
-    listener.vnode = vnode;
-
-    let name;
-    for (name in on) {
-        addEventListener(elm, name, listener);
+    for (const name in on) {
+        const handler = on[name];
+        addEventListener(elm, name, (event: Event) => {
+            handler(event);
+        });
     }
 }
-
-export default {
-    update: updateAllEventListeners,
-    create: createAllEventListeners,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/events.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/events.ts
@@ -21,8 +21,6 @@ export function applyEventListeners(vnode: VElement) {
 
     for (const name in on) {
         const handler = on[name];
-        addEventListener(elm, name, (event: Event) => {
-            handler(event);
-        });
+        addEventListener(elm, name, handler);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isUndefined, keys } from '@lwc/shared';
-import { setProperty, getProperty } from '../../renderer';
+import { assert, isNull, isUndefined, keys } from '@lwc/shared';
+
+import { getProperty, setProperty } from '../../renderer';
 import { VElement } from '../../3rdparty/snabbdom/types';
 
 function isLiveBindingProp(sel: string, key: string): boolean {
@@ -14,13 +15,13 @@ function isLiveBindingProp(sel: string, key: string): boolean {
     return sel === 'input' && (key === 'value' || key === 'checked');
 }
 
-function update(oldVnode: VElement, vnode: VElement) {
+export function patchProps(oldVnode: VElement | null, vnode: VElement) {
     const props = vnode.data.props;
-
     if (isUndefined(props)) {
         return;
     }
-    const oldProps = oldVnode.data.props;
+
+    const oldProps = isNull(oldVnode) ? undefined : oldVnode.data.props;
     if (oldProps === props) {
         return;
     }
@@ -47,10 +48,3 @@ function update(oldVnode: VElement, vnode: VElement) {
         }
     }
 }
-
-const emptyVNode = { data: {} } as VElement;
-
-export default {
-    create: (vnode: VElement) => update(emptyVNode, vnode),
-    update,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
@@ -5,13 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
+
 import { getClassList } from '../../renderer';
-import { VNode } from '../../3rdparty/snabbdom/types';
+import { VElement } from '../../3rdparty/snabbdom/types';
 
 // The HTML class property becomes the vnode.data.classMap object when defined as a string in the template.
 // The compiler takes care of transforming the inline classnames into an object. It's faster to set the
 // different classnames properties individually instead of via a string.
-function createClassAttribute(vnode: VNode) {
+export function applyStaticClassAttribute(vnode: VElement) {
     const {
         elm,
         data: { classMap },
@@ -26,7 +27,3 @@ function createClassAttribute(vnode: VNode) {
         classList.add(name);
     }
 }
-
-export default {
-    create: createClassAttribute,
-};

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -5,13 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
+
 import { setCSSStyleProperty } from '../../renderer';
-import { VNode } from '../../3rdparty/snabbdom/types';
+import { VElement } from '../../3rdparty/snabbdom/types';
 
 // The HTML style property becomes the vnode.data.styleDecls object when defined as a string in the template.
 // The compiler takes care of transforming the inline style into an object. It's faster to set the
 // different style properties individually instead of via a string.
-function createStyleAttribute(vnode: VNode) {
+export function applyStaticStyleAttribute(vnode: VElement) {
     const {
         elm,
         data: { styleDecls },
@@ -26,7 +27,3 @@ function createStyleAttribute(vnode: VNode) {
         setCSSStyleProperty(elm, prop, value, important);
     }
 }
-
-export default {
-    create: createStyleAttribute,
-};

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
@@ -1,6 +1,6 @@
 <x-attribute-component-global-html>
   <template shadowroot="open">
-    <x-child data-test="test" accesskey="A" contenteditable="true" draggable="true" hidden id="foo" itemprop="foo" spellcheck="true" tabindex="-1" class="foo bar" style="color: red; background: blue">
+    <x-child class="foo bar" style="color: red; background: blue" data-test="test" accesskey="A" contenteditable="true" draggable="true" hidden id="foo" itemprop="foo" spellcheck="true" tabindex="-1">
       <template shadowroot="open">
         Passthrough properties:
         <ul>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic/expected.html
@@ -1,6 +1,6 @@
 <x-attribute-dynamic>
   <template shadowroot="open">
-    <div data-foo="foo" class="foo" style="color: red;">
+    <div class="foo" style="color: red;" data-foo="foo">
     </div>
   </template>
 </x-attribute-dynamic>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/expected.html
@@ -1,6 +1,6 @@
 <x-attribute-global-html>
   <template shadowroot="open">
-    <div accesskey="A" contenteditable="true" data-test="test" draggable="true" hidden id="foo" itemprop="foo" lang="fr" spellcheck="true" tabindex="-1" title="foo" class="foo bar" style="color: red; background: blue">
+    <div class="foo bar" style="color: red; background: blue" accesskey="A" contenteditable="true" data-test="test" draggable="true" hidden id="foo" itemprop="foo" lang="fr" spellcheck="true" tabindex="-1" title="foo">
     </div>
   </template>
 </x-attribute-global-html>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-static/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-static/expected.html
@@ -1,6 +1,6 @@
 <x-attribute-static>
   <template shadowroot="open">
-    <div data-foo="foo" class="foo bar foo-bar" style="color: red; background-color: blue">
+    <div class="foo bar foo-bar" style="color: red; background-color: blue" data-foo="foo">
     </div>
   </template>
 </x-attribute-static>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/if-conditional-slot/expected.html
@@ -12,14 +12,14 @@
               <slot name="falseslot">
               </slot>
             </template>
-            <x-child slot="trueslot" class="slotted-child">
+            <x-child class="slotted-child" slot="trueslot">
               <template shadowroot="open">
                 <slot>
                 </slot>
               </template>
               Testing if:true
             </x-child>
-            <x-child slot="falseslot" class="slotted-child">
+            <x-child class="slotted-child" slot="falseslot">
               <template shadowroot="open">
                 <slot>
                 </slot>
@@ -36,14 +36,14 @@
           <x-slotted>
             <template shadowroot="open">
             </template>
-            <x-child slot="trueslot" class="slotted-child">
+            <x-child class="slotted-child" slot="trueslot">
               <template shadowroot="open">
                 <slot>
                 </slot>
               </template>
               Testing if:true
             </x-child>
-            <x-child slot="falseslot" class="slotted-child">
+            <x-child class="slotted-child" slot="falseslot">
               <template shadowroot="open">
                 <slot>
                 </slot>


### PR DESCRIPTION
## Details

This PR removes some of the duplicated code related to attributes and properties patching. Patching attributes and properties are now done by a single function called `patchElementPropsAndAttrs`:
- combine logic for standard elements and custom elements patching
- removes the concept of create and update hooks

This PR is part of the larger refactor for [coupling the rehydration logic from the diffing logic](https://github.com/salesforce/lwc/pull/2608).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

This PR changes the order in which the props and attributes are set after the element creation.

**Before:** Static and dynamic attributes patching are interleaved.
- Event listeners (create)
- Attributes (created & update)
- Props (create & update)
- Static class names (create)
- Dynamic class names (create & update)
- Static styles (create)
- Dynamic styles (create & update)

**After:** All the static patching is done first (only at creation) and then all the dynamic patching.
- Event listeners (create)
- Static class names (create)
- Static styles (create)
- Attributes (created & update)
- Props (create & update)
- Dynamic class names (create & update)
- Dynamic styles (create & update)

While both patching order results in the same runtime behavior. This directly impacts the order in which attributes are serialized (see SSR snapshot tests updates for more details).

## GUS work item
W-10409559
