### PR TITLE
feat(hydration): support hydration in customElements.define

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -46,6 +46,8 @@ export function deprecatedBuildCustomElementConstructor(
     return Ctor.CustomElementConstructor;
 }
 
+// Note: WeakSet is not supported in IE11, and the polyfill is not performant enough.
+//       This WeakSet usage is valid because this functionality is not meant to run in IE11.
 const hydratedCustomElements = new WeakSet<Element>();
 
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -68,10 +68,7 @@ export function hydrateComponent(
 
     if (getAssociatedVMIfPresent(element)) {
         /* eslint-disable-next-line no-console */
-        console.warn(
-            `"hydrateComponent" expects an element that is not hydrated, instead received %o.`,
-            element
-        );
+        console.warn(`"hydrateComponent" expects an element that is not hydrated.`, element);
         return;
     }
 

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -10,6 +10,7 @@ import {
     LightningElement,
     hydrateRootElement,
     connectRootElement,
+    getAssociatedVMIfPresent,
 } from '@lwc/engine-core';
 import { isFunction, isNull, isObject } from '@lwc/shared';
 import { setIsHydrating } from '../renderer';
@@ -35,6 +36,15 @@ export function hydrateComponent(
         throw new TypeError(
             `"hydrateComponent" expects an object as the third parameter but instead received ${props}.`
         );
+    }
+
+    if (getAssociatedVMIfPresent(element)) {
+        /* eslint-disable-next-line no-console */
+        console.warn(
+            `"hydrateComponent" expects an element that is not hydrated, instead received %o.`,
+            element
+        );
+        return;
     }
 
     try {

--- a/packages/integration-karma/helpers/test-hydrate.js
+++ b/packages/integration-karma/helpers/test-hydrate.js
@@ -32,7 +32,7 @@ window.HydrateTest = (function (lwc, testUtils) {
             includeShadowRoots: true,
         });
 
-        const testTarget = fragment.querySelector('x-main');
+        const testTarget = fragment.body.firstChild;
         if (!browserSupportsDeclarativeShadowDOM) {
             polyfillDeclarativeShadowDom(testTarget);
         }
@@ -45,7 +45,8 @@ window.HydrateTest = (function (lwc, testUtils) {
 
     function runTest(ssrRendered, Component, testConfig) {
         const container = appendTestTarget(ssrRendered);
-        let target = container.querySelector('x-main');
+        const selector = container.firstChild.tagName;
+        let target = container.querySelector(selector);
 
         const snapshot = testConfig.snapshot ? testConfig.snapshot(target) : {};
 
@@ -57,7 +58,7 @@ window.HydrateTest = (function (lwc, testUtils) {
         consoleSpy.reset();
 
         // let's select again the target, it should be the same elements as in the snapshot
-        target = container.querySelector('x-main');
+        target = container.querySelector(selector);
         return testConfig.test(target, snapshot, consoleSpy.calls);
     }
 

--- a/packages/integration-karma/helpers/test-hydrate.js
+++ b/packages/integration-karma/helpers/test-hydrate.js
@@ -45,7 +45,7 @@ window.HydrateTest = (function (lwc, testUtils) {
 
     function runTest(ssrRendered, Component, testConfig) {
         const container = appendTestTarget(ssrRendered);
-        const selector = container.firstChild.tagName;
+        const selector = container.firstChild.tagName.toLowerCase();
         let target = container.querySelector(selector);
 
         const snapshot = testConfig.snapshot ? testConfig.snapshot(target) : {};
@@ -54,7 +54,12 @@ window.HydrateTest = (function (lwc, testUtils) {
         const clientProps = testConfig.clientProps || props;
 
         const consoleSpy = testUtils.spyConsole();
-        lwc.hydrateComponent(target, Component, clientProps);
+
+        if (testConfig.useCustomElementRegistry) {
+            customElements.define(selector, Component.CustomElementConstructor);
+        } else {
+            lwc.hydrateComponent(target, Component, clientProps);
+        }
         consoleSpy.reset();
 
         // let's select again the target, it should be the same elements as in the snapshot

--- a/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -23,6 +23,7 @@ ssr.setHooks({
     },
 });
 
+let guid = 0;
 const COMPONENT_UNDER_TEST = 'main';
 
 const TEMPLATE = `
@@ -87,7 +88,7 @@ function getSsrCode(moduleCode, testConfig) {
         ${testConfig};
         config = config || {};
         ${moduleCode};
-        moduleOutput = LWC.renderComponent('x-${COMPONENT_UNDER_TEST}', Main, config.props || {});`
+        moduleOutput = LWC.renderComponent('x-${COMPONENT_UNDER_TEST}-${guid++}', Main, config.props || {});`
     );
 
     vm.createContext(context);

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/index.spec.js
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/index.spec.js
@@ -4,16 +4,18 @@ export default {
     },
     useCustomElementRegistry: true,
     snapshot(target) {
-        const p = target.querySelector('p');
         return {
-            p,
-            text: p.firstChild,
+            p: target.querySelector('p'),
+            span: target.querySelector('span'),
         };
     },
     test(target, snapshots) {
-        const p = target.querySelector('p');
-        expect(p).toBe(snapshots.p);
-        expect(p.firstChild).toBe(snapshots.text);
-        expect(p.textContent).toBe('Hello world');
+        const hydratedSnapshots = this.snapshot(target);
+
+        expect(snapshots.p.textContent).toBe('hello from the server');
+        expect(snapshots.span).toBeNull();
+
+        expect(hydratedSnapshots.p).toBeNull();
+        expect(hydratedSnapshots.span.textContent).toBe('hello from the client');
     },
 };

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/index.spec.js
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/index.spec.js
@@ -1,0 +1,19 @@
+export default {
+    props: {
+        isServer: true,
+    },
+    useCustomElementRegistry: true,
+    snapshot(target) {
+        const p = target.querySelector('p');
+        return {
+            p,
+            text: p.firstChild,
+        };
+    },
+    test(target, snapshots) {
+        const p = target.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.firstChild).toBe(snapshots.text);
+        expect(p.textContent).toBe('Hello world');
+    },
+};

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.html
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.html
@@ -1,0 +1,8 @@
+<template lwc:render-mode="light">
+    <template if:true={isServer}>
+        <p>Hello from the server</p>
+    </template>
+    <template if:false={isServer}>
+        <span>Hello from the client</span>
+    </template>
+</template>

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.html
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.html
@@ -1,8 +1,8 @@
 <template lwc:render-mode="light">
     <template if:true={isServer}>
-        <p>Hello from the server</p>
+        <p>hello from the server</p>
     </template>
     <template if:false={isServer}>
-        <span>Hello from the client</span>
+        <span>hello from the client</span>
     </template>
 </template>

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.js
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom-mismatch/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    static renderMode = 'light';
+
+    @api isServer = false;
+}

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom/index.spec.js
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom/index.spec.js
@@ -1,0 +1,16 @@
+export default {
+    useCustomElementRegistry: true,
+    snapshot(target) {
+        const p = target.querySelector('p');
+        return {
+            p,
+            text: p.firstChild,
+        };
+    },
+    test(target, snapshots) {
+        const p = target.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.firstChild).toBe(snapshots.text);
+        expect(p.textContent).toBe('Hello world');
+    },
+};

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom/x/main/main.html
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom/x/main/main.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <p>Hello world</p>
+</template>

--- a/packages/integration-karma/test-hydration/customElement-define/light-dom/x/main/main.js
+++ b/packages/integration-karma/test-hydration/customElement-define/light-dom/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/integration-karma/test-hydration/customElement-define/simple/index.spec.js
+++ b/packages/integration-karma/test-hydration/customElement-define/simple/index.spec.js
@@ -1,0 +1,16 @@
+export default {
+    useCustomElementRegistry: true,
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            text: p.firstChild,
+        };
+    },
+    test(target, snapshots) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.firstChild).toBe(snapshots.text);
+        expect(p.textContent).toBe('Hello world');
+    },
+};

--- a/packages/integration-karma/test-hydration/customElement-define/simple/x/main/main.html
+++ b/packages/integration-karma/test-hydration/customElement-define/simple/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p>Hello world</p>
+</template>

--- a/packages/integration-karma/test-hydration/customElement-define/simple/x/main/main.js
+++ b/packages/integration-karma/test-hydration/customElement-define/simple/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {}

--- a/packages/integration-karma/test-hydration/errors/already-hydrated-ce/index.spec.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated-ce/index.spec.js
@@ -4,8 +4,7 @@ export default {
         hydrateComponent(target, Component, {});
 
         const consoleCalls = consoleSpy.calls;
-        const expectedMessage =
-            '"hydrateComponent" expects an element that is not hydrated, instead received';
+        const expectedMessage = '"hydrateComponent" expects an element that is not hydrated.';
         expect(consoleCalls.warn).toHaveSize(1);
         expect(consoleCalls.warn[0][0]).toContain(expectedMessage);
     },

--- a/packages/integration-karma/test-hydration/errors/already-hydrated-ce/index.spec.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated-ce/index.spec.js
@@ -1,0 +1,12 @@
+export default {
+    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
+        customElements.define(target.tagName.toLowerCase(), Component.CustomElementConstructor);
+        hydrateComponent(target, Component, {});
+
+        const consoleCalls = consoleSpy.calls;
+        const expectedMessage =
+            '"hydrateComponent" expects an element that is not hydrated, instead received';
+        expect(consoleCalls.warn).toHaveSize(1);
+        expect(consoleCalls.warn[0][0]).toContain(expectedMessage);
+    },
+};

--- a/packages/integration-karma/test-hydration/errors/already-hydrated-ce/x/main/main.html
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated-ce/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p>Hello world</p>
+</template>

--- a/packages/integration-karma/test-hydration/errors/already-hydrated-ce/x/main/main.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated-ce/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {}

--- a/packages/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
@@ -1,0 +1,15 @@
+export default {
+    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
+        hydrateComponent(target, Component, {});
+
+        hydrateComponent(target, Component, {});
+        customElements.define(target.tagName.toLowerCase(), Component.CustomElementConstructor);
+
+        const consoleCalls = consoleSpy.calls;
+        const expectedMessage =
+            '"hydrateComponent" expects an element that is not hydrated, instead received';
+        expect(consoleCalls.warn).toHaveSize(2);
+        expect(consoleCalls.warn[0][0]).toContain(expectedMessage);
+        expect(consoleCalls.warn[1][0]).toContain(expectedMessage);
+    },
+};

--- a/packages/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
@@ -6,8 +6,7 @@ export default {
         customElements.define(target.tagName.toLowerCase(), Component.CustomElementConstructor);
 
         const consoleCalls = consoleSpy.calls;
-        const expectedMessage =
-            '"hydrateComponent" expects an element that is not hydrated, instead received';
+        const expectedMessage = '"hydrateComponent" expects an element that is not hydrated.';
         expect(consoleCalls.warn).toHaveSize(2);
         expect(consoleCalls.warn[0][0]).toContain(expectedMessage);
         expect(consoleCalls.warn[1][0]).toContain(expectedMessage);

--- a/packages/integration-karma/test-hydration/errors/already-hydrated/x/main/main.html
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p>Hello world</p>
+</template>

--- a/packages/integration-karma/test-hydration/errors/already-hydrated/x/main/main.js
+++ b/packages/integration-karma/test-hydration/errors/already-hydrated/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {}


### PR DESCRIPTION
## Details
This PR implements the [`customElements.define`](https://github.com/salesforce/lwc-rfcs/blob/master/text/0117-ssr-rehydration.md#customelementsdefine) section of the [SSR Hydration RFC](https://github.com/salesforce/lwc-rfcs/blob/master/text/0117-ssr-rehydration.md).

It also changes the bailout mechanism for hydration: before this PR the bailout mechanism was to replace the element with the client rendered element (via `createElement`), in this PR, we replace the content of the element with the csr content.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
