### PR TITLE
fix(hydration): empty interpolated text mistmatch

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -59,7 +59,7 @@ function hydrateText(vnode: VText, node: Node) {
         // eslint-disable-next-line lwc-internal/no-global-node
         validateNodeType(vnode, node, Node.TEXT_NODE);
 
-        if (node.nodeValue !== vnode.text) {
+        if (node.nodeValue !== vnode.text && !(node.nodeValue === '\u200D' && vnode.text === '')) {
             logWarn(
                 'Hydration mismatch: text values do not match, will recover from the difference',
                 vnode.owner

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -23,7 +23,7 @@ function serializeChildNodes(children: HostChildNode[]): string {
         .map((child): string => {
             switch (child.type) {
                 case HostNodeType.Text:
-                    return htmlEscape(child.value);
+                    return child.value === '' ? '\u200C' : htmlEscape(child.value);
                 case HostNodeType.Comment:
                     return `<!--${htmlEscape(child.value)}-->`;
                 case HostNodeType.Raw:

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -23,7 +23,7 @@ function serializeChildNodes(children: HostChildNode[]): string {
         .map((child): string => {
             switch (child.type) {
                 case HostNodeType.Text:
-                    return child.value === '' ? '\u200C' : htmlEscape(child.value);
+                    return child.value === '' ? '\u200D' : htmlEscape(child.value);
                 case HostNodeType.Comment:
                     return `<!--${htmlEscape(child.value)}-->`;
                 case HostNodeType.Raw:

--- a/packages/integration-karma/test-hydration/mismatches/empty-nodes/index.spec.js
+++ b/packages/integration-karma/test-hydration/mismatches/empty-nodes/index.spec.js
@@ -1,0 +1,18 @@
+export default {
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            firstText: p.childNodes[0],
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshots = this.snapshot(target);
+
+        expect(snapshots.p).toBe(hydratedSnapshots.p);
+        expect(snapshots.firstText).toBe(hydratedSnapshots.firstText);
+
+        expect(consoleCalls.error).toHaveSize(0);
+        expect(consoleCalls.warn).toHaveSize(0);
+    },
+};

--- a/packages/integration-karma/test-hydration/mismatches/empty-nodes/x/main/main.html
+++ b/packages/integration-karma/test-hydration/mismatches/empty-nodes/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{emptyText}<span>foo</span></p>
+</template>

--- a/packages/integration-karma/test-hydration/mismatches/empty-nodes/x/main/main.js
+++ b/packages/integration-karma/test-hydration/mismatches/empty-nodes/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    get emptyText() {
+        return '';
+    }
+}


### PR DESCRIPTION
## Details
This PR fixes an issue while hydrating an empty text expression (#2657 ).

Given a component with the following template:

```html
<template>
  <p>{emptyText}</p>
</template>
```

SSR will generate an HTML like `<x-main><p></p></x-main>`, which when parsed by the browser, does not include a `TextNode` as child of `p`, however, our render mechanism will generate a `TextVNode` as child of the `p` vnode, which triggers a mismatch while hydrating.

This PR solves this issue by adding a zero-width non-joiner (ZWNJ) character on the server for empty TextNodes and taking this into account while hydrating, so we do not warn about a mismatch when hydrating the SSR content on the client.

Note: Another alternative could be to generate a `null` vnode on the client for empty text vnodes. I'm not too fond of this approach because it will punish the diffing algo multiple times, whereas the method from this PR will only impact SSR and hydration once.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

* ✅ No, it does not introduce an observable change.