### PR TITLE
test(perf-benchmarks): set shadow mixed mode flag

### DIFF
--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-native-styled-component-create-10k-same.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-native-styled-component-create-10k-same.benchmark.js
@@ -12,6 +12,7 @@ const NUM_COMPONENTS = 10000;
 
 // Create 10k components with the same CSS in each component
 // These components are native, but run with synthetic shadow loaded (mixed mode)
+window.lwcRuntimeFlags.ENABLE_MIXED_SHADOW_MODE = true;
 StyledComponent.shadowSupportMode = 'any';
 styledComponentBenchmark(
     `ss-benchmark-styled-component/create/10k/same`,

--- a/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-native-styled-component-create-1k-different.benchmark.js
+++ b/packages/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-native-styled-component-create-1k-different.benchmark.js
@@ -12,6 +12,7 @@ const NUM_COMPONENTS = 1000;
 
 // Create 1k components with different CSS in each component
 // These components are native, but run with synthetic shadow loaded (mixed mode)
+window.lwcRuntimeFlags.ENABLE_MIXED_SHADOW_MODE = true;
 for (const component of components) {
     component.shadowSupportMode = 'any';
 }


### PR DESCRIPTION
## Details

In #2723 we disabled mixed mode by default, but we forgot to re-enable the flag for these perf tests, which are designed to test native-shadow-in-mixed-mode. (The flag was removed from the tests in #2611.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
