### PR TITLE
chore(perf-benchmarks): tweak default constants

### DIFF
--- a/packages/perf-benchmarks/scripts/build.js
+++ b/packages/perf-benchmarks/scripts/build.js
@@ -20,11 +20,11 @@ const writeFile = promisify(fs.writeFile);
 const {
     BENCHMARK_REPO = 'https://github.com/salesforce/lwc.git',
     BENCHMARK_REF = 'master',
-    BENCHMARK_AUTO_SAMPLE_CONDITIONS = '25%', // how much difference we want to determine between A and B
+    BENCHMARK_AUTO_SAMPLE_CONDITIONS = '1%', // how much difference we want to determine between A and B
 } = process.env;
 let {
-    BENCHMARK_SAMPLE_SIZE = 50, // minimum number of samples to run
-    BENCHMARK_TIMEOUT = 5, // timeout in minutes during auto-sampling (after the minimum samples). If 0, no auto-sampling
+    BENCHMARK_SAMPLE_SIZE = 100, // minimum number of samples to run
+    BENCHMARK_TIMEOUT = 15, // timeout in minutes during auto-sampling (after the minimum samples). If 0, no auto-sampling
 } = process.env;
 
 const toInt = (num) => (typeof num === 'number' ? num : parseInt(num, 10));


### PR DESCRIPTION
## Details

These are basically the defaults I use whenever I'm running perf tests on my PRs; it seems silly not to just update them here.

The old defaults (especially `25%`) were based on thinking we were going to run Tachometer on every PR, so I wanted very conservative numbers so that the tests didn't spend a lot of time just to tell us there's a 0% difference. Nowadays we only use the perf tests on-demand, so it makes sense to make the defaults stricter.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->