### PR TITLE
refactor(engine-core): remove unnecessary props/attrs assertions

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isNull, isUndefined, keys, StringCharCodeAt } from '@lwc/shared';
+import { isNull, isUndefined, StringCharCodeAt } from '@lwc/shared';
 
 import { setAttribute, removeAttribute } from '../../renderer';
 import { VElement } from '../../3rdparty/snabbdom/types';
@@ -25,13 +25,6 @@ export function patchAttributes(oldVnode: VElement | null, vnode: VElement) {
     const oldAttrs = isNull(oldVnode) ? EmptyObject : oldVnode.data.attrs;
     if (oldAttrs === attrs) {
         return;
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            oldAttrs === EmptyObject || keys(oldAttrs).join(',') === keys(attrs).join(','),
-            `vnode.data.attrs cannot change shape.`
-        );
     }
 
     const { elm } = vnode;

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isNull, isUndefined, keys } from '@lwc/shared';
+import { isNull, isUndefined } from '@lwc/shared';
 
 import { getProperty, setProperty } from '../../renderer';
 import { VElement } from '../../3rdparty/snabbdom/types';
@@ -26,13 +26,6 @@ export function patchProps(oldVnode: VElement | null, vnode: VElement) {
     const oldProps = isNull(oldVnode) ? EmptyObject : oldVnode.data.props;
     if (oldProps === props) {
         return;
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            oldProps === EmptyObject || keys(oldProps).join(',') === keys(props).join(','),
-            'vnode.data.props cannot change shape.'
-        );
     }
 
     const isFirstPatch = isNull(oldVnode);


### PR DESCRIPTION
## Details

This PR removes the assertions in properties and attributes patching (https://github.com/salesforce/lwc/pull/2630#discussion_r783956758). 

Those assertions were added at the time where we were still figuring out how to compile HTML to JavaScript. Those asserts will never execute as long as the VNodes originates from a template generated by the `@lwc/template-compiler`. The assertions should be safe to delete now.

This PR is part of the larger refactor for [coupling the rehydration logic from the diffing logic](https://github.com/salesforce/lwc/pull/2608).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10409559
