### PR TITLE
fix(engine-dom): add isNodeFromTemplate() support for native roots in mixed mode

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -5,7 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { isFalse, isUndefined, KEY__SHADOW_RESOLVER } from '@lwc/shared';
+import {
+    getPrototypeOf,
+    hasOwnProperty,
+    isFalse,
+    isUndefined,
+    KEY__SHADOW_RESOLVER,
+} from '@lwc/shared';
 import { isSyntheticShadowDefined } from '../renderer';
 
 // TODO [#2472]: Remove this workaround when appropriate.
@@ -27,7 +33,11 @@ export function isNodeFromTemplate(node: Node): boolean {
     }
 
     const rootNode = node.getRootNode();
-    if (rootNode instanceof ShadowRoot && isFalse('synthetic' in rootNode)) {
+    const isShadowRootInstance = rootNode instanceof ShadowRoot;
+    if (
+        isShadowRootInstance &&
+        isFalse(hasOwnProperty.call(getPrototypeOf(rootNode), 'synthetic'))
+    ) {
         return true;
     }
 
@@ -38,5 +48,5 @@ export function isNodeFromTemplate(node: Node): boolean {
         return !isUndefined((node as any)[KEY__SHADOW_RESOLVER]);
     }
 
-    return rootNode instanceof ShadowRoot;
+    return isShadowRootInstance;
 }

--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -19,10 +19,13 @@ import { isSyntheticShadowDefined } from '../renderer';
 const _Node = Node;
 
 /**
- * EXPERIMENTAL: This function detects whether or not a Node is controlled by a LWC template. This
- * API is subject to change or being removed.
+ * EXPERIMENTAL: The purpose of this function is to detect shadowed nodes. As noted below, it
+ * returns `false` for nodes that are manually inserted without using the `lwc:dom="manual"`
+ * directive within a synthetic root.
+ *
+ * This API can be removed once Locker V1 is no longer supported.
  */
-export function isNodeFromTemplate(node: Node): boolean {
+function isNodeShadowed(node: Node): boolean {
     if (isFalse(node instanceof _Node)) {
         return false;
     }
@@ -50,3 +53,6 @@ export function isNodeFromTemplate(node: Node): boolean {
 
     return isShadowRootInstance;
 }
+
+// Rename to maintain backcompat
+export { isNodeShadowed as isNodeFromTemplate };

--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -25,12 +25,18 @@ export function isNodeFromTemplate(node: Node): boolean {
     if (node instanceof ShadowRoot) {
         return false;
     }
+
+    const rootNode = node.getRootNode();
+    if (rootNode instanceof ShadowRoot && isFalse('synthetic' in rootNode)) {
+        return true;
+    }
+
     if (isSyntheticShadowDefined) {
         // TODO [#1252]: old behavior that is still used by some pieces of the platform,
         // specifically, nodes inserted manually on places where `lwc:dom="manual"` directive is not
         // used, will be considered global elements.
         return !isUndefined((node as any)[KEY__SHADOW_RESOLVER]);
     }
-    const root = node.getRootNode();
-    return root instanceof ShadowRoot;
+
+    return rootNode instanceof ShadowRoot;
 }

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -33,35 +33,33 @@ it('should return false on the shadow root', () => {
     expect(isNodeFromTemplate(elm.shadowRoot)).toBe(false);
 });
 
-if (!process.env.MIXED_SHADOW) {
-    it('should return true on elements rendered from the template', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
+it('should return true on elements rendered from the template', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
 
-        const div = elm.shadowRoot.querySelector('div');
-        expect(isNodeFromTemplate(div)).toBe(true);
+    const div = elm.shadowRoot.querySelector('div');
+    expect(isNodeFromTemplate(div)).toBe(true);
+});
+
+it('should return true on elements manually inserted in the DOM inside an element with lwc:dom="manual"', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
+
+    const div = document.createElement('div');
+    elm.shadowRoot.querySelector('div').appendChild(div);
+
+    // TODO [#1253]: optimization to synchronously adopt new child nodes added
+    // to this elm, we can do that by patching the most common operations
+    // on the node itself
+    if (!process.env.NATIVE_SHADOW) {
+        expect(isNodeFromTemplate(div)).toBe(false); // it is false sync because MO hasn't pick up the element yet
+    }
+    return new Promise((resolve) => {
+        setTimeout(resolve);
+    }).then(() => {
+        expect(isNodeFromTemplate(div)).toBe(true); // it is true async because MO has already pick up the element
     });
-
-    it('should return true on elements manually inserted in the DOM inside an element with lwc:dom="manual"', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-
-        const div = document.createElement('div');
-        elm.shadowRoot.querySelector('div').appendChild(div);
-
-        // TODO [#1253]: optimization to synchronously adopt new child nodes added
-        // to this elm, we can do that by patching the most common operations
-        // on the node itself
-        if (!process.env.NATIVE_SHADOW) {
-            expect(isNodeFromTemplate(div)).toBe(false); // it is false sync because MO hasn't pick up the element yet
-        }
-        return new Promise((resolve) => {
-            setTimeout(resolve);
-        }).then(() => {
-            expect(isNodeFromTemplate(div)).toBe(true); // it is true async because MO has already pick up the element
-        });
-    });
-}
+});
 
 // TODO [#1252]: old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
@@ -74,9 +72,7 @@ if (!process.env.NATIVE_SHADOW) {
         const span = document.createElement('span');
         elm.shadowRoot.querySelector('h2').appendChild(span);
 
-        return new Promise((resolve) => {
-            setTimeout(resolve);
-        }).then(() => {
+        return new Promise(setTimeout).then(() => {
             expect(isNodeFromTemplate(span)).toBe(false);
         });
     });

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -72,7 +72,9 @@ if (!process.env.NATIVE_SHADOW) {
         const span = document.createElement('span');
         elm.shadowRoot.querySelector('h2').appendChild(span);
 
-        return new Promise(setTimeout).then(() => {
+        return new Promise((resolve) => {
+            setTimeout(resolve);
+        }).then(() => {
             expect(isNodeFromTemplate(span)).toBe(false);
         });
     });


### PR DESCRIPTION
## Details

With the introduction of mixed shadow mode, it is now possible to have native roots exist alongside synthetic roots. The motivation for this change is that the current logic returns `false` for nodes in native roots because we look for shadow resolvers which do not exist for nodes shadowed by native roots. The proposed change adds an additional test to account for nodes shadowed by native roots.

It should be pointed out that manually inserted nodes inside a native root will now always return `true`, where it would previously return `true` when all roots were native (i.e., when `@lwc/synthetic-shadow` is not applied), and `false` when all roots were synthetic (i.e., when `@lwc/synthetic-shadow` is applied). The existing use case for manually inserted nodes within synthetic roots does not carry over to native roots, AFAIK. **Locker team to confirm that this is acceptable before merging.**

## Does this pull request introduce a breaking change?

No

## Does this pull request introduce an observable change?

No

## GUS work item

W-10026505