### PR TITLE
refactor(template-compiler): remove apis template fn argument

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -15,6 +15,8 @@ export { default as track } from './decorators/track';
 export { default as wire } from './decorators/wire';
 export { readonly } from './readonly';
 
+export { default as renderApi } from './api';
+
 export { setFeatureFlag, setFeatureFlagForTest } from '@lwc/features';
 
 // Internal APIs used by renderers -----------------------------------------------------------------

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -21,7 +21,6 @@ import {
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 
-import api, { RenderAPI } from './api';
 import {
     resetComponentRoot,
     runWithBoundaryProtection,
@@ -43,7 +42,7 @@ import { getTemplateOrSwappedTemplate, setActiveVM } from './hot-swaps';
 import { VNodes } from './vnodes';
 
 export interface Template {
-    (api: RenderAPI, cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
+    (cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
 
     /** The list of slot names used in the template. */
     slots?: string[];
@@ -199,7 +198,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 // Set the global flag that template is being updated
                 isUpdatingTemplate = true;
 
-                vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache);
+                vnodes = html.call(undefined, component, cmpSlots, context.tplCache);
                 const { styleVNode } = context;
                 if (!isNull(styleVNode)) {
                     ArrayUnshift.call(vnodes, styleVNode);

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -21,6 +21,7 @@ import {
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 
+import api, { RenderAPI } from './api';
 import {
     resetComponentRoot,
     runWithBoundaryProtection,
@@ -42,7 +43,7 @@ import { getTemplateOrSwappedTemplate, setActiveVM } from './hot-swaps';
 import { VNodes } from './vnodes';
 
 export interface Template {
-    (cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
+    (api: RenderAPI, cmp: object, slotSet: SlotSet, cache: TemplateCache): VNodes;
 
     /** The list of slot names used in the template. */
     slots?: string[];
@@ -198,7 +199,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 // Set the global flag that template is being updated
                 isUpdatingTemplate = true;
 
-                vnodes = html.call(undefined, component, cmpSlots, context.tplCache);
+                vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache);
                 const { styleVNode } = context;
                 if (!isNull(styleVNode)) {
                     ArrayUnshift.call(vnodes, styleVNode);

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -19,6 +19,7 @@ export {
     track,
     wire,
     readonly,
+    renderApi,
     unwrap,
     setFeatureFlag,
     setFeatureFlagForTest,

--- a/packages/@lwc/engine-server/src/index.ts
+++ b/packages/@lwc/engine-server/src/index.ts
@@ -18,6 +18,7 @@ export {
     track,
     wire,
     readonly,
+    renderApi,
     unwrap,
     setFeatureFlag,
     setFeatureFlagForTest,

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -88,7 +88,7 @@
     key: 0
   };
 
-  function tmpl$1($cmp, $slotset, $ctx) {
+  function tmpl$1($api, $cmp, $slotset, $ctx) {
     return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x))])];
     /*LWC compiler vX.X.X*/
   }
@@ -162,7 +162,7 @@
     key: 1
   };
 
-  function tmpl($cmp, $slotset, $ctx) {
+  function tmpl($api, $cmp, $slotset, $ctx) {
     return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_compat_config_simple_app.js
@@ -81,15 +81,15 @@
 
   var _implicitScopedStylesheets = undefined;
 
+  var api_dynamic_text = lwc.renderApi._ES5ProxyType ? lwc.renderApi.get("d") : lwc.renderApi.d,
+      api_text = lwc.renderApi._ES5ProxyType ? lwc.renderApi.get("t") : lwc.renderApi.t,
+      api_element$1 = lwc.renderApi._ES5ProxyType ? lwc.renderApi.get("h") : lwc.renderApi.h;
   var stc0$1 = {
     key: 0
   };
 
-  function tmpl$1($api, $cmp, $slotset, $ctx) {
-    var api_dynamic_text = $api._ES5ProxyType ? $api.get("d") : $api.d,
-        api_text = $api._ES5ProxyType ? $api.get("t") : $api.t,
-        api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
-    return [api_element("div", stc0$1, [api_text(api_dynamic_text($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x))])];
+  function tmpl$1($cmp, $slotset, $ctx) {
+    return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp._ES5ProxyType ? $cmp.get("x") : $cmp.x))])];
     /*LWC compiler vX.X.X*/
   }
 
@@ -147,6 +147,8 @@
     tmpl: _tmpl$1
   });
 
+  var api_custom_element = lwc.renderApi._ES5ProxyType ? lwc.renderApi.get("c") : lwc.renderApi.c,
+      api_element = lwc.renderApi._ES5ProxyType ? lwc.renderApi.get("h") : lwc.renderApi.h;
   var stc0 = {
     classMap: {
       "container": true
@@ -160,9 +162,7 @@
     key: 1
   };
 
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    var api_custom_element = $api._ES5ProxyType ? $api.get("c") : $api.c,
-        api_element = $api._ES5ProxyType ? $api.get("h") : $api.h;
+  function tmpl($cmp, $slotset, $ctx) {
     return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -10,12 +10,12 @@
 
     var _implicitScopedStylesheets = undefined;
 
+    const {d: api_dynamic_text, t: api_text, h: api_element$1} = lwc.renderApi;
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
-      return [api_element("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
+    function tmpl$1($cmp, $slotset, $ctx) {
+      return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
@@ -51,6 +51,7 @@
       tmpl: _tmpl$1
     });
 
+    const {c: api_custom_element, h: api_element} = lwc.renderApi;
     const stc0 = {
       classMap: {
         "container": true
@@ -63,8 +64,7 @@
       },
       key: 1
     };
-    function tmpl($api, $cmp, $slotset, $ctx) {
-      const {c: api_custom_element, h: api_element} = $api;
+    function tmpl($cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app.js
@@ -14,7 +14,7 @@
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($cmp, $slotset, $ctx) {
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
       return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
@@ -64,7 +64,7 @@
       },
       key: 1
     };
-    function tmpl($cmp, $slotset, $ctx) {
+    function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -18,7 +18,7 @@
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($cmp, $slotset, $ctx) {
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
       return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
@@ -68,7 +68,7 @@
       },
       key: 1
     };
-    function tmpl($cmp, $slotset, $ctx) {
+    function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_css_resolver.js
@@ -14,12 +14,12 @@
 
     var _implicitScopedStylesheets = undefined;
 
+    const {d: api_dynamic_text, t: api_text, h: api_element$1} = lwc.renderApi;
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
-      return [api_element("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
+    function tmpl$1($cmp, $slotset, $ctx) {
+      return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
@@ -55,6 +55,7 @@
       tmpl: _tmpl$1
     });
 
+    const {c: api_custom_element, h: api_element} = lwc.renderApi;
     const stc0 = {
       classMap: {
         "container": true
@@ -67,8 +68,7 @@
       },
       key: 1
     };
-    function tmpl($api, $cmp, $slotset, $ctx) {
-      const {c: api_custom_element, h: api_element} = $api;
+    function tmpl($cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -5,7 +5,7 @@
     const stc0 = {
       key: 0
     };
-    function tmpl($cmp, $slotset, $ctx) {
+    function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_element("h1", stc0, [api_text("hello")])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -1,11 +1,11 @@
 (function (lwc) {
     'use strict';
 
+    const {t: api_text, h: api_element} = lwc.renderApi;
     const stc0 = {
       key: 0
     };
-    function tmpl($api, $cmp, $slotset, $ctx) {
-      const {t: api_text, h: api_element} = $api;
+    function tmpl($cmp, $slotset, $ctx) {
       return [api_element("h1", stc0, [api_text("hello")])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -10,12 +10,12 @@
 
     var _implicitScopedStylesheets = undefined;
 
+    const {d: api_dynamic_text, t: api_text, h: api_element$1} = lwc.renderApi;
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
-      return [api_element("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
+    function tmpl$1($cmp, $slotset, $ctx) {
+      return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
@@ -51,6 +51,7 @@
       tmpl: _tmpl$1
     });
 
+    const {c: api_custom_element, h: api_element} = lwc.renderApi;
     const stc0 = {
       classMap: {
         "container": true
@@ -63,8 +64,7 @@
       },
       key: 1
     };
-    function tmpl($api, $cmp, $slotset, $ctx) {
-      const {c: api_custom_element, h: api_element} = $api;
+    function tmpl($cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_relative.js
@@ -14,7 +14,7 @@
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($cmp, $slotset, $ctx) {
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
       return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
@@ -64,7 +64,7 @@
       },
       key: 1
     };
-    function tmpl($cmp, $slotset, $ctx) {
+    function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("x-foo", _xFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
@@ -5,7 +5,7 @@
   const stc0 = {
     key: 0
   };
-  function tmpl($cmp, $slotset, $ctx) {
+  function tmpl($api, $cmp, $slotset, $ctx) {
     return [api_element("pre", stc0, [api_text(api_dynamic_text($cmp.hello))])];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_third_party.js
@@ -1,11 +1,11 @@
 (function (lwc) {
   'use strict';
 
+  const {d: api_dynamic_text, t: api_text, h: api_element} = lwc.renderApi;
   const stc0 = {
     key: 0
   };
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
+  function tmpl($cmp, $slotset, $ctx) {
     return [api_element("pre", stc0, [api_text(api_dynamic_text($cmp.hello))])];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -9,11 +9,11 @@
   stylesheet.$scoped$ = true;
   var _implicitScopedStylesheets = [stylesheet];
 
+  const {h: api_element} = lwc.renderApi;
   const stc0 = {
     key: 0
   };
-  function tmpl($api, $cmp, $slotset, $ctx) {
-    const {h: api_element} = $api;
+  function tmpl($cmp, $slotset, $ctx) {
     return [api_element("div", stc0)];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -13,7 +13,7 @@
   const stc0 = {
     key: 0
   };
-  function tmpl($cmp, $slotset, $ctx) {
+  function tmpl($api, $cmp, $slotset, $ctx) {
     return [api_element("div", stc0)];
     /*LWC compiler vX.X.X*/
   }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -14,7 +14,7 @@
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($cmp, $slotset, $ctx) {
+    function tmpl$1($api, $cmp, $slotset, $ctx) {
       return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
@@ -64,7 +64,7 @@
       },
       key: 1
     };
-    function tmpl($cmp, $slotset, $ctx) {
+    function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("ts-foo", _tsFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_ts_simple_app.js
@@ -10,12 +10,12 @@
 
     var _implicitScopedStylesheets = undefined;
 
+    const {d: api_dynamic_text, t: api_text, h: api_element$1} = lwc.renderApi;
     const stc0$1 = {
       key: 0
     };
-    function tmpl$1($api, $cmp, $slotset, $ctx) {
-      const {d: api_dynamic_text, t: api_text, h: api_element} = $api;
-      return [api_element("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
+    function tmpl$1($cmp, $slotset, $ctx) {
+      return [api_element$1("div", stc0$1, [api_text(api_dynamic_text($cmp.x))])];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl$1 = lwc.registerTemplate(tmpl$1);
@@ -51,6 +51,7 @@
       tmpl: _tmpl$1
     });
 
+    const {c: api_custom_element, h: api_element} = lwc.renderApi;
     const stc0 = {
       classMap: {
         "container": true
@@ -63,8 +64,7 @@
       },
       key: 1
     };
-    function tmpl($api, $cmp, $slotset, $ctx) {
-      const {c: api_custom_element, h: api_element} = $api;
+    function tmpl($cmp, $slotset, $ctx) {
       return [api_element("div", stc0, [api_custom_element("ts-foo", _tsFoo, stc1)])];
       /*LWC compiler vX.X.X*/
     }

--- a/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
@@ -65,7 +65,7 @@ it('should compile correctly simple components', () => {
             </div>
         </template>
     `);
-    renderFn({})(apis);
+    renderFn({}, apis)();
 
     expect(calls).toMatchObject([
         ['api_text#1', ['Hello']],
@@ -88,7 +88,7 @@ it('should look up for rendering a component', () => {
         </template>
     `);
 
-    renderFn(modules)(apis);
+    renderFn(modules, apis)();
 
     expect(calls).toMatchObject([
         ['api_component#1', ['x-foo', XFoo, { key: expect.any(Number) }]],
@@ -101,7 +101,7 @@ it('should should attach template metadata', () => {
             <slot name="foo"></slot>
         </template>
     `);
-    const tmpl = renderFn({});
+    const tmpl = renderFn({}, {});
 
     expect(tmpl.slots).toEqual(['foo']);
 });

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("iframe", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     allow: "geolocation https://google-developers.appspot.com",
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("iframe", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     src: "http://www.example.com/image.png",
@@ -20,8 +21,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("img", stc0),
     api_element("video", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -21,7 +21,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("img", stc0),
     api_element("video", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
@@ -1,14 +1,14 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  fid: api_scoped_frag_id,
+  t: api_text,
+  h: api_element,
+  gid: api_scoped_id,
+} = renderApi;
 const stc0 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    fid: api_scoped_frag_id,
-    t: api_text,
-    h: api_element,
-    gid: api_scoped_id,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "a",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
@@ -8,7 +8,7 @@ const {
 const stc0 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "a",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
@@ -1,14 +1,14 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  fid: api_scoped_frag_id,
+  t: api_text,
+  h: api_element,
+  gid: api_scoped_id,
+} = renderApi;
 const stc0 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    fid: api_scoped_frag_id,
-    t: api_text,
-    h: api_element,
-    gid: api_scoped_id,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "a",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
@@ -8,7 +8,7 @@ const {
 const stc0 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "a",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
@@ -21,7 +21,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("a", stc0, [api_text("Yasaka Taxi")]),
     api_element("map", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     href: "#yasaka-taxi",
@@ -20,8 +21,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("a", stc0, [api_text("Yasaka Taxi")]),
     api_element("map", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
@@ -1,7 +1,7 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, c: api_custom_element } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { gid: api_scoped_id, c: api_custom_element } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
@@ -1,7 +1,7 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
 const { gid: api_scoped_id, c: api_custom_element } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
@@ -1,5 +1,6 @@
 import _xButton from "x/button";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     Class: "r",
@@ -12,8 +13,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("x-button", _xButton, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
@@ -13,7 +13,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("x-button", _xButton, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
 const stc0 = {
   attrs: {
     hidden: "",
@@ -48,8 +49,7 @@ const stc7 = {
   },
   key: 9,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("boolean present")]),
     api_element("p", stc1, [api_text("empty string, should be true")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -49,7 +49,7 @@ const stc7 = {
   },
   key: 9,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("boolean present")]),
     api_element("p", stc1, [api_text("empty string, should be true")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -64,7 +64,7 @@ const stc8 = {
   },
   key: 9,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("input", stc0),
     api_element("input", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element, t: api_text, c: api_custom_element } = renderApi;
 const stc0 = {
   attrs: {
     required: "",
@@ -63,8 +64,7 @@ const stc8 = {
   },
   key: 9,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element, t: api_text, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("input", stc0),
     api_element("input", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
 const stc0 = {
   attrs: {
     hidden: "",
@@ -26,8 +27,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("x")]),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -27,7 +27,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("x")]),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("x")]),
     api_element("input", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     hidden: "",
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("p", stc0, [api_text("x")]),
     api_element("input", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     foo: true,
@@ -26,8 +27,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0),
     api_element("div", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -27,7 +27,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0),
     api_element("div", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("p", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("p", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -10,7 +10,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("p", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -9,8 +10,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("p", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
@@ -1,6 +1,7 @@
 import _nsBaz1 from "ns/baz1";
 import _nsBaz2 from "ns/baz2";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     accessKey: "with-hyphen",
@@ -13,8 +14,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("ns-baz-1", _nsBaz1, stc0),
     api_custom_element("ns-baz-2", _nsBaz2, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
@@ -14,7 +14,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("ns-baz-1", _nsBaz1, stc0),
     api_custom_element("ns-baz-2", _nsBaz2, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -1,5 +1,6 @@
 import _fooBar from "foo/bar";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element, c: api_custom_element } = renderApi;
 const stc0 = {
   attrs: {
     title: "",
@@ -13,8 +14,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("p", stc0), api_custom_element("foo-bar", _fooBar, stc1)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -14,7 +14,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("p", stc0), api_custom_element("foo-bar", _fooBar, stc1)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     type: "checkbox",
@@ -12,8 +13,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("input", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -13,7 +13,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("input", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -11,7 +11,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("textarea", stc1, [api_text("x")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -10,8 +11,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("textarea", stc1, [api_text("x")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -9,8 +10,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [api_element("p", stc1, [api_text("x")])]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -10,7 +10,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [api_element("p", stc1, [api_text("x")])]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -1,17 +1,17 @@
 import _xSubject from "x/subject";
 import _xDescription from "x/description";
 import _xTextarea from "x/textarea";
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    gid: api_scoped_id,
-    c: api_custom_element,
-    t: api_text,
-    h: api_element,
-    k: api_key,
-    i: api_iterator,
-    f: api_flatten,
-  } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const {
+  gid: api_scoped_id,
+  c: api_custom_element,
+  t: api_text,
+  h: api_element,
+  k: api_key,
+  i: api_iterator,
+  f: api_flatten,
+} = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return api_flatten([
     api_custom_element("x-subject", _xSubject, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -11,7 +11,7 @@ const {
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_custom_element("x-subject", _xSubject, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -1,6 +1,7 @@
 import _nsFoo from "ns/foo";
 import _nsBar from "ns/bar";
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const { gid: api_scoped_id, c: api_custom_element, h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     test: true,
@@ -40,8 +41,7 @@ const stc4 = {
 const stc5 = {
   "aria-hidden": "hidden",
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, c: api_custom_element, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("ns-foo", _nsFoo, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -41,7 +41,7 @@ const stc4 = {
 const stc5 = {
   "aria-hidden": "hidden",
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("ns-foo", _nsFoo, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
@@ -11,7 +11,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("lightning-combobox", _lightningCombobox, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
@@ -1,5 +1,6 @@
 import _lightningCombobox from "lightning/combobox";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     ariaDescribedBy: "not-scoped-foo",
@@ -10,8 +11,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("lightning-combobox", _lightningCombobox, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
@@ -1,7 +1,7 @@
 import _lightningCombobox from "lightning/combobox";
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, c: api_custom_element } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { gid: api_scoped_id, c: api_custom_element } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("lightning-combobox", _lightningCombobox, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
@@ -1,7 +1,7 @@
 import _lightningCombobox from "lightning/combobox";
 import { registerTemplate, renderApi } from "lwc";
 const { gid: api_scoped_id, c: api_custom_element } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("lightning-combobox", _lightningCombobox, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
@@ -19,7 +19,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     spellcheck: false,
@@ -18,8 +19,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     spellcheck: true,
@@ -18,8 +19,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
@@ -19,7 +19,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0),
     api_custom_element("x-foo", _xFoo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -36,7 +36,7 @@ const stc6 = {
   styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
   key: 6,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0),
     api_element("div", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   styleDecls: [["color", "blue", false]],
   key: 0,
@@ -35,8 +36,7 @@ const stc6 = {
   styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
   key: 6,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0),
     api_element("div", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
@@ -1,12 +1,12 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    ti: api_tab_index,
-    t: api_text,
-    h: api_element,
-    c: api_custom_element,
-  } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const {
+  ti: api_tab_index,
+  t: api_text,
+  h: api_element,
+  c: api_custom_element,
+} = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "p",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
@@ -6,7 +6,7 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "p",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("somefancytag", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     min: "4",
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("somefancytag", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -8,7 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("section", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     foo: true,
@@ -7,8 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("section", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_text("Hello world")];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_text("Hello world")];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", {
       style: $cmp.customStyle,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", {
       style: $cmp.customStyle,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   styleDecls: [
     ["background", "blue", true],
@@ -7,8 +8,7 @@ const stc0 = {
   ],
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -8,7 +8,7 @@ const stc0 = {
   ],
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -15,7 +15,7 @@ const stc1 = {
   ],
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("section", stc0), api_element("section", stc1)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   styleDecls: [
     ["font-size", "12px", false],
@@ -14,8 +15,7 @@ const stc1 = {
   ],
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("section", stc0), api_element("section", stc1)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
@@ -1,10 +1,10 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { k: api_key, h: api_element, i: api_iterator } = renderApi;
 const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, h: api_element, i: api_iterator } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "svg",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
@@ -4,7 +4,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "svg",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -11,7 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     "slds-button__icon": true,
@@ -10,8 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text("Root")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -3,7 +3,7 @@ const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text("Root")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_text("foo")];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_text("foo")];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { co: api_comment, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { co: api_comment, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_comment(" This is an HTML comment "),
     api_element("button", stc0, [api_text("click me")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -3,7 +3,7 @@ const { co: api_comment, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_comment(" This is an HTML comment "),
     api_element("button", stc0, [api_text("click me")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -10,7 +10,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -1,16 +1,16 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  co: api_comment,
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    co: api_comment,
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     $cmp.truthyValue ? api_comment(" HTML comment inside if:true ") : null,
     $cmp.truthyValue ? api_element("p", stc0, [api_text("true branch")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { co: api_comment, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { co: api_comment, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     $cmp.truthyValue ? api_comment(" HTML comment inside if:true ") : null,
     $cmp.truthyValue ? api_element("p", stc0, [api_text("true branch")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { co: api_comment, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { co: api_comment, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_comment(" This is an HTML comment "),
     api_element("button", stc0, [api_text("click me")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -3,7 +3,7 @@ const { co: api_comment, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_comment(" This is an HTML comment "),
     api_element("button", stc0, [api_text("click me")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -1,18 +1,18 @@
 import _xChild from "x/child";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  co: api_comment,
+  t: api_text,
+  h: api_element,
+  c: api_custom_element,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    co: api_comment,
-    t: api_text,
-    h: api_element,
-    c: api_custom_element,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-child", _xChild, stc0, [
       api_comment(" HTML comment inside slot "),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -12,7 +12,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-child", _xChild, stc0, [
       api_comment(" HTML comment inside slot "),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -11,7 +11,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_element("div", stc0, [api_text("sibling")]),
     api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -1,17 +1,17 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  t: api_text,
+  h: api_element,
+  dc: api_dynamic_component,
+  f: api_flatten,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    t: api_text,
-    h: api_element,
-    dc: api_dynamic_component,
-    f: api_flatten,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return api_flatten([
     api_element("div", stc0, [api_text("sibling")]),
     api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { dc: api_dynamic_component, f: api_flatten } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { dc: api_dynamic_component, f: api_flatten } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return api_flatten([
     api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
   ]);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
@@ -3,7 +3,7 @@ const { dc: api_dynamic_component, f: api_flatten } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
   ]);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -1,4 +1,11 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  t: api_text,
+  i: api_iterator,
+  h: api_element,
+  f: api_flatten,
+  k: api_key,
+} = renderApi;
 const stc0 = {
   classMap: {
     s1: true,
@@ -36,14 +43,7 @@ const stc7 = {
 const stc8 = {
   key: 10,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    t: api_text,
-    i: api_iterator,
-    h: api_element,
-    f: api_flatten,
-    k: api_key,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -43,7 +43,7 @@ const stc7 = {
 const stc8 = {
   key: 10,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
@@ -1,4 +1,11 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,14 +15,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
@@ -15,7 +15,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
@@ -18,7 +18,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
@@ -1,4 +1,11 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,14 +18,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -1,19 +1,19 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+  f: api_flatten,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-    f: api_flatten,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -13,7 +13,7 @@ const stc0 = {
 const stc1 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { k: api_key, t: api_text, h: api_element, i: api_iterator } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, t: api_text, h: api_element, i: api_iterator } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
@@ -13,7 +13,7 @@ const stc0 = {
 const stc1 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
@@ -1,19 +1,19 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+  f: api_flatten,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-    f: api_flatten,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,8 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
@@ -12,7 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, d: api_dynamic_text } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, d: api_dynamic_text } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue === true ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue === true ? api_element("p", stc1, [api_text("1")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.state.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
@@ -3,7 +3,7 @@ const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.state.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
     !$cmp.isTrue2 ? api_element("p", stc1, [api_text("2")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
     !$cmp.isTrue2 ? api_element("p", stc1, [api_text("2")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
     $cmp.isTrue ? api_element("p", stc1, [api_text("2")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
     $cmp.isTrue ? api_element("p", stc1, [api_text("2")]) : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,8 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("1")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -12,7 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("1")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
@@ -3,7 +3,7 @@ const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       $cmp.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
@@ -1,5 +1,13 @@
 import _aB from "a/b";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  shc: api_sanitize_html_content,
+  h: api_element,
+  k: api_key,
+  i: api_iterator,
+  f: api_flatten,
+  c: api_custom_element,
+} = renderApi;
 const stc0 = {
   classMap: {
     s2: true,
@@ -11,15 +19,7 @@ const stc1 = {
     dom: "manual",
   },
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    shc: api_sanitize_html_content,
-    h: api_element,
-    k: api_key,
-    i: api_iterator,
-    f: api_flatten,
-    c: api_custom_element,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element(
       "a-b",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
@@ -19,7 +19,7 @@ const stc1 = {
     dom: "manual",
   },
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element(
       "a-b",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
@@ -1,11 +1,11 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { shc: api_sanitize_html_content, h: api_element } = renderApi;
 const stc0 = {
   lwc: {
     dom: "manual",
   },
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { shc: api_sanitize_html_content, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("div", {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
@@ -5,7 +5,7 @@ const stc0 = {
     dom: "manual",
   },
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("div", {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
@@ -12,7 +12,7 @@ const stc0 = {
 const stc1 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
@@ -1,18 +1,18 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
@@ -12,7 +12,7 @@ const stc0 = {
 const stc1 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
@@ -1,18 +1,18 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
@@ -1,17 +1,17 @@
 import _nsItem from "ns/item";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  c: api_custom_element,
+  i: api_iterator,
+  h: api_element,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    c: api_custom_element,
-    i: api_iterator,
-    h: api_element,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
@@ -11,7 +11,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "ul",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
@@ -1,4 +1,11 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,14 +15,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
@@ -15,7 +15,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
@@ -6,7 +6,7 @@ const {
   h: api_element,
   i: api_iterator,
 } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_iterator($cmp.features, function (feature) {
     return api_iterator(
       feature.innerFeatures,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return api_iterator($cmp.features, function (feature) {
     return api_iterator(
       feature.innerFeatures,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -12,7 +12,7 @@ const stc0 = {
 const stc1 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -1,18 +1,18 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -3,7 +3,7 @@ const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text("Root")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -3,7 +3,7 @@ const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text("Root")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot, f: api_flatten } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,8 +12,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot, f: api_flatten } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return api_flatten([
     api_element("p", stc0, [api_text("Root")]),
     api_slot("", stc1, [api_text("Default")], $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -12,7 +12,7 @@ const stc2 = {
   },
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_element("p", stc0, [api_text("Root")]),
     api_slot("", stc1, [api_text("Default")], $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
@@ -1,10 +1,10 @@
 import _nsFoo from "ns/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { b: api_bind, c: api_custom_element, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { b: api_bind, c: api_custom_element, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   const { _m0 } = $ctx;
   return [
     api_element("section", stc0, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
@@ -4,7 +4,7 @@ const { b: api_bind, c: api_custom_element, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0 } = $ctx;
   return [
     api_element("section", stc0, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
@@ -3,7 +3,7 @@ const { b: api_bind, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0, _m1 } = $ctx;
   return [
     api_element("section", stc0, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { b: api_bind, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { b: api_bind, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   const { _m0, _m1 } = $ctx;
   return [
     api_element("section", stc0, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { b: api_bind, t: api_text, h: api_element } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { b: api_bind, t: api_text, h: api_element } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   const { _m0, _m1, _m2, _m3 } = $ctx;
   return [
     api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { b: api_bind, t: api_text, h: api_element } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0, _m1, _m2, _m3 } = $ctx;
   return [
     api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
@@ -3,7 +3,7 @@ const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
@@ -3,7 +3,7 @@ const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
@@ -1,11 +1,11 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    d: api_dynamic_text,
-    t: api_text,
-    i: api_iterator,
-    f: api_flatten,
-  } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const {
+  d: api_dynamic_text,
+  t: api_text,
+  i: api_iterator,
+  f: api_flatten,
+} = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return api_flatten([
     api_text(
       api_dynamic_text($cmp.val) +

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
@@ -5,7 +5,7 @@ const {
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_text(
       api_dynamic_text($cmp.val) +

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   props: {
     value: "{value}",
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("input", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("input", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
@@ -1,6 +1,6 @@
-import { registerTemplate } from "lwc";
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text } = $api;
+import { registerTemplate, renderApi } from "lwc";
+const { d: api_dynamic_text, t: api_text } = renderApi;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_text(api_dynamic_text($cmp.text))];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { d: api_dynamic_text, t: api_text } = renderApi;
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_text(api_dynamic_text($cmp.text))];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
@@ -3,7 +3,7 @@ const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text(api_dynamic_text($cmp.text))])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("p", stc0, [api_text(api_dynamic_text($cmp.text))])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -16,7 +16,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("unknonwtag", stc0),
     api_custom_element("x-custom-component", _xCustomComponent, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -1,5 +1,6 @@
 import _xCustomComponent from "x/customComponent";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element, c: api_custom_element, t: api_text } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -15,8 +16,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element, c: api_custom_element, t: api_text } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("unknonwtag", stc0),
     api_custom_element("x-custom-component", _xCustomComponent, stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   context: {
     lwc: {
@@ -7,8 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
@@ -8,7 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   context: {
     lwc: {
@@ -7,8 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
@@ -8,7 +8,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text(api_dynamic_text($cmp.obj.sub))]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { d: api_dynamic_text, t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text(api_dynamic_text($cmp.obj.sub))]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -3,7 +3,7 @@ const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("div", stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -3,7 +3,7 @@ const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("h1", stc0, [api_text("hello")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -1,9 +1,9 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("h1", stc0, [api_text("hello")])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -6,8 +7,7 @@ const stc1 = [];
 const stc2 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_slot("", stc0, stc1, $slotset),
     api_slot("", stc2, stc1, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
@@ -7,7 +7,7 @@ const stc1 = [];
 const stc2 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_slot("", stc0, stc1, $slotset),
     api_slot("", stc2, stc1, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
@@ -13,7 +13,7 @@ const stc2 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_slot("foo", stc0, stc1, $slotset),
     api_slot("foo", stc2, stc1, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { s: api_slot } = renderApi;
 const stc0 = {
   attrs: {
     name: "foo",
@@ -12,8 +13,7 @@ const stc2 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_slot("foo", stc0, stc1, $slotset),
     api_slot("foo", stc2, stc1, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
@@ -9,7 +9,7 @@ const {
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
@@ -1,15 +1,15 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  d: api_dynamic_text,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    d: api_dynamic_text,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element(
       "section",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate } from "lwc";
 const stc0 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return stc0;
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
@@ -1,7 +1,6 @@
 import { registerTemplate } from "lwc";
 const stc0 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {} = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return stc0;
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
@@ -7,7 +7,7 @@ const stc0 = {
   key: 1,
 };
 const stc1 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_iterator($cmp.items, function (item) {
     return api_element(
       "div",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = renderApi;
 const stc0 = {
   attrs: {
     name: "james",
@@ -6,8 +7,7 @@ const stc0 = {
   key: 1,
 };
 const stc1 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return api_iterator($cmp.items, function (item) {
     return api_element(
       "div",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
@@ -4,7 +4,7 @@ const stc0 = {
   key: 1,
 };
 const stc1 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return api_iterator($cmp.items, function (item) {
     return api_element(
       "div",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
@@ -1,10 +1,10 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = renderApi;
 const stc0 = {
   key: 1,
 };
 const stc1 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return api_iterator($cmp.items, function (item) {
     return api_element(
       "div",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
@@ -1,5 +1,6 @@
 import _xCmp from "x/cmp";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   classMap: {
     foo: true,
@@ -9,8 +10,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("x-cmp", _xCmp, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
@@ -10,7 +10,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("x-cmp", _xCmp, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("color-profile", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
   },
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("section", stc0, [api_element("color-profile", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
@@ -1,13 +1,13 @@
 import _xTest from "x/test";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   props: {
     json: '[{"column":"ID","value":"5e","operator":"equals","f":true}]',
   },
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("x-test", _xTest, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
@@ -7,7 +7,7 @@ const stc0 = {
   },
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("x-test", _xTest, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -1,16 +1,16 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  b: api_bind,
+  t: api_text,
+  h: api_element,
+  k: api_key,
+  d: api_dynamic_text,
+  i: api_iterator,
+} = renderApi;
 const stc0 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    b: api_bind,
-    t: api_text,
-    h: api_element,
-    k: api_key,
-    d: api_dynamic_text,
-    i: api_iterator,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   const { _m0 } = $ctx;
   return [
     api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -10,7 +10,7 @@ const {
 const stc0 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0 } = $ctx;
   return [
     api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -1,12 +1,12 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("h1", stc0, [api_text("hello")]),
     api_element("br", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -6,7 +6,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("h1", stc0, [api_text("hello")]),
     api_element("br", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -1,13 +1,13 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  t: api_text,
+  k: api_key,
+  h: api_element,
+  i: api_iterator,
+  f: api_flatten,
+} = renderApi;
 const stc0 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    t: api_text,
-    k: api_key,
-    h: api_element,
-    i: api_iterator,
-    f: api_flatten,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return $cmp.isTrue
     ? api_flatten([
         api_text("Outer"),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -7,7 +7,7 @@ const {
   f: api_flatten,
 } = renderApi;
 const stc0 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return $cmp.isTrue
     ? api_flatten([
         api_text("Outer"),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -9,7 +9,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_slot(
       "secret-slot",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   attrs: {
     name: "secret-slot",
@@ -8,8 +9,7 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_slot(
       "secret-slot",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("table", stc0, [
       api_element("tbody", stc1, [api_element("tr", stc2)]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("table", stc0, [
       api_element("tbody", stc1, [api_element("tr", stc2)]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
@@ -4,7 +4,7 @@ const { c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("x-test", _xTest, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
@@ -1,10 +1,10 @@
 import _xTest from "x/test";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("x-test", _xTest, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
@@ -8,7 +8,7 @@ const stc1 = {
   key: 1,
 };
 const stc2 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0, [
       api_slot("", stc1, stc2, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
@@ -1,5 +1,6 @@
 import _xFoo from "x/foo";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { s: api_slot, c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -7,8 +8,7 @@ const stc1 = {
   key: 1,
 };
 const stc2 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-foo", _xFoo, stc0, [
       api_slot("", stc1, stc2, $slotset),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -17,8 +18,7 @@ const stc3 = {
 const stc4 = {
   key: 4,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -18,7 +18,7 @@ const stc3 = {
 const stc4 = {
   key: 4,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,8 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("Sibling")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -12,7 +12,7 @@ const stc2 = {
 const stc3 = {
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("Sibling")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -8,8 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -9,7 +9,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -32,8 +33,7 @@ const stc7 = {
 const stc8 = {
   key: 8,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("Before header")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -33,7 +33,7 @@ const stc7 = {
 const stc8 = {
   key: 8,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("p", stc1, [api_text("Before header")]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -17,7 +17,7 @@ const stc2 = {
   key: 2,
 };
 const stc3 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0, [
       api_custom_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -1,5 +1,12 @@
 import _xB from "x/b";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  h: api_element,
+  t: api_text,
+  i: api_iterator,
+  f: api_flatten,
+  c: api_custom_element,
+} = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -10,14 +17,7 @@ const stc2 = {
   key: 2,
 };
 const stc3 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    h: api_element,
-    t: api_text,
-    i: api_iterator,
-    f: api_flatten,
-    c: api_custom_element,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0, [
       api_custom_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
@@ -4,7 +4,7 @@ const { c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_custom_element("x-cmp", _xCmp, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
@@ -1,10 +1,10 @@
 import _xCmp from "x/cmp";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_custom_element("x-cmp", _xCmp, stc0)];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -14,7 +14,7 @@ const stc0 = {
   key: 0,
 };
 const stc1 = [];
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element(
       "a-b",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -1,5 +1,12 @@
 import _aB from "a/b";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const {
+  k: api_key,
+  t: api_text,
+  h: api_element,
+  i: api_iterator,
+  c: api_custom_element,
+} = renderApi;
 const stc0 = {
   classMap: {
     s2: true,
@@ -7,14 +14,7 @@ const stc0 = {
   key: 0,
 };
 const stc1 = [];
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const {
-    k: api_key,
-    t: api_text,
-    h: api_element,
-    i: api_iterator,
-    c: api_custom_element,
-  } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_custom_element(
       "a-b",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
@@ -1,5 +1,6 @@
 import _nsCmp from "ns/cmp";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -18,8 +19,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
@@ -19,7 +19,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -12,7 +12,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, s: api_slot } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -11,8 +12,7 @@ const stc1 = {
 const stc2 = {
   key: 2,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, s: api_slot } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_slot(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
@@ -1,5 +1,6 @@
 import _nsCmp from "ns/cmp";
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -18,8 +19,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element, c: api_custom_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
@@ -19,7 +19,7 @@ const stc3 = {
   },
   key: 3,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { gid: api_scoped_id, h: api_element, t: api_text } = renderApi;
 const stc0 = {
   attrs: {
     width: "400",
@@ -389,8 +390,7 @@ const stc42 = {
   key: 46,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, h: api_element, t: api_text } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -390,7 +390,7 @@ const stc42 = {
   key: 46,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { t: api_text, h: api_element } = renderApi;
 const stc0 = {
   key: 0,
 };
@@ -36,8 +37,7 @@ const stc4 = {
 const stc5 = {
   key: 5,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0, [
       api_element("svg", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -37,7 +37,7 @@ const stc4 = {
 const stc5 = {
   key: 5,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("div", stc0, [
       api_element("svg", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { gid: api_scoped_id, h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     height: "150",
@@ -44,8 +45,7 @@ const stc4 = {
   key: 5,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -45,7 +45,7 @@ const stc4 = {
   key: 5,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
@@ -17,7 +17,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
@@ -1,4 +1,9 @@
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const {
+  gid: api_scoped_id,
+  h: api_element,
+  fid: api_scoped_frag_id,
+} = renderApi;
 const stc0 = {
   attrs: {
     width: "100px",
@@ -12,8 +17,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, h: api_element, fid: api_scoped_frag_id } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
@@ -17,7 +17,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
@@ -1,4 +1,9 @@
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const {
+  gid: api_scoped_id,
+  h: api_element,
+  fid: api_scoped_frag_id,
+} = renderApi;
 const stc0 = {
   attrs: {
     width: "100px",
@@ -12,8 +17,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, h: api_element, fid: api_scoped_frag_id } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element, t: api_text } = renderApi;
 const stc0 = {
   attrs: {
     version: "1.1",
@@ -40,8 +41,7 @@ const stc3 = {
   key: 3,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element, t: api_text } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("rect", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -41,7 +41,7 @@ const stc3 = {
   key: 3,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("rect", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -11,7 +11,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("svg", stc0, [api_element("path", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     xmlns: "http://www.w3.org/2000/svg",
@@ -10,8 +11,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("svg", stc0, [api_element("path", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   attrs: {
     width: "200",
@@ -18,8 +19,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [api_element("svg", stc0, [api_element("image", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -19,7 +19,7 @@ const stc1 = {
   key: 1,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_element("svg", stc0, [api_element("image", stc1)])];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate } from "lwc";
+import { registerTemplate, renderApi } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   key: 0,
   svg: true,
@@ -87,8 +88,7 @@ const stc21 = {
   key: 21,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("a", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -88,7 +88,7 @@ const stc21 = {
   key: 21,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("a", stc1),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const { fid: api_scoped_frag_id, h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     "slds-icon": true,
@@ -10,8 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { fid: api_scoped_frag_id, h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-expression-value/expected.js
@@ -11,7 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -1,4 +1,5 @@
-import { registerTemplate, sanitizeAttribute } from "lwc";
+import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
+const { h: api_element } = renderApi;
 const stc0 = {
   classMap: {
     "slds-icon": true,
@@ -10,8 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($api, $cmp, $slotset, $ctx) {
-  const { h: api_element } = $api;
+function tmpl($cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -11,7 +11,7 @@ const stc0 = {
   key: 0,
   svg: true,
 };
-function tmpl($cmp, $slotset, $ctx) {
+function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("svg", stc0, [
       api_element("use", {

--- a/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
@@ -9,7 +9,11 @@ import * as t from '../../shared/estree';
 import { TEMPLATE_FUNCTION_NAME, TEMPLATE_MODULES_PARAMETER } from '../../shared/constants';
 
 import CodeGen from '../codegen';
-import { identifierFromComponentName, generateTemplateMetadata } from '../helpers';
+import {
+    identifierFromComponentName,
+    generateTemplateMetadata,
+    generateApisInitialization,
+} from '../helpers';
 import { optimizeStaticExpressions } from '../optimize';
 
 /**
@@ -32,6 +36,7 @@ import { optimizeStaticExpressions } from '../optimize';
  * ```
  */
 export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
+    const apisInit = generateApisInitialization(codeGen);
     const lookups = Array.from(codeGen.referencedComponents)
         .sort()
         .map((name) => {
@@ -52,6 +57,7 @@ export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.P
     const metadata = generateTemplateMetadata(codeGen);
 
     return t.program([
+        ...apisInit,
         ...lookups,
         ...optimizedTemplateDeclarations,
         ...metadata,

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -13,7 +13,11 @@ import {
 } from '../../shared/constants';
 
 import CodeGen from '../codegen';
-import { identifierFromComponentName, generateTemplateMetadata } from '../helpers';
+import {
+    identifierFromComponentName,
+    generateTemplateMetadata,
+    generateApisInitialization,
+} from '../helpers';
 import { optimizeStaticExpressions } from '../optimize';
 
 function generateComponentImports(codeGen: CodeGen): t.ImportDeclaration[] {
@@ -57,6 +61,8 @@ function generateLwcApisImport(codeGen: CodeGen): t.ImportDeclaration {
  * ```
  */
 export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
+    const apisInit = generateApisInitialization(codeGen);
+
     codeGen.usedLwcApis.add(SECURE_REGISTER_TEMPLATE_METHOD_NAME);
 
     const imports = [...generateComponentImports(codeGen), generateLwcApisImport(codeGen)];
@@ -66,6 +72,7 @@ export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.P
     const optimizedTemplateDeclarations = optimizeStaticExpressions(templateFn);
 
     const templateBody = [
+        ...apisInit,
         ...optimizedTemplateDeclarations,
         t.exportDefaultDeclaration(
             t.callExpression(t.identifier(SECURE_REGISTER_TEMPLATE_METHOD_NAME), [

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -15,7 +15,7 @@ import {
     isIf,
     isDynamicDirective,
 } from '../shared/ast';
-import { TEMPLATE_FUNCTION_NAME, TEMPLATE_PARAMS } from '../shared/constants';
+import { RENDER_API, TEMPLATE_FUNCTION_NAME, TEMPLATE_PARAMS } from '../shared/constants';
 
 import CodeGen from './codegen';
 
@@ -161,6 +161,31 @@ export function generateTemplateMetadata(codeGen: CodeGen): t.Statement[] {
     }
 
     return metadataExpressions;
+}
+
+/**
+ * @todo: probably a better location is module.ts.
+ * @param codeGen
+ */
+export function generateApisInitialization(codeGen: CodeGen): t.VariableDeclaration[] {
+    if (Object.keys(codeGen.usedApis).length === 0) {
+        return [];
+    }
+
+    codeGen.usedLwcApis.add(RENDER_API);
+
+    return [
+        t.variableDeclaration('const', [
+            t.variableDeclarator(
+                t.objectPattern(
+                    Object.keys(codeGen.usedApis).map((name) =>
+                        t.assignmentProperty(t.identifier(name), codeGen.usedApis[name])
+                    )
+                ),
+                t.identifier(RENDER_API)
+            ),
+        ]),
+    ];
 }
 
 const DECLARATION_DELIMITER = /;(?![^(]*\))/g;

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -528,25 +528,11 @@ function transform(codeGen: CodeGen): t.Expression {
 function generateTemplateFunction(codeGen: CodeGen): t.FunctionDeclaration {
     const returnedValue = transform(codeGen);
 
-    const args = [
-        TEMPLATE_PARAMS.API,
-        TEMPLATE_PARAMS.INSTANCE,
-        TEMPLATE_PARAMS.SLOT_SET,
-        TEMPLATE_PARAMS.CONTEXT,
-    ].map((id) => t.identifier(id));
+    const args = [TEMPLATE_PARAMS.INSTANCE, TEMPLATE_PARAMS.SLOT_SET, TEMPLATE_PARAMS.CONTEXT].map(
+        (id) => t.identifier(id)
+    );
 
-    const body: t.Statement[] = [
-        t.variableDeclaration('const', [
-            t.variableDeclarator(
-                t.objectPattern(
-                    Object.keys(codeGen.usedApis).map((name) =>
-                        t.assignmentProperty(t.identifier(name), codeGen.usedApis[name])
-                    )
-                ),
-                t.identifier(TEMPLATE_PARAMS.API)
-            ),
-        ]),
-    ];
+    const body: t.Statement[] = [];
 
     if (codeGen.memorizedIds.length) {
         body.push(

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -528,9 +528,12 @@ function transform(codeGen: CodeGen): t.Expression {
 function generateTemplateFunction(codeGen: CodeGen): t.FunctionDeclaration {
     const returnedValue = transform(codeGen);
 
-    const args = [TEMPLATE_PARAMS.INSTANCE, TEMPLATE_PARAMS.SLOT_SET, TEMPLATE_PARAMS.CONTEXT].map(
-        (id) => t.identifier(id)
-    );
+    const args = [
+        TEMPLATE_PARAMS.API,
+        TEMPLATE_PARAMS.INSTANCE,
+        TEMPLATE_PARAMS.SLOT_SET,
+        TEMPLATE_PARAMS.CONTEXT,
+    ].map((id) => t.identifier(id));
 
     const body: t.Statement[] = [];
 

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -21,7 +21,7 @@ import parseTemplate from './parser';
 import generate from './codegen';
 
 import { TemplateCompileResult, TemplateParseResult } from './shared/types';
-import { TEMPLATE_MODULES_PARAMETER } from './shared/constants';
+import { RENDER_API, TEMPLATE_MODULES_PARAMETER } from './shared/constants';
 
 export * from './shared/types';
 export { Config } from './config';
@@ -83,5 +83,5 @@ export function compileToFunction(source: string): Function {
     }
 
     const code = generate(parsingResults.root, options);
-    return new Function(TEMPLATE_MODULES_PARAMETER, code);
+    return new Function(TEMPLATE_MODULES_PARAMETER, RENDER_API, code);
 }

--- a/packages/@lwc/template-compiler/src/shared/constants.ts
+++ b/packages/@lwc/template-compiler/src/shared/constants.ts
@@ -6,13 +6,13 @@
  */
 export const SECURE_REGISTER_TEMPLATE_METHOD_NAME = 'registerTemplate';
 export const LWC_MODULE_NAME = 'lwc';
+export const RENDER_API = 'renderApi';
 export const TEMPLATE_MODULES_PARAMETER: string = 'modules';
 
 export const TEMPLATE_FUNCTION_NAME: string = 'tmpl';
 
 export const TEMPLATE_PARAMS: { [label: string]: string } = {
     INSTANCE: '$cmp',
-    API: '$api',
     SLOT_SET: '$slotset',
     CONTEXT: '$ctx',
 };

--- a/packages/@lwc/template-compiler/src/shared/constants.ts
+++ b/packages/@lwc/template-compiler/src/shared/constants.ts
@@ -13,6 +13,7 @@ export const TEMPLATE_FUNCTION_NAME: string = 'tmpl';
 
 export const TEMPLATE_PARAMS: { [label: string]: string } = {
     INSTANCE: '$cmp',
+    API: '$api',
     SLOT_SET: '$slotset',
     CONTEXT: '$ctx',
 };


### PR DESCRIPTION
## Details

This PR exposes the renderApi into the `lwc` module, so we can remove the `$api` argument in the template function of the module in favor of hoisting the used apis outside the template function.

The changes on this PR are required for #2688.

Commits:
- [0f98091](https://github.com/salesforce/lwc/pull/2758/commits/0f9809114c5294271166cb233569fe664925af06)[](https://github.com/jodarove) contains the functional changes (desired)
- [4bff6d1](https://github.com/salesforce/lwc/pull/2758/commits/4bff6d17608627ccb851819e72ff00ae5ff9b1ff) updates the snapshots.
- [25f64ec](https://github.com/salesforce/lwc/pull/2758/commits/25f64ec08ee7a924f79bef0ec75f05a58eb24409) adds support for the legacy API (act compiler).

Note: As part of this PR, I noticed two things:

1. In our codebase, `compileToFunction` is only used for test, and only 4 tests, opened #2757 to remove it.
2. We need to support the legacy tpl format too because of the ACT compiler or (my preference) we could modify the ACT compiler so it matches the new compilation output.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce an observable change. (as it is)
* 🚨 Yes, it does introduce a breaking change. (desired, which needs act compiler modifications)


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change. (as it is)
* ⚠️ Yes, it does include an observable change. (if we decide to update the ACT compiler)

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
