### PR TITLE
chore(engine-core): skip features plugin for unnecessary files

### DIFF
--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -11,21 +11,8 @@ const path = require('path');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescriptPlugin = require('@rollup/plugin-typescript');
-
-const babel = require('@babel/core');
-const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
+const lwcFeatures = require('../../../../scripts/rollup/lwcFeatures');
 const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
-
-function rollupFeaturesPlugin() {
-    return {
-        name: 'rollup-plugin-lwc-features',
-        transform(source) {
-            return babel.transform(source, {
-                plugins: [babelFeaturesPlugin],
-            }).code;
-        },
-    };
-}
 
 const { version, dependencies, peerDependencies } = require('../package.json');
 
@@ -55,7 +42,7 @@ module.exports = {
             noEmitOnError: true,
         }),
         writeDistAndTypes(),
-        rollupFeaturesPlugin(),
+        lwcFeatures(),
     ],
 
     onwarn({ code, message }) {

--- a/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
@@ -7,8 +7,7 @@
 const path = require('path');
 const rollupTypescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const babel = require('@babel/core');
-const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
+const lwcFeatures = require('../../../../../scripts/rollup/lwcFeatures');
 const { version } = require('../../package.json');
 
 const entry = path.resolve(__dirname, '../../src/index.ts');
@@ -21,17 +20,6 @@ function wrapModule() {
     return {
         renderChunk(code) {
             return `${banner}\nexport default function enableSyntheticShadow() {\n${code}\n}`;
-        },
-    };
-}
-
-function rollupFeaturesPlugin() {
-    return {
-        name: 'rollup-plugin-lwc-features',
-        transform(source) {
-            return babel.transform(source, {
-                plugins: [babelFeaturesPlugin],
-            }).code;
         },
     };
 }
@@ -56,7 +44,7 @@ function rollupConfig({ wrap } = {}) {
                 tsconfig: path.join(__dirname, '../../tsconfig.json'),
                 noEmitOnError: true,
             }),
-            rollupFeaturesPlugin(),
+            lwcFeatures(),
         ].filter(Boolean),
     };
 }

--- a/packages/lwc/scripts/utils/rollup.js
+++ b/packages/lwc/scripts/utils/rollup.js
@@ -8,19 +8,7 @@ const path = require('path');
 const rollupReplace = require('@rollup/plugin-replace');
 const { terser: rollupTerser } = require('rollup-plugin-terser');
 const babel = require('@babel/core');
-const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
 const { generateTargetName } = require('./helpers');
-
-function rollupFeaturesPlugin(prod) {
-    return {
-        name: 'rollup-plugin-lwc-features',
-        transform(source) {
-            return babel.transform(source, {
-                plugins: [[babelFeaturesPlugin, { prod }]],
-            }).code;
-        },
-    };
-}
 
 function babelCompatPlugin() {
     return {
@@ -58,7 +46,6 @@ function rollupConfig(config) {
                         'process.env.NODE_ENV': JSON.stringify('production'),
                         preventAssignment: true,
                     }),
-                rollupFeaturesPlugin(prod),
                 compatMode && babelCompatPlugin(),
             ],
         },

--- a/scripts/rollup/lwcFeatures.js
+++ b/scripts/rollup/lwcFeatures.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const babel = require('@babel/core');
+const babelFeaturesPlugin = require('@lwc/features/src/babel-plugin');
+
+/**
+ * Small Rollup plugin that applies the Babel plugin for @lwc/features
+ */
+module.exports = function lwcFeatures() {
+    return {
+        id: 'rollup-plugin-lwc-features',
+        transform(source, id) {
+            if (id.includes('/node_modules/') || !source.includes('@lwc/features')) {
+                // Skip 3rd-party files and files that don't mention @lwc/features
+                return null;
+            }
+            return babel.transform(source, {
+                plugins: [babelFeaturesPlugin],
+            }).code;
+        },
+    };
+};


### PR DESCRIPTION
## Details

Moves the `@lwc/features` Babel/Rollup plugin to its own file and skips running it on any unnecessary files.

This speeds up the total `yarn` build from 0m27.716s to 0m26.425s (**1.3s faster**) (median of 5 iterations).

I checked, and this doesn't really change the output `dist` files. The whitespace is a bit different because of Babel not running, but the `.min.js` files are the same so nothing really changed.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->


