### PR TITLE
fix(perf-benchmarks): remove tachometer note when running perf

### DIFF
--- a/packages/perf-benchmarks/README.md
+++ b/packages/perf-benchmarks/README.md
@@ -54,7 +54,7 @@ You can also use these environment variables to adjust the default benchmark set
 
 ```shell
 BENCHMARK_SAMPLE_SIZE=50
-BENCHMARK_HORIZON=25%
+BENCHMARK_AUTO_SAMPLE_CONDITIONS=25%
 BENCHMARK_TIMEOUT=5
 ```
 

--- a/packages/perf-benchmarks/scripts/build.js
+++ b/packages/perf-benchmarks/scripts/build.js
@@ -20,7 +20,7 @@ const writeFile = promisify(fs.writeFile);
 const {
     BENCHMARK_REPO = 'https://github.com/salesforce/lwc.git',
     BENCHMARK_REF = 'master',
-    BENCHMARK_HORIZON = '25%', // how much difference we want to determine between A and B
+    BENCHMARK_AUTO_SAMPLE_CONDITIONS = '25%', // how much difference we want to determine between A and B
 } = process.env;
 let {
     BENCHMARK_SAMPLE_SIZE = 50, // minimum number of samples to run
@@ -69,7 +69,7 @@ async function createTachometerJson(htmlFilename, benchmarkName) {
     return {
         $schema: 'https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json',
         sampleSize: BENCHMARK_SAMPLE_SIZE,
-        horizons: [BENCHMARK_HORIZON],
+        autoSampleConditions: [BENCHMARK_AUTO_SAMPLE_CONDITIONS],
         timeout: BENCHMARK_TIMEOUT,
         benchmarks: [
             {


### PR DESCRIPTION
## Details

This PR removes this note from [Tachometer](https://github.com/Polymer/tachometer) when running the perf tests:

```sh
$ ../../node_modules/.bin/tach --config dist/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-create-1k.tachometer.json

NOTE: The "horizons" setting has been renamed to "autoSampleConditions".
Please rename it.
```


## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
