### PR TITLE
refactor(engine-dom): improve typings for constructed stylesheets

### DIFF
--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -223,7 +223,7 @@ export function createStylesheet(vm: VM, stylesheets: string[]): VNode | null {
                 insertGlobalStylesheet(stylesheets[i]);
             } else {
                 // local level
-                insertStylesheet(stylesheets[i], root!.shadowRoot);
+                insertStylesheet(stylesheets[i], root!.shadowRoot!);
             }
         }
     }

--- a/packages/@lwc/engine-core/src/renderer.ts
+++ b/packages/@lwc/engine-core/src/renderer.ts
@@ -252,7 +252,7 @@ export function setInsertGlobalStylesheet(insertGlobalStylesheetImpl: insertGlob
     insertGlobalStylesheet = insertGlobalStylesheetImpl;
 }
 
-type insertStylesheetFunc = (content: string, target: N) => void;
+type insertStylesheetFunc = (content: string, target: ShadowRoot) => void;
 export let insertStylesheet: insertStylesheetFunc;
 export function setInsertStylesheet(insertStylesheetImpl: insertStylesheetFunc) {
     insertStylesheet = insertStylesheetImpl;

--- a/packages/@lwc/engine-dom/tsconfig.json
+++ b/packages/@lwc/engine-dom/tsconfig.json
@@ -7,5 +7,5 @@
         "lib": ["dom", "es2018"]
     },
 
-    "include": ["src/"]
+    "include": ["src/", "typings/"]
 }

--- a/packages/@lwc/engine-dom/typings/constructableStyleSheets.d.ts
+++ b/packages/@lwc/engine-dom/typings/constructableStyleSheets.d.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// This informs the TS compiler about constructed stylesheets.
+// It can be removed when this is fixed: https://github.com/Microsoft/TypeScript/issues/30022
+declare interface DocumentOrShadowRoot {
+    adoptedStyleSheets: CSSStyleSheet[];
+}
+
+declare interface CSSStyleSheet {
+    replaceSync(text: string): void;
+}


### PR DESCRIPTION
## Details

TypeScript doesn't have typings for constructed stylesheets (https://github.com/Microsoft/TypeScript/issues/30022), so I was hacking around it with `as any`. That's a code smell – let's just include the typings while we wait for TypeScript to add them.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
