### PR TITLE
refactor: Make `createVM` accept a `LightningElement` constructor

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -255,6 +255,11 @@ export function getComponentInternalDef(Ctor: unknown): ComponentDef {
     return def;
 }
 
+export function getComponentHtmlPrototype(Ctor: unknown): HTMLElementConstructor {
+    const def = getComponentInternalDef(Ctor);
+    return def.bridge;
+}
+
 const lightingElementDef: ComponentDef = {
     ctor: LightningElement,
     name: LightningElement.name,

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -18,7 +18,7 @@ export { readonly } from './readonly';
 export { setFeatureFlag, setFeatureFlagForTest } from '@lwc/features';
 
 // Internal APIs used by renderers -----------------------------------------------------------------
-export { getComponentInternalDef } from './def';
+export { getComponentHtmlPrototype } from './def';
 export {
     createVM,
     connectRootElement,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -29,8 +29,8 @@ import { addCallbackToNextTick, EmptyArray, EmptyObject } from './utils';
 import { invokeServiceHook, Services } from './services';
 import { invokeComponentCallback, invokeComponentConstructor } from './invoker';
 import { Template } from './template';
-import { ComponentDef } from './def';
-import { LightningElement } from './base-lightning-element';
+import { ComponentDef, getComponentInternalDef } from './def';
+import { LightningElement, LightningElementConstructor } from './base-lightning-element';
 import {
     logOperationStart,
     logOperationEnd,
@@ -267,7 +267,7 @@ function getNearestShadowAncestor(vm: VM): VM | null {
 
 export function createVM<HostNode, HostElement>(
     elm: HostElement,
-    def: ComponentDef,
+    ctor: LightningElementConstructor,
     options: {
         mode: ShadowRootMode;
         owner: VM<HostNode, HostElement> | null;
@@ -275,6 +275,7 @@ export function createVM<HostNode, HostElement>(
     }
 ): VM {
     const { mode, owner, tagName } = options;
+    const def = getComponentInternalDef(ctor);
 
     const vm: VM = {
         elm,

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -9,7 +9,7 @@ import {
     createVM,
     connectRootElement,
     disconnectRootElement,
-    getComponentInternalDef,
+    getComponentHtmlPrototype,
     LightningElement,
 } from '@lwc/engine-core';
 
@@ -46,12 +46,12 @@ export function deprecatedBuildCustomElementConstructor(
 }
 
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {
-    const def = getComponentInternalDef(Ctor);
+    const HtmlPrototype = getComponentHtmlPrototype(Ctor);
 
-    return class extends def.bridge {
+    return class extends HtmlPrototype {
         constructor() {
             super();
-            createVM(this, def, {
+            createVM(this, Ctor, {
                 mode: 'open',
                 owner: null,
                 tagName: this.tagName,

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -6,7 +6,6 @@
  */
 import { assert, assign, isFunction, isNull, isObject, isUndefined, toString } from '@lwc/shared';
 import {
-    getComponentInternalDef,
     createVM,
     connectRootElement,
     disconnectRootElement,
@@ -104,8 +103,7 @@ export function createElement(
      * an upgradable custom element.
      */
     const element = new UpgradableConstructor((elm: HTMLElement) => {
-        const def = getComponentInternalDef(Ctor);
-        createVM(elm, def, {
+        createVM(elm, Ctor, {
             tagName: sel,
             mode: options.mode !== 'closed' ? 'open' : 'closed',
             owner: null,

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -5,12 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import {
-    createVM,
-    getComponentInternalDef,
-    LightningElement,
-    hydrateRootElement,
-} from '@lwc/engine-core';
+import { createVM, LightningElement, hydrateRootElement } from '@lwc/engine-core';
 import { isFunction, isNull, isObject } from '@lwc/shared';
 import { setIsHydrating } from '../renderer';
 import { createElement } from './create-element';
@@ -38,14 +33,12 @@ export function hydrateComponent(
         );
     }
 
-    const def = getComponentInternalDef(Ctor);
-
     try {
         // Let the renderer know we are hydrating, so it does not replace the existing shadowRoot
         // and uses the same algo to create the stylesheets as in SSR.
         setIsHydrating(true);
 
-        createVM(element, def, {
+        createVM(element, Ctor, {
             mode: 'open',
             owner: null,
             tagName: element.tagName.toLowerCase(),

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -4,12 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    createVM,
-    connectRootElement,
-    getComponentInternalDef,
-    LightningElement,
-} from '@lwc/engine-core';
+import { createVM, connectRootElement, LightningElement } from '@lwc/engine-core';
 import { isString, isFunction, isObject, isNull } from '@lwc/shared';
 
 import { createElement } from '../renderer';
@@ -50,10 +45,7 @@ export function renderComponent(
     }
 
     const element = createElement(tagName);
-
-    const def = getComponentInternalDef(Ctor);
-
-    createVM(element, def, {
+    createVM(element, Ctor, {
         mode: 'open',
         owner: null,
         tagName,

--- a/packages/integration-karma/test/hydration/index.spec.js
+++ b/packages/integration-karma/test/hydration/index.spec.js
@@ -13,8 +13,12 @@ if (process.env.NATIVE_SHADOW) {
         const anElement = document.createElement('div');
 
         expect(() => {
-            hydrateComponent(anElement, anElement.constructor, {});
-        }).toThrowError(
+            try {
+                hydrateComponent(anElement, anElement.constructor, {});
+            } catch (error) {
+                // Ignore the rehydration error.
+            }
+        }).toLogErrorDev(
             /is not a valid component, or does not extends LightningElement from "lwc". You probably forgot to add the extend clause on the class declaration./
         );
     });


### PR DESCRIPTION
## Details

This PR changes the way `createVM` is invoked to accept a `LightningElement` constructor as a second argument instead of a component def. This change provides multiple benefits:
- it removes the need to invoke `getComponentInternalDef` before invoking `createVM`. 
- it also allows removing the `getComponentInternalDef` from the APIs exposed from `@lwc/engine-core`. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10409559