### PR TITLE
test: test templates compiled with ACTCompiler

### DIFF
--- a/packages/integration-karma/test/act/act-components/README.md
+++ b/packages/integration-karma/test/act/act-components/README.md
@@ -1,0 +1,6 @@
+# ACTCompiler components
+
+These components are copied over from the ACTCompiler's unit tests (`ActToCompilerDataConverterUnitTest.java`).
+They correspond to the dev versions of the output compiler code.
+
+To make these easier to work with in the tests, they are also wrapped in functions that take a `define` argument.

--- a/packages/integration-karma/test/act/act-components/README.md
+++ b/packages/integration-karma/test/act/act-components/README.md
@@ -4,3 +4,5 @@ These components are copied over from the ACTCompiler's unit tests (`ActToCompil
 They correspond to the dev versions of the output compiler code.
 
 To make these easier to work with in the tests, they are also wrapped in functions that take a `define` argument.
+
+You can find more detail about the strategy in [this document](https://salesforce.quip.com/Pv5GAib0nZLx).

--- a/packages/integration-karma/test/act/act-components/README.md
+++ b/packages/integration-karma/test/act/act-components/README.md
@@ -1,8 +1,10 @@
-# ACTCompiler components
+# ACT compiler components
 
-These components are copied over from the ACTCompiler's unit tests (`ActToCompilerDataConverterUnitTest.java`).
+These components are copied over from the ACT compiler's unit tests (`ActToCompilerDataConverterUnitTest.java`).
 They correspond to the dev versions of the output compiler code.
 
 To make these easier to work with in the tests, they are also wrapped in functions that take a `define` argument.
+
+Don't update the content in this folder unless the ACT compiler's output is updated.
 
 You can find more detail about the strategy in [this document](https://salesforce.quip.com/Pv5GAib0nZLx).

--- a/packages/integration-karma/test/act/act-components/test-attrs.js
+++ b/packages/integration-karma/test/act/act-components/test-attrs.js
@@ -1,0 +1,37 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/something', 'lwc'], function (_uiSomething, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'ui-something',
+                    _uiSomething__default['default'],
+                    {
+                        attrs: {
+                            'data-blah-de-blah': 'special-data-attribute',
+                            'data-blah-blah': 'anotherDataAttribute',
+                        },
+                        props: {
+                            role: 'listitem',
+                        },
+                        key: 1,
+                    },
+                    []
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-body-slot.js
+++ b/packages/integration-karma/test/act/act-components/test-body-slot.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/something', 'lwc'],
+        function (_forceFoo, _uiSomething, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-something',
+                                _uiSomething__default['default'],
+                                {
+                                    props: {
+                                        text: 'Hello',
+                                    },
+                                    key: 2,
+                                },
+                                []
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-class-attr.js
+++ b/packages/integration-karma/test/act/act-components/test-class-attr.js
@@ -1,0 +1,34 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/something', 'lwc'], function (_uiSomething, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'ui-something',
+                    _uiSomething__default['default'],
+                    {
+                        classMap: {
+                            'slds-has-divider_top': true,
+                            'slds-grid': true,
+                        },
+                        key: 1,
+                    },
+                    []
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-conditional-false-attribute.js
+++ b/packages/integration-karma/test/act/act-components/test-conditional-false-attribute.js
@@ -1,0 +1,35 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/boolean', 'lwc'], function (_uiBoolean, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiBoolean__default = /*#__PURE__*/ _interopDefaultLegacy(_uiBoolean);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                !$cmp.state.irrelevant
+                    ? api_custom_element(
+                          'ui-boolean',
+                          _uiBoolean__default['default'],
+                          {
+                              props: {
+                                  other: 'irrelevant',
+                              },
+                              key: 1,
+                          },
+                          []
+                      )
+                    : null,
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-conditional-true-attribute.js
+++ b/packages/integration-karma/test/act/act-components/test-conditional-true-attribute.js
@@ -1,0 +1,35 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/boolean', 'lwc'], function (_uiBoolean, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiBoolean__default = /*#__PURE__*/ _interopDefaultLegacy(_uiBoolean);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                $cmp.state.irrelevant
+                    ? api_custom_element(
+                          'ui-boolean',
+                          _uiBoolean__default['default'],
+                          {
+                              props: {
+                                  other: 'irrelevant',
+                              },
+                              key: 1,
+                          },
+                          []
+                      )
+                    : null,
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-empty-slot-element-creation.js
+++ b/packages/integration-karma/test/act/act-components/test-empty-slot-element-creation.js
@@ -1,0 +1,59 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/another', 'lwc'],
+        function (_forceFoo, _uiAnother, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiAnother__default = /*#__PURE__*/ _interopDefaultLegacy(_uiAnother);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element, s: api_slot } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-another',
+                                _uiAnother__default['default'],
+                                {
+                                    props: {
+                                        value: 'Foo',
+                                    },
+                                    key: 2,
+                                },
+                                []
+                            ),
+                            api_slot(
+                                '',
+                                {
+                                    key: 3,
+                                },
+                                [],
+                                $slotset
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.slots = [''];
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-empty-slot.js
+++ b/packages/integration-karma/test/act/act-components/test-empty-slot.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['force/foo', 'lwc'], function (_forceFoo, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'force-foo',
+                    _forceFoo__default['default'],
+                    {
+                        props: {
+                            name: 'Elizabeth Shaw',
+                        },
+                        key: 1,
+                    },
+                    []
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-html-tags.js
+++ b/packages/integration-karma/test/act/act-components/test-html-tags.js
@@ -1,0 +1,73 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['html/tags', 'lwc'], function (_htmlTags, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _htmlTags__default = /*#__PURE__*/ _interopDefaultLegacy(_htmlTags);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { h: api_element, t: api_text, c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'html-tags',
+                    _htmlTags__default['default'],
+                    {
+                        key: 1,
+                    },
+                    [
+                        api_element(
+                            'span',
+                            {
+                                styleDecls: [['color', 'blue', false]],
+                                classMap: {
+                                    class1: true,
+                                },
+                                key: 2,
+                            },
+                            []
+                        ),
+                        api_element(
+                            'div',
+                            {
+                                attrs: {
+                                    title: 'test',
+                                },
+                                key: 3,
+                            },
+                            [
+                                api_element(
+                                    'h1',
+                                    {
+                                        key: 4,
+                                    },
+                                    []
+                                ),
+                            ]
+                        ),
+                        api_element(
+                            'img',
+                            {
+                                attrs: {
+                                    src: 'data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+                                    alt: 'Smiley face',
+                                    height: '42',
+                                },
+                                key: 5,
+                            },
+                            []
+                        ),
+                        api_text('</img>'),
+                    ]
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-multiple-children-in-slot.js
+++ b/packages/integration-karma/test/act/act-components/test-multiple-children-in-slot.js
@@ -1,0 +1,61 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/something', 'lwc'],
+        function (_forceFoo, _uiSomething, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-something',
+                                _uiSomething__default['default'],
+                                {
+                                    props: {
+                                        text: 'Hello 1',
+                                    },
+                                    key: 2,
+                                },
+                                []
+                            ),
+                            api_custom_element(
+                                'ui-something',
+                                _uiSomething__default['default'],
+                                {
+                                    props: {
+                                        text: 'Hello 2',
+                                    },
+                                    key: 3,
+                                },
+                                []
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-multiple-slots.js
+++ b/packages/integration-karma/test/act/act-components/test-multiple-slots.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/something', 'ui/another', 'lwc'],
+        function (_forceFoo, _uiSomething, _uiAnother, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            var _uiAnother__default = /*#__PURE__*/ _interopDefaultLegacy(_uiAnother);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-something',
+                                _uiSomething__default['default'],
+                                {
+                                    attrs: {
+                                        slot: 'first',
+                                    },
+                                    props: {
+                                        text: 'Hello',
+                                    },
+                                    key: 2,
+                                },
+                                []
+                            ),
+                            api_custom_element(
+                                'ui-another',
+                                _uiAnother__default['default'],
+                                {
+                                    attrs: {
+                                        slot: 'second',
+                                    },
+                                    props: {
+                                        value: 'Foo',
+                                    },
+                                    key: 3,
+                                },
+                                []
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-nested-html-tags.js
+++ b/packages/integration-karma/test/act/act-components/test-nested-html-tags.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['nested/htmlTags', 'lwc'],
+        function (_nestedHtmlTags, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _nestedHtmlTags__default = /*#__PURE__*/ _interopDefaultLegacy(_nestedHtmlTags);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { h: api_element, c: api_custom_element } = $api;
+                return [
+                    api_custom_element(
+                        'nested-html-tags',
+                        _nestedHtmlTags__default['default'],
+                        {
+                            key: 1,
+                        },
+                        [
+                            api_element(
+                                'div',
+                                {
+                                    key: 2,
+                                },
+                                [
+                                    api_element(
+                                        'div',
+                                        {
+                                            classMap: {
+                                                inner: true,
+                                            },
+                                            key: 3,
+                                        },
+                                        [
+                                            api_element(
+                                                'div',
+                                                {
+                                                    key: 4,
+                                                },
+                                                []
+                                            ),
+                                            api_element(
+                                                'h2',
+                                                {
+                                                    key: 5,
+                                                },
+                                                []
+                                            ),
+                                        ]
+                                    ),
+                                ]
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-property-reference.js
+++ b/packages/integration-karma/test/act/act-components/test-property-reference.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['ui/outputpercent', 'lwc'],
+        function (_uiOutputpercent, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _uiOutputpercent__default = /*#__PURE__*/ _interopDefaultLegacy(_uiOutputpercent);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { b: api_bind, c: api_custom_element } = $api;
+                const { _m0 } = $ctx;
+                return [
+                    api_custom_element(
+                        'ui-outputpercent',
+                        _uiOutputpercent__default['default'],
+                        {
+                            props: {
+                                notWhitelisted: $cmp.non.value,
+                                templateExpression: $cmp.state.recordAvatars,
+                                label: $cmp.data.label,
+                                value: $cmp.data.record,
+                            },
+                            key: 1,
+                            on: {
+                                togglesectioncollapsed:
+                                    _m0 || ($ctx._m0 = api_bind($cmp.handleToggleSectionCollapsed)),
+                            },
+                        },
+                        []
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-props.js
+++ b/packages/integration-karma/test/act/act-components/test-props.js
@@ -1,0 +1,37 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/something', 'lwc'], function (_uiSomething, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'ui-something',
+                    _uiSomething__default['default'],
+                    {
+                        props: {
+                            mode: 'VIEW',
+                            propWithDash: 'X',
+                            fieldLabel: '',
+                            trueAttr: true,
+                            camelCase: 'YZ',
+                        },
+                        key: 1,
+                    },
+                    []
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/act-components/test-slot-adjacent-to-named-slot.js
+++ b/packages/integration-karma/test/act/act-components/test-slot-adjacent-to-named-slot.js
@@ -1,0 +1,83 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/another', 'ui/something', 'lwc'],
+        function (_forceFoo, _uiAnother, _uiSomething, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiAnother__default = /*#__PURE__*/ _interopDefaultLegacy(_uiAnother);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element, s: api_slot } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-another',
+                                _uiAnother__default['default'],
+                                {
+                                    attrs: {
+                                        slot: 'adjacent',
+                                    },
+                                    props: {
+                                        value: 'Foo',
+                                    },
+                                    key: 2,
+                                },
+                                []
+                            ),
+                            api_custom_element(
+                                'ui-another',
+                                _uiAnother__default['default'],
+                                {
+                                    props: {
+                                        value: 'Foo',
+                                    },
+                                    key: 3,
+                                },
+                                []
+                            ),
+                            api_slot(
+                                '',
+                                {
+                                    key: 4,
+                                },
+                                [
+                                    api_custom_element(
+                                        'ui-something',
+                                        _uiSomething__default['default'],
+                                        {
+                                            key: 5,
+                                        },
+                                        []
+                                    ),
+                                ],
+                                $slotset
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.slots = [''];
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-slot-element-creation-with-duplicate-slot-names.js
+++ b/packages/integration-karma/test/act/act-components/test-slot-element-creation-with-duplicate-slot-names.js
@@ -1,0 +1,81 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/something', 'ui/somethingElse', 'lwc'],
+        function (_forceFoo, _uiSomething, _uiSomethingElse, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            var _uiSomethingElse__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomethingElse);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element, s: api_slot } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_slot(
+                                'first',
+                                {
+                                    attrs: {
+                                        name: 'first',
+                                    },
+                                    key: 2,
+                                },
+                                [
+                                    api_custom_element(
+                                        'ui-something',
+                                        _uiSomething__default['default'],
+                                        {
+                                            key: 3,
+                                        },
+                                        []
+                                    ),
+                                ],
+                                $slotset
+                            ),
+                            api_slot(
+                                'first',
+                                {
+                                    attrs: {
+                                        name: 'first',
+                                    },
+                                    key: 4,
+                                },
+                                [
+                                    api_custom_element(
+                                        'ui-something-else',
+                                        _uiSomethingElse__default['default'],
+                                        {
+                                            key: 5,
+                                        },
+                                        []
+                                    ),
+                                ],
+                                $slotset
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.slots = ['first'];
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-slot-in-grandchild.js
+++ b/packages/integration-karma/test/act/act-components/test-slot-in-grandchild.js
@@ -1,0 +1,69 @@
+/* eslint-disable */
+export default function (define) {
+    return define(
+        'records/recordLayout2',
+        ['force/foo', 'ui/something', 'ui/another', 'lwc'],
+        function (_forceFoo, _uiSomething, _uiAnother, lwc) {
+            function _interopDefaultLegacy(e) {
+                return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+            }
+            var _forceFoo__default = /*#__PURE__*/ _interopDefaultLegacy(_forceFoo);
+            var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+            var _uiAnother__default = /*#__PURE__*/ _interopDefaultLegacy(_uiAnother);
+            function tmpl($api, $cmp, $slotset, $ctx) {
+                const { c: api_custom_element } = $api;
+                return [
+                    api_custom_element(
+                        'force-foo',
+                        _forceFoo__default['default'],
+                        {
+                            props: {
+                                name: 'Elizabeth Shaw',
+                            },
+                            key: 1,
+                        },
+                        [
+                            api_custom_element(
+                                'ui-something',
+                                _uiSomething__default['default'],
+                                {
+                                    attrs: {
+                                        slot: 'first',
+                                    },
+                                    props: {
+                                        text: 'Hello',
+                                    },
+                                    key: 2,
+                                },
+                                [
+                                    api_custom_element(
+                                        'ui-another',
+                                        _uiAnother__default['default'],
+                                        {
+                                            attrs: {
+                                                slot: 'second',
+                                            },
+                                            props: {
+                                                value: 'Foo',
+                                            },
+                                            key: 3,
+                                        },
+                                        []
+                                    ),
+                                ]
+                            ),
+                        ]
+                    ),
+                ];
+            }
+
+            var _tmpl = lwc.registerTemplate(tmpl);
+            tmpl.stylesheets = [];
+            tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+            var recordLayout2 = lwc.registerComponent(_tmpl, {
+                tmpl: _tmpl,
+            });
+            return recordLayout2;
+        }
+    );
+}

--- a/packages/integration-karma/test/act/act-components/test-style-attr.js
+++ b/packages/integration-karma/test/act/act-components/test-style-attr.js
@@ -1,0 +1,34 @@
+/* eslint-disable */
+export default function (define) {
+    return define('records/recordLayout2', ['ui/something', 'lwc'], function (_uiSomething, lwc) {
+        function _interopDefaultLegacy(e) {
+            return e && typeof e === 'object' && 'default' in e ? e : { default: e };
+        }
+        var _uiSomething__default = /*#__PURE__*/ _interopDefaultLegacy(_uiSomething);
+        function tmpl($api, $cmp, $slotset, $ctx) {
+            const { c: api_custom_element } = $api;
+            return [
+                api_custom_element(
+                    'ui-something',
+                    _uiSomething__default['default'],
+                    {
+                        styleDecls: [
+                            ['color', 'blue', true],
+                            ['text-align', 'center', false],
+                        ],
+                        key: 1,
+                    },
+                    []
+                ),
+            ];
+        }
+
+        var _tmpl = lwc.registerTemplate(tmpl);
+        tmpl.stylesheets = [];
+        tmpl.stylesheetToken = 'records-recordLayout2_recordLayout2';
+        var recordLayout2 = lwc.registerComponent(_tmpl, {
+            tmpl: _tmpl,
+        });
+        return recordLayout2;
+    });
+}

--- a/packages/integration-karma/test/act/force/foo/foo.html
+++ b/packages/integration-karma/test/act/force/foo/foo.html
@@ -1,0 +1,7 @@
+<template>
+  <div data-id="name">{name}</div>
+  <slot></slot>
+  <slot name="first"></slot>
+  <slot name="second"></slot>
+  <slot name="adjacent"></slot>
+</template>

--- a/packages/integration-karma/test/act/force/foo/foo.js
+++ b/packages/integration-karma/test/act/force/foo/foo.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api name;
+}

--- a/packages/integration-karma/test/act/html/tags/tags.html
+++ b/packages/integration-karma/test/act/html/tags/tags.html
@@ -1,0 +1,3 @@
+<template>
+  <slot></slot>
+</template>

--- a/packages/integration-karma/test/act/html/tags/tags.js
+++ b/packages/integration-karma/test/act/html/tags/tags.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/act/index.spec.js
+++ b/packages/integration-karma/test/act/index.spec.js
@@ -1,0 +1,381 @@
+import { createElement, LightningElement } from 'lwc';
+import HtmlTags from 'html/tags';
+import UiSomething from 'ui/something';
+import UiSomethingElse from 'ui/somethingElse';
+import UiBoolean from 'ui/boolean';
+import UiAnother from 'ui/another';
+import UiOutputPercent from 'ui/outputpercent';
+import ForceFoo from 'force/foo';
+import NestedHtmlTags from 'nested/htmlTags';
+import { extractDataIds } from 'test-utils';
+import testProps from './act-components/test-props';
+import testAttrs from './act-components/test-attrs';
+import testBodySlot from './act-components/test-body-slot';
+import testClassAttr from './act-components/test-class-attr';
+import testConditionalFalseAttribute from './act-components/test-conditional-false-attribute';
+import testConditionalTrueAttribute from './act-components/test-conditional-true-attribute';
+import testEmptySlot from './act-components/test-empty-slot';
+import testEmptySlotElementCreation from './act-components/test-empty-slot-element-creation';
+import testHtmlTags from './act-components/test-html-tags';
+import testMultipleChildrenInSlot from './act-components/test-multiple-children-in-slot';
+import testMultipleSlots from './act-components/test-multiple-slots';
+import testNestedHtmlTags from './act-components/test-nested-html-tags';
+import testPropertyReference from './act-components/test-property-reference';
+import testSlotAdjacentToNamedSlot from './act-components/test-slot-adjacent-to-named-slot';
+import testSlotElementCreationWithDuplicateSlotNames from './act-components/test-slot-element-creation-with-duplicate-slot-names';
+import testSlotInGrandchild from './act-components/test-slot-in-grandchild';
+import testStyleAttr from './act-components/test-style-attr';
+
+// Tests that confirm that the runtime LWC engine-dom is compatible with the compiled templates
+// from the ACTCompiler
+describe('ACTCompiler', () => {
+    // These can't be imported from 'lwc'` because @lwc/rollup-plugin won't allow it
+    const { registerComponent, registerTemplate, registerDecorators } = LWC;
+
+    function createComponentFromTemplate(
+        template,
+        { props = {}, propsToTrack = [], methods = {} } = {}
+    ) {
+        const publicProps = {};
+        for (const prop of Object.keys(props)) {
+            if (!propsToTrack.includes(prop)) {
+                publicProps[prop] = { config: 0 };
+            }
+        }
+
+        class CustomElement extends LightningElement {
+            constructor(...args) {
+                super(...args);
+                for (const key of Object.keys(props)) {
+                    this[key] = props[key];
+                }
+            }
+        }
+
+        for (const methodName of Object.keys(methods)) {
+            Object.defineProperty(CustomElement.prototype, methodName, {
+                value: methods[methodName],
+            });
+        }
+
+        const track = {};
+        for (const prop of propsToTrack) {
+            track[prop] = 1;
+        }
+
+        registerDecorators(CustomElement, {
+            publicProps,
+            track,
+        });
+
+        return registerComponent(CustomElement, {
+            tmpl: template,
+        });
+    }
+
+    function loadDependencies(dependencies) {
+        return dependencies.map((depName) => {
+            switch (depName) {
+                case 'force/foo':
+                    return ForceFoo;
+                case 'html/tags':
+                    return HtmlTags;
+                case 'lwc':
+                    return { registerComponent, registerTemplate };
+                case 'nested/htmlTags':
+                    return NestedHtmlTags;
+                case 'ui/another':
+                    return UiAnother;
+                case 'ui/boolean':
+                    return UiBoolean;
+                case 'ui/outputpercent':
+                    return UiOutputPercent;
+                case 'ui/something':
+                    return UiSomething;
+                case 'ui/somethingElse':
+                    return UiSomethingElse;
+                default:
+                    throw new Error('Unknown dependency: ' + depName);
+            }
+        });
+    }
+
+    function directoryNameToComponentName(dirName) {
+        const [namespace, name] = dirName.split('/');
+        return namespace + '-' + name.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+    }
+
+    function createAndInsertActComponent(createComponent, options) {
+        const define = (moduleName, dependencyNames, moduleDef) => {
+            const dependencies = loadDependencies(dependencyNames);
+            const template = moduleDef(...dependencies);
+            const componentName = directoryNameToComponentName(moduleName);
+            const Component = createComponentFromTemplate(template, options);
+            return createElement(componentName, { is: Component });
+        };
+
+        const component = createComponent(define);
+        document.body.appendChild(component);
+        return component;
+    }
+
+    it('props', () => {
+        const component = createAndInsertActComponent(testProps);
+
+        expect(component.tagName.toLowerCase()).toEqual('records-record-layout2');
+        expect(component.shadowRoot.children.length).toEqual(1);
+        expect(component.shadowRoot.children[0].tagName.toLowerCase()).toEqual('ui-something');
+
+        const nodes = extractDataIds(component);
+
+        expect(nodes.mode.textContent).toEqual('VIEW');
+        expect(nodes.propWithDash.textContent).toEqual('X');
+        expect(nodes.fieldLabel.textContent).toEqual('');
+        expect(nodes.trueAttr.textContent).toEqual('true');
+        expect(nodes.camelCase.textContent).toEqual('YZ');
+    });
+
+    it('attrs', () => {
+        const component = createAndInsertActComponent(testAttrs);
+
+        const uiSomething = component.shadowRoot.querySelector('ui-something');
+        expect(uiSomething.getAttribute('data-blah-de-blah')).toEqual('special-data-attribute');
+        expect(uiSomething.getAttribute('data-blah-blah')).toEqual('anotherDataAttribute');
+        expect(uiSomething.getAttribute('role')).toEqual('listitem');
+    });
+
+    it('body slot', () => {
+        const component = createAndInsertActComponent(testBodySlot);
+
+        expect(component.shadowRoot.children.length).toEqual(1);
+        expect(component.shadowRoot.children[0].tagName.toLowerCase()).toEqual('force-foo');
+
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        expect(forceFoo.children.length).toEqual(1);
+        expect(forceFoo.children[0].tagName.toLowerCase()).toEqual('ui-something');
+
+        const nodes = extractDataIds(component);
+
+        expect(nodes.name.textContent).toEqual('Elizabeth Shaw');
+        expect(nodes.text.textContent).toEqual('Hello');
+    });
+
+    it('class attribute', () => {
+        const component = createAndInsertActComponent(testClassAttr);
+        const uiSomething = component.shadowRoot.querySelector('ui-something');
+        expect(uiSomething.classList.length).toEqual(2);
+        expect(uiSomething.classList.contains('slds-has-divider_top')).toEqual(true);
+        expect(uiSomething.classList.contains('slds-grid')).toEqual(true);
+    });
+
+    it('conditional false attribute - false', () => {
+        const component = createAndInsertActComponent(testConditionalFalseAttribute, {
+            props: { state: { irrelevant: false } },
+            propsToTrack: ['state'],
+        });
+
+        expect(component.shadowRoot.children.length).toEqual(1);
+        expect(component.shadowRoot.children[0].tagName.toLowerCase()).toEqual('ui-boolean');
+
+        const nodes = extractDataIds(component);
+        expect(nodes.other.textContent).toEqual('irrelevant');
+    });
+
+    it('conditional false attribute - true', () => {
+        const component = createAndInsertActComponent(testConditionalFalseAttribute, {
+            props: { state: { irrelevant: true } },
+            propsToTrack: ['state'],
+        });
+
+        expect(component.shadowRoot.children.length).toEqual(0);
+    });
+
+    it('conditional true attribute - true', () => {
+        const component = createAndInsertActComponent(testConditionalTrueAttribute, {
+            props: { state: { irrelevant: true } },
+            propsToTrack: ['state'],
+        });
+
+        expect(component.shadowRoot.children.length).toEqual(1);
+        expect(component.shadowRoot.children[0].tagName.toLowerCase()).toEqual('ui-boolean');
+
+        const nodes = extractDataIds(component);
+        expect(nodes.other.textContent).toEqual('irrelevant');
+    });
+
+    it('conditional true attribute - false', () => {
+        const component = createAndInsertActComponent(testConditionalTrueAttribute, {
+            props: { state: { irrelevant: false } },
+            propsToTrack: ['state'],
+        });
+
+        expect(component.shadowRoot.children.length).toEqual(0);
+    });
+
+    it('empty slot', () => {
+        const component = createAndInsertActComponent(testEmptySlot);
+
+        expect(component.shadowRoot.children.length).toEqual(1);
+        expect(component.shadowRoot.children[0].tagName.toLowerCase()).toEqual('force-foo');
+        expect(component.shadowRoot.querySelector('force-foo').children.length).toEqual(0);
+    });
+
+    it('empty slot element creation', () => {
+        const component = createAndInsertActComponent(testEmptySlotElementCreation);
+
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        const uiAnother = forceFoo.querySelector('ui-another');
+        expect(uiAnother.children.length).toEqual(0); // slot is empty
+
+        const nodes = extractDataIds(component);
+        expect(nodes.name.textContent).toEqual('Elizabeth Shaw');
+        expect(nodes.value.textContent).toEqual('Foo');
+    });
+
+    it('html tags', () => {
+        const component = createAndInsertActComponent(testHtmlTags);
+        expect(component.shadowRoot.querySelector('html-tags').innerHTML).toEqual(
+            '<span class="class1" style="color: blue;"></span><div title="test"><h1></h1></div><img ' +
+                'src="data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="' +
+                ' alt="Smiley face" height="42">&lt;/img&gt;'
+        );
+    });
+
+    it('multiple children in slot', () => {
+        const component = createAndInsertActComponent(testMultipleChildrenInSlot);
+
+        expect(component.shadowRoot.querySelectorAll('ui-something').length).toEqual(2);
+        expect(
+            component.shadowRoot
+                .querySelectorAll('ui-something')[0]
+                .shadowRoot.querySelector('[data-id="text"]').textContent
+        ).toEqual('Hello 1');
+        expect(
+            component.shadowRoot
+                .querySelectorAll('ui-something')[1]
+                .shadowRoot.querySelector('[data-id="text"]').textContent
+        ).toEqual('Hello 2');
+    });
+
+    it('multiple slots', () => {
+        const component = createAndInsertActComponent(testMultipleSlots);
+
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        const defaultSlot = forceFoo.shadowRoot.querySelector('slot');
+        const firstSlot = forceFoo.shadowRoot.querySelector('slot[name="first"]');
+        const secondSlot = forceFoo.shadowRoot.querySelector('slot[name="second"]');
+        expect(defaultSlot.assignedNodes().length).toEqual(0);
+        expect(firstSlot.assignedNodes().length).toEqual(1);
+        expect(secondSlot.assignedNodes().length).toEqual(1);
+
+        const nodes1 = extractDataIds(firstSlot.assignedNodes()[0]);
+        expect(nodes1.text.textContent).toEqual('Hello');
+        const nodes2 = extractDataIds(secondSlot.assignedNodes()[0]);
+        expect(nodes2.value.textContent).toEqual('Foo');
+    });
+
+    it('nested HTML tags', () => {
+        const component = createAndInsertActComponent(testNestedHtmlTags);
+
+        expect(component.shadowRoot.querySelector('nested-html-tags').innerHTML).toEqual(
+            '<div><div class="inner"><div></div><h2></h2></div></div>'
+        );
+    });
+
+    it('property reference and events', () => {
+        let callCount = 0;
+        const component = createAndInsertActComponent(testPropertyReference, {
+            props: {
+                non: {
+                    value: 'foobar',
+                },
+                state: {
+                    recordAvatars: 'foobaz',
+                },
+                data: {
+                    label: 'bazquux',
+                    record: 'quuxbar',
+                },
+            },
+            propsToTrack: ['non'],
+            methods: {
+                handleToggleSectionCollapsed() {
+                    callCount++;
+                    this.non.value = 'foobar' + callCount;
+                },
+            },
+        });
+
+        const nodes = extractDataIds(component);
+
+        expect(nodes.notWhitelisted.textContent).toEqual('foobar');
+        expect(nodes.templateExpression.textContent).toEqual('foobaz');
+        expect(nodes.label.textContent).toEqual('bazquux');
+        expect(nodes.value.textContent).toEqual('quuxbar');
+
+        expect(callCount).toEqual(0);
+
+        const outputPercent = component.shadowRoot.querySelector('ui-outputpercent');
+        outputPercent.fireToggleSectionCollapsedEvent();
+        return Promise.resolve()
+            .then(() => {
+                expect(callCount).toEqual(1);
+                expect(nodes.notWhitelisted.textContent).toEqual('foobar1');
+                outputPercent.fireToggleSectionCollapsedEvent();
+            })
+            .then(() => {
+                expect(callCount).toEqual(2);
+                expect(nodes.notWhitelisted.textContent).toEqual('foobar2');
+            });
+    });
+
+    it('slot adjacent to named slot', () => {
+        const component = createAndInsertActComponent(testSlotAdjacentToNamedSlot);
+
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        const defaultSlot = forceFoo.shadowRoot.querySelector('slot');
+        const adjacentSlot = forceFoo.shadowRoot.querySelector('slot[name="adjacent"]');
+        expect(defaultSlot.assignedNodes().length).toEqual(2);
+        expect(adjacentSlot.assignedNodes().length).toEqual(1);
+        expect(defaultSlot.assignedNodes()[0].tagName.toLowerCase()).toEqual('ui-another');
+        expect(defaultSlot.assignedNodes()[1].tagName.toLowerCase()).toEqual('slot');
+        expect(defaultSlot.assignedNodes()[1].assignedNodes().length).toEqual(0);
+        expect(adjacentSlot.assignedNodes()[0].tagName.toLowerCase()).toEqual('ui-another');
+        expect(extractDataIds(defaultSlot.assignedNodes()[0]).value.textContent).toEqual('Foo');
+        expect(extractDataIds(adjacentSlot.assignedNodes()[0]).value.textContent).toEqual('Foo');
+    });
+
+    it('slot element creation with duplicate slot names', () => {
+        const component = createAndInsertActComponent(
+            testSlotElementCreationWithDuplicateSlotNames
+        );
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        const defaultSlot = forceFoo.shadowRoot.querySelector('slot');
+        expect(defaultSlot.assignedNodes().length).toEqual(2);
+        expect(defaultSlot.assignedNodes()[0].name).toEqual('first');
+        expect(defaultSlot.assignedNodes()[1].name).toEqual('first');
+        expect(defaultSlot.assignedNodes()[0].children.length).toEqual(1);
+        expect(defaultSlot.assignedNodes()[1].children.length).toEqual(1);
+        expect(defaultSlot.assignedNodes()[0].children[0].tagName.toLowerCase()).toEqual(
+            'ui-something'
+        );
+        expect(defaultSlot.assignedNodes()[1].children[0].tagName.toLowerCase()).toEqual(
+            'ui-something-else'
+        );
+    });
+
+    it('slot in grandchild', () => {
+        const component = createAndInsertActComponent(testSlotInGrandchild);
+        const forceFoo = component.shadowRoot.querySelector('force-foo');
+        const firstSlot = forceFoo.shadowRoot.querySelector('slot[name="first"]');
+        expect(firstSlot.assignedNodes().length).toEqual(1);
+        expect(firstSlot.assignedNodes()[0].tagName.toLowerCase()).toEqual('ui-something');
+    });
+
+    it('style attribute', () => {
+        const component = createAndInsertActComponent(testStyleAttr);
+        const uiSomething = component.shadowRoot.querySelector('ui-something');
+        expect(uiSomething.style.color).toEqual('blue');
+        expect(uiSomething.style.textAlign).toEqual('center');
+    });
+});

--- a/packages/integration-karma/test/act/index.spec.js
+++ b/packages/integration-karma/test/act/index.spec.js
@@ -234,11 +234,28 @@ describe('ACTCompiler', () => {
 
     it('html tags', () => {
         const component = createAndInsertActComponent(testHtmlTags);
-        expect(component.shadowRoot.querySelector('html-tags').innerHTML).toEqual(
-            '<span class="class1" style="color: blue;"></span><div title="test"><h1></h1></div><img ' +
-                'src="data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="' +
-                ' alt="Smiley face" height="42">&lt;/img&gt;'
+
+        const htmlTags = component.shadowRoot.querySelector('html-tags');
+
+        expect(htmlTags.childNodes.length).toEqual(4);
+        const span = htmlTags.childNodes[0];
+        const div = htmlTags.childNodes[1];
+        const img = htmlTags.childNodes[2];
+        const text = htmlTags.childNodes[3];
+
+        expect(span.tagName.toLowerCase()).toEqual('span');
+        expect(span.style.color).toEqual('blue');
+        expect(span.className).toEqual('class1');
+
+        expect(div.getAttribute('title')).toEqual('test');
+        expect(div.children.length).toEqual(1);
+        expect(div.children[0].tagName.toLowerCase()).toEqual('h1');
+        expect(img.src).toEqual(
+            'data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
         );
+        expect(img.alt).toEqual('Smiley face');
+        expect(img.getAttribute('height')).toEqual('42');
+        expect(text.textContent).toEqual('</img>');
     });
 
     it('multiple children in slot', () => {
@@ -277,8 +294,19 @@ describe('ACTCompiler', () => {
     it('nested HTML tags', () => {
         const component = createAndInsertActComponent(testNestedHtmlTags);
 
-        expect(component.shadowRoot.querySelector('nested-html-tags').innerHTML).toEqual(
-            '<div><div class="inner"><div></div><h2></h2></div></div>'
+        const nestedHtmlTags = component.shadowRoot.querySelector('nested-html-tags');
+
+        expect(nestedHtmlTags.children.length).toEqual(1);
+        expect(nestedHtmlTags.children[0].tagName.toLowerCase()).toEqual('div');
+        expect(nestedHtmlTags.children[0].children.length).toEqual(1);
+        expect(nestedHtmlTags.children[0].children[0].tagName.toLowerCase()).toEqual('div');
+        expect(nestedHtmlTags.children[0].children[0].className).toEqual('inner');
+        expect(nestedHtmlTags.children[0].children[0].children.length).toEqual(2);
+        expect(nestedHtmlTags.children[0].children[0].children[0].tagName.toLowerCase()).toEqual(
+            'div'
+        );
+        expect(nestedHtmlTags.children[0].children[0].children[1].tagName.toLowerCase()).toEqual(
+            'h2'
         );
     });
 

--- a/packages/integration-karma/test/act/index.spec.js
+++ b/packages/integration-karma/test/act/index.spec.js
@@ -232,31 +232,34 @@ describe('ACTCompiler', () => {
         expect(nodes.value.textContent).toEqual('Foo');
     });
 
-    it('html tags', () => {
-        const component = createAndInsertActComponent(testHtmlTags);
+    if (!process.env.COMPAT) {
+        // IE11 does not implement childNodes correctly
+        it('html tags', () => {
+            const component = createAndInsertActComponent(testHtmlTags);
 
-        const htmlTags = component.shadowRoot.querySelector('html-tags');
+            const htmlTags = component.shadowRoot.querySelector('html-tags');
 
-        expect(htmlTags.childNodes.length).toEqual(4);
-        const span = htmlTags.childNodes[0];
-        const div = htmlTags.childNodes[1];
-        const img = htmlTags.childNodes[2];
-        const text = htmlTags.childNodes[3];
+            expect(htmlTags.childNodes.length).toEqual(4);
+            const span = htmlTags.childNodes[0];
+            const div = htmlTags.childNodes[1];
+            const img = htmlTags.childNodes[2];
+            const text = htmlTags.childNodes[3];
 
-        expect(span.tagName.toLowerCase()).toEqual('span');
-        expect(span.style.color).toEqual('blue');
-        expect(span.className).toEqual('class1');
+            expect(span.tagName.toLowerCase()).toEqual('span');
+            expect(span.style.color).toEqual('blue');
+            expect(span.className).toEqual('class1');
 
-        expect(div.getAttribute('title')).toEqual('test');
-        expect(div.children.length).toEqual(1);
-        expect(div.children[0].tagName.toLowerCase()).toEqual('h1');
-        expect(img.src).toEqual(
-            'data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
-        );
-        expect(img.alt).toEqual('Smiley face');
-        expect(img.getAttribute('height')).toEqual('42');
-        expect(text.textContent).toEqual('</img>');
-    });
+            expect(div.getAttribute('title')).toEqual('test');
+            expect(div.children.length).toEqual(1);
+            expect(div.children[0].tagName.toLowerCase()).toEqual('h1');
+            expect(img.src).toEqual(
+                'data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
+            );
+            expect(img.alt).toEqual('Smiley face');
+            expect(img.getAttribute('height')).toEqual('42');
+            expect(text.textContent).toEqual('</img>');
+        });
+    }
 
     it('multiple children in slot', () => {
         const component = createAndInsertActComponent(testMultipleChildrenInSlot);

--- a/packages/integration-karma/test/act/nested/htmlTags/htmlTags.html
+++ b/packages/integration-karma/test/act/nested/htmlTags/htmlTags.html
@@ -1,0 +1,3 @@
+<template>
+  <slot></slot>
+</template>

--- a/packages/integration-karma/test/act/nested/htmlTags/htmlTags.js
+++ b/packages/integration-karma/test/act/nested/htmlTags/htmlTags.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/act/ui/another/another.html
+++ b/packages/integration-karma/test/act/ui/another/another.html
@@ -1,0 +1,3 @@
+<template>
+  <div data-id="value">{value}</div>
+</template>

--- a/packages/integration-karma/test/act/ui/another/another.js
+++ b/packages/integration-karma/test/act/ui/another/another.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api value;
+}

--- a/packages/integration-karma/test/act/ui/boolean/boolean.html
+++ b/packages/integration-karma/test/act/ui/boolean/boolean.html
@@ -1,0 +1,3 @@
+<template>
+  <div data-id="other">{other}</div>
+</template>

--- a/packages/integration-karma/test/act/ui/boolean/boolean.js
+++ b/packages/integration-karma/test/act/ui/boolean/boolean.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api other;
+}

--- a/packages/integration-karma/test/act/ui/outputpercent/outputpercent.html
+++ b/packages/integration-karma/test/act/ui/outputpercent/outputpercent.html
@@ -1,0 +1,6 @@
+<template>
+  <div data-id="notWhitelisted">{notWhitelisted}</div>
+  <div data-id="templateExpression">{templateExpression}</div>
+  <div data-id="label">{label}</div>
+  <div data-id="value">{value}</div>
+</template>

--- a/packages/integration-karma/test/act/ui/outputpercent/outputpercent.js
+++ b/packages/integration-karma/test/act/ui/outputpercent/outputpercent.js
@@ -1,0 +1,17 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api notWhitelisted;
+    @api templateExpression;
+    @api label;
+    @api value;
+
+    @api fireToggleSectionCollapsedEvent() {
+        this.dispatchEvent(
+            new CustomEvent('togglesectioncollapsed', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+}

--- a/packages/integration-karma/test/act/ui/something/something.html
+++ b/packages/integration-karma/test/act/ui/something/something.html
@@ -1,0 +1,9 @@
+<template>
+  <div data-id="mode">{mode}</div>
+  <div data-id="propWithDash">{propWithDash}</div>
+  <div data-id="fieldLabel">{fieldLabel}</div>
+  <div data-id="trueAttr">{trueAttr}</div>
+  <div data-id="camelCase">{camelCase}</div>
+  <div data-id="text">{text}</div>
+  <slot name="second"></slot>
+</template>

--- a/packages/integration-karma/test/act/ui/something/something.js
+++ b/packages/integration-karma/test/act/ui/something/something.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api mode;
+    @api propWithDash;
+    @api fieldLabel;
+    @api trueAttr;
+    @api camelCase;
+    @api text;
+}

--- a/packages/integration-karma/test/act/ui/somethingElse/somethingElse.html
+++ b/packages/integration-karma/test/act/ui/somethingElse/somethingElse.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/integration-karma/test/act/ui/somethingElse/somethingElse.js
+++ b/packages/integration-karma/test/act/ui/somethingElse/somethingElse.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

This is part 2 of decoupling us from the ACTCompiler. It adds tests to confirm that `@lwc/engine-dom` is compatible with component templates compiled using the ACTCompiler. The templates in this test are copied from the unit tests for the ACTCompiler itself.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10277244
