### PR TITLE
refactor(engine-core): Cache `renderRoot` on the `VM` object

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -248,7 +248,9 @@ export const LightningElement: LightningElementConstructor = function (
     associateVM(elm, vm);
 
     if (vm.renderMode === RenderMode.Shadow) {
-        doAttachShadow(vm);
+        vm.renderRoot = doAttachShadow(vm);
+    } else {
+        vm.renderRoot = elm;
     }
 
     // Adding extra guard rails in DEV mode.
@@ -260,7 +262,7 @@ export const LightningElement: LightningElementConstructor = function (
     return this;
 };
 
-function doAttachShadow(vm: VM) {
+function doAttachShadow(vm: VM): ShadowRoot {
     const {
         elm,
         mode,
@@ -268,18 +270,20 @@ function doAttachShadow(vm: VM) {
         def: { ctor },
     } = vm;
 
-    const cmpRoot = attachShadow(elm, {
+    const shadowRoot = attachShadow(elm, {
         [KEY__SYNTHETIC_MODE]: shadowMode === ShadowMode.Synthetic,
         delegatesFocus: Boolean(ctor.delegatesFocus),
         mode,
     } as any);
 
-    vm.cmpRoot = cmpRoot;
-    associateVM(cmpRoot, vm);
+    vm.shadowRoot = shadowRoot;
+    associateVM(shadowRoot, vm);
 
     if (process.env.NODE_ENV !== 'production') {
-        patchShadowRootWithRestrictions(cmpRoot);
+        patchShadowRootWithRestrictions(shadowRoot);
     }
+
+    return shadowRoot;
 }
 
 function warnIfInvokedDuringConstruction(vm: VM, methodOrPropName: string) {
@@ -452,7 +456,7 @@ LightningElement.prototype = {
             }
         }
 
-        return vm.cmpRoot;
+        return vm.shadowRoot;
     },
 
     get shadowRoot(): null {

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -36,7 +36,6 @@ import { logError, logWarn } from '../shared/logger';
 
 import {
     createVM,
-    getRenderRoot,
     appendVM,
     removeVM,
     hydrateVM,
@@ -339,12 +338,12 @@ function setScopeTokenClassIfNecessary(elm: Element, owner: VM) {
 }
 
 function linkNodeToShadow(elm: Node, owner: VM) {
-    const { renderMode, shadowMode } = owner;
+    const { renderRoot, renderMode, shadowMode } = owner;
 
     // TODO [#1164]: this should eventually be done by the polyfill directly
     if (isSyntheticShadowDefined) {
         if (shadowMode === ShadowMode.Synthetic || renderMode === RenderMode.Light) {
-            (elm as any)[KEY__SHADOW_RESOLVER] = getRenderRoot(owner)[KEY__SHADOW_RESOLVER];
+            (elm as any)[KEY__SHADOW_RESOLVER] = renderRoot[KEY__SHADOW_RESOLVER];
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -221,7 +221,7 @@ export function createStylesheet(vm: VM, stylesheets: string[]): VNode | null {
                 insertGlobalStylesheet(stylesheets[i]);
             } else {
                 // local level
-                insertStylesheet(stylesheets[i], root!.cmpRoot);
+                insertStylesheet(stylesheets[i], root!.shadowRoot);
             }
         }
     }


### PR DESCRIPTION
## Details

The VM render root is the node used as container to render a given LWC component. It can either be a `ShadowRoot` if the component is a shadow DOM component or an `HTMLElement` in the case of a Light DOM component. The diffing algo needs the render root when starting the diffing to process to know where to render the template, but also when creating a new VNode.

Looking up the render root is currently done by the intermediary of `getRenderRoot`. This value can safely be cached on the VM to avoid the function call overhead, especially when creating VNodes.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10409559
