### PR TITLE
perf: only clone old children once

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -544,6 +544,7 @@ function updateDynamicChildren(parentElm: Node, oldCh: VNodes, newCh: VNodes) {
     let idxInOld: number;
     let elmToMove: VNode | null | undefined;
     let before: any;
+    let clonedOldCh = false;
     while (oldStartIdx <= oldEndIdx && newStartIdx <= newEndIdx) {
         if (!isVNode(oldStartVnode)) {
             oldStartVnode = oldCh[++oldStartIdx]; // Vnode might have been moved left
@@ -595,9 +596,15 @@ function updateDynamicChildren(parentElm: Node, oldCh: VNodes, newCh: VNodes) {
                         // Delete the old child, but copy the array since it is read-only.
                         // The `oldCh` will be GC'ed after `updateDynamicChildren` is complete,
                         // so we only care about the `oldCh` object inside this function.
-                        const oldChClone = [...oldCh];
-                        oldChClone[idxInOld] = undefined as any;
-                        oldCh = oldChClone;
+                        // To avoid cloning over and over again, we check `clonedOldCh`
+                        // and only clone once.
+                        if (!clonedOldCh) {
+                            clonedOldCh = true;
+                            oldCh = [...oldCh];
+                        }
+
+                        // We've already cloned at least once, so it's no longer read-only
+                        (oldCh as any[])[idxInOld] = undefined;
                         newStartVnode.hook.move(elmToMove, parentElm, oldStartVnode.elm!);
                     }
                 }

--- a/packages/integration-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/table-diffing/index.spec.js
@@ -101,7 +101,7 @@ describe('Table diffing', () => {
         };
         expect(getRowContents()).toEqual(ids);
 
-        const sortedIds = ids.sort((a, b) => (a < b ? -1 : 1));
+        const sortedIds = ids.sort((a, b) => (a - b));
 
         elm.rows = sortedIds.map((id) => ({ id }));
 

--- a/packages/integration-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/table-diffing/index.spec.js
@@ -87,4 +87,26 @@ describe('Table diffing', () => {
             expect(r1).toBe(e4);
         });
     });
+
+    it('sorting a table', () => {
+        const elm = createElement('x-table', { is: Table });
+        const ids = [0, 9, 1, 5, 2, 3, 8, 4, 6, 7];
+        elm.rows = ids.map((id) => ({ id }));
+        document.body.appendChild(elm);
+
+        const getRowContents = () => {
+            return [...elm.shadowRoot.querySelectorAll('x-row')].map((row) =>
+                parseInt(row.shadowRoot.querySelector('span').textContent, 10)
+            );
+        };
+        expect(getRowContents()).toEqual(ids);
+
+        const sortedIds = ids.sort((a, b) => (a < b ? -1 : 1));
+
+        elm.rows = sortedIds.map((id) => ({ id }));
+
+        return Promise.resolve().then(() => {
+            expect(getRowContents()).toEqual(sortedIds);
+        });
+    });
 });

--- a/packages/integration-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/integration-karma/test/rendering/table-diffing/index.spec.js
@@ -101,7 +101,7 @@ describe('Table diffing', () => {
         };
         expect(getRowContents()).toEqual(ids);
 
-        const sortedIds = ids.sort((a, b) => (a - b));
+        const sortedIds = ids.sort((a, b) => a - b);
 
         elm.rows = sortedIds.map((id) => ({ id }));
 


### PR DESCRIPTION
## Details

Fixes #2680. As noted in https://github.com/salesforce/lwc/issues/2680#issuecomment-1030378111, for sorting large lists of elements, this clone operation may happen frequently, so we should probably try to limit the cloning, even if it makes the code a bit uglier.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-10540506](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000lFVTbYAO/view)
