### PR TITLE
Revert "Remove object spread transpilation plugin (#2465)"

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -41,3 +41,13 @@ it('should transform class fields', async () => {
 
     expect(code).not.toContain('foo;');
 });
+
+it('should object spread', async () => {
+    const actual = `
+        export const test = { ...a, b: 1 }
+    `;
+    const { code } = await transform(actual, 'foo.js', TRANSFORMATION_OPTIONS);
+
+    expect(code).toContain('b: 1');
+    expect(code).not.toContain('...a');
+});

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -7,6 +7,7 @@
 import * as babel from '@babel/core';
 
 import babelClassPropertiesPlugin from '@babel/plugin-proposal-class-properties';
+import babelObjectRestSpreadPlugin from '@babel/plugin-proposal-object-rest-spread';
 import lwcClassTransformPlugin from '@lwc/babel-plugin-component';
 
 import { normalizeToCompilerError, TransformerErrors } from '@lwc/errors';
@@ -42,6 +43,10 @@ export default function scriptTransform(
             plugins: [
                 [lwcClassTransformPlugin, { isExplicitImport, dynamicImports }],
                 [babelClassPropertiesPlugin, { loose: true }],
+
+                // This plugin should be removed in a future version. The object-rest-spread is
+                // already a stage 4 feature. The LWC compile should leave this syntax untouched.
+                babelObjectRestSpreadPlugin,
             ],
         })!;
     } catch (e) {


### PR DESCRIPTION
This reverts commit 30a8bd7f52f394995e431d60be3c936f1090bee1.

## Details

Revert the removal of object spread plugin. Temporary revert that enables the transpilation of the object spread operator until updates can be made to serve compat assets to legacy Edge browsers.

## Does this pull request introduce a breaking change?

No

## GUS work item

W-10129064