### PR TITLE
perf(engine-dom): use adoptedStyleSheets.push

### DIFF
--- a/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -103,11 +103,11 @@ if (process.env.NATIVE_SHADOW) {
         return Promise.resolve().then(() => {
             const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map(
                 (xSimple) => {
-                    // if constructable stylesheets are supported, return that rather than <style> tags
-                    return (
-                        xSimple.shadowRoot.adoptedStyleSheets ||
-                        xSimple.shadowRoot.querySelector('style')
-                    );
+                    // If constructable stylesheets are supported, return that rather than <style> tags
+                    // In Chrome 99+, adoptedStyleSheets is a proxy, so we have to clone it to compare
+                    return xSimple.shadowRoot.adoptedStyleSheets
+                        ? [...xSimple.shadowRoot.adoptedStyleSheets]
+                        : xSimple.shadowRoot.querySelector('style');
                 }
             );
 


### PR DESCRIPTION
## Details

Chrome recently made `adoptedStyleSheets` mutable (see [this post](https://blog.chromium.org/2022/02/chrome-99-css-cascade-layers-new-picker.html) and https://github.com/WICG/construct-stylesheets/issues/45). The idea is that, instead of doing:

```js
shadowRoot.adoptedStyleSheets = [...adoptedStyleSheets, sheet]
```

...you can do:

```js
shadowRoot.adoptedStyleSheets.push(sheet)
```

### Benchmarking

In prior testing (https://github.com/WICG/construct-stylesheets/issues/94#issuecomment-832147900), I indeed found some overhead from cloning and re-assigning the array. This is actually why we don't use `adoptedStyleSheets` at the `document` level – it tends to have so many stylesheets that the perf cost of repeatedly cloning the array is too high.

Just to be sure, I wrote [a new microbenchmark](https://bl.ocks.org/nolanlawson/raw/dbd5cda339d5a58d0027df1d0e6e1b6b/). It confirms that calling `push` is indeed faster than re-assigning the array. With 1000 components and 100 stylesheets per component, testing the median of 5 runs on Chrome Canary 100, I got **4491.3ms** (re-assignment) vs **334.5ms** (push), so it's a pretty big difference.

### Feature detection

Unfortunately, there doesn't seem to be a straightforward way of testing that `adoptedStyleSheets.push` is supported. In the old (frozen) array, it has all of the mutation methods (`push`, `shift`, `pop`, etc.), but if you call them, they throw an error:

```
TypeError: Cannot add property 0, object is not extensible
```

The most succinct detection method I found is:

```js
const supported = Object.getOwnPropertyDescriptor(document.adoptedStyleSheets, 'length').writable
```

This is correctly `true` in Chrome Canary 100 and `false` in Chrome 97. It's also correctly `false` in Firefox Nightly 98 with the constructable stylesheets flag enabled.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
