### PR TITLE
fix(template-compiler): omit api_key for key outside iteration

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -701,15 +701,8 @@ function updateStaticChildren(c1: VNodes, c2: VNodes, parent: ParentNode) {
         if (n2 !== n1) {
             if (isVNode(n1)) {
                 if (isVNode(n2)) {
-                    if (isSameVnode(n1, n2)) {
-                        // both vnodes are equivalent, and we just need to patch them
-                        patch(n1, n2);
-                    } else {
-                        // TODO [#2697]: it is possible for the template to define key attributes outside of an
-                        //  iteration, leading to a situation where static children have different keys.
-                        unmount(n1, parent, true);
-                        mount(n2, parent, anchor);
-                    }
+                    // both vnodes are equivalent, and we just need to patch them
+                    patch(n1, n2);
                     anchor = n2.elm!;
                 } else {
                     // removing the old vnode since the new one is null

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1149
+ * Next error code: 1150
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -598,7 +598,7 @@ export const ParserDiagnostics = {
     KEY_SHOULD_BE_IN_ITERATION: {
         code: 1149,
         message:
-            'Invalid key attribute on element <{0}>. The key attribute should be applied to an element with for:each or for:item, or to a direct child of that element. This key will be ignored, and may throw an error in future versions of LWC.',
+            'Invalid key attribute on element <{0}>. The key attribute should be applied to an element with for:each or iterator:*, or to a direct child of a <template> element with for:each or iterator:*. This key will be ignored, and may throw an error in future versions of LWC.',
         level: DiagnosticLevel.Warning,
         url: '',
     },

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -595,4 +595,11 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Warning,
         url: '',
     },
+    KEY_SHOULD_BE_IN_ITERATION: {
+        code: 1149,
+        message:
+            'Invalid key attribute on element <{0}>. The key attribute should be applied to an element with for:each or for:item, or to a direct child of that element. This key will be ignored, and may throw an error in future versions of LWC.',
+        level: DiagnosticLevel.Warning,
+        url: '',
+    },
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -1,11 +1,10 @@
 import { registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, h: api_element } = $api;
-  return [
-    api_element("div", {
-      key: api_key(0, $cmp.keyGetter),
-    }),
-  ];
+  const { h: api_element } = $api;
+  return [api_element("div", stc0)];
 }
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/metadata.json
@@ -1,3 +1,15 @@
 {
-    "warnings": []
+    "warnings": [
+        {
+            "code": 1149,
+            "message": "LWC1149: Invalid key attribute on element <div>. The key attribute should be applied to an element with for:each or for:item, or to a direct child of that element. This key will be ignored, and may throw an error in future versions of LWC.",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 10,
+                "start": 20,
+                "length": 15
+            }
+        }
+    ]
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1149,
-            "message": "LWC1149: Invalid key attribute on element <div>. The key attribute should be applied to an element with for:each or for:item, or to a direct child of that element. This key will be ignored, and may throw an error in future versions of LWC.",
+            "message": "LWC1149: Invalid key attribute on element <div>. The key attribute should be applied to an element with for:each or iterator:*, or to a direct child of a <template> element with for:each or iterator:*. This key will be ignored, and may throw an error in future versions of LWC.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -758,7 +758,11 @@ function applyKey(ctx: ParserCtx, parsedAttr: ParsedAttribute, element: BaseElem
             }
         }
 
-        element.directives.push(ast.keyDirective(keyAttribute.value, keyAttribute.location));
+        if (forOfParent || forEachParent) {
+            element.directives.push(ast.keyDirective(keyAttribute.value, keyAttribute.location));
+        } else {
+            ctx.warnOnNode(ParserDiagnostics.KEY_SHOULD_BE_IN_ITERATION, keyAttribute, [tag]);
+        }
     } else if (isInIteratorElement(ctx)) {
         ctx.throwOnNode(ParserDiagnostics.MISSING_KEY_IN_ITERATOR, element, [tag]);
     }


### PR DESCRIPTION
## Details

Partially addresses #2697.

The idea is that if a template is like this:

```html
<template>
  <x-foo key={myKey}></x-foo>
</template>
```

Then we should _not_ render it with `api_key`, but instead ignore the `key`.

**How we currently render it:**

```js
function tmpl($api, $cmp) {
  const { k: api_key, c: api_custom_element } = $api;
  return [
    api_custom_element("x-foo", _xFoo, { key: api_key(0, $cmp.myKey) }),
  ];
}
```

**This PR:**

```js
function tmpl($api) {
  const { c: api_custom_element } = $api;
  return [api_custom_element("x-foo", _xFoo, { key: 0 })];
}
```

This PR also emits a warning if we find a `key` outside of an iteration.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

Almost everyone using a `key` outside of an iteration is probably doing it as a mistake, and even if they are, it should only impact the internals of our vnode-diffing engine.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10720220
