### PR TITLE
fix(engine-core): correctly check stylesheet mismatch

### DIFF
--- a/packages/@lwc/engine-core/src/framework/secure-template.ts
+++ b/packages/@lwc/engine-core/src/framework/secure-template.ts
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined } from '@lwc/shared';
 import { Template } from './template';
 import { checkVersionMismatch } from './check-version-mismatch';
-import { flattenStylesheets } from './utils';
 
 const signedTemplateSet: Set<Template> = new Set();
 
@@ -20,22 +18,13 @@ export function isTemplateRegistered(tpl: Template): boolean {
     return signedTemplateSet.has(tpl);
 }
 
-function checkTemplateVersionMismatch(template: Template) {
-    checkVersionMismatch(template, 'template');
-    if (!isUndefined(template.stylesheets)) {
-        for (const stylesheet of flattenStylesheets(template.stylesheets)) {
-            checkVersionMismatch(stylesheet, 'stylesheet');
-        }
-    }
-}
-
 /**
  * INTERNAL: This function can only be invoked by compiled code. The compiler
  * will prevent this function from being imported by userland code.
  */
 export function registerTemplate(tpl: Template): Template {
     if (process.env.NODE_ENV !== 'production') {
-        checkTemplateVersionMismatch(tpl);
+        checkVersionMismatch(tpl, 'template');
     }
     signedTemplateSet.add(tpl);
     // chaining this method as a way to wrap existing

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -21,6 +21,7 @@ import { RenderMode, ShadowMode, VM } from './vm';
 import { Template } from './template';
 import { getStyleOrSwappedStyle } from './hot-swaps';
 import { VNode } from './vnodes';
+import { checkVersionMismatch } from './check-version-mismatch';
 
 /**
  * Function producing style based on a host and a shadow selector. This function is invoked by
@@ -122,6 +123,8 @@ function evaluateStylesheetsContent(
             ArrayPush.apply(content, evaluateStylesheetsContent(stylesheet, stylesheetToken, vm));
         } else {
             if (process.env.NODE_ENV !== 'production') {
+                // Check for compiler version mismatch in dev mode only
+                checkVersionMismatch(stylesheet, 'stylesheet');
                 // in dev-mode, we support hot swapping of stylesheet, which means that
                 // the component instance might be attempting to use an old version of
                 // the stylesheet, while internally, we have a replacement for it.

--- a/packages/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -73,8 +73,14 @@ if (!process.env.COMPAT) {
                         /*LWC compiler v123.456.789*/
                     },
                 ];
+                registerTemplate(tmpl);
+                class CustomElement extends LightningElement {}
+                registerComponent(CustomElement, { tmpl });
+
+                const elm = createElement('x-component', { is: CustomElement });
+
                 expect(() => {
-                    registerTemplate(tmpl);
+                    document.body.appendChild(elm);
                 }).toLogErrorDev(
                     new RegExp(
                         `LWC WARNING: current engine is v${process.env.LWC_VERSION}, but stylesheet was compiled with v123.456.789`


### PR DESCRIPTION
## Details

As it turns out, we cannot check for stylesheet version mismatches in `registerTemplate`, because it's called before the `tmpl.stylesheets` are set:

https://github.com/salesforce/lwc/blob/6e148383ca47ec047f5fba6d258fab7ba6865a15/packages/%40lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js#L20-L24

Furthermore, a user can set stylesheets dynamically in the `render` function (https://github.com/salesforce/lwc-test/pull/147).

So the only place we can reliably check for mismatches is when the stylesheet is actually rendered. This PR does that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

Stylesheet mismatch errors will actually be logged now. (Assuming you have stylesheet mismatches, but not template/component mismatches.)

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10161256
