### PR TITLE
refactor(engine-core): Expose single entrypoint into the diffing algo

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -67,7 +67,7 @@ import {
     updateElmHook,
     createCustomElmHook,
     updateCustomElmHook,
-    updateChildrenHook,
+    patchChildren,
     allocateChildrenHook,
     markAsDynamicChildren,
     hydrateChildrenHook,
@@ -172,7 +172,7 @@ const ElementHook: Hooks<VElement> = {
     },
     update: (oldVnode, vnode) => {
         updateElmHook(oldVnode, vnode);
-        updateChildrenHook(oldVnode, vnode);
+        patchChildren(vnode.elm!, oldVnode.children, vnode.children);
     },
     insert: (vnode, parentNode, referenceNode) => {
         insertNodeHook(vnode, parentNode, referenceNode);
@@ -256,7 +256,7 @@ const CustomElementHook: Hooks<VCustomElement> = {
         }
         // in fallback mode, the children will be always empty, so, nothing
         // will happen, but in native, it does allocate the light dom
-        updateChildrenHook(oldVnode, vnode);
+        patchChildren(vnode.elm!, oldVnode.children, vnode.children);
         if (vm) {
             if (process.env.NODE_ENV !== 'production') {
                 assert.isTrue(

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -440,9 +440,6 @@ export function removeElmHook(vnode: VElement) {
     }
 }
 
-// slow path routine
-// NOTE: we should probably more this routine to the synthetic shadow folder
-// and get the allocation to be cached by in the elm instead of in the VM
 function allocateInSlot(vm: VM, children: VNodes) {
     const { cmpSlots: oldSlots } = vm;
     const cmpSlots = (vm.cmpSlots = create(null));

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -4,17 +4,21 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayFilter, ArrayJoin, assert, isArray, isNull, isUndefined, keys } from '@lwc/shared';
+import {
+    ArrayFilter,
+    ArrayJoin,
+    ArrayPush,
+    assert,
+    create,
+    isArray,
+    isFalse,
+    isNull,
+    isUndefined,
+    keys,
+} from '@lwc/shared';
 import { getClassList, setText, getAttribute, remove, insert } from '../renderer';
 import { EmptyArray, parseStyleText } from './utils';
-import {
-    createVM,
-    allocateInSlot,
-    getAssociatedVMIfPresent,
-    VM,
-    ShadowMode,
-    RenderMode,
-} from './vm';
+import { createVM, getAssociatedVMIfPresent, VM, ShadowMode, RenderMode } from './vm';
 import { VNode, VCustomElement, VElement, VNodes } from '../3rdparty/snabbdom/types';
 import modEvents from './modules/events';
 import modAttrs from './modules/attrs';
@@ -26,6 +30,7 @@ import modStaticStyle from './modules/static-style-attr';
 import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import { getComponentInternalDef } from './def';
+import { markComponentAsDirty } from './component';
 import { logError } from '../shared/logger';
 
 function observeElementChildNodes(elm: Element) {
@@ -431,6 +436,55 @@ export function removeElmHook(vnode: VElement) {
         const ch = children[j];
         if (!isNull(ch)) {
             ch.hook.remove(ch, elm!);
+        }
+    }
+}
+
+// slow path routine
+// NOTE: we should probably more this routine to the synthetic shadow folder
+// and get the allocation to be cached by in the elm instead of in the VM
+function allocateInSlot(vm: VM, children: VNodes) {
+    const { cmpSlots: oldSlots } = vm;
+    const cmpSlots = (vm.cmpSlots = create(null));
+    for (let i = 0, len = children.length; i < len; i += 1) {
+        const vnode = children[i];
+        if (isNull(vnode)) {
+            continue;
+        }
+        const { data } = vnode;
+        const slotName = ((data.attrs && data.attrs.slot) || '') as string;
+        const vnodes: VNodes = (cmpSlots[slotName] = cmpSlots[slotName] || []);
+        // re-keying the vnodes is necessary to avoid conflicts with default content for the slot
+        // which might have similar keys. Each vnode will always have a key that
+        // starts with a numeric character from compiler. In this case, we add a unique
+        // notation for slotted vnodes keys, e.g.: `@foo:1:1`
+        if (!isUndefined(vnode.key)) {
+            vnode.key = `@${slotName}:${vnode.key}`;
+        }
+        ArrayPush.call(vnodes, vnode);
+    }
+    if (isFalse(vm.isDirty)) {
+        // We need to determine if the old allocation is really different from the new one
+        // and mark the vm as dirty
+        const oldKeys = keys(oldSlots);
+        if (oldKeys.length !== keys(cmpSlots).length) {
+            markComponentAsDirty(vm);
+            return;
+        }
+        for (let i = 0, len = oldKeys.length; i < len; i += 1) {
+            const key = oldKeys[i];
+            if (isUndefined(cmpSlots[key]) || oldSlots[key].length !== cmpSlots[key].length) {
+                markComponentAsDirty(vm);
+                return;
+            }
+            const oldVNodes = oldSlots[key];
+            const vnodes = cmpSlots[key];
+            for (let j = 0, a = cmpSlots[key].length; j < a; j += 1) {
+                if (oldVNodes[j] !== vnodes[j]) {
+                    markComponentAsDirty(vm);
+                    return;
+                }
+            }
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -151,12 +151,11 @@ export function updateElmHook(oldVnode: VElement, vnode: VElement) {
     modComputedStyle.update(oldVnode, vnode);
 }
 
-export function updateChildrenHook(oldVnode: VElement, vnode: VElement) {
-    const { elm, children } = vnode;
-    if (hasDynamicChildren(children)) {
-        updateDynamicChildren(elm!, oldVnode.children, children);
+export function patchChildren(parent: ParentNode, oldCh: VNodes, newCh: VNodes) {
+    if (hasDynamicChildren(newCh)) {
+        updateDynamicChildren(parent, oldCh, newCh);
     } else {
-        updateStaticChildren(elm!, oldVnode.children, children);
+        updateStaticChildren(parent, oldCh, newCh);
     }
 }
 
@@ -445,6 +444,6 @@ export function markAsDynamicChildren(children: VNodes) {
     FromIteration.set(children, 1);
 }
 
-export function hasDynamicChildren(children: VNodes): boolean {
+function hasDynamicChildren(children: VNodes): boolean {
     return FromIteration.has(children);
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -36,13 +36,12 @@ import {
     logGlobalOperationEnd,
     logGlobalOperationStart,
 } from './profiler';
-import { hasDynamicChildren, hydrateChildrenHook } from './hooks';
+import { hydrateChildrenHook, patchChildren } from './hooks';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
 import { removeActiveVM } from './hot-swaps';
 
-import { updateDynamicChildren, updateStaticChildren } from '../3rdparty/snabbdom/snabbdom';
 import { VNodes, VCustomElement, VNode } from '../3rdparty/snabbdom/types';
 import { addErrorComponentStack } from '../shared/error';
 
@@ -444,7 +443,6 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
         // patch function mutates vnodes by adding the element reference,
         // however, if patching fails it contains partial changes.
         if (oldCh !== newCh) {
-            const fn = hasDynamicChildren(newCh) ? updateDynamicChildren : updateStaticChildren;
             runWithBoundaryProtection(
                 vm,
                 vm,
@@ -454,8 +452,8 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 },
                 () => {
                     // job
-                    const elementToRenderTo = getRenderRoot(vm);
-                    fn(elementToRenderTo, oldCh, newCh);
+                    const renderRoot = getRenderRoot(vm);
+                    patchChildren(renderRoot, oldCh, newCh);
                 },
                 () => {
                     // post

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -18,7 +18,6 @@ import {
     isObject,
     isTrue,
     isUndefined,
-    keys,
 } from '@lwc/shared';
 import { isSyntheticShadowDefined, ssr, remove, isNativeShadowDefined } from '../renderer';
 import type { HostNode, HostElement } from '../renderer';
@@ -687,55 +686,6 @@ function getErrorBoundaryVM(vm: VM): VM | undefined {
         }
 
         currentVm = currentVm.owner;
-    }
-}
-
-// slow path routine
-// NOTE: we should probably more this routine to the synthetic shadow folder
-// and get the allocation to be cached by in the elm instead of in the VM
-export function allocateInSlot(vm: VM, children: VNodes) {
-    const { cmpSlots: oldSlots } = vm;
-    const cmpSlots = (vm.cmpSlots = create(null));
-    for (let i = 0, len = children.length; i < len; i += 1) {
-        const vnode = children[i];
-        if (isNull(vnode)) {
-            continue;
-        }
-        const { data } = vnode;
-        const slotName = ((data.attrs && data.attrs.slot) || '') as string;
-        const vnodes: VNodes = (cmpSlots[slotName] = cmpSlots[slotName] || []);
-        // re-keying the vnodes is necessary to avoid conflicts with default content for the slot
-        // which might have similar keys. Each vnode will always have a key that
-        // starts with a numeric character from compiler. In this case, we add a unique
-        // notation for slotted vnodes keys, e.g.: `@foo:1:1`
-        if (!isUndefined(vnode.key)) {
-            vnode.key = `@${slotName}:${vnode.key}`;
-        }
-        ArrayPush.call(vnodes, vnode);
-    }
-    if (isFalse(vm.isDirty)) {
-        // We need to determine if the old allocation is really different from the new one
-        // and mark the vm as dirty
-        const oldKeys = keys(oldSlots);
-        if (oldKeys.length !== keys(cmpSlots).length) {
-            markComponentAsDirty(vm);
-            return;
-        }
-        for (let i = 0, len = oldKeys.length; i < len; i += 1) {
-            const key = oldKeys[i];
-            if (isUndefined(cmpSlots[key]) || oldSlots[key].length !== cmpSlots[key].length) {
-                markComponentAsDirty(vm);
-                return;
-            }
-            const oldVNodes = oldSlots[key];
-            const vnodes = cmpSlots[key];
-            for (let j = 0, a = cmpSlots[key].length; j < a; j += 1) {
-                if (oldVNodes[j] !== vnodes[j]) {
-                    markComponentAsDirty(vm);
-                    return;
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Details

The diffing algo exposes multiple entry points today: `updateDynamicChildren` and `updateStaticChildren`. This PR abstracts that away and exposes a single entry point called `patchChildren`. 

This PR also moves the `allocateInSlot` function into `hooks.ts`. This method is a diffing algo internal detail and has nothing to do with the VM itself.

This PR is part of the larger refactor for [coupling the rehydration logic from the diffing logic](https://github.com/salesforce/lwc/pull/2608).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10409559
