### PR TITLE
refactor(engine-core): slotting mechanism to remove vnode.owner

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -118,7 +118,7 @@ function patch(n1: VNode, n2: VNode, vm: VM) {
     }
 }
 
-function mount(node: VNode, parent: ParentNode, anchor: Node | null, vm: VM) {
+export function mount(node: VNode, parent: ParentNode, anchor: Node | null, vm: VM) {
     switch (node.type) {
         case VNodeType.Text:
             mountText(node, parent, anchor, vm);

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -352,7 +352,7 @@ function unmount(vnode: VNode, parent: ParentNode, doRemove: boolean = false) {
             unmountVNodes(
                 isUndefined(vnode.aChildren) ? vnode.children : vnode.aChildren,
                 (elm as ParentNode) ?? parent,
-                !elm && doRemove
+                true // slot content is removed to trigger `slotchange` event when removing slot.
             );
             break;
 
@@ -579,13 +579,6 @@ function allocateInSlot(vm: VM, children: VNodes, owner: VM) {
         }
 
         const { vnodes } = (cmpSlots[slotName] = cmpSlots[slotName] || { owner, vnodes: [] });
-        // re-keying the vnodes is necessary to avoid conflicts with default content for the slot
-        // which might have similar keys. Each vnode will always have a key that
-        // starts with a numeric character from compiler. In this case, we add a unique
-        // notation for slotted vnodes keys, e.g.: `@foo:1:1`
-        if (!isUndefined(vnode.key)) {
-            vnode.key = `@${slotName}:${vnode.key}`;
-        }
         ArrayPush.call(vnodes, vnode);
     }
     if (isFalse(vm.isDirty)) {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -75,16 +75,7 @@ function validateSlots(vm: VM, html: Template) {
     const { slots = EmptyArray } = html;
 
     for (const slotName in cmpSlots) {
-        // eslint-disable-next-line lwc-internal/no-production-assert
-        assert.isTrue(
-            isArray(cmpSlots[slotName]),
-            `Slots can only be set to an array, instead received ${toString(
-                cmpSlots[slotName]
-            )} for slot "${slotName}" in ${vm}.`
-        );
-
         if (slotName !== '' && ArrayIndexOf.call(slots, slotName) === -1) {
-            // TODO [#1297]: this should never really happen because the compiler should always validate
             // eslint-disable-next-line lwc-internal/no-production-assert
             logError(
                 `Ignoring unknown provided slot name "${slotName}" in ${vm}. Check for a typo on the slot attribute.`,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -41,7 +41,7 @@ import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './decorators/api';
 import { removeActiveVM } from './hot-swaps';
-import { VNodes, VCustomElement, VNode, VNodeType } from './vnodes';
+import { AllocatedVNodes, VCustomElement, VNode, VNodes, VNodeType } from './vnodes';
 
 import type { HostNode, HostElement } from '../renderer';
 
@@ -52,7 +52,7 @@ export interface TemplateCache {
 }
 
 export interface SlotSet {
-    [key: string]: VNodes;
+    [key: string]: AllocatedVNodes;
 }
 
 export const enum VMState {
@@ -434,7 +434,7 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
                 },
                 () => {
                     // job
-                    patchChildren(oldCh, newCh, renderRoot);
+                    patchChildren(oldCh, newCh, renderRoot, vm);
                 },
                 () => {
                     // post
@@ -598,8 +598,7 @@ function runChildNodesDisconnectedCallback(vm: VM) {
 }
 
 function runLightChildNodesDisconnectedCallback(vm: VM) {
-    const { aChildren: adoptedChildren } = vm;
-    recursivelyDisconnectChildren(adoptedChildren);
+    recursivelyDisconnectChildren(vm.aChildren);
 }
 
 /**
@@ -615,6 +614,7 @@ function recursivelyDisconnectChildren(vnodes: VNodes) {
 
         if (!isNull(vnode) && !isUndefined(vnode.elm)) {
             switch (vnode.type) {
+                case VNodeType.Slot:
                 case VNodeType.Element:
                     recursivelyDisconnectChildren(vnode.children);
                     break;

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -13,19 +13,31 @@ export const enum VNodeType {
     Text,
     Comment,
     Element,
+    Slot,
     CustomElement,
 }
 
-export type VNode = VText | VComment | VElement | VCustomElement;
+export type VNode = VText | VComment | VElement | VSlot | VCustomElement;
 export type VParentElement = VElement | VCustomElement;
 export type VNodes = Readonly<Array<VNode | null>>;
+
+export interface AllocatedVNodes {
+    owner: VM;
+    vnodes: VNodes;
+}
 
 export interface BaseVNode {
     type: VNodeType;
     elm: Node | undefined;
     sel: string | undefined;
     key: Key | undefined;
-    owner: VM;
+}
+
+export interface VSlot extends VBaseElement {
+    type: VNodeType.Slot;
+    sel: 'slot';
+    owner: VM | undefined;
+    aChildren: VNodes | undefined;
 }
 
 export interface VText extends BaseVNode {
@@ -83,7 +95,9 @@ export interface VElementData extends VNodeData {
 
 export function isVBaseElement(vnode: VNode): vnode is VElement | VCustomElement {
     const { type } = vnode;
-    return type === VNodeType.Element || type === VNodeType.CustomElement;
+    return (
+        type === VNodeType.Element || type === VNodeType.CustomElement || type === VNodeType.Slot
+    );
 }
 
 export function isSameVnode(vnode1: VNode, vnode2: VNode): boolean {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -12,12 +12,12 @@ const stc2 = {
   key: 2,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot, f: api_flatten } = $api;
-  return api_flatten([
+  const { t: api_text, h: api_element, s: api_slot } = $api;
+  return [
     api_element("p", stc0, [api_text("Root")]),
     api_slot("", stc1, [api_text("Default")], $slotset),
     api_slot("named", stc2, [api_text("Named")], $slotset),
-  ]);
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -7,14 +7,7 @@
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
 import { BaseElement, ChildNode, LWCDirectiveRenderMode, Node } from '../shared/types';
-import {
-    isParentNode,
-    isSlot,
-    isForBlock,
-    isBaseElement,
-    isIf,
-    isDynamicDirective,
-} from '../shared/ast';
+import { isParentNode, isForBlock, isBaseElement, isIf, isDynamicDirective } from '../shared/ast';
 import { TEMPLATE_FUNCTION_NAME, TEMPLATE_PARAMS } from '../shared/constants';
 
 import CodeGen from './codegen';
@@ -74,8 +67,7 @@ export function shouldFlatten(codeGen: CodeGen, children: ChildNode[]): boolean 
                 ((isBaseElement(child) && isDynamic(child)) ||
                     // If node is only a control flow node and does not map to a stand alone element.
                     // Search children to determine if it should be flattened.
-                    (isIf(child) && shouldFlatten(codeGen, child.children)) ||
-                    (codeGen.renderMode === LWCDirectiveRenderMode.light && isSlot(child))))
+                    (isIf(child) && shouldFlatten(codeGen, child.children))))
     );
 }
 

--- a/packages/integration-karma/test/light-dom/slotting/x/conditionalSlottedContent/conditionalSlottedContent.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/conditionalSlottedContent/conditionalSlottedContent.html
@@ -1,0 +1,9 @@
+<template lwc:render-mode="light">
+    <x-light-container-no-default-content data-id="x-container">
+        <template if:true={showContent}>
+            <p slot="upper" data-id="upper-text">Upper Slotted content</p>
+            <p data-id="default-text">Slotted content</p>
+            <p slot="lower" data-id="lower-text">Lower Slotted content</p>
+        </template>
+    </x-light-container-no-default-content>
+</template>

--- a/packages/integration-karma/test/light-dom/slotting/x/conditionalSlottedContent/conditionalSlottedContent.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/conditionalSlottedContent/conditionalSlottedContent.js
@@ -1,0 +1,12 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ConditionalSlottedContent extends LightningElement {
+    static renderMode = 'light';
+
+    showContent = false;
+
+    @api
+    toggleContent() {
+        this.showContent = !this.showContent;
+    }
+}

--- a/packages/integration-karma/test/light-dom/slotting/x/lightContainerNoDefaultContent/lightContainerNoDefaultContent.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/lightContainerNoDefaultContent/lightContainerNoDefaultContent.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    <span data-id="lc-content-start">start</span>
+    <slot name="upper"></slot>
+    <slot></slot>
+    <slot name="lower"></slot>
+    <span data-id="lc-content-end">end</span>
+</template>

--- a/packages/integration-karma/test/light-dom/slotting/x/lightContainerNoDefaultContent/lightContainerNoDefaultContent.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/lightContainerNoDefaultContent/lightContainerNoDefaultContent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class LightContainerNoDefaultContent extends LightningElement {
+    static renderMode = 'light';
+}


### PR DESCRIPTION
## Details

The main goal of this PR is to remove the `owner` property of the `vnode`. The proposed solution changes how the slotting mechanism works to provide the correct `owner` while rendering.

`vnode.owner` is mainly used to associate an element with the proper shadow (and to set scoped styles) and is always the same as the VM being rendered, except for the slotted content, this PR mainly focuses on storing the owner only for the slot (and slotted content) and properly switching the owner when rendering.

This PR creates a new type of `VSlot` vnode, to be returned from the `s()` (template API) function, along with the corresponding mount/patch/unmount logic that takes care of rendering the slot and slotted content correctly while switching from "VM being rendered" while patching.

Missing:

- [x] Hydration logic: the hydration logic needs to accommodate this change (requires #2729 ).
- [x] (compiled code) investigate if we can remove the `flatten` call on nodes with slots (if we flatten them for the light dom case).
- [ ] run perf tests
- [x] LightDom: there is no test for it, but before this PR, the slotted content to a LightDom component is passed as part of the children, with this change, we need to patch those children dynamically (updateDynamicChildren), but in order to do it, we need an element at the beginning of both old and new children, that does not change between patches so it serves as an anchor (and to get the parentNode from it) for the diffing algo. An empty text (or comment) should be sufficient.


## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
