### PR TITLE
chore(perf-benchmarks): print results in markdown table

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "prepare": "husky install && yarn build",
     "clean": "lerna run clean && lerna clean --yes && rm -rf node_modules",
-    "lint": "eslint packages/ scripts/ --ext=js,ts",
-    "format": "prettier --write '{packages,scripts}/**/*.{js,ts,json,md}'",
+    "lint": "eslint packages/ scripts/ --ext=js,mjs,ts",
+    "format": "prettier --write '{packages,scripts}/**/*.{js,mjs,ts,json,md}'",
     "bundlesize": "bundlesize --config ./scripts/bundlesize/bundlesize.config.json",
     "build": "lerna run build --ignore perf-benchmarks --ignore perf-benchmarks-components --ignore integration-tests",
     "build:performance": "yarn run build:performance:components && yarn run build:performance:benchmarks",
@@ -66,8 +66,8 @@
     "worker-farm": "^1.7.0"
   },
   "lint-staged": {
-    "**/*.{js,ts}": "eslint",
-    "{packages,scripts}/**/*.{js,ts,json,md}": "prettier --write"
+    "**/*.{js,mjs,ts}": "eslint",
+    "{packages,scripts}/**/*.{js,mjs,ts,json,md}": "prettier --write"
   },
   "workspaces": [
     "packages/@lwc/*",

--- a/packages/perf-benchmarks/package.json
+++ b/packages/perf-benchmarks/package.json
@@ -4,7 +4,9 @@
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c && node scripts/build.js && ./scripts/fix-deps.sh",
-        "test": "for file in $(find dist -name *.tachometer.json); do tach --config $file; done"
+        "test": "yarn test:run && yarn test:format",
+        "test:run": "for file in $(find dist -name '*.tachometer.json'); do tach --config $file --json-file $(echo $file | sed 's/.json/.results.json/'); done",
+        "test:format": "node ./scripts/format-results.mjs $(find dist -name '*.results.json')"
     },
     "//": "Note it's important for Tachometer that any deps it needs to swap out are dependencies, not devDependencies",
     "dependencies": {
@@ -14,6 +16,7 @@
         "perf-benchmarks-components": "2.7.4"
     },
     "devDependencies": {
+        "markdown-table": "^3.0.2",
         "glob-hash": "^1.0.5",
         "tachometer": "^0.5.10"
     }

--- a/packages/perf-benchmarks/scripts/format-results.mjs
+++ b/packages/perf-benchmarks/scripts/format-results.mjs
@@ -66,7 +66,7 @@ async function main() {
         })
     );
 
-    console.log(markdownTable([header, ...results].sort((a, b) => (a[0] < b[0] ? -1 : 1))));
+    console.log(markdownTable([header, ...results.sort((a, b) => (a[0] < b[0] ? -1 : 1))]));
 }
 
 main().catch((err) => {

--- a/packages/perf-benchmarks/scripts/format-results.mjs
+++ b/packages/perf-benchmarks/scripts/format-results.mjs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Forms the JSON results from multiple Tachometer runs and outputs a Markdown table of results.
+ */
+
+import { markdownTable } from 'markdown-table';
+import fs from 'fs/promises';
+
+function avg(a, b) {
+    return (a + b) / 2;
+}
+
+function fmt(num) {
+    return num.toFixed(2);
+}
+
+async function main() {
+    const jsonFiles = [...process.argv].filter((_) => _.endsWith('.json'));
+    const header = [
+        'Benchmark',
+        'Before (low)',
+        'Before (high)',
+        'Before (avg)',
+        'After (low)',
+        'After (high)',
+        'After (avg)',
+        'Delta (low)',
+        'Delta (high)',
+        'Delta (avg)',
+        'Delta perc (low)',
+        'Delta perc (high)',
+        'Delta perc (avg)',
+    ];
+
+    const results = await Promise.all(
+        jsonFiles.map(async (file) => {
+            const json = JSON.parse(await fs.readFile(file, 'utf8'));
+            const { benchmarks } = json;
+            const { low: deltaAbsLow, high: deltaAbsHigh } = benchmarks[0].differences[1].absolute;
+            const { low: deltaPercLow, high: deltaPercHigh } =
+                benchmarks[0].differences[1].percentChange;
+            const { low: beforeLow, high: beforeHigh } = benchmarks[1].mean;
+            const { low: afterLow, high: afterHigh } = benchmarks[0].mean;
+            const benchmarkName = benchmarks[0].name.replace('-this-change', '');
+            return [
+                benchmarkName,
+                fmt(beforeLow),
+                fmt(beforeHigh),
+                fmt(avg(beforeLow, beforeHigh)),
+                fmt(afterLow),
+                fmt(afterHigh),
+                fmt(avg(afterLow, afterHigh)),
+                fmt(deltaAbsLow),
+                fmt(deltaAbsHigh),
+                fmt(avg(deltaAbsLow, deltaAbsHigh)),
+                fmt(deltaPercLow / 100),
+                fmt(deltaPercHigh / 100),
+                fmt(avg(deltaPercLow, deltaPercHigh) / 100),
+            ];
+        })
+    );
+
+    console.log(markdownTable([header, ...results].sort((a, b) => (a[0] < b[0] ? -1 : 1))));
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8924,6 +8924,11 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+markdown-table@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.2.tgz#9b59eb2c1b22fe71954a65ff512887065a7bb57c"
+  integrity sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==
+
 marky@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.2.tgz#4456765b4de307a13d263a69b0c79bf226e68323"


### PR DESCRIPTION
## Details

I should have done this a while ago, but this changes `yarn test:performance` so that it outputs a nice Markdown table of the results. This is how I generate my screenshots of the perf results. (I use a markdown-to-excel converter, then I paste into a spreadsheet.)

I also fixed our eslint/prettier scripts to handle `.mjs` files since I noticed it wasn't doing that. (I'm not introducing the first `.mjs` file; there are others.)

The output looks like this (note that these results are just an example):

```
| Benchmark                                          | Before (low) | Before (high) | Before (avg) | After (low) | After (high) | After (avg) | Delta (low) | Delta (high) | Delta (avg) | Delta perc (low) | Delta perc (high) | Delta perc (avg) |
| -------------------------------------------------- | ------------ | ------------- | ------------ | ----------- | ------------ | ----------- | ----------- | ------------ | ----------- | ---------------- | ----------------- | ---------------- |
| dom-light-styled-component-create-10k-same         | 115.09       | 131.61        | 123.35       | 119.46      | 133.44       | 126.45      | -7.72       | 13.92        | 3.10        | -0.06            | 0.11              | 0.03             |
| dom-light-styled-component-create-1k-different     | 64.41        | 281.69        | 173.05       | 22.43       | 301.97       | 162.20      | -187.87     | 166.17       | -10.85      | -1.06            | 0.94              | -0.06            |
| dom-ss-native-styled-component-create-10k-same     | 127.40       | 257.00        | 192.20       | 110.22      | 267.78       | 189.00      | -105.21     | 98.81        | -3.20       | -0.54            | 0.51              | -0.02            |
| dom-ss-native-styled-component-create-1k-different | 134.37       | 166.13        | 150.25       | 133.45      | 155.05       | 144.25      | -25.21      | 13.21        | -6.00       | -0.16            | 0.08              | -0.04            |
| dom-ss-slot-create-container-5k                    | 354.59       | 561.71        | 458.15       | 215.17      | 783.13       | 499.15      | -261.28     | 343.28       | 41.00       | -0.58            | 0.76              | 0.09             |
| dom-ss-slot-update-slotted-content-5k              | 257.99       | 265.61        | 261.80       | 224.05      | 306.65       | 265.35      | -37.92      | 45.02        | 3.55        | -0.14            | 0.17              | 0.01             |
| dom-ss-styled-component-create-10k-same            | 137.46       | 281.04        | 209.25       | 47.48       | 400.72       | 224.10      | -175.80     | 205.50       | 14.85       | -0.85            | 0.99              | 0.07             |
| dom-ss-styled-component-create-1k-different        | 150.67       | 182.43        | 166.55       | 124.41      | 203.19       | 163.80      | -45.22      | 39.72        | -2.75       | -0.27            | 0.24              | -0.02            |
| dom-styled-component-create-10k-same               | 172.25       | 202.75        | 187.50       | 141.41      | 229.09       | 185.25      | -48.66      | 44.16        | -2.25       | -0.26            | 0.24              | -0.01            |
| dom-styled-component-create-1k-different           | 121.59       | 181.31        | 151.45       | 131.63      | 168.47       | 150.05      | -36.49      | 33.69        | -1.40       | -0.24            | 0.22              | -0.01            |
| dom-table-create-10k                               | 141.36       | 189.64        | 165.50       | 150.78      | 174.92       | 162.85      | -29.64      | 24.34        | -2.65       | -0.18            | 0.14              | -0.02            |
| dom-table-hydrate-1k                               | -1.12        | 75.12         | 37.00        | 8.83        | 63.47        | 36.15       | -47.75      | 46.05        | -0.85       | -1.27            | 1.23              | -0.02            |
| dom-tablecmp-append-1k                             | 30.46        | 69.84         | 50.15        | 40.26       | 63.14        | 51.70       | -21.22      | 24.32        | 1.55        | -0.43            | 0.50              | 0.03             |
| dom-tablecmp-create-10k                            | 271.87       | 485.33        | 378.60       | 19.77       | 769.43       | 394.60      | -373.73     | 405.73       | 16.00       | -0.99            | 1.07              | 0.04             |
| dom-tablecmp-create-1k                             | 8.79         | 120.61        | 64.70        | -246.89     | 420.19       | 86.65       | -316.24     | 360.14       | 21.95       | -4.94            | 5.62              | 0.34             |
| dom-tablecmp-hydrate-1k                            | 28.61        | 55.29         | 41.95        | 27.15       | 57.65        | 42.40       | -19.81      | 20.71        | 0.45        | -0.47            | 0.50              | 0.01             |
| dom-trackedcmp-create-10k                          | 220.22       | 498.48        | 359.35       | 271.02      | 394.28       | 332.65      | -178.87     | 125.47       | -26.70      | -0.47            | 0.32              | -0.07            |
| dom-wc-append-1k                                   | 5.19         | 12.81         | 9.00         | 7.03        | 9.57         | 8.30        | -4.72       | 3.32         | -0.70       | -0.49            | 0.34              | -0.08            |
| dom-wc-create-10k                                  | -204.58      | 341.78        | 68.60        | 42.34       | 46.16        | 44.25       | -297.54     | 248.84       | -24.35      | -2.92            | 2.21              | -0.35            |
| dom-wc-create-1k                                   | 5.20         | 14.10         | 9.65         | 4.80        | 13.70        | 9.25        | -6.69       | 5.89         | -0.40       | -0.68            | 0.60              | -0.04            |
| server-table-render-10k                            | 202.38       | 217.62        | 210.00       | 173.51      | 252.29       | 212.90      | -37.22      | 43.02        | 2.90        | -0.18            | 0.20              | 0.01             |
| server-tablecmp-render-10k                         | 188.93       | 234.67        | 211.80       | 66.35       | 373.85       | 220.10      | -147.14     | 163.74       | 8.30        | -0.70            | 0.77              | 0.04             |
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

