### PR TITLE
chore(build): add dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ packages/integration-tests/.env
 # custom node_modules for testing
 !packages/@lwc/module-resolver/src/__tests__/**/node_modules/
 !packages/@lwc/rollup-plugin/src/__tests__/**/node_modules/
+
+# dev mode caches
+tsconfig.tsbuildinfo
+.rollup.cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ If this fails with an error about *UNABLE_TO_GET_ISSUER_CERT_LOCALLY*, *Error: u
 yarn build
 ```
 
+## Dev / watch mode
+
+```bash
+yarn dev
+```
+
 ## Testing
 
 ### Unit Testing LWC

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:performance": "yarn run build:performance:components && yarn run build:performance:benchmarks",
     "build:performance:components": "lerna exec --scope perf-benchmarks-components -- yarn build",
     "build:performance:benchmarks": "lerna exec --scope perf-benchmarks -- yarn build",
+    "dev": "lerna run dev --parallel --ignore perf-benchmarks --ignore perf-benchmarks-components --ignore integration-tests",
     "test": "jest --config ./scripts/jest/root.config.js",
     "test:debug": "node --inspect node_modules/.bin/jest --config ./scripts/jest/root.config.js --runInBand --watch",
     "test:ci": "yarn test --no-cache --coverage --runInBand",

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -16,7 +16,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc && node ./scripts/update-compiler-version.js"
+        "build": "tsc && node ./scripts/update-compiler-version.js",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -17,7 +17,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-core/scripts/rollup.config.js
+++ b/packages/@lwc/engine-core/scripts/rollup.config.js
@@ -10,7 +10,7 @@
 const path = require('path');
 
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('@rollup/plugin-typescript');
+const typescript = require('../../../../scripts/rollup/typescript');
 const lwcFeatures = require('../../../../scripts/rollup/lwcFeatures');
 const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 
@@ -36,17 +36,13 @@ module.exports = {
         nodeResolve({
             resolveOnly: [/^@lwc\//, 'observable-membrane'],
         }),
-        typescriptPlugin({
-            target: 'es2017',
-            tsconfig: path.join(__dirname, '../tsconfig.json'),
-            noEmitOnError: true,
-        }),
+        typescript(),
         writeDistAndTypes(),
         lwcFeatures(),
     ],
 
     onwarn({ code, message }) {
-        if (code !== 'CIRCULAR_DEPENDENCY') {
+        if (!process.env.ROLLUP_WATCH && code !== 'CIRCULAR_DEPENDENCY') {
             throw new Error(message);
         }
     },

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -17,7 +17,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -9,7 +9,7 @@
 
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('@rollup/plugin-typescript');
+const typescript = require('../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../package.json');
 
@@ -33,16 +33,12 @@ module.exports = {
         nodeResolve({
             resolveOnly: [/^@lwc\//],
         }),
-        typescriptPlugin({
-            target: 'es2017',
-            tsconfig: path.join(__dirname, '../tsconfig.json'),
-            noEmitOnError: true,
-        }),
+        typescript(),
         writeDistAndTypes(),
     ],
 
     onwarn({ code, message }) {
-        if (code !== 'CIRCULAR_DEPENDENCY') {
+        if (!process.env.ROLLUP_WATCH && code !== 'CIRCULAR_DEPENDENCY') {
             throw new Error(message);
         }
     },

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -17,7 +17,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config scripts/rollup.config.js"
+        "build": "rollup --config scripts/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -7,7 +7,7 @@
 
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescriptPlugin = require('@rollup/plugin-typescript');
+const typescript = require('../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../package.json');
 
@@ -31,16 +31,12 @@ module.exports = {
         nodeResolve({
             resolveOnly: [/^@lwc\//],
         }),
-        typescriptPlugin({
-            target: 'es2017',
-            tsconfig: path.join(__dirname, '../tsconfig.json'),
-            noEmitOnError: true,
-        }),
+        typescript(),
         writeDistAndTypes(),
     ],
 
     onwarn({ code, message }) {
-        if (code !== 'CIRCULAR_DEPENDENCY') {
+        if (!process.env.ROLLUP_WATCH && code !== 'CIRCULAR_DEPENDENCY') {
             throw new Error(message);
         }
     },

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -16,7 +16,8 @@
     "typings": "dist/types/index.d.ts",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc"
+        "build": "tsc",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -17,7 +17,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/features/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/features/scripts/rollup/rollup.config.js
@@ -6,8 +6,7 @@
  */
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescript = require('@rollup/plugin-typescript');
-
+const typescript = require('../../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version, dependencies, peerDependencies } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/flags.ts');
@@ -32,11 +31,7 @@ function rollupConfig({ format }) {
             nodeResolve({
                 resolveOnly: [/^@lwc\//],
             }),
-            typescript({
-                target: 'es2017',
-                tsconfig: path.join(__dirname, '../../tsconfig.json'),
-                noEmitOnError: true,
-            }),
+            typescript(),
             writeDistAndTypes(),
         ],
         external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -14,7 +14,8 @@
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "license": "MIT",
     "files": [

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -16,7 +16,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc"
+        "build": "tsc",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -18,6 +18,7 @@
     "scripts": {
         "build": "rollup --config ./scripts/rollup/rollup.config.js",
         "postbuild": "node ../../../scripts/tasks/verify-treeshakable.js ./dist/index.js",
+        "dev": "rollup  --config scripts/rollup/rollup.config.js --watch --no-watch.clearScreen",
         "clean": "rm -rf dist/ types/"
     },
     "files": [

--- a/packages/@lwc/shared/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/shared/scripts/rollup/rollup.config.js
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const path = require('path');
-const typescript = require('@rollup/plugin-typescript');
 const replace = require('@rollup/plugin-replace');
+const typescript = require('../../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
@@ -31,11 +31,7 @@ function rollupConfig({ format }) {
                 preventAssignment: true,
                 'process.env.LWC_VERSION': JSON.stringify(version),
             }),
-            typescript({
-                target: 'es2017',
-                tsconfig: path.join(__dirname, '../../tsconfig.json'),
-                noEmitOnError: true,
-            }),
+            typescript(),
             writeDistAndTypes(),
         ],
     };

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -16,7 +16,8 @@
     "types": "dist/types/index.d.ts",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc"
+        "build": "tsc",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -16,7 +16,8 @@
     "module": "dist/synthetic-shadow.js",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/"

--- a/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/synthetic-shadow/scripts/rollup/rollup.config.js
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const path = require('path');
-const rollupTypescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const typescript = require('../../../../../scripts/rollup/typescript');
 const lwcFeatures = require('../../../../../scripts/rollup/lwcFeatures');
 const { version } = require('../../package.json');
 
@@ -39,13 +39,14 @@ function rollupConfig({ wrap } = {}) {
             nodeResolve({
                 only: [/^@lwc\//],
             }),
-            rollupTypescript({
-                target: 'es2017',
-                tsconfig: path.join(__dirname, '../../tsconfig.json'),
-                noEmitOnError: true,
-            }),
+            typescript(),
             lwcFeatures(),
         ].filter(Boolean),
+        onwarn({ code, message }) {
+            if (!process.env.ROLLUP_WATCH && code !== 'CIRCULAR_DEPENDENCY') {
+                throw new Error(message);
+            }
+        },
     };
 }
 

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -16,7 +16,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "tsc"
+        "build": "tsc",
+        "dev": "tsc --watch --preserveWatchOutput  --incremental"
     },
     "devDependencies": {
         "@types/estree": "0.0.50",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -17,7 +17,8 @@
     "typings": "types/index.d.ts",
     "scripts": {
         "clean": "rm -rf dist/ types/",
-        "build": "rollup --config ./scripts/rollup/rollup.config.js"
+        "build": "rollup --config ./scripts/rollup/rollup.config.js",
+        "dev": "rollup  --config scripts/rollup/rollup.config.js --watch --no-watch.clearScreen"
     },
     "files": [
         "dist/",

--- a/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
+++ b/packages/@lwc/wire-service/scripts/rollup/rollup.config.js
@@ -6,7 +6,7 @@
  */
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
-const typescript = require('@rollup/plugin-typescript');
+const typescript = require('../../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../../scripts/rollup/writeDistAndTypes');
 const { version } = require('../../package.json');
 const entry = path.resolve(__dirname, '../../src/index.ts');
@@ -31,11 +31,7 @@ function rollupConfig({ format }) {
             nodeResolve({
                 only: [/^@lwc\//],
             }),
-            typescript({
-                target: 'es2017',
-                tsconfig: path.join(__dirname, '../../tsconfig.json'),
-                noEmitOnError: true,
-            }),
+            typescript(),
             writeDistAndTypes(),
         ],
     };

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -17,7 +17,8 @@
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf dist/",
-        "build": "node scripts/build.js"
+        "build": "node scripts/build.js",
+        "dev": "node scripts/build.js --watch"
     },
     "files": [
         "dist/",

--- a/packages/lwc/scripts/build.js
+++ b/packages/lwc/scripts/build.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const path = require('path');
-const generateTargets = require('./utils/generate_targets');
+const { buildTargets, watchTargets } = require('./utils/generate_targets');
 const { createDir, getEs6ModuleEntry, buildBundleConfig } = require('./utils/helpers');
 
 // -- globals -----------------------------------------------------------------
@@ -88,7 +88,12 @@ function buildWireService(targets) {
         ]),
     ];
     process.stdout.write('\n# Generating LWC artifacts...\n');
-    await generateTargets(allTargets);
+    const watch = process.argv.includes('--watch');
+    if (watch) {
+        watchTargets(allTargets);
+    } else {
+        await buildTargets(allTargets);
+    }
 })().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/packages/lwc/scripts/utils/child_worker.js
+++ b/packages/lwc/scripts/utils/child_worker.js
@@ -6,11 +6,13 @@
  */
 const { worker } = require('workerpool');
 const { rollup } = require('rollup');
+const { rollupWatch } = require('./rollup_watch');
 const { rollupConfig, generateTarget } = require('./rollup');
 
-async function compile(targets, workerId) {
+async function build(targets, workerId) {
     const targetConfigs = targets.map((config) => rollupConfig(config));
-    const bundle = await rollup(targetConfigs[0].inputOptions); // inputOptions are all the same
+    const { inputOptions } = targetConfigs[0]; // inputOptions are all the same
+    const bundle = await rollup(inputOptions);
     await Promise.all(
         targetConfigs.map(async ({ outputOptions, display }) => {
             await generateTarget({
@@ -23,6 +25,12 @@ async function compile(targets, workerId) {
     );
 }
 
+function watch(target) {
+    const { inputOptions, outputOptions } = rollupConfig(target);
+    rollupWatch({ inputOptions, outputOptions });
+}
+
 worker({
-    compile,
+    build,
+    watch,
 });

--- a/packages/lwc/scripts/utils/generate_targets.js
+++ b/packages/lwc/scripts/utils/generate_targets.js
@@ -8,10 +8,6 @@ const workerpool = require('workerpool');
 const isCI = require('is-ci');
 const os = require('os');
 
-const pool = workerpool.pool(require.resolve('./child_worker.js'), {
-    maxWorkers: isCI ? 2 : os.cpus().length,
-});
-
 // Group the targets based on their input configuration, which allows us to run
 // rollup.rollup() once per unique input combination, and then bundle.generate
 // multiple times for each unique output combination.
@@ -27,15 +23,48 @@ function groupByInputOptions(configs) {
     return Object.values(keysToConfigs);
 }
 
-module.exports = async function generateTargets(targets) {
-    const targetGroups = groupByInputOptions(targets);
+async function buildTargets(targets) {
     let workerId = 0;
 
+    const pool = workerpool.pool(require.resolve('./child_worker.js'), {
+        maxWorkers: isCI ? 2 : os.cpus().length,
+    });
     try {
+        const targetGroups = groupByInputOptions(targets);
         await Promise.all(
-            targetGroups.map((targetGroup) => pool.exec('compile', [targetGroup, workerId++]))
+            targetGroups.map((targetGroup) => pool.exec('build', [targetGroup, workerId++]))
         );
     } finally {
         await pool.terminate();
     }
+}
+
+function watchTargets(targets) {
+    const watchTargets = targets.filter(({ prod, format, debug }) => {
+        // In watch mode, we only need to build what we need for local testing in Karma
+        return format === 'iife' && !prod && !debug;
+    });
+
+    // In watch mode, we need one separate worker for every individual build. There's no point in pooling
+    // because they all have to run in parallel.
+    const pool = workerpool.pool(require.resolve('./child_worker.js'), {
+        maxWorkers: watchTargets.length,
+    });
+    watchTargets.forEach((target) => {
+        pool.exec('watch', [target]).catch((err) => {
+            console.error(err);
+        });
+    });
+
+    process.on('SIGINT', () => {
+        // Gracefully exist on Ctrl-C
+        pool.terminate().catch((err) => {
+            console.error(err);
+        });
+    });
+}
+
+module.exports = {
+    buildTargets,
+    watchTargets,
 };

--- a/packages/lwc/scripts/utils/rollup_watch.js
+++ b/packages/lwc/scripts/utils/rollup_watch.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const path = require('path');
+const rollup = require('rollup');
+
+function rollupWatch({ inputOptions, outputOptions }) {
+    const rootDir = path.resolve(__dirname, '../..');
+    const input = inputOptions.input;
+    const relativeId = path.relative(rootDir, outputOptions.file);
+
+    const watcher = rollup.watch({
+        ...inputOptions,
+        output: outputOptions,
+        watch: {
+            clearScreen: false,
+        },
+    });
+
+    // This is largely borrowed from Rollup's --watch cli implementation:
+    // https://github.com/rollup/rollup/blob/b8315e03f9790d610a413316fbf6d565f9340cab/cli/run/watch-cli.ts#L83-L135
+    watcher.on('event', (event) => {
+        switch (event.code) {
+            case 'BUNDLE_START':
+                console.error(`bundles ${input} → ${relativeId}...`);
+                break;
+
+            case 'BUNDLE_END':
+                console.error(`created ${relativeId} in ${event.duration}ms`);
+                break;
+        }
+
+        if (event.result) {
+            event.result.close().catch((err) => {
+                console.error(err);
+            });
+        }
+    });
+}
+
+module.exports = {
+    rollupWatch,
+};

--- a/scripts/rollup/typescript.js
+++ b/scripts/rollup/typescript.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const typescriptPlugin = require('@rollup/plugin-typescript');
+const path = require('path');
+
+// Basic @rollup/plugin-typescript config that can be shared between packages
+module.exports = function typescript() {
+    return typescriptPlugin({
+        target: 'es2017',
+        tsconfig: path.join(process.cwd(), 'tsconfig.json'),
+        noEmitOnError: true,
+        ...(process.env.ROLLUP_WATCH && {
+            incremental: true,
+            outputToFilesystem: true,
+        }),
+    });
+};

--- a/scripts/rollup/typescript.js
+++ b/scripts/rollup/typescript.js
@@ -7,13 +7,15 @@
 const typescriptPlugin = require('@rollup/plugin-typescript');
 const path = require('path');
 
+const { ROLLUP_WATCH: watchMode } = process.env;
+
 // Basic @rollup/plugin-typescript config that can be shared between packages
 module.exports = function typescript() {
     return typescriptPlugin({
         target: 'es2017',
         tsconfig: path.join(process.cwd(), 'tsconfig.json'),
-        noEmitOnError: true,
-        ...(process.env.ROLLUP_WATCH && {
+        noEmitOnError: !watchMode, // in watch mode, do not exit with an error if typechecking fails
+        ...(watchMode && {
             incremental: true,
             outputToFilesystem: true,
         }),


### PR DESCRIPTION
## Details

Rather than running `yarn build` to recompile (which takes 23s on my machine), we can run `yarn dev`, which starts a watcher in every package and rebuilds incrementally when the files change.

Testing locally, I can make a change to `@lwc/shared` and the changes propagate out to `lwc` in a few seconds.

This makes local testing much more pleasant (e.g. for testing in Karma).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
