### PR TITLE
chore: bump to 2.7.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "exact": true,
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "2.7.2"
+  "version": "2.7.3"
 }

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.7.2",
+    "version": "2.7.3",
     "main": "src/index.js",
     "typings": "types/index.d.ts",
     "license": "MIT",
@@ -21,7 +21,7 @@
     ],
     "dependencies": {
         "@babel/helper-module-imports": "~7.16.7",
-        "@lwc/errors": "2.7.2",
+        "@lwc/errors": "2.7.3",
         "line-column": "~1.0.2"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/compiler",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "LWC compiler",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,11 +25,11 @@
         "@babel/core": "~7.16.7",
         "@babel/plugin-proposal-class-properties": "~7.16.7",
         "@babel/plugin-proposal-object-rest-spread": "~7.16.7",
-        "@lwc/babel-plugin-component": "2.7.2",
-        "@lwc/errors": "2.7.2",
-        "@lwc/shared": "2.7.2",
-        "@lwc/style-compiler": "2.7.2",
-        "@lwc/template-compiler": "2.7.2"
+        "@lwc/babel-plugin-component": "2.7.3",
+        "@lwc/errors": "2.7.3",
+        "@lwc/shared": "2.7.3",
+        "@lwc/style-compiler": "2.7.3",
+        "@lwc/template-compiler": "2.7.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-core",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Core LWC engine APIs.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/features": "2.7.2",
-        "@lwc/shared": "2.7.2"
+        "@lwc/features": "2.7.3",
+        "@lwc/shared": "2.7.3"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-dom",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Renders LWC components in a DOM environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.7.2",
-        "@lwc/shared": "2.7.2"
+        "@lwc/engine-core": "2.7.3",
+        "@lwc/shared": "2.7.3"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-server",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Renders LWC components in a server environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.7.2",
-        "@lwc/shared": "2.7.2"
+        "@lwc/engine-core": "2.7.3",
+        "@lwc/shared": "2.7.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/errors",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "LWC Error Utilities",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/features",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "LWC Features Flags",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,7 +24,7 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.7.2"
+        "@lwc/shared": "2.7.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.7.2",
+    "version": "2.7.3",
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "scripts": {

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/rollup-plugin",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Rollup plugin to compile LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -17,11 +17,11 @@
         "src/*.js"
     ],
     "devDependencies": {
-        "@lwc/compiler": "2.7.2",
-        "@lwc/engine-dom": "2.7.2"
+        "@lwc/compiler": "2.7.3",
+        "@lwc/engine-dom": "2.7.3"
     },
     "dependencies": {
-        "@lwc/module-resolver": "2.7.2",
+        "@lwc/module-resolver": "2.7.3",
         "@rollup/pluginutils": "~4.1.1"
     },
     "peerDependencies": {

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/shared",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Utilities and methods that are shared across packages",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/style-compiler",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,7 +22,7 @@
         "dist/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.7.2",
+        "@lwc/shared": "2.7.3",
         "postcss": "~8.4.5",
         "postcss-selector-parser": "~6.0.8",
         "postcss-value-parser": "~4.2.0",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/synthetic-shadow",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Synthetic Shadow Root for LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -36,8 +36,8 @@
         "access": "public"
     },
     "devDependencies": {
-        "@lwc/features": "2.7.2",
-        "@lwc/shared": "2.7.2"
+        "@lwc/features": "2.7.3",
+        "@lwc/shared": "2.7.3"
     },
     "gitHead": "94040389ab8fc717b8753e503f659489480a327d"
 }

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/template-compiler",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Template compiler package",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,8 +25,8 @@
     },
     "//": "Currently can't upgrade estree-walker to v3.0.0 because it dropped CommonJS support: https://git.io/JXguS",
     "dependencies": {
-        "@lwc/errors": "2.7.2",
-        "@lwc/shared": "2.7.2",
+        "@lwc/errors": "2.7.3",
+        "@lwc/shared": "2.7.3",
         "acorn": "~8.7.0",
         "astring": "~1.8.1",
         "estree-walker": "~2.0.2",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/wire-service",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "@wire service",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.7.2",
-        "@lwc/shared": "2.7.2"
+        "@lwc/engine-core": "2.7.3",
+        "@lwc/shared": "2.7.3"
     },
     "lwc": {
         "modules": [

--- a/packages/integration-karma/package.json
+++ b/packages/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "integration-karma",
     "private": true,
-    "version": "2.7.2",
+    "version": "2.7.3",
     "scripts": {
         "start": "karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers Chrome",
@@ -14,11 +14,11 @@
         "coverage": "node ./scripts/merge-coverage.js"
     },
     "devDependencies": {
-        "@lwc/compiler": "2.7.2",
-        "@lwc/engine-dom": "2.7.2",
-        "@lwc/engine-server": "2.7.2",
-        "@lwc/rollup-plugin": "2.7.2",
-        "@lwc/synthetic-shadow": "2.7.2",
+        "@lwc/compiler": "2.7.3",
+        "@lwc/engine-dom": "2.7.3",
+        "@lwc/engine-server": "2.7.3",
+        "@lwc/rollup-plugin": "2.7.3",
+        "@lwc/synthetic-shadow": "2.7.3",
         "chokidar": "^3.5.2",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "integration-tests",
     "private": true,
-    "version": "2.7.2",
+    "version": "2.7.3",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -20,7 +20,7 @@
         "sauce:prod_compat": "MODE=prod_compat yarn build:prod_compat && MODE=prod_compat wdio ./scripts/wdio.sauce.conf.js"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.7.2",
+        "@lwc/rollup-plugin": "2.7.3",
         "@wdio/cli": "^7.16.13",
         "@wdio/local-runner": "^7.16.13",
         "@wdio/mocha-framework": "^7.16.13",
@@ -30,7 +30,7 @@
         "@wdio/static-server-service": "^7.16.13",
         "deepmerge": "^4.2.2",
         "dotenv": "^10.0.0",
-        "lwc": "2.7.2",
+        "lwc": "2.7.3",
         "minimist": "^1.2.5",
         "webdriverio": "^7.16.13"
     }

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -41,12 +41,12 @@
         ]
     },
     "dependencies": {
-        "@lwc/compiler": "2.7.2",
-        "@lwc/engine-dom": "2.7.2",
-        "@lwc/engine-server": "2.7.2",
-        "@lwc/features": "2.7.2",
-        "@lwc/synthetic-shadow": "2.7.2",
-        "@lwc/wire-service": "2.7.2"
+        "@lwc/compiler": "2.7.3",
+        "@lwc/engine-dom": "2.7.3",
+        "@lwc/engine-server": "2.7.3",
+        "@lwc/features": "2.7.3",
+        "@lwc/synthetic-shadow": "2.7.3",
+        "@lwc/wire-service": "2.7.3"
     },
     "gitHead": "94040389ab8fc717b8753e503f659489480a327d"
 }

--- a/packages/perf-benchmarks-components/package.json
+++ b/packages/perf-benchmarks-components/package.json
@@ -1,11 +1,11 @@
 {
     "name": "perf-benchmarks-components",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.7.2"
+        "@lwc/rollup-plugin": "2.7.3"
     }
 }

--- a/packages/perf-benchmarks/package.json
+++ b/packages/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "perf-benchmarks",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -8,10 +8,10 @@
     },
     "//": "Note it's important for Tachometer that any deps it needs to swap out are dependencies, not devDependencies",
     "dependencies": {
-        "@lwc/engine-dom": "2.7.2",
-        "@lwc/engine-server": "2.7.2",
-        "@lwc/synthetic-shadow": "2.7.2",
-        "perf-benchmarks-components": "2.7.2"
+        "@lwc/engine-dom": "2.7.3",
+        "@lwc/engine-server": "2.7.3",
+        "@lwc/synthetic-shadow": "2.7.3",
+        "perf-benchmarks-components": "2.7.3"
     },
     "devDependencies": {
         "glob-hash": "^1.0.5",


### PR DESCRIPTION
## Details

2.7.3 release. Designed to replace the botched 2.7.2 release.