### PR TITLE
chore(features): DISABLE_MIXED_SHADOW_MODE

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -13,7 +13,6 @@
  * shape of a component. It is also used internally to apply extra optimizations.
  */
 
-import features from '@lwc/features';
 import {
     assert,
     assign,
@@ -147,14 +146,9 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
     errorCallback = errorCallback || superDef.errorCallback;
     render = render || superDef.render;
 
-    let shadowSupportMode;
-    if (features.DISABLE_MIXED_SHADOW_MODE) {
-        shadowSupportMode = ShadowSupportMode.Default;
-    } else {
-        shadowSupportMode = superDef.shadowSupportMode;
-        if (!isUndefined(ctorShadowSupportMode)) {
-            shadowSupportMode = ctorShadowSupportMode;
-        }
+    let shadowSupportMode = superDef.shadowSupportMode;
+    if (!isUndefined(ctorShadowSupportMode)) {
+        shadowSupportMode = ctorShadowSupportMode;
     }
 
     let renderMode = superDef.renderMode;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -13,6 +13,7 @@
  * shape of a component. It is also used internally to apply extra optimizations.
  */
 
+import features from '@lwc/features';
 import {
     assert,
     assign,
@@ -146,9 +147,14 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
     errorCallback = errorCallback || superDef.errorCallback;
     render = render || superDef.render;
 
-    let shadowSupportMode = superDef.shadowSupportMode;
-    if (!isUndefined(ctorShadowSupportMode)) {
-        shadowSupportMode = ctorShadowSupportMode;
+    let shadowSupportMode;
+    if (features.DISABLE_MIXED_SHADOW_MODE) {
+        shadowSupportMode = ShadowSupportMode.Default;
+    } else {
+        shadowSupportMode = superDef.shadowSupportMode;
+        if (!isUndefined(ctorShadowSupportMode)) {
+            shadowSupportMode = ctorShadowSupportMode;
+        }
     }
 
     let renderMode = superDef.renderMode;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -363,7 +363,9 @@ function computeShadowMode(vm: VM) {
             // everything defaults to native when the synthetic shadow polyfill is unavailable.
             shadowMode = ShadowMode.Native;
         } else if (isNativeShadowDefined) {
-            if (def.shadowSupportMode === ShadowSupportMode.Any) {
+            if (features.DISABLE_MIXED_SHADOW_MODE) {
+                shadowMode = ShadowMode.Synthetic;
+            } else if (def.shadowSupportMode === ShadowSupportMode.Any) {
                 shadowMode = ShadowMode.Native;
             } else {
                 const shadowAncestor = getNearestShadowAncestor(vm);

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -8,6 +8,7 @@ import { create, keys, defineProperty, isUndefined, isBoolean, globalThis } from
 import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 const features: FeatureFlagMap = {
+    DISABLE_MIXED_SHADOW_MODE: null,
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
     ENABLE_HMR: null,

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -8,14 +8,14 @@ import { create, keys, defineProperty, isUndefined, isBoolean, globalThis } from
 import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 const features: FeatureFlagMap = {
-    ENABLE_REACTIVE_SETTER: null,
-    ENABLE_HMR: null,
-    ENABLE_INNER_OUTER_TEXT_PATCH: null,
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
-    ENABLE_NODE_LIST_PATCH: null,
+    ENABLE_HMR: null,
     ENABLE_HTML_COLLECTIONS_PATCH: null,
+    ENABLE_INNER_OUTER_TEXT_PATCH: null,
+    ENABLE_NODE_LIST_PATCH: null,
     ENABLE_NODE_PATCH: null,
+    ENABLE_REACTIVE_SETTER: null,
     ENABLE_WIRE_SYNC_EMIT: null,
 };
 

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -17,6 +17,13 @@ export type FeatureFlagValue = boolean | null;
 
 export interface FeatureFlagMap {
     /**
+     * LWC engine flag to disable mixed shadow mode. Setting this flag to `true` reverts the
+     * application behavior to the old behavior, such that only the presence of the synthetic shadow
+     * polyfill dictates whether instantiated roots are synthetic or native.
+     */
+    DISABLE_MIXED_SHADOW_MODE: FeatureFlagValue;
+
+    /**
      * LWC engine flag to make setter reactive.
      */
     ENABLE_REACTIVE_SETTER: FeatureFlagValue;

--- a/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -24,10 +24,13 @@ if (!process.env.NATIVE_SHADOW) {
             setFeatureFlagForTest('DISABLE_MIXED_SHADOW_MODE', true);
         });
 
+        it('should be configured as "any" (sanity)', () => {
+            expect(Valid.shadowSupportMode === 'any').toBeTrue();
+        });
+
         it('should disable mixed shadow mode', () => {
             const elm = createElement('x-valid', { is: Valid });
             expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
-            expect(Valid.shadowSupportMode === 'any').toBeTrue();
         });
 
         afterEach(() => {

--- a/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -1,4 +1,5 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import { isSyntheticShadowRootInstance } from 'test-utils';
 
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
@@ -16,3 +17,21 @@ describe('shadowSupportMode static property', () => {
         }).not.toThrowError();
     });
 });
+
+if (!process.env.NATIVE_SHADOW) {
+    describe('DISABLE_MIXED_SHADOW_MODE', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('DISABLE_MIXED_SHADOW_MODE', true);
+        });
+
+        it('should disable mixed shadow mode', () => {
+            const elm = createElement('x-valid', { is: Valid });
+            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
+            expect(Valid.shadowSupportMode === 'any').toBeTrue();
+        });
+
+        afterEach(() => {
+            setFeatureFlagForTest('DISABLE_MIXED_SHADOW_MODE', false);
+        });
+    });
+}


### PR DESCRIPTION
## Details

Disables mixed shadow mode. Defaults to `false` as mixed shadow mode is enabled by default.

## Does this pull request introduce a breaking change?

No

## Does this pull request introduce an observable change?

No

## GUS work item

W-10699885