### PR TITLE
chore: the mixed shadow mode feature flag should be disabled by default

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -383,10 +383,8 @@ function computeShadowMode(vm: VM) {
             // ShadowMode.Native implies "not synthetic shadow" which is consistent with how
             // everything defaults to native when the synthetic shadow polyfill is unavailable.
             shadowMode = ShadowMode.Native;
-        } else if (isNativeShadowDefined) {
-            if (features.DISABLE_MIXED_SHADOW_MODE) {
-                shadowMode = ShadowMode.Synthetic;
-            } else if (def.shadowSupportMode === ShadowSupportMode.Any) {
+        } else if (features.ENABLE_MIXED_SHADOW_MODE && isNativeShadowDefined) {
+            if (def.shadowSupportMode === ShadowSupportMode.Any) {
                 shadowMode = ShadowMode.Native;
             } else {
                 const shadowAncestor = getNearestShadowAncestor(vm);

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -384,7 +384,8 @@ function computeShadowMode(vm: VM) {
             // everything defaults to native when the synthetic shadow polyfill is unavailable.
             shadowMode = ShadowMode.Native;
         } else if (isNativeShadowDefined) {
-            // Not combined with above condition because feature flags must be standalone.
+            // Not combined with above condition because @lwc/features only supports identifiers in
+            // the if-condition.
             if (features.ENABLE_MIXED_SHADOW_MODE) {
                 if (def.shadowSupportMode === ShadowSupportMode.Any) {
                     shadowMode = ShadowMode.Native;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -383,20 +383,28 @@ function computeShadowMode(vm: VM) {
             // ShadowMode.Native implies "not synthetic shadow" which is consistent with how
             // everything defaults to native when the synthetic shadow polyfill is unavailable.
             shadowMode = ShadowMode.Native;
-        } else if (features.ENABLE_MIXED_SHADOW_MODE && isNativeShadowDefined) {
-            if (def.shadowSupportMode === ShadowSupportMode.Any) {
-                shadowMode = ShadowMode.Native;
-            } else {
-                const shadowAncestor = getNearestShadowAncestor(vm);
-                if (!isNull(shadowAncestor) && shadowAncestor.shadowMode === ShadowMode.Native) {
-                    // Transitive support for native Shadow DOM. A component in native mode
-                    // transitively opts all of its descendants into native.
+        } else if (isNativeShadowDefined) {
+            // Not combined with above condition because feature flags must be standalone.
+            if (features.ENABLE_MIXED_SHADOW_MODE) {
+                if (def.shadowSupportMode === ShadowSupportMode.Any) {
                     shadowMode = ShadowMode.Native;
                 } else {
-                    // Synthetic if neither this component nor any of its ancestors are configured
-                    // to be native.
-                    shadowMode = ShadowMode.Synthetic;
+                    const shadowAncestor = getNearestShadowAncestor(vm);
+                    if (
+                        !isNull(shadowAncestor) &&
+                        shadowAncestor.shadowMode === ShadowMode.Native
+                    ) {
+                        // Transitive support for native Shadow DOM. A component in native mode
+                        // transitively opts all of its descendants into native.
+                        shadowMode = ShadowMode.Native;
+                    } else {
+                        // Synthetic if neither this component nor any of its ancestors are configured
+                        // to be native.
+                        shadowMode = ShadowMode.Synthetic;
+                    }
                 }
+            } else {
+                shadowMode = ShadowMode.Synthetic;
             }
         } else {
             // Synthetic if there is no native Shadow DOM support.

--- a/packages/@lwc/features/README.md
+++ b/packages/@lwc/features/README.md
@@ -57,6 +57,18 @@ if (ENABLE_AWESOME_FEATURE) {
 }
 ```
 
+```
+// Does not work
+if (isTrue(features.ENABLE_AWESOME_FEATURE)) {
+    // awesome feature
+}
+
+// Does work
+if (features.ENABLE_AWESOME_FEATURE) {
+    // awesome feature
+}
+```
+
 #### Initialization code cannot be tested
 
 Toggling the value of `ENABLE_FOO` during a test will not change the return

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -8,12 +8,12 @@ import { create, keys, defineProperty, isUndefined, isBoolean, globalThis } from
 import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 const features: FeatureFlagMap = {
-    DISABLE_MIXED_SHADOW_MODE: null,
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
     ENABLE_HMR: null,
     ENABLE_HTML_COLLECTIONS_PATCH: null,
     ENABLE_INNER_OUTER_TEXT_PATCH: null,
+    ENABLE_MIXED_SHADOW_MODE: null,
     ENABLE_NODE_LIST_PATCH: null,
     ENABLE_NODE_PATCH: null,
     ENABLE_REACTIVE_SETTER: null,

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -17,11 +17,10 @@ export type FeatureFlagValue = boolean | null;
 
 export interface FeatureFlagMap {
     /**
-     * LWC engine flag to disable mixed shadow mode. Setting this flag to `true` reverts the
-     * application behavior to the old behavior, such that only the presence of the synthetic shadow
-     * polyfill dictates whether instantiated roots are synthetic or native.
+     * LWC engine flag to enable mixed shadow mode. Setting this flag to `true` enables usage of
+     * native shadow DOM even when the synthetic shadow polyfill is applied.
      */
-    DISABLE_MIXED_SHADOW_MODE: FeatureFlagValue;
+    ENABLE_MIXED_SHADOW_MODE: FeatureFlagValue;
 
     /**
      * LWC engine flag to make setter reactive.

--- a/packages/integration-karma/test/light-dom/scoped-styles/index.spec.js
+++ b/packages/integration-karma/test/light-dom/scoped-styles/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import Basic from 'x/basic';
 import Other from 'x/other';
 import Switchable from 'x/switchable';
@@ -6,6 +6,14 @@ import Unscoped from 'x/unscoped';
 import ShadowWithScoped from 'x/shadowWithScoped';
 
 describe('Light DOM scoped CSS', () => {
+    beforeAll(() => {
+        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
+    });
+
+    afterAll(() => {
+        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
+    });
+
     it('should scope scoped CSS and allow unscoped CSS to leak out', () => {
         const basicElement = createElement('x-basic', { is: Basic });
         const otherElement = createElement('x-other', { is: Other });

--- a/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
-import { isSyntheticShadowRootInstance } from 'test-utils';
+import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
@@ -18,23 +18,25 @@ describe('shadowSupportMode static property', () => {
     });
 });
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('DISABLE_MIXED_SHADOW_MODE', () => {
-        beforeEach(() => {
-            setFeatureFlagForTest('DISABLE_MIXED_SHADOW_MODE', true);
-        });
-
-        it('should be configured as "any" (sanity)', () => {
-            expect(Valid.shadowSupportMode === 'any').toBeTrue();
-        });
-
-        it('should disable mixed shadow mode', () => {
-            const elm = createElement('x-valid', { is: Valid });
-            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
-        });
-
-        afterEach(() => {
-            setFeatureFlagForTest('DISABLE_MIXED_SHADOW_MODE', false);
-        });
+describe('ENABLE_MIXED_SHADOW_MODE', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
     });
-}
+
+    it('should be configured as "any" (sanity)', () => {
+        expect(Valid.shadowSupportMode === 'any').toBeTrue();
+    });
+
+    it('should enable mixed shadow mode', () => {
+        const elm = createElement('x-valid', { is: Valid });
+        if (process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+            expect(isNativeShadowRootInstance(elm.shadowRoot)).toBeTrue();
+        } else {
+            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
+        }
+    });
+
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
+    });
+});

--- a/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,8 +1,16 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import Test from 'x/test';
 
 if (!process.env.COMPAT) {
     describe('scoped-ids', () => {
+        beforeAll(() => {
+            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
+        });
+
+        afterAll(() => {
+            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
+        });
+
         it('should entrust id scoping to native shadow (static)', () => {
             const elm = createElement('x-test', { is: Test });
             document.body.appendChild(elm);

--- a/packages/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
 import ResetExtendsAny from 'x/resetExtendsAny';
@@ -18,8 +18,13 @@ if (!process.env.NATIVE_SHADOW) {
         let elm;
 
         beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
             elm = createElement('x-native-container', { is: NativeContainer });
             document.body.appendChild(elm);
+        });
+
+        afterAll(() => {
+            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
         });
 
         it('should attach a native shadow root when possible', () => {


### PR DESCRIPTION
## Details

Changes the mixed shadow mode feature flag implementation to be disabled by default.

## Does this pull request introduce a breaking change?

Yes, for any projects using this feature via the open source distribution since it was enabled by default in [v2.7.1](https://github.com/salesforce/lwc/releases/tag/v2.7.1). The feature must be enabled to continue using it ([documentation](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/features/README.md)).

## GUS work item

W-10802779