### PR TITLE
fix: module exports default undefined/null/etc

### DIFF
--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -21,13 +21,16 @@ const signedTemplateMap: Map<LightningElementConstructor, Template> = new Map();
  * will prevent this function from being imported by userland code.
  */
 export function registerComponent(
-    Ctor: LightningElementConstructor,
+    // We typically expect a LightningElementConstructor, but technically you can call this with anything
+    Ctor: any,
     { tmpl }: { tmpl: Template }
-): LightningElementConstructor {
-    if (process.env.NODE_ENV !== 'production') {
-        checkVersionMismatch(Ctor, 'component');
+): any {
+    if (isFunction(Ctor)) {
+        if (process.env.NODE_ENV !== 'production') {
+            checkVersionMismatch(Ctor, 'component');
+        }
+        signedTemplateMap.set(Ctor, tmpl);
     }
-    signedTemplateMap.set(Ctor, tmpl);
     // chaining this method as a way to wrap existing assignment of component constructor easily,
     // without too much transformation
     return Ctor;

--- a/packages/integration-karma/test/component/default-export/index.spec.js
+++ b/packages/integration-karma/test/component/default-export/index.spec.js
@@ -1,0 +1,16 @@
+import Component from 'x/component';
+import { createElement } from 'lwc';
+import { extractDataIds } from 'test-utils';
+
+describe('default export', () => {
+    it('should work when a module exports non-components as default', () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+        const nodes = extractDataIds(elm);
+
+        expect(nodes.undef.textContent).toEqual('undefined');
+        expect(nodes.nil.textContent).toEqual('null');
+        expect(nodes.zero.textContent).toEqual('0');
+        expect(nodes.string.textContent).toEqual('"bar"');
+    });
+});

--- a/packages/integration-karma/test/component/default-export/x/component/component.html
+++ b/packages/integration-karma/test/component/default-export/x/component/component.html
@@ -1,0 +1,6 @@
+<template>
+  <div data-id="undef">{undef}</div>
+  <div data-id="nil">{nil}</div>
+  <div data-id="zero">{zero}</div>
+  <div data-id="string">{string}</div>
+</template>

--- a/packages/integration-karma/test/component/default-export/x/component/component.js
+++ b/packages/integration-karma/test/component/default-export/x/component/component.js
@@ -1,0 +1,15 @@
+import { LightningElement } from 'lwc';
+
+import undef from './undef.js';
+import nil from './nil.js';
+import zero from './zero.js';
+import string from './string.js';
+
+const stringify = (_) => (typeof _ === 'undefined' ? 'undefined' : JSON.stringify(_));
+
+export default class extends LightningElement {
+    undef = stringify(undef);
+    nil = stringify(nil);
+    zero = stringify(zero);
+    string = stringify(string);
+}

--- a/packages/integration-karma/test/component/default-export/x/component/nil.js
+++ b/packages/integration-karma/test/component/default-export/x/component/nil.js
@@ -1,0 +1,1 @@
+export default Math.random() < 0 ? 'foo' : null; // trick bundler/minifier into not dead-code-eliminating this

--- a/packages/integration-karma/test/component/default-export/x/component/string.js
+++ b/packages/integration-karma/test/component/default-export/x/component/string.js
@@ -1,0 +1,1 @@
+export default Math.random() < 0 ? 'foo' : 'bar'; // trick bundler/minifier into not dead-code-eliminating this

--- a/packages/integration-karma/test/component/default-export/x/component/undef.js
+++ b/packages/integration-karma/test/component/default-export/x/component/undef.js
@@ -1,0 +1,1 @@
+export default Math.random() < 0 ? 'foo' : undefined; // trick bundler/minifier into not dead-code-eliminating this

--- a/packages/integration-karma/test/component/default-export/x/component/zero.js
+++ b/packages/integration-karma/test/component/default-export/x/component/zero.js
@@ -1,0 +1,1 @@
+export default Math.random() < 0 ? 'foo' : 0; // trick bundler/minifier into not dead-code-eliminating this


### PR DESCRIPTION


## Details

Modules can export anything they want, including undefined and null. In those cases, our compiler automatically calls `registerComponent` on them.

Arguably we should not be calling `registerComponent` on those exports, but we do, so this PR fixes that case.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

Export null/undefined will not throw an error now.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10814962
