### PR TITLE
chore: remove `noUnusedLocal` from `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "strict": true,
-    "noUnusedLocals": true,
 
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
## Details

Currently, typescript is configured to error out whenever code contains unused bindings. While it's important to ensure we aren't shipping dead code to production, it is extremely annoying when refactoring code. It's is currently impossible to run unit and integration tests if the code contains unused locals. 

It should be safe to remove the `noUnusedLocal` flag since the eslint  [`no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) rule already protects us against this. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->