### PR TITLE
perf: only add scope token when stylesheets are present

### DIFF
--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -80,7 +80,9 @@ function serialize(
     buffer += 'if (_implicitScopedStylesheets) {\n';
     buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets)\n`;
     buffer += `}\n`;
-    buffer += `tmpl.stylesheetToken = "${scopeToken}"\n`;
+    buffer += 'if (_implicitStylesheets || _implicitScopedStylesheets) {\n';
+    buffer += `  tmpl.stylesheetToken = "${scopeToken}"\n`;
+    buffer += '}\n';
 
     return buffer;
 }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -217,7 +217,7 @@ function observeElementChildNodes(elm: Element) {
     (elm as any).$domManual$ = true;
 }
 
-function setElementShadowToken(elm: Element, token: string | undefined) {
+function setElementShadowToken(elm: Element, token: string) {
     (elm as any).$shadowToken$ = token;
 }
 
@@ -306,9 +306,11 @@ function fallbackElmHook(elm: Element, vnode: VBaseElement) {
             // this element will now accept any manual content inserted into it
             observeElementChildNodes(elm);
         }
-        // when running in synthetic shadow mode, we need to set the shadowToken value
-        // into each element from the template, so they can be styled accordingly.
-        setElementShadowToken(elm, stylesheetToken);
+        if (!isUndefined(stylesheetToken)) {
+            // when running in synthetic shadow mode, we need to set the shadowToken value
+            // into each element from the template, so they can be styled accordingly.
+            setElementShadowToken(elm, stylesheetToken);
+        }
     }
     if (process.env.NODE_ENV !== 'production') {
         const {
@@ -374,7 +376,9 @@ function createViewModelHook(elm: HTMLElement, vnode: VCustomElement): VM {
         const { stylesheetToken } = owner.context;
         // when running in synthetic shadow mode, we need to set the shadowToken value
         // into each element from the template, so they can be styled accordingly.
-        setElementShadowToken(elm, stylesheetToken);
+        if (!isUndefined(stylesheetToken)) {
+            setElementShadowToken(elm, stylesheetToken);
+        }
     }
 
     vm = createVM(elm, ctor, {

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -73,11 +73,13 @@ export function updateStylesheetToken(vm: VM, template: Template) {
         hasTokenInClass: oldHasTokenInClass,
         hasTokenInAttribute: oldHasTokenInAttribute,
     } = context;
-    if (oldHasTokenInClass) {
-        getClassList(elm).remove(makeHostToken(oldToken!));
-    }
-    if (oldHasTokenInAttribute) {
-        removeAttribute(elm, makeHostToken(oldToken!));
+    if (!isUndefined(oldToken)) {
+        if (oldHasTokenInClass) {
+            getClassList(elm).remove(makeHostToken(oldToken));
+        }
+        if (oldHasTokenInAttribute) {
+            removeAttribute(elm, makeHostToken(oldToken));
+        }
     }
 
     // Apply the new template styling token to the host element, if the new template has any

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -78,6 +78,8 @@
 
   var _implicitStylesheets = [stylesheet];
 
+  var _implicitScopedStylesheets = undefined;
+
   var stc0$1 = {
     key: 0
   };
@@ -97,7 +99,9 @@
     __callKey2((tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets).push, "apply", tmpl$1._ES5ProxyType ? tmpl$1.get("stylesheets") : tmpl$1.stylesheets, _implicitStylesheets);
   }
 
-  __setKey(tmpl$1, "stylesheetToken", "x-foo_foo");
+  if (_implicitStylesheets || _implicitScopedStylesheets) {
+    __setKey(tmpl$1, "stylesheetToken", "x-foo_foo");
+  }
 
   function _createSuper$1(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct$1(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
@@ -162,8 +166,6 @@
   var _tmpl = lwc.registerTemplate(tmpl);
 
   __setKey(tmpl, "stylesheets", []);
-
-  __setKey(tmpl, "stylesheetToken", "x-app_app");
 
   function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var _getPrototypeOf2; var NewTarget = (_getPrototypeOf2 = _getPrototypeOf(this), _getPrototypeOf2._ES5ProxyType ? _getPrototypeOf2.get("constructor") : _getPrototypeOf2.constructor); result = __callKey3(Reflect, "construct", Super, arguments, NewTarget); } else { result = __callKey2(Super, "apply", this, arguments); } return _possibleConstructorReturn(this, result); }; }
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -7,6 +7,8 @@
     }
     var _implicitStylesheets = [stylesheet];
 
+    var _implicitScopedStylesheets = undefined;
+
     const stc0$1 = {
       key: 0
     };
@@ -21,7 +23,9 @@
     if (_implicitStylesheets) {
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
-    tmpl$1.stylesheetToken = "x-foo_foo";
+    if (_implicitStylesheets || _implicitScopedStylesheets) {
+      tmpl$1.stylesheetToken = "x-foo_foo";
+    }
 
     class Foo extends lwc.LightningElement {
       constructor(...args) {
@@ -62,7 +66,6 @@
     }
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
-    tmpl.stylesheetToken = "x-app_app";
 
     class App extends lwc.LightningElement {
       constructor() {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -11,6 +11,8 @@
     }
     var _implicitStylesheets = [stylesheet];
 
+    var _implicitScopedStylesheets = undefined;
+
     const stc0$1 = {
       key: 0
     };
@@ -25,7 +27,9 @@
     if (_implicitStylesheets) {
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
-    tmpl$1.stylesheetToken = "x-foo_foo";
+    if (_implicitStylesheets || _implicitScopedStylesheets) {
+      tmpl$1.stylesheetToken = "x-foo_foo";
+    }
 
     class Foo extends lwc.LightningElement {
       constructor(...args) {
@@ -66,7 +70,6 @@
     }
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
-    tmpl.stylesheetToken = "x-app_app";
 
     class App extends lwc.LightningElement {
       constructor() {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -7,6 +7,8 @@
     }
     var _implicitStylesheets = [stylesheet];
 
+    var _implicitScopedStylesheets = undefined;
+
     const stc0$1 = {
       key: 0
     };
@@ -21,7 +23,9 @@
     if (_implicitStylesheets) {
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
-    tmpl$1.stylesheetToken = "x-foo_foo";
+    if (_implicitStylesheets || _implicitScopedStylesheets) {
+      tmpl$1.stylesheetToken = "x-foo_foo";
+    }
 
     class Foo extends lwc.LightningElement {
       constructor(...args) {
@@ -62,7 +66,6 @@
     }
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
-    tmpl.stylesheetToken = "x-app_app";
 
     class App extends lwc.LightningElement {
       constructor() {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
@@ -10,7 +10,6 @@
   }
   var _tmpl = lwc.registerTemplate(tmpl);
   tmpl.stylesheets = [];
-  tmpl.stylesheetToken = "x-app_app";
 
   function fake() {
     return 'woo hoo';

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -21,7 +21,9 @@
   if (_implicitScopedStylesheets) {
     tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
   }
-  tmpl.stylesheetToken = "x-app_app";
+  if (_implicitScopedStylesheets) {
+    tmpl.stylesheetToken = "x-app_app";
+  }
 
   class App extends lwc.LightningElement {}
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -7,6 +7,8 @@
     }
     var _implicitStylesheets = [stylesheet];
 
+    var _implicitScopedStylesheets = undefined;
+
     const stc0$1 = {
       key: 0
     };
@@ -21,7 +23,9 @@
     if (_implicitStylesheets) {
       tmpl$1.stylesheets.push.apply(tmpl$1.stylesheets, _implicitStylesheets);
     }
-    tmpl$1.stylesheetToken = "ts-foo_foo";
+    if (_implicitStylesheets || _implicitScopedStylesheets) {
+      tmpl$1.stylesheetToken = "ts-foo_foo";
+    }
 
     class Foo extends lwc.LightningElement {
       constructor(...args) {
@@ -62,7 +66,6 @@
     }
     var _tmpl = lwc.registerTemplate(tmpl);
     tmpl.stylesheets = [];
-    tmpl.stylesheetToken = "ts-app_app";
 
     class App extends lwc.LightningElement {
       constructor() {

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/grave-accents/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/grave-accents/expected.js
@@ -1,1 +1,1 @@
-export default [];
+export default undefined;

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -86,7 +86,11 @@ export default function serialize(result: Result, config: Config): string {
     }
 
     // exports
-    buffer += `export default [${stylesheetList.join(', ')}];`;
+    if (stylesheetList.length) {
+        buffer += `export default [${stylesheetList.join(', ')}];`;
+    } else {
+        buffer += `export default undefined;`;
+    }
 
     return buffer;
 }

--- a/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 
 import Multi from 'x/multi';
+import MultiNoStyleInFirst from 'x/multiNoStyleInFirst';
 
 describe('multiple templates', () => {
     it('can render multiple templates with different styles', () => {
@@ -22,5 +23,38 @@ describe('multiple templates', () => {
             // element should not be dirty after template change
             expect(element.querySelector('div').hasAttribute('foo')).toEqual(false);
         });
+    });
+
+    it('works when first template has no scoped style but second template does', () => {
+        const element = createElement('x-multi-no-style-in-first', { is: MultiNoStyleInFirst });
+        document.body.appendChild(element);
+        return Promise.resolve()
+            .then(() => {
+                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
+                    'rgb(0, 0, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('0px');
+                element.next();
+            })
+            .then(() => {
+                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('5px');
+                element.next();
+            })
+            .then(() => {
+                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
+                    'rgb(0, 0, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('0px');
+                element.next();
+            })
+            .then(() => {
+                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('5px');
+            });
     });
 });

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/a.html
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/a.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+  <div class="red">a</div>
+</template>

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/b.html
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/b.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+  <div class="red">b</div>
+</template>

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/b.scoped.css
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/b.scoped.css
@@ -1,0 +1,7 @@
+.red {
+    color: red;
+}
+
+:host {
+    margin-left: 5px;
+}

--- a/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/multiNoStyleInFirst.js
+++ b/packages/integration-karma/test/light-dom/multiple-templates/x/multiNoStyleInFirst/multiNoStyleInFirst.js
@@ -1,0 +1,17 @@
+import { LightningElement, api } from 'lwc';
+import A from './a.html';
+import B from './b.html';
+
+export default class MultiNoStyleInFirst extends LightningElement {
+    static renderMode = 'light';
+    current = A;
+
+    @api
+    next() {
+        this.current = this.current === A ? B : A;
+    }
+
+    render() {
+        return this.current;
+    }
+}

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
@@ -1,5 +1,6 @@
 import { createElement } from 'lwc';
 import Multi from 'x/multi';
+import MultiNoStyleInFirst from 'x/multiNoStyleInFirst';
 
 if (process.env.NATIVE_SHADOW) {
     describe('Shadow DOM styling - multiple shadow DOM components', () => {
@@ -39,3 +40,64 @@ if (process.env.NATIVE_SHADOW) {
         });
     });
 }
+
+describe('multiple stylesheets rendered in same component', () => {
+    it('works when first template has no style but second template does', () => {
+        const element = createElement('x-multi-no-style-in-first', { is: MultiNoStyleInFirst });
+        document.body.appendChild(element);
+        return Promise.resolve()
+            .then(() => {
+                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+                    'rgb(0, 0, 0)'
+                );
+                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+                    'rgb(0, 0, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('0px');
+                element.next();
+                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            })
+            .then(() => {
+                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+                    'rgb(0, 128, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('5px');
+                element.next();
+                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            })
+            .then(() => {
+                if (process.env.NATIVE_SHADOW) {
+                    // TODO [#2466]: In native shadow, stylesheets are not removed from the DOM
+                    expect(
+                        getComputedStyle(element.shadowRoot.querySelector('.red')).color
+                    ).toEqual('rgb(255, 0, 0)');
+                    expect(
+                        getComputedStyle(element.shadowRoot.querySelector('.green')).color
+                    ).toEqual('rgb(0, 128, 0)');
+                    expect(getComputedStyle(element).marginLeft).toEqual('5px');
+                } else {
+                    expect(
+                        getComputedStyle(element.shadowRoot.querySelector('.red')).color
+                    ).toEqual('rgb(0, 0, 0)');
+                    expect(
+                        getComputedStyle(element.shadowRoot.querySelector('.green')).color
+                    ).toEqual('rgb(0, 0, 0)');
+                    expect(getComputedStyle(element).marginLeft).toEqual('0px');
+                }
+                element.next();
+                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            })
+            .then(() => {
+                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+                    'rgb(0, 128, 0)'
+                );
+                expect(getComputedStyle(element).marginLeft).toEqual('5px');
+            });
+    });
+});

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/a.html
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/a.html
@@ -1,0 +1,4 @@
+<template>
+  <div class="red">a</div>
+  <div lwc:dom="manual" class="manual"></div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/b.css
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/b.css
@@ -1,0 +1,11 @@
+.red {
+    color: red;
+}
+
+:host {
+    margin-left: 5px;
+}
+
+.green {
+    color: green;
+}

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/b.html
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/b.html
@@ -1,0 +1,4 @@
+<template>
+  <div class="red">b</div>
+  <div lwc:dom="manual" class="manual"></div>
+</template>

--- a/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/multiNoStyleInFirst.js
+++ b/packages/integration-karma/test/shadow-dom/multiple-templates/x/multiNoStyleInFirst/multiNoStyleInFirst.js
@@ -1,0 +1,20 @@
+import { LightningElement, api } from 'lwc';
+import A from './a.html';
+import B from './b.html';
+
+export default class MultiNoStyleInFirst extends LightningElement {
+    current = A;
+
+    @api
+    next() {
+        this.current = this.current === A ? B : A;
+    }
+
+    render() {
+        return this.current;
+    }
+
+    renderedCallback() {
+        this.template.querySelector('.manual').innerHTML = '<div class="green">manual</div>';
+    }
+}

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/index.spec.js
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/index.spec.js
@@ -1,0 +1,56 @@
+import { createElement } from 'lwc';
+
+import Unstyled from 'x/unstyled';
+import Styled from 'x/styled';
+
+describe('dom manual sharing nodes', () => {
+    it('has correct styles when sharing nodes from styled to unstyled component', () => {
+        const unstyled = createElement('x-unstyled', { is: Unstyled });
+        const styled = createElement('x-styled', { is: Styled });
+        document.body.appendChild(unstyled);
+        document.body.appendChild(styled);
+
+        return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+            .then(() => {
+                expect(
+                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
+                ).toEqual('rgb(0, 0, 0)');
+                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+
+                styled.insertManualNode(unstyled.getManualNode());
+                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            })
+            .then(() => {
+                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+            });
+    });
+
+    it('has correct styles when sharing nodes from unstyled to styled component', () => {
+        const unstyled = createElement('x-unstyled', { is: Unstyled });
+        const styled = createElement('x-styled', { is: Styled });
+        document.body.appendChild(unstyled);
+        document.body.appendChild(styled);
+
+        return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+            .then(() => {
+                expect(
+                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
+                ).toEqual('rgb(0, 0, 0)');
+                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+                    'rgb(255, 0, 0)'
+                );
+
+                unstyled.insertManualNode(styled.getManualNode());
+                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            })
+            .then(() => {
+                expect(
+                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
+                ).toEqual('rgb(0, 0, 0)');
+            });
+    });
+});

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.css
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.css
@@ -1,0 +1,3 @@
+.manual {
+  color: red;
+}

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.html
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.html
@@ -1,0 +1,3 @@
+<template>
+  <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.js
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/styled/styled.js
@@ -1,0 +1,19 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    renderedCallback() {
+        this.template.querySelector('div').innerHTML = '<div class="manual">manual</div>';
+    }
+
+    @api
+    getManualNode() {
+        return this.template.querySelector('.manual');
+    }
+
+    @api
+    insertManualNode(node) {
+        const div = this.template.querySelector('div');
+        div.innerHTML = ''; // clear
+        div.appendChild(node);
+    }
+}

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/unstyled/unstyled.html
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/unstyled/unstyled.html
@@ -1,0 +1,3 @@
+<template>
+  <div lwc:dom="manual"></div>
+</template>

--- a/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/unstyled/unstyled.js
+++ b/packages/integration-karma/test/synthetic-shadow/dom-manual-sharing-nodes/x/unstyled/unstyled.js
@@ -1,0 +1,19 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    renderedCallback() {
+        this.template.querySelector('div').innerHTML = '<div class="manual">manual</div>';
+    }
+
+    @api
+    getManualNode() {
+        return this.template.querySelector('.manual');
+    }
+
+    @api
+    insertManualNode(node) {
+        const div = this.template.querySelector('div');
+        div.innerHTML = ''; // clear
+        div.appendChild(node);
+    }
+}


### PR DESCRIPTION
## Details

This is a small perf improvement for templates that have no stylesheet.

For such templates, we can avoid setting a `stylesheetToken` on the `tmpl` function altogether. This allows the runtime engine to avoid doing any of the normal synthetic shadow work for that component (adding the attribute, removing the attribute, setting `$shadowToken$` on the element).

The [perf benchmarks](https://docs.google.com/spreadsheets/d/19CxtGBs333jOG8sA2QHf0mGu_IEdUmxfquc7uJRdhww/edit?usp=sharing) are modestly improved:

![Screen Shot 2022-02-01 at 2 52 30 PM](https://user-images.githubusercontent.com/283842/152065815-5d1aa1f0-3fe9-4901-bbd9-8c1e0e43880e.png)

I ran the test [twice](https://docs.google.com/spreadsheets/d/13ptIEB6ntPXtBYOjn0Ja2NcABQUo1G-Axg42PDh7128/edit?usp=sharing) and got the same results. 

### How many components will this affect?

To get an idea of how many templates have no stylesheets, I did an informal analysis of GUS using a conditional breakpoint:

![Screen Shot 2022-02-01 at 2 49 47 PM](https://user-images.githubusercontent.com/283842/152065180-01f539b2-dcfb-464f-98df-576a24aa86ca.png)

And I found that (somewhat surprisingly) about 75% of components have no stylesheets. (342 with stylesheets vs 1050 without stylesheets, after clicking around GUS a bit.)

### Any edge cases?

There was one situation that I thought might be observable "enough" to break existing usecases. Imagine this:

1. You have two components, A and B
2. A has stylesheets, B doesn't
3. Both have `lwc:dom=manual`
4. You are manually passing DOM elements from A to B (i.e. removing from A and inserting into B)

In the above case, because we are skipping `set element.$shadowToken$` for the component without a stylesheet, the element would retain the attribute from the previous component rather than having its attribute removed, so it would have the old styles.

This case seems pretty unconventional, but I've learned to be surprised by what people are actually doing in the wild. So in this PR, I opted to _not_ apply this optimization to nodes that are are adopted in `lwc:dom=manual` mode. This actually still gets us the perf benefits described in the benchmarks, without breaking "node sharing." I also added a test.

For the record, the place where I _would_ have made this change is here:

https://github.com/salesforce/lwc/blob/2f49fa90510636e1447a3f9c711aa658f82c3138/packages/%40lwc/synthetic-shadow/src/faux-shadow/portal.ts#L40

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

You could observe that we are no longer adding attributes for no-stylesheet templates in synthetic shadow mode (or classes in scoped light DOM mode). But ideally people should not be predicting/targeting these attributes.