### PR TITLE
refactor(engine-core): Extract hydration from rendering logic

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -81,23 +81,9 @@ function h(sel: string, data: VElementData, children: VNodes): VElement {
                 vmBeingRendered
             );
         }
-        forEach.call(children, (childVnode: VNode | null | undefined) => {
-            if (childVnode != null) {
-                assert.isTrue(
-                    childVnode &&
-                        'sel' in childVnode &&
-                        'data' in childVnode &&
-                        'children' in childVnode &&
-                        'text' in childVnode &&
-                        'elm' in childVnode &&
-                        'key' in childVnode,
-                    `${childVnode} is not a vnode.`
-                );
-            }
-        });
     }
 
-    let text, elm;
+    let elm;
     const { key } = data;
 
     return {
@@ -105,7 +91,6 @@ function h(sel: string, data: VElementData, children: VNodes): VElement {
         sel,
         data,
         children,
-        text,
         elm,
         key,
         hook: ElementHook,
@@ -197,31 +182,14 @@ function c(
                 vmBeingRendered
             );
         }
-        if (arguments.length === 4) {
-            forEach.call(children, (childVnode: VNode | null | undefined) => {
-                if (childVnode != null) {
-                    assert.isTrue(
-                        childVnode &&
-                            'sel' in childVnode &&
-                            'data' in childVnode &&
-                            'children' in childVnode &&
-                            'text' in childVnode &&
-                            'elm' in childVnode &&
-                            'key' in childVnode,
-                        `${childVnode} is not a vnode.`
-                    );
-                }
-            });
-        }
     }
     const { key } = data;
-    let text, elm;
+    let elm;
     const vnode: VCustomElement = {
         type: VNodeType.CustomElement,
         sel,
         data,
         children,
-        text,
         elm,
         key,
 
@@ -348,12 +316,11 @@ function f(items: any[]): any[] {
 // [t]ext node
 function t(text: string): VText {
     const data = EmptyObject;
-    let sel, children, key, elm;
+    let sel, key, elm;
     return {
         type: VNodeType.Text,
         sel,
         data,
-        children,
         text,
         elm,
         key,
@@ -366,12 +333,11 @@ function t(text: string): VText {
 // [co]mment node
 function co(text: string): VComment {
     const data = EmptyObject;
-    let sel, children, key, elm;
+    let sel, key, elm;
     return {
         type: VNodeType.Comment,
         sel,
         data,
-        children,
         text,
         elm,
         key,

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -47,7 +47,7 @@ import {
     ElementHook,
     TextHook,
     markAsDynamicChildren,
-} from './hooks';
+} from './rendering';
 
 const SymbolIterator: typeof Symbol.iterator = Symbol.iterator;
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -31,7 +31,16 @@ import { EmptyArray, EmptyObject } from './utils';
 import { isComponentConstructor } from './def';
 import { ShadowMode, SlotSet, VM, RenderMode } from './vm';
 import { LightningElementConstructor } from './base-lightning-element';
-import { VNode, VNodes, VElement, VText, VCustomElement, VComment, VElementData } from './vnodes';
+import {
+    VNode,
+    VNodes,
+    VElement,
+    VText,
+    VCustomElement,
+    VComment,
+    VElementData,
+    VNodeType,
+} from './vnodes';
 import {
     CommentHook,
     CustomElementHook,
@@ -92,6 +101,7 @@ function h(sel: string, data: VElementData, children: VNodes): VElement {
     const { key } = data;
 
     return {
+        type: VNodeType.Element,
         sel,
         data,
         children,
@@ -207,6 +217,7 @@ function c(
     const { key } = data;
     let text, elm;
     const vnode: VCustomElement = {
+        type: VNodeType.CustomElement,
         sel,
         data,
         children,
@@ -339,6 +350,7 @@ function t(text: string): VText {
     const data = EmptyObject;
     let sel, children, key, elm;
     return {
+        type: VNodeType.Text,
         sel,
         data,
         children,
@@ -356,6 +368,7 @@ function co(text: string): VComment {
     const data = EmptyObject;
     let sel, children, key, elm;
     return {
+        type: VNodeType.Comment,
         sel,
         data,
         children,

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -81,6 +81,17 @@ function h(sel: string, data: VElementData, children: VNodes): VElement {
                 vmBeingRendered
             );
         }
+        forEach.call(children, (childVnode: VNode | null | undefined) => {
+            if (childVnode != null) {
+                assert.isTrue(
+                    'type' in childVnode &&
+                        'sel' in childVnode &&
+                        'elm' in childVnode &&
+                        'key' in childVnode,
+                    `${childVnode} is not a vnode.`
+                );
+            }
+        });
     }
 
     let elm;
@@ -181,6 +192,19 @@ function c(
                 `Invalid 'style' attribute passed to <${sel}> is ignored. This attribute must be a string value.`,
                 vmBeingRendered
             );
+        }
+        if (arguments.length === 4) {
+            forEach.call(children, (childVnode: VNode | null | undefined) => {
+                if (childVnode != null) {
+                    assert.isTrue(
+                        'type' in childVnode &&
+                            'sel' in childVnode &&
+                            'elm' in childVnode &&
+                            'key' in childVnode,
+                        `${childVnode} is not a vnode.`
+                    );
+                }
+            });
         }
     }
     const { key } = data;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -27,7 +27,7 @@ import { logError } from '../shared/logger';
 
 import { invokeEventListener } from './invoker';
 import { getVMBeingRendered } from './template';
-import { EmptyArray, EmptyObject } from './utils';
+import { EmptyArray } from './utils';
 import { isComponentConstructor } from './def';
 import { ShadowMode, SlotSet, VM, RenderMode } from './vm';
 import { LightningElementConstructor } from './base-lightning-element';
@@ -315,12 +315,10 @@ function f(items: any[]): any[] {
 
 // [t]ext node
 function t(text: string): VText {
-    const data = EmptyObject;
     let sel, key, elm;
     return {
         type: VNodeType.Text,
         sel,
-        data,
         text,
         elm,
         key,
@@ -332,12 +330,10 @@ function t(text: string): VText {
 
 // [co]mment node
 function co(text: string): VComment {
-    const data = EmptyObject;
     let sel, key, elm;
     return {
         type: VNodeType.Comment,
         sel,
-        data,
         text,
         elm,
         key,

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -51,7 +51,17 @@ import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from
 import { markComponentAsDirty } from './component';
 import { getUpgradableConstructor } from './upgradable-element';
 import { EmptyArray, parseStyleText } from './utils';
-import { VNode, VNodes, VCustomElement, VElement, VText, VComment, Hooks, Key } from './vnodes';
+import {
+    VNode,
+    VNodes,
+    VCustomElement,
+    VElement,
+    VText,
+    VComment,
+    Hooks,
+    Key,
+    VBaseElement,
+} from './vnodes';
 
 import { patchAttributes } from './modules/attrs';
 import { patchProps } from './modules/props';
@@ -377,7 +387,7 @@ function removeNode(vnode: VNode, parentNode: Node) {
     }
 }
 
-function patchElementPropsAndAttrs(oldVnode: VElement | null, vnode: VElement) {
+function patchElementPropsAndAttrs(oldVnode: VBaseElement | null, vnode: VBaseElement) {
     if (isNull(oldVnode)) {
         applyEventListeners(vnode);
         applyStaticClassAttribute(vnode);
@@ -392,12 +402,12 @@ function patchElementPropsAndAttrs(oldVnode: VElement | null, vnode: VElement) {
     patchProps(oldVnode, vnode);
 }
 
-function hydrateElmHook(vnode: VElement) {
+function hydrateElmHook(vnode: VBaseElement) {
     applyEventListeners(vnode);
     patchProps(null, vnode);
 }
 
-function fallbackElmHook(elm: Element, vnode: VElement) {
+function fallbackElmHook(elm: Element, vnode: VBaseElement) {
     const { owner } = vnode;
     setScopeTokenClassIfNecessary(elm, owner);
     if (owner.shadowMode === ShadowMode.Synthetic) {
@@ -500,7 +510,7 @@ function createViewModelHook(elm: HTMLElement, vnode: VCustomElement): VM {
     return vm;
 }
 
-function createChildrenHook(vnode: VElement) {
+function createChildrenHook(vnode: VBaseElement) {
     const { elm, children } = vnode;
     for (let j = 0; j < children.length; ++j) {
         const ch = children[j];

--- a/packages/@lwc/engine-core/src/framework/hooks.ts
+++ b/packages/@lwc/engine-core/src/framework/hooks.ts
@@ -87,7 +87,7 @@ export const TextHook: Hooks<VText> = {
     insert: insertNode,
     move: insertNode, // same as insert for text nodes
     remove: removeNode,
-    hydrate: (vNode: VNode, node: Node) => {
+    hydrate: (vNode: VText, node: Node) => {
         if (process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line lwc-internal/no-global-node
             if (node.nodeType !== Node.TEXT_NODE) {
@@ -121,7 +121,7 @@ export const CommentHook: Hooks<VComment> = {
     insert: insertNode,
     move: insertNode,
     remove: removeNode,
-    hydrate: (vNode: VNode, node: Node) => {
+    hydrate: (vNode: VComment, node: Node) => {
         if (process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line lwc-internal/no-global-node
             if (node.nodeType !== Node.COMMENT_NODE) {
@@ -353,7 +353,7 @@ function linkNodeToShadow(elm: Node, owner: VM) {
     }
 }
 
-function updateNodeHook(oldVnode: VNode, vnode: VNode) {
+function updateNodeHook(oldVnode: VText | VComment, vnode: VText | VComment) {
     const { elm, text } = vnode;
 
     if (oldVnode.text !== text) {

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isUndefined, ArrayFilter, ArrayJoin, assert, keys } from '@lwc/shared';
+
+import { logError, logWarn } from '../shared/logger';
+import { getAttribute, getClassList } from '../renderer';
+
+import { parseStyleText } from './utils';
+import { allocateChildren } from './hooks';
+import {
+    createVM,
+    hydrateVM,
+    runConnectedCallback,
+    VM,
+    VMState,
+    RenderMode,
+    LwcDomMode,
+} from './vm';
+import {
+    VNodes,
+    VBaseElement,
+    VNode,
+    VNodeType,
+    VText,
+    VComment,
+    VElement,
+    VCustomElement,
+} from './vnodes';
+
+import { patchProps } from './modules/props';
+import { applyEventListeners } from './modules/events';
+
+function hydrate(vnode: VNode, node: Node) {
+    switch (vnode.type) {
+        case VNodeType.Text:
+            hydrateText(vnode, node);
+            break;
+
+        case VNodeType.Comment:
+            hydrateComment(vnode, node);
+            break;
+
+        case VNodeType.Element:
+            hydrateElement(vnode, node);
+            break;
+
+        case VNodeType.CustomElement:
+            hydrateCustomElement(vnode, node);
+            break;
+    }
+}
+
+function hydrateText(vnode: VText, node: Node) {
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line lwc-internal/no-global-node
+        validateNodeType(vnode, node, Node.TEXT_NODE);
+
+        if (node.nodeValue !== vnode.text) {
+            logWarn(
+                'Hydration mismatch: text values do not match, will recover from the difference',
+                vnode.owner
+            );
+        }
+    }
+
+    // always set the text value to the one from the vnode.
+    node.nodeValue = vnode.text ?? null;
+    vnode.elm = node;
+}
+
+function hydrateComment(vnode: VComment, node: Node) {
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line lwc-internal/no-global-node
+        validateNodeType(vnode, node, Node.COMMENT_NODE);
+
+        if (node.nodeValue !== vnode.text) {
+            logWarn(
+                'Hydration mismatch: comment values do not match, will recover from the difference',
+                vnode.owner
+            );
+        }
+    }
+
+    // always set the text value to the one from the vnode.
+    node.nodeValue = vnode.text ?? null;
+    vnode.elm = node;
+}
+
+function hydrateElement(vnode: VElement, node: Node) {
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line lwc-internal/no-global-node
+        validateNodeType<Element>(vnode, node, Node.ELEMENT_NODE);
+        validateElement(vnode, node);
+    }
+
+    const elm = node as Element;
+    vnode.elm = elm;
+
+    const { context } = vnode.data;
+    const isDomManual = Boolean(
+        !isUndefined(context) && !isUndefined(context.lwc) && context.lwc.dom === LwcDomMode.Manual
+    );
+
+    if (isDomManual) {
+        // it may be that this element has lwc:inner-html, we need to diff and in case are the same,
+        // remove the innerHTML from props so it reuses the existing dom elements.
+        const { props } = vnode.data;
+        if (!isUndefined(props) && !isUndefined(props.innerHTML)) {
+            if (elm.innerHTML === props.innerHTML) {
+                delete props.innerHTML;
+            } else {
+                logWarn(
+                    `Mismatch hydrating element <${elm.tagName.toLowerCase()}>: innerHTML values do not match for element, will recover from the difference`,
+                    vnode.owner
+                );
+            }
+        }
+    }
+
+    patchElementPropsAndAttrs(vnode);
+
+    if (!isDomManual) {
+        hydrateChildren(vnode.elm.childNodes, vnode.children, vnode.owner);
+    }
+}
+
+function hydrateCustomElement(vnode: VCustomElement, node: Node) {
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line lwc-internal/no-global-node
+        validateNodeType<Element>(vnode, node, Node.ELEMENT_NODE);
+        validateElement(vnode, node);
+    }
+
+    const elm = node as Element;
+    const { sel, mode, ctor, owner } = vnode;
+
+    const vm = createVM(elm, ctor, {
+        mode,
+        owner,
+        tagName: sel,
+    });
+
+    vnode.elm = elm;
+
+    allocateChildren(vnode, vm);
+
+    patchElementPropsAndAttrs(vnode);
+
+    // Insert hook section:
+    if (process.env.NODE_ENV !== 'production') {
+        assert.isTrue(vm.state === VMState.created, `${vm} cannot be recycled.`);
+    }
+    runConnectedCallback(vm);
+
+    if (vm.renderMode !== RenderMode.Light) {
+        // VM is not rendering in Light DOM, we can proceed and hydrate the slotted content.
+        // Note: for Light DOM, this is handled while hydrating the VM
+        hydrateChildren(vnode.elm.childNodes, vnode.children, vm);
+    }
+
+    hydrateVM(vm);
+}
+
+export function hydrateChildren(elmChildren: NodeListOf<ChildNode>, children: VNodes, vm: VM) {
+    if (process.env.NODE_ENV !== 'production') {
+        const filteredVNodes = ArrayFilter.call(children, (vnode) => !!vnode);
+
+        if (elmChildren.length !== filteredVNodes.length) {
+            logError(
+                `Hydration mismatch: incorrect number of rendered nodes, expected ${filteredVNodes.length} but found ${elmChildren.length}.`,
+                vm
+            );
+            throwHydrationError();
+        }
+    }
+
+    let childNodeIndex = 0;
+    for (let i = 0; i < children.length; i++) {
+        const childVnode = children[i];
+
+        if (childVnode !== null) {
+            const childNode = elmChildren[childNodeIndex];
+            hydrate(childVnode, childNode);
+
+            childNodeIndex++;
+        }
+    }
+}
+
+function patchElementPropsAndAttrs(vnode: VBaseElement) {
+    applyEventListeners(vnode);
+    patchProps(null, vnode);
+}
+
+function throwHydrationError(): never {
+    assert.fail('Server rendered elements do not match client side generated elements');
+}
+
+function validateNodeType<T extends Node>(
+    vnode: VNode,
+    node: Node,
+    nodeType: number
+): asserts node is T {
+    if (node.nodeType !== nodeType) {
+        logError('Hydration mismatch: incorrect node type received', vnode.owner);
+        assert.fail('Hydration mismatch: incorrect node type received.');
+    }
+}
+
+function validateElement(vnode: VBaseElement, elm: Element) {
+    if (vnode.sel.toLowerCase() !== elm.tagName.toLowerCase()) {
+        logError(
+            `Hydration mismatch: expecting element with tag "${vnode.sel.toLowerCase()}" but found "${elm.tagName.toLowerCase()}".`,
+            vnode.owner
+        );
+
+        throwHydrationError();
+    }
+
+    const hasIncompatibleAttrs = validateAttrs(vnode, elm);
+    const hasIncompatibleClass = validateClassAttr(vnode, elm);
+    const hasIncompatibleStyle = validateStyleAttr(vnode, elm);
+    const isVNodeAndElementCompatible =
+        hasIncompatibleAttrs && hasIncompatibleClass && hasIncompatibleStyle;
+
+    if (!isVNodeAndElementCompatible) {
+        throwHydrationError();
+    }
+}
+
+function validateAttrs(vnode: VBaseElement, elm: Element): boolean {
+    const {
+        data: { attrs = {} },
+    } = vnode;
+
+    let nodesAreCompatible = true;
+
+    // Validate attributes, though we could always recovery from those by running the update mods.
+    // Note: intentionally ONLY matching vnodes.attrs to elm.attrs, in case SSR is adding extra attributes.
+    for (const [attrName, attrValue] of Object.entries(attrs)) {
+        const elmAttrValue = getAttribute(elm, attrName);
+        if (String(attrValue) !== elmAttrValue) {
+            logError(
+                `Mismatch hydrating element <${elm.tagName.toLowerCase()}>: attribute "${attrName}" has different values, expected "${attrValue}" but found "${elmAttrValue}"`,
+                vnode.owner
+            );
+            nodesAreCompatible = false;
+        }
+    }
+
+    return nodesAreCompatible;
+}
+
+function validateClassAttr(vnode: VBaseElement, elm: Element): boolean {
+    const {
+        data: { className, classMap },
+    } = vnode;
+
+    let nodesAreCompatible = true;
+    let vnodeClassName;
+
+    if (!isUndefined(className) && String(className) !== elm.className) {
+        // className is used when class is bound to an expr.
+        nodesAreCompatible = false;
+        vnodeClassName = className;
+    } else if (!isUndefined(classMap)) {
+        // classMap is used when class is set to static value.
+        const classList = getClassList(elm);
+        let computedClassName = '';
+
+        // all classes from the vnode should be in the element.classList
+        for (const name in classMap) {
+            computedClassName += ' ' + name;
+            if (!classList.contains(name)) {
+                nodesAreCompatible = false;
+            }
+        }
+
+        vnodeClassName = computedClassName.trim();
+
+        if (classList.length > keys(classMap).length) {
+            nodesAreCompatible = false;
+        }
+    }
+
+    if (!nodesAreCompatible) {
+        logError(
+            `Mismatch hydrating element <${elm.tagName.toLowerCase()}>: attribute "class" has different values, expected "${vnodeClassName}" but found "${
+                elm.className
+            }"`,
+            vnode.owner
+        );
+    }
+
+    return nodesAreCompatible;
+}
+
+function validateStyleAttr(vnode: VBaseElement, elm: Element): boolean {
+    const {
+        data: { style, styleDecls },
+    } = vnode;
+    const elmStyle = getAttribute(elm, 'style') || '';
+    let vnodeStyle;
+    let nodesAreCompatible = true;
+
+    if (!isUndefined(style) && style !== elmStyle) {
+        nodesAreCompatible = false;
+        vnodeStyle = style;
+    } else if (!isUndefined(styleDecls)) {
+        const parsedVnodeStyle = parseStyleText(elmStyle);
+        const expectedStyle = [];
+        // styleMap is used when style is set to static value.
+        for (let i = 0, n = styleDecls.length; i < n; i++) {
+            const [prop, value, important] = styleDecls[i];
+            expectedStyle.push(`${prop}: ${value + (important ? ' important!' : '')}`);
+
+            const parsedPropValue = parsedVnodeStyle[prop];
+
+            if (isUndefined(parsedPropValue)) {
+                nodesAreCompatible = false;
+            } else if (!parsedPropValue.startsWith(value)) {
+                nodesAreCompatible = false;
+            } else if (important && !parsedPropValue.endsWith('!important')) {
+                nodesAreCompatible = false;
+            }
+        }
+
+        if (keys(parsedVnodeStyle).length > styleDecls.length) {
+            nodesAreCompatible = false;
+        }
+
+        vnodeStyle = ArrayJoin.call(expectedStyle, ';');
+    }
+
+    if (!nodesAreCompatible) {
+        // style is used when class is bound to an expr.
+        logError(
+            `Mismatch hydrating element <${elm.tagName.toLowerCase()}>: attribute "style" has different values, expected "${vnodeStyle}" but found "${elmStyle}".`,
+            vnode.owner
+        );
+    }
+
+    return nodesAreCompatible;
+}

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined, ArrayFilter, ArrayJoin, assert, keys } from '@lwc/shared';
+import { isUndefined, ArrayFilter, ArrayJoin, assert, keys, isNull } from '@lwc/shared';
 
 import { logError, logWarn } from '../shared/logger';
 import { getAttribute, getClassList } from '../renderer';
@@ -181,7 +181,7 @@ export function hydrateChildren(elmChildren: NodeListOf<ChildNode>, children: VN
     for (let i = 0; i < children.length; i++) {
         const childVnode = children[i];
 
-        if (childVnode !== null) {
+        if (!isNull(childVnode)) {
             const childNode = elmChildren[childNodeIndex];
             hydrate(childVnode, childNode);
 

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -10,7 +10,7 @@ import { logError, logWarn } from '../shared/logger';
 import { getAttribute, getClassList } from '../renderer';
 
 import { parseStyleText } from './utils';
-import { allocateChildren } from './hooks';
+import { allocateChildren } from './rendering';
 import {
     createVM,
     hydrateVM,
@@ -136,6 +136,8 @@ function hydrateCustomElement(vnode: VCustomElement, node: Node) {
     }
 
     const elm = node as Element;
+    vnode.elm = elm;
+
     const { sel, mode, ctor, owner } = vnode;
 
     const vm = createVM(elm, ctor, {
@@ -144,10 +146,7 @@ function hydrateCustomElement(vnode: VCustomElement, node: Node) {
         tagName: sel,
     });
 
-    vnode.elm = elm;
-
     allocateChildren(vnode, vm);
-
     patchElementPropsAndAttrs(vnode);
 
     // Insert hook section:

--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -10,11 +10,11 @@ import { setAttribute, removeAttribute } from '../../renderer';
 
 import { unlockAttribute, lockAttribute } from '../attributes';
 import { EmptyObject } from '../utils';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 const ColonCharCode = 58;
 
-export function patchAttributes(oldVnode: VElement | null, vnode: VElement) {
+export function patchAttributes(oldVnode: VBaseElement | null, vnode: VBaseElement) {
     const { attrs } = vnode.data;
     if (isUndefined(attrs)) {
         return;

--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -17,7 +17,7 @@ import {
 import { getClassList } from '../../renderer';
 
 import { EmptyObject, SPACE_CHAR } from '../utils';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 const classNameToClassMap = create(null);
 
@@ -57,7 +57,7 @@ function getMapFromClassName(className: string | undefined): Record<string, bool
     return map;
 }
 
-export function patchClassAttribute(oldVnode: VElement | null, vnode: VElement) {
+export function patchClassAttribute(oldVnode: VBaseElement | null, vnode: VBaseElement) {
     const {
         elm,
         data: { className: newClass },

--- a/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
@@ -7,10 +7,10 @@
 import { isNull, isString } from '@lwc/shared';
 
 import { setAttribute, removeAttribute } from '../../renderer';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 // The style property is a string when defined via an expression in the template.
-export function patchStyleAttribute(oldVnode: VElement | null, vnode: VElement) {
+export function patchStyleAttribute(oldVnode: VBaseElement | null, vnode: VBaseElement) {
     const {
         elm,
         data: { style: newStyle },

--- a/packages/@lwc/engine-core/src/framework/modules/events.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/events.ts
@@ -7,9 +7,9 @@
 import { isUndefined } from '@lwc/shared';
 
 import { addEventListener } from '../../renderer';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
-export function applyEventListeners(vnode: VElement) {
+export function applyEventListeners(vnode: VBaseElement) {
     const {
         elm,
         data: { on },

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -9,7 +9,7 @@ import { isNull, isUndefined } from '@lwc/shared';
 import { getProperty, setProperty } from '../../renderer';
 
 import { EmptyObject } from '../utils';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 function isLiveBindingProp(sel: string, key: string): boolean {
     // For properties with live bindings, we read values from the DOM element
@@ -17,7 +17,7 @@ function isLiveBindingProp(sel: string, key: string): boolean {
     return sel === 'input' && (key === 'value' || key === 'checked');
 }
 
-export function patchProps(oldVnode: VElement | null, vnode: VElement) {
+export function patchProps(oldVnode: VBaseElement | null, vnode: VBaseElement) {
     const { props } = vnode.data;
     if (isUndefined(props)) {
         return;

--- a/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
@@ -7,12 +7,12 @@
 import { isUndefined } from '@lwc/shared';
 
 import { getClassList } from '../../renderer';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 // The HTML class property becomes the vnode.data.classMap object when defined as a string in the template.
 // The compiler takes care of transforming the inline classnames into an object. It's faster to set the
 // different classnames properties individually instead of via a string.
-export function applyStaticClassAttribute(vnode: VElement) {
+export function applyStaticClassAttribute(vnode: VBaseElement) {
     const {
         elm,
         data: { classMap },

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -7,12 +7,12 @@
 import { isUndefined } from '@lwc/shared';
 
 import { setCSSStyleProperty } from '../../renderer';
-import { VElement } from '../vnodes';
+import { VBaseElement } from '../vnodes';
 
 // The HTML style property becomes the vnode.data.styleDecls object when defined as a string in the template.
 // The compiler takes care of transforming the inline style into an object. It's faster to set the
 // different style properties individually instead of via a string.
-export function applyStaticStyleAttribute(vnode: VElement) {
+export function applyStaticStyleAttribute(vnode: VBaseElement) {
     const {
         elm,
         data: { styleDecls },

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -206,7 +206,7 @@ export const CustomElementHook: Hooks<VCustomElement> = {
             // will take care of disconnecting any child VM attached to its shadow as well.
             removeVM(vm);
         }
-    }
+    },
 };
 
 function isVNode(vnode: any): vnode is VNode {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -30,6 +30,10 @@ import {
     isSyntheticShadowDefined,
 } from '../renderer';
 
+import { EmptyArray } from './utils';
+import { markComponentAsDirty } from './component';
+import { getUpgradableConstructor } from './upgradable-element';
+import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
 import {
     createVM,
     appendVM,
@@ -43,10 +47,6 @@ import {
     RenderMode,
     LwcDomMode,
 } from './vm';
-import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
-import { markComponentAsDirty } from './component';
-import { getUpgradableConstructor } from './upgradable-element';
-import { EmptyArray } from './utils';
 import {
     VNode,
     VNodes,
@@ -58,6 +58,7 @@ import {
     Key,
     VBaseElement,
     isVBaseElement,
+    isSameVnode,
 } from './vnodes';
 
 import { patchAttributes } from './modules/attrs';
@@ -207,10 +208,6 @@ export const CustomElementHook: Hooks<VCustomElement> = {
         }
     }
 };
-
-function sameVnode(vnode1: VNode, vnode2: VNode): boolean {
-    return vnode1.key === vnode2.key && vnode1.sel === vnode2.sel;
-}
 
 function isVNode(vnode: any): vnode is VNode {
     return vnode != null;
@@ -552,21 +549,21 @@ function updateDynamicChildren(parentElm: Node, oldCh: VNodes, newCh: VNodes) {
             newStartVnode = newCh[++newStartIdx];
         } else if (!isVNode(newEndVnode)) {
             newEndVnode = newCh[--newEndIdx];
-        } else if (sameVnode(oldStartVnode, newStartVnode)) {
+        } else if (isSameVnode(oldStartVnode, newStartVnode)) {
             patchVnode(oldStartVnode, newStartVnode);
             oldStartVnode = oldCh[++oldStartIdx];
             newStartVnode = newCh[++newStartIdx];
-        } else if (sameVnode(oldEndVnode, newEndVnode)) {
+        } else if (isSameVnode(oldEndVnode, newEndVnode)) {
             patchVnode(oldEndVnode, newEndVnode);
             oldEndVnode = oldCh[--oldEndIdx];
             newEndVnode = newCh[--newEndIdx];
-        } else if (sameVnode(oldStartVnode, newEndVnode)) {
+        } else if (isSameVnode(oldStartVnode, newEndVnode)) {
             // Vnode moved right
             patchVnode(oldStartVnode, newEndVnode);
             newEndVnode.hook.move(oldStartVnode, parentElm, nextSibling(oldEndVnode.elm!));
             oldStartVnode = oldCh[++oldStartIdx];
             newEndVnode = newCh[--newEndIdx];
-        } else if (sameVnode(oldEndVnode, newStartVnode)) {
+        } else if (isSameVnode(oldEndVnode, newStartVnode)) {
             // Vnode moved left
             patchVnode(oldEndVnode, newStartVnode);
             newStartVnode.hook.move(oldEndVnode, parentElm, oldStartVnode.elm!);

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -37,7 +37,7 @@ import {
     logGlobalOperationEnd,
     logGlobalOperationStart,
 } from './profiler';
-import { patchChildren } from './hooks';
+import { patchChildren } from './rendering';
 import { hydrateChildren } from './hydration';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -37,7 +37,8 @@ import {
     logGlobalOperationEnd,
     logGlobalOperationStart,
 } from './profiler';
-import { hydrateChildrenHook, patchChildren } from './hooks';
+import { patchChildren } from './hooks';
+import { hydrateChildren } from './hydration';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
@@ -73,6 +74,10 @@ export const enum ShadowMode {
 export const enum ShadowSupportMode {
     Any = 'any',
     Default = 'reset',
+}
+
+export const enum LwcDomMode {
+    Manual = 'manual',
 }
 
 export interface Context {
@@ -434,7 +439,7 @@ function hydrate(vm: VM) {
 
         const vmChildren =
             vm.renderMode === RenderMode.Light ? vm.elm.childNodes : vm.elm.shadowRoot.childNodes;
-        hydrateChildrenHook(vmChildren, children, vm);
+        hydrateChildren(vmChildren, children, vm);
 
         runRenderedCallback(vm);
     }

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -23,7 +23,6 @@ export type VNodes = Array<VNode | null>;
 export interface BaseVNode {
     type: VNodeType;
     sel: string | undefined;
-    data: VNodeData;
     elm: Node | undefined;
     key: Key | undefined;
     hook: Hooks<any>;
@@ -33,7 +32,7 @@ export interface BaseVNode {
 export interface VText extends BaseVNode {
     type: VNodeType.Text;
     sel: undefined;
-    elm: Node | undefined;
+    elm: Text | undefined;
     text: string;
     key: undefined;
 }
@@ -41,6 +40,7 @@ export interface VText extends BaseVNode {
 export interface VComment extends BaseVNode {
     type: VNodeType.Comment;
     sel: undefined;
+    elm: Comment | undefined;
     text: string;
     key: undefined;
 }
@@ -88,4 +88,9 @@ export interface Hooks<N extends VNode> {
     update: (oldVNode: N, vNode: N) => void;
     remove: (vNode: N, parentNode: Node) => void;
     hydrate: (vNode: N, node: Node) => void;
+}
+
+export function isVBaseElement(vnode: VNode): vnode is VElement | VCustomElement {
+    const { type } = vnode;
+    return type === VNodeType.Element || type === VNodeType.CustomElement;
 }

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -89,7 +89,6 @@ export interface Hooks<N extends VNode> {
     move: (vNode: N, parentNode: Node, referenceNode: Node | null) => void;
     update: (oldVNode: N, vNode: N) => void;
     remove: (vNode: N, parentNode: Node) => void;
-    hydrate: (vNode: N, node: Node) => void;
 }
 
 export function isVBaseElement(vnode: VNode): vnode is VElement | VCustomElement {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -4,22 +4,23 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-/**
- @license
- Copyright (c) 2015 Simon Friis Vindum.
- This code may only be used under the MIT License found at
- https://github.com/snabbdom/snabbdom/blob/master/LICENSE
- Code distributed by Snabbdom as part of the Snabbdom project at
- https://github.com/snabbdom/snabbdom/
- */
 
 import { VM } from './vm';
 
 export type Key = string | number;
 
+export const enum VNodeType {
+    Text,
+    Comment,
+    Element,
+    CustomElement,
+}
+
+export type VNode = VText | VComment | VElement | VCustomElement;
 export type VNodes = Array<VNode | null>;
 
-export interface VNode {
+export interface BaseVNode {
+    type: VNodeType;
     sel: string | undefined;
     data: VNodeData;
     children: VNodes | undefined;
@@ -30,7 +31,24 @@ export interface VNode {
     owner: VM;
 }
 
-export interface VElement extends VNode {
+export interface VText extends BaseVNode {
+    type: VNodeType.Text;
+    sel: undefined;
+    children: undefined;
+    elm: Node | undefined;
+    text: string;
+    key: undefined;
+}
+
+export interface VComment extends BaseVNode {
+    type: VNodeType.Comment;
+    sel: undefined;
+    children: undefined;
+    text: string;
+    key: undefined;
+}
+
+export interface VBaseElement extends BaseVNode {
     sel: string;
     data: VElementData;
     children: VNodes;
@@ -39,26 +57,16 @@ export interface VElement extends VNode {
     key: Key;
 }
 
-export interface VCustomElement extends VElement {
+export interface VElement extends VBaseElement {
+    type: VNodeType.Element;
+}
+
+export interface VCustomElement extends VBaseElement {
+    type: VNodeType.CustomElement;
     mode: 'closed' | 'open';
     ctor: any;
     // copy of the last allocated children.
     aChildren?: VNodes;
-}
-
-export interface VText extends VNode {
-    sel: undefined;
-    children: undefined;
-    elm: Node | undefined;
-    text: string;
-    key: undefined;
-}
-
-export interface VComment extends VNode {
-    sel: undefined;
-    children: undefined;
-    text: string;
-    key: undefined;
 }
 
 export interface VNodeData {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -17,15 +17,14 @@ export const enum VNodeType {
 }
 
 export type VNode = VText | VComment | VElement | VCustomElement;
+export type VParentElement = VElement | VCustomElement;
 export type VNodes = Array<VNode | null>;
 
 export interface BaseVNode {
     type: VNodeType;
     sel: string | undefined;
     data: VNodeData;
-    children: VNodes | undefined;
     elm: Node | undefined;
-    text: string | undefined;
     key: Key | undefined;
     hook: Hooks<any>;
     owner: VM;
@@ -34,7 +33,6 @@ export interface BaseVNode {
 export interface VText extends BaseVNode {
     type: VNodeType.Text;
     sel: undefined;
-    children: undefined;
     elm: Node | undefined;
     text: string;
     key: undefined;
@@ -43,7 +41,6 @@ export interface VText extends BaseVNode {
 export interface VComment extends BaseVNode {
     type: VNodeType.Comment;
     sel: undefined;
-    children: undefined;
     text: string;
     key: undefined;
 }
@@ -53,7 +50,6 @@ export interface VBaseElement extends BaseVNode {
     data: VElementData;
     children: VNodes;
     elm: Element | undefined;
-    text: undefined;
     key: Key;
 }
 

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -22,17 +22,20 @@ export type VNodes = Array<VNode | null>;
 
 export interface BaseVNode {
     type: VNodeType;
-    sel: string | undefined;
     elm: Node | undefined;
+    // FIXME: Remove unused `sel` property on VText and VComment.
+    sel: string | undefined;
+    // FIXME: Remove unused `key` property on VText and VComment.
     key: Key | undefined;
     hook: Hooks<any>;
+    // FIXME: Remove `owner` property on VNodes. This would enable hoisting VNodes creation outside
+    // render method.
     owner: VM;
 }
 
 export interface VText extends BaseVNode {
     type: VNodeType.Text;
     sel: undefined;
-    elm: Text | undefined;
     text: string;
     key: undefined;
 }
@@ -40,7 +43,6 @@ export interface VText extends BaseVNode {
 export interface VComment extends BaseVNode {
     type: VNodeType.Comment;
     sel: undefined;
-    elm: Comment | undefined;
     text: string;
     key: undefined;
 }

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -23,13 +23,9 @@ export type VNodes = Array<VNode | null>;
 export interface BaseVNode {
     type: VNodeType;
     elm: Node | undefined;
-    // FIXME: Remove unused `sel` property on VText and VComment.
     sel: string | undefined;
-    // FIXME: Remove unused `key` property on VText and VComment.
     key: Key | undefined;
     hook: Hooks<any>;
-    // FIXME: Remove `owner` property on VNodes. This would enable hoisting VNodes creation outside
-    // render method.
     owner: VM;
 }
 
@@ -94,4 +90,8 @@ export interface Hooks<N extends VNode> {
 export function isVBaseElement(vnode: VNode): vnode is VElement | VCustomElement {
     const { type } = vnode;
     return type === VNodeType.Element || type === VNodeType.CustomElement;
+}
+
+export function isSameVnode(vnode1: VNode, vnode2: VNode): boolean {
+    return vnode1.key === vnode2.key && vnode1.sel === vnode2.sel;
 }

--- a/packages/@lwc/shared/src/assert.ts
+++ b/packages/@lwc/shared/src/assert.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export function invariant(value: any, msg: string) {
+export function invariant(value: any, msg: string): asserts value {
     if (!value) {
         throw new Error(`Invariant Violation: ${msg}`);
     }
 }
 
-export function isTrue(value: any, msg: string) {
+export function isTrue(value: any, msg: string): asserts value {
     if (!value) {
         throw new Error(`Assert Violation: ${msg}`);
     }
@@ -22,6 +22,6 @@ export function isFalse(value: any, msg: string) {
     }
 }
 
-export function fail(msg: string) {
+export function fail(msg: string): never {
     throw new Error(msg);
 }

--- a/packages/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
+++ b/packages/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
@@ -21,7 +21,7 @@ export default {
 
         expect(consoleCalls.error).toHaveSize(2);
         expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: expecting element with tag "undefined" but found "span"'
+            '[LWC error]: Hydration mismatch: Unexpected VNode type.'
         );
         expect(consoleCalls.error[1][0]).toContain('Recovering from error while hydrating');
     },

--- a/packages/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
+++ b/packages/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
@@ -21,7 +21,7 @@ export default {
 
         expect(consoleCalls.error).toHaveSize(2);
         expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: Unexpected VNode type.'
+            '[LWC error]: Hydration mismatch: incorrect node type received'
         );
         expect(consoleCalls.error[1][0]).toContain('Recovering from error while hydrating');
     },

--- a/packages/integration-karma/test-hydration/mismatches/textNode-instead-of-element/index.spec.js
+++ b/packages/integration-karma/test-hydration/mismatches/textNode-instead-of-element/index.spec.js
@@ -21,7 +21,7 @@ export default {
 
         expect(consoleCalls.error).toHaveSize(2);
         expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: incorrect number of rendered nodes, expected 1 but found 0'
+            '[LWC error]: Hydration mismatch: incorrect node type received'
         );
         expect(consoleCalls.error[1][0]).toContain('Recovering from error while hydrating');
     },


### PR DESCRIPTION
## Details

This PR is part of the larger refactor for [coupling the rehydration logic from the diffing logic](https://github.com/salesforce/lwc/pull/2608). 

It breaks apart the rehydration logic from the rendering logic. The new entry point for the hydration logic is now the `hydrateChildren` function. As a side effect, the rehydration logic can be completely tree-shaken if `hydrateComponent` is never imported by the application.

This PR also set the foundations for getting rid of the VNodes hooks. It adds a new `type` property that can be used to choose the appropriate diffing/hydration logic without relying on hooks.  

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10409559