### PR TITLE
chore(nucleus): remove ui-interaction-explorer-components

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -8,7 +8,6 @@ branches:
       auto-start: true
       auto-start-from-forks: false
       required-downstream-deps:
-        - automation-platform/ui-interaction-explorer-components
         - communities/microsite-template-marketing
         - communities/shared-experience-components
         - communities/ui-b2b-components


### PR DESCRIPTION
This has been failing since #2666, most likely due to the object spread change.

In their tests, you can see the failure is due to something called `_objectSpread`.