### PR TITLE
refactor(hydration): remove explicit DOM api usages in engine-core

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -41,6 +41,7 @@ import {
 import { patchProps } from './modules/props';
 import { applyEventListeners } from './modules/events';
 
+// These values are the ones from Node.nodeType (https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
 const enum EnvNodeTypes {
     ELEMENT = 1,
     TEXT = 3,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -149,8 +149,7 @@ function hydrateElement(vnode: VElement, node: Node) {
 
 function hydrateCustomElement(vnode: VCustomElement, node: Node) {
     if (process.env.NODE_ENV !== 'production') {
-        // eslint-disable-next-line lwc-internal/no-global-node
-        validateNodeType<Element>(vnode, node, Node.ELEMENT_NODE);
+        validateNodeType<Element>(vnode, node, EnvNodeTypes.ELEMENT);
         validateElement(vnode, node);
     }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -19,7 +19,13 @@ import {
     isUndefined,
 } from '@lwc/shared';
 
-import { isSyntheticShadowDefined, ssr, remove, isNativeShadowDefined } from '../renderer';
+import {
+    isSyntheticShadowDefined,
+    ssr,
+    remove,
+    isNativeShadowDefined,
+    getChildNodes,
+} from '../renderer';
 import type { HostNode, HostElement } from '../renderer';
 import { addErrorComponentStack } from '../shared/error';
 
@@ -440,7 +446,9 @@ function hydrate(vm: VM) {
         vm.children = children;
 
         const vmChildren =
-            vm.renderMode === RenderMode.Light ? vm.elm.childNodes : vm.elm.shadowRoot.childNodes;
+            vm.renderMode === RenderMode.Light
+                ? getChildNodes(vm.elm)
+                : getChildNodes(vm.elm.shadowRoot);
         hydrateChildren(vmChildren, children, vm);
 
         runRenderedCallback(vm);

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -231,7 +231,22 @@ export function appendVM(vm: VM) {
 }
 
 export function hydrateVM(vm: VM) {
-    hydrate(vm);
+    if (isTrue(vm.isDirty)) {
+        // manually diffing/patching here.
+        // This routine is:
+        // patchShadowRoot(vm, children);
+        //  -> addVnodes.
+        const children = renderComponent(vm);
+        vm.children = children;
+
+        const vmChildren =
+            vm.renderMode === RenderMode.Light
+                ? getChildNodes(vm.elm)
+                : getChildNodes(vm.elm.shadowRoot);
+        hydrateChildren(vmChildren, children, vm);
+
+        runRenderedCallback(vm);
+    }
 }
 
 // just in case the component comes back, with this we guarantee re-rendering it
@@ -433,25 +448,6 @@ function rehydrate(vm: VM) {
     if (isTrue(vm.isDirty)) {
         const children = renderComponent(vm);
         patchShadowRoot(vm, children);
-    }
-}
-
-function hydrate(vm: VM) {
-    if (isTrue(vm.isDirty)) {
-        // manually diffing/patching here.
-        // This routine is:
-        // patchShadowRoot(vm, children);
-        //  -> addVnodes.
-        const children = renderComponent(vm);
-        vm.children = children;
-
-        const vmChildren =
-            vm.renderMode === RenderMode.Light
-                ? getChildNodes(vm.elm)
-                : getChildNodes(vm.elm.shadowRoot);
-        hydrateChildren(vmChildren, children, vm);
-
-        runRenderedCallback(vm);
     }
 }
 


### PR DESCRIPTION
## Details
This PR removes explicit usage of DOM apis within engine-core that were introduced with the hydration feature.

Note: The issue about `Node` and `Element` is still present, but we do have this issue in other places of `engine-core`.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

