### PR TITLE
fix(babel-plugin-component): remove import validation

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-default-import-on-lwc/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-default-import-on-lwc/actual.js
@@ -1,1 +1,0 @@
-import engine from "lwc";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-default-import-on-lwc/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-default-import-on-lwc/error.json
@@ -1,9 +1,0 @@
-{
-    "message": "LWC1089: Invalid import. \"lwc\" doesn't have default export.",
-    "loc": {
-        "line": 1,
-        "column": 7,
-        "start": 7,
-        "length": 6
-    }
-}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-namespace-import-on-lwc/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-namespace-import-on-lwc/actual.js
@@ -1,2 +1,0 @@
-import * as engine from "lwc";
-export default class extends engine.LightningElement {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-namespace-import-on-lwc/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-if-using-namespace-import-on-lwc/error.json
@@ -1,9 +1,0 @@
-{
-    "message": "LWC1090: Invalid import. Namespace imports are not allowed on \"lwc\", instead use named imports \"import { LightningElement } from 'lwc'\".",
-    "loc": {
-        "line": 1,
-        "column": 7,
-        "start": 7,
-        "length": 11
-    }
-}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-when-a-non-supported-lwc-api-is-imported/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-when-a-non-supported-lwc-api-is-imported/actual.js
@@ -1,3 +1,0 @@
-import { registerTemplate } from "lwc";
-import tmpl from "./localTemplate.html";
-registerTemplate(tmpl);

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-when-a-non-supported-lwc-api-is-imported/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/throws-when-a-non-supported-lwc-api-is-imported/error.json
@@ -1,9 +1,0 @@
-{
-    "message": "LWC1091: Invalid import. \"registerTemplate\" is not part of the lwc api.",
-    "loc": {
-        "line": 1,
-        "column": 0,
-        "start": 0,
-        "length": 0
-    }
-}

--- a/packages/@lwc/babel-plugin-component/src/constants.js
+++ b/packages/@lwc/babel-plugin-component/src/constants.js
@@ -34,27 +34,6 @@ const LWC_PACKAGE_EXPORTS = {
     WIRE_DECORATOR: 'wire',
 };
 
-const LWC_SUPPORTED_APIS = new Set([
-    // From "@lwc/engine-core"
-    ...Object.values(LWC_PACKAGE_EXPORTS),
-    'getComponentDef',
-    'getComponentConstructor',
-    'isComponentConstructor',
-    'createContextProvider',
-    'readonly',
-    'register',
-    'setFeatureFlagForTest',
-    'unwrap',
-
-    // From "@lwc/engine-dom"
-    'hydrateComponent',
-    'buildCustomElementConstructor',
-    'createElement',
-
-    // From "@lwc/engine-server"
-    'renderComponent',
-]);
-
 const LWC_COMPONENT_PROPERTIES = {
     PUBLIC_PROPS: 'publicProps',
     PUBLIC_METHODS: 'publicMethods',
@@ -79,7 +58,6 @@ module.exports = {
     DISALLOWED_PROP_SET,
     LWC_PACKAGE_ALIAS,
     LWC_PACKAGE_EXPORTS,
-    LWC_SUPPORTED_APIS,
     LWC_COMPONENT_PROPERTIES,
     REGISTER_COMPONENT_ID,
     REGISTER_DECORATORS_ID,

--- a/packages/@lwc/babel-plugin-component/src/index.js
+++ b/packages/@lwc/babel-plugin-component/src/index.js
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const { LWCClassErrors } = require('@lwc/errors');
-
 const component = require('./component');
-const { LWC_SUPPORTED_APIS } = require('./constants');
 const {
     decorators,
     removeImportedDecoratorSpecifiers,
@@ -16,7 +13,7 @@ const {
 const dedupeImports = require('./dedupe-imports');
 const dynamicImports = require('./dynamic-imports');
 const compilerVersionNumber = require('./compiler-version-number');
-const { generateError, getEngineImportSpecifiers } = require('./utils');
+const { getEngineImportSpecifiers } = require('./utils');
 
 /**
  * The transform is done in 2 passes:
@@ -43,17 +40,6 @@ module.exports = function LwcClassTransform(api) {
             Program: {
                 enter(path) {
                     const engineImportSpecifiers = getEngineImportSpecifiers(path);
-
-                    // Validate what is imported from 'lwc'. This validation will eventually be moved out from the compiler
-                    // and into a lint rule.
-                    engineImportSpecifiers.forEach(({ name }) => {
-                        if (!LWC_SUPPORTED_APIS.has(name)) {
-                            throw generateError(path, {
-                                errorInfo: LWCClassErrors.INVALID_IMPORT_PROHIBITED_API,
-                                messageArgs: [name],
-                            });
-                        }
-                    });
 
                     // Validate the usage of LWC decorators.
                     validateImportedLwcDecoratorUsage(engineImportSpecifiers);

--- a/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/lwc-class.ts
@@ -18,28 +18,6 @@ export const LWCClassErrors = {
             'Invalid import. The argument "{0}" must be a stringLiteral for dynamic imports when strict mode is enabled.',
         url: '',
     },
-
-    INVALID_IMPORT_MISSING_DEFAULT_EXPORT: {
-        code: 1089,
-        message: 'Invalid import. "{0}" doesn\'t have default export.',
-        level: DiagnosticLevel.Error,
-        url: '',
-    },
-
-    INVALID_IMPORT_NAMESPACE_IMPORTS_NOT_ALLOWED: {
-        code: 1090,
-        message:
-            'Invalid import. Namespace imports are not allowed on "{0}", instead use named imports "import { {1} } from \'{2}\'".',
-        level: DiagnosticLevel.Error,
-        url: '',
-    },
-
-    INVALID_IMPORT_PROHIBITED_API: {
-        code: 1091,
-        message: 'Invalid import. "{0}" is not part of the lwc api.',
-        level: DiagnosticLevel.Error,
-        url: '',
-    },
 };
 
 export const DecoratorErrors = {


### PR DESCRIPTION
## Details

Fixes: https://github.com/salesforce/lwc/issues/1284

Removes `import ... from 'lwc'` validations from `@lwc/babel-plugin-component`.

This cannot be merged until https://github.com/salesforce/eslint-plugin-lwc/pull/85 is shipped and running in core.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10151021
