### PR TITLE
perf: hoist static vnodes

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -49,6 +49,13 @@ function addVNodeToChildLWC(vnode: VCustomElement) {
     ArrayPush.call(getVMBeingRendered()!.velements, vnode);
 }
 
+// [s]et [o]wner
+function so(vnode: VNode): VNode {
+    vnode.owner = getVMBeingRendered()!;
+
+    return vnode;
+}
+
 // [h]tml node
 function h(
     sel: string,
@@ -554,6 +561,7 @@ const api = ObjectFreeze({
     co,
     dc,
     ti,
+    so,
     gid,
     fid,
     shc,

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -52,7 +52,6 @@ function addVNodeToChildLWC(vnode: VCustomElement) {
 // [s]et [o]wner
 function so(vnode: VNode): VNode {
     vnode.owner = getVMBeingRendered()!;
-    vnode.isStatic = true;
 
     return vnode;
 }

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -50,7 +50,12 @@ function addVNodeToChildLWC(vnode: VCustomElement) {
 }
 
 // [h]tml node
-function h(sel: string, data: VElementData, children: VNodes = EmptyArray): VElement {
+function h(
+    sel: string,
+    data: VElementData,
+    children: VNodes = EmptyArray,
+    isStatic: boolean = false
+): VElement {
     const vmBeingRendered = getVMBeingRendered()!;
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `h() 1st argument sel must be a string.`);
@@ -99,6 +104,7 @@ function h(sel: string, data: VElementData, children: VNodes = EmptyArray): VEle
         elm,
         key,
         owner: vmBeingRendered,
+        isStatic,
     };
 }
 
@@ -332,7 +338,7 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string): VText {
+function t(text: string, isStatic: boolean = false): VText {
     let sel, key, elm;
     return {
         type: VNodeType.Text,
@@ -341,11 +347,12 @@ function t(text: string): VText {
         elm,
         key,
         owner: getVMBeingRendered()!,
+        isStatic,
     };
 }
 
 // [co]mment node
-function co(text: string): VComment {
+function co(text: string, isStatic: boolean = false): VComment {
     let sel, key, elm;
     return {
         type: VNodeType.Comment,
@@ -354,6 +361,7 @@ function co(text: string): VComment {
         elm,
         key,
         owner: getVMBeingRendered()!,
+        isStatic,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -52,17 +52,13 @@ function addVNodeToChildLWC(vnode: VCustomElement) {
 // [s]et [o]wner
 function so(vnode: VNode): VNode {
     vnode.owner = getVMBeingRendered()!;
+    vnode.isStatic = true;
 
     return vnode;
 }
 
 // [h]tml node
-function h(
-    sel: string,
-    data: VElementData,
-    children: VNodes = EmptyArray,
-    isStatic: boolean = false
-): VElement {
+function h(sel: string, data: VElementData, children: VNodes = EmptyArray): VElement {
     const vmBeingRendered = getVMBeingRendered()!;
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(isString(sel), `h() 1st argument sel must be a string.`);
@@ -111,7 +107,6 @@ function h(
         elm,
         key,
         owner: vmBeingRendered,
-        isStatic,
     };
 }
 
@@ -345,7 +340,7 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string, isStatic: boolean = false): VText {
+function t(text: string): VText {
     let sel, key, elm;
     return {
         type: VNodeType.Text,
@@ -354,12 +349,11 @@ function t(text: string, isStatic: boolean = false): VText {
         elm,
         key,
         owner: getVMBeingRendered()!,
-        isStatic,
     };
 }
 
 // [co]mment node
-function co(text: string, isStatic: boolean = false): VComment {
+function co(text: string): VComment {
     let sel, key, elm;
     return {
         type: VNodeType.Comment,
@@ -368,7 +362,6 @@ function co(text: string, isStatic: boolean = false): VComment {
         elm,
         key,
         owner: getVMBeingRendered()!,
-        isStatic,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -58,6 +58,7 @@ export type {
 export {
     setAssertInstanceOfHTMLElement,
     setAttachShadow,
+    setCloneNode,
     setCreateComment,
     setCreateElement,
     setCreateText,

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -174,22 +174,18 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
         sel,
         owner,
         data: { svg },
+        isStatic,
     } = vnode;
 
-    if (vnode.isStatic) {
+    if (isStatic) {
         if (vnode.elm) {
-            // @todo: what to do about the owner for synthetic shadow and fallbackElmHook
-
-            // @todo: cloned subtree is not associated with the proper shadow. The restrictions and styles will be
-            //        ok.
-            //        maybe modify synthetic shadow and get the owner from ancestors?
             vnode.elm = vnode.elm.cloneNode(true) as Element;
 
             linkNodeToShadow(vnode.elm, owner, true);
 
             if (process.env.NODE_ENV !== 'production') {
                 // @todo: take out the restrictions patching
-                // @todo: should we traverse the tree?
+                // @todo: should we traverse the tree to set restrictions on inner nodes?
                 fallbackElmHook(vnode.elm, vnode);
             }
 
@@ -734,6 +730,7 @@ function updateStaticChildren(c1: VNodes, c2: VNodes, parent: ParentNode) {
         const n2 = c2[i];
 
         if (n2 !== n1) {
+            // if n1 === n2, they are null or the same hoisted vnode.
             if (isVNode(n1)) {
                 if (isVNode(n2)) {
                     // both vnodes are equivalent, and we just need to patch them
@@ -748,7 +745,8 @@ function updateStaticChildren(c1: VNodes, c2: VNodes, parent: ParentNode) {
                 anchor = n2.elm!;
             }
         } else if (n2 !== null) {
-            // it is hoisted
+            // it is a hoisted vnode, patch does nothing for a hoisted vnode,
+            // but we need to update the anchor.
             anchor = n2.elm!;
         }
     }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -174,8 +174,7 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
     const {
         sel,
         owner,
-        data: { svg },
-        isStatic,
+        data: { svg, isStatic },
     } = vnode;
 
     if (isStatic) {
@@ -194,10 +193,9 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
             return;
         }
 
-        // @todo: hackalert: for now, let's mark all children as static and set the owner
+        // @todo: hackalert: for now, let's set the owner in all children
         const ch = vnode.children;
         for (let i = 0, n = ch.length; i < n; i++) {
-            ch[i]!.isStatic = true;
             ch[i]!.owner = owner;
         }
     }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -183,20 +183,21 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
             //        ok.
             //        maybe modify synthetic shadow and get the owner from ancestors?
             vnode.elm = vnode.elm.cloneNode(true) as Element;
-            linkNodeToShadow(vnode.elm, owner);
-            fallbackElmHook(vnode.elm, vnode);
 
             // @todo: hackalert: doing a traversal to set the proper shadow, just to reduce test failures
-            // const treeWalker = document.createTreeWalker(
-            //     vnode.elm,
-            //     NodeFilter.SHOW_ELEMENT & NodeFilter.SHOW_COMMENT & NodeFilter.SHOW_TEXT,
-            // );
-            // let currentNode: Node | null = treeWalker.currentNode;
-            //
-            // while(currentNode) {
-            //     linkNodeToShadow(currentNode, owner);
-            //     currentNode = treeWalker.nextNode();
-            // }
+            const treeWalker = document.createTreeWalker(
+                vnode.elm,
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT
+            );
+            let currentNode: Node | null = treeWalker.currentNode;
+
+            while (currentNode) {
+                linkNodeToShadow(currentNode, owner);
+                currentNode = treeWalker.nextNode();
+            }
+
+            fallbackElmHook(vnode.elm, vnode);
+
             insertNode(vnode.elm, parent, anchor);
             return;
         }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -29,6 +29,7 @@ import {
     createComment,
     getClassList,
     isSyntheticShadowDefined,
+    cloneNode,
 } from '../renderer';
 
 import { EmptyArray } from './utils';
@@ -179,17 +180,17 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
 
     if (isStatic) {
         if (vnode.protoElm) {
-            vnode.elm = vnode.protoElm.cloneNode(true) as Element;
+            const el = (vnode.elm = cloneNode(vnode.protoElm, true));
 
-            linkNodeToShadow(vnode.elm, owner, true);
+            linkNodeToShadow(el, owner, true);
 
             if (process.env.NODE_ENV !== 'production') {
                 // @todo: take out the restrictions patching
                 // @todo: should we traverse the tree to set restrictions on inner nodes?
-                fallbackElmHook(vnode.elm, vnode);
+                fallbackElmHook(el, vnode);
             }
 
-            insertNode(vnode.elm, parent, anchor);
+            insertNode(el, parent, anchor);
             return;
         }
 
@@ -216,7 +217,7 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
 
     if (isStatic) {
         // clone the rendered node in case it is manually manipulated.
-        vnode.protoElm = elm.cloneNode(true);
+        vnode.protoElm = cloneNode(elm, true);
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -178,8 +178,8 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
     } = vnode;
 
     if (isStatic) {
-        if (vnode.elm) {
-            vnode.elm = vnode.elm.cloneNode(true) as Element;
+        if (vnode.protoElm) {
+            vnode.elm = vnode.protoElm.cloneNode(true) as Element;
 
             linkNodeToShadow(vnode.elm, owner, true);
 
@@ -213,6 +213,11 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
 
     insertNode(elm, parent, anchor);
     mountVNodes(vnode.children, elm, null);
+
+    if (isStatic) {
+        // clone the rendered node in case it is manually manipulated.
+        vnode.protoElm = elm.cloneNode(true);
+    }
 }
 
 function patchElement(n1: VElement, n2: VElement) {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -186,6 +186,17 @@ function mountElement(vnode: VElement, parent: ParentNode, anchor: Node | null) 
             linkNodeToShadow(vnode.elm, owner);
             fallbackElmHook(vnode.elm, vnode);
 
+            // @todo: hackalert: doing a traversal to set the proper shadow, just to reduce test failures
+            // const treeWalker = document.createTreeWalker(
+            //     vnode.elm,
+            //     NodeFilter.SHOW_ELEMENT & NodeFilter.SHOW_COMMENT & NodeFilter.SHOW_TEXT,
+            // );
+            // let currentNode: Node | null = treeWalker.currentNode;
+            //
+            // while(currentNode) {
+            //     linkNodeToShadow(currentNode, owner);
+            //     currentNode = treeWalker.nextNode();
+            // }
             insertNode(vnode.elm, parent, anchor);
             return;
         }

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -26,6 +26,7 @@ export interface BaseVNode {
     sel: string | undefined;
     key: Key | undefined;
     owner: VM;
+    isStatic?: boolean;
 }
 
 export interface VText extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -53,6 +53,7 @@ export interface VBaseElement extends BaseVNode {
 
 export interface VElement extends VBaseElement {
     type: VNodeType.Element;
+    protoElm?: Element;
 }
 
 export interface VCustomElement extends VBaseElement {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -26,7 +26,6 @@ export interface BaseVNode {
     sel: string | undefined;
     key: Key | undefined;
     owner: VM;
-    isStatic?: boolean;
 }
 
 export interface VText extends BaseVNode {
@@ -76,6 +75,7 @@ export interface VNodeData {
     readonly context?: Readonly<Record<string, Readonly<Record<string, any>>>>;
     readonly on?: Readonly<Record<string, (event: Event) => any>>;
     readonly svg?: boolean;
+    readonly isStatic?: boolean;
 }
 
 export interface VElementData extends VNodeData {

--- a/packages/@lwc/engine-core/src/renderer.ts
+++ b/packages/@lwc/engine-core/src/renderer.ts
@@ -58,6 +58,12 @@ export function setRemove(removeImpl: removeFunc) {
     remove = removeImpl;
 }
 
+type cloneNodeFunc = (node: N, deep: boolean) => N;
+export let cloneNode: cloneNodeFunc;
+export function setCloneNode(cloneNodeImpl: cloneNodeFunc) {
+    cloneNode = cloneNodeImpl;
+}
+
 type createElementFunc = (tagName: string, namespace?: string) => E;
 export let createElement: createElementFunc;
 export function setCreateElement(createElementImpl: createElementFunc) {

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined } from '@lwc/shared';
+import { isNull, isUndefined } from '@lwc/shared';
 
 import { VM } from '../framework/vm';
 import { getComponentStack } from './format';
@@ -12,7 +12,7 @@ import { getComponentStack } from './format';
 function log(method: 'warn' | 'error', message: string, vm?: VM) {
     let msg = `[LWC ${method}]: ${message}`;
 
-    if (!isUndefined(vm)) {
+    if (!isUndefined(vm) && !isNull(vm)) {
         msg = `${msg}\n${getComponentStack(vm)}`;
     }
 

--- a/packages/@lwc/engine-dom/src/initializeRenderer.ts
+++ b/packages/@lwc/engine-dom/src/initializeRenderer.ts
@@ -8,6 +8,7 @@
 import {
     setAssertInstanceOfHTMLElement,
     setAttachShadow,
+    setCloneNode,
     setCreateComment,
     setCreateElement,
     setCreateText,
@@ -51,6 +52,7 @@ import {
 import {
     assertInstanceOfHTMLElement,
     attachShadow,
+    cloneNode,
     createComment,
     createElement,
     createText,
@@ -93,6 +95,7 @@ import {
 
 setAssertInstanceOfHTMLElement(assertInstanceOfHTMLElement);
 setAttachShadow(attachShadow);
+setCloneNode(cloneNode);
 setCreateComment(createComment);
 setCreateElement(createElement);
 setCreateText(createText);

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -179,6 +179,10 @@ export function createElement(tagName: string, namespace?: string): Element {
         : document.createElementNS(namespace, tagName);
 }
 
+export function cloneNode(node: Node, deep: boolean): Node {
+    return node.cloneNode(deep);
+}
+
 export function createText(content: string): Node {
     return document.createTextNode(content);
 }

--- a/packages/@lwc/engine-server/src/initializeRenderer.ts
+++ b/packages/@lwc/engine-server/src/initializeRenderer.ts
@@ -8,6 +8,7 @@
 import {
     setAssertInstanceOfHTMLElement,
     setAttachShadow,
+    setCloneNode,
     setCreateComment,
     setCreateElement,
     setCreateText,
@@ -51,6 +52,7 @@ import {
 import {
     assertInstanceOfHTMLElement,
     attachShadow,
+    cloneNode,
     createComment,
     createElement,
     createText,
@@ -93,6 +95,7 @@ import {
 
 setAssertInstanceOfHTMLElement(assertInstanceOfHTMLElement);
 setAttachShadow(attachShadow);
+setCloneNode(cloneNode);
 setCreateComment(createComment);
 setCreateElement(createElement);
 setCreateText(createText);

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -96,6 +96,10 @@ export function remove(node: N, parent: E) {
     parent.children.splice(nodeIndex, 1);
 }
 
+export function cloneNode(node: N) {
+    return node;
+}
+
 export { createElement };
 
 export function createText(content: string): HostNode {

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -3,7 +3,8 @@
 
     const {t: api_text, h: api_element, so: api_set_owner} = lwc.renderApi;
     const $hoisted1 = api_element("h1", {
-      key: 0
+      key: 0,
+      "isStatic": true
     }, [api_text("hello")]);
     function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_set_owner($hoisted1)];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -2,11 +2,11 @@
     'use strict';
 
     const {t: api_text, h: api_element} = lwc.renderApi;
-    const stc0 = {
+    const $hoisted1 = api_element("h1", {
       key: 0
-    };
+    }, [api_text("hello")], true);
     function tmpl($api, $cmp, $slotset, $ctx) {
-      return [api_element("h1", stc0, [api_text("hello")])];
+      return [$hoisted1];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl = lwc.registerTemplate(tmpl);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -4,7 +4,7 @@
     const {t: api_text, h: api_element, so: api_set_owner} = lwc.renderApi;
     const $hoisted1 = api_element("h1", {
       key: 0
-    }, [api_text("hello")], true);
+    }, [api_text("hello")]);
     function tmpl($api, $cmp, $slotset, $ctx) {
       return [api_set_owner($hoisted1)];
       /*LWC compiler vX.X.X*/

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_non_component_class.js
@@ -1,12 +1,12 @@
 (function (lwc) {
     'use strict';
 
-    const {t: api_text, h: api_element} = lwc.renderApi;
+    const {t: api_text, h: api_element, so: api_set_owner} = lwc.renderApi;
     const $hoisted1 = api_element("h1", {
       key: 0
     }, [api_text("hello")], true);
     function tmpl($api, $cmp, $slotset, $ctx) {
-      return [$hoisted1];
+      return [api_set_owner($hoisted1)];
       /*LWC compiler vX.X.X*/
     }
     var _tmpl = lwc.registerTemplate(tmpl);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -11,7 +11,8 @@
 
   const {h: api_element, so: api_set_owner} = lwc.renderApi;
   const $hoisted1 = api_element("div", {
-    key: 0
+    key: 0,
+    "isStatic": true
   }, []);
   function tmpl($api, $cmp, $slotset, $ctx) {
     return [api_set_owner($hoisted1)];

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -10,11 +10,11 @@
   var _implicitScopedStylesheets = [stylesheet];
 
   const {h: api_element} = lwc.renderApi;
-  const stc0 = {
+  const $hoisted1 = api_element("div", {
     key: 0
-  };
+  }, [], true);
   function tmpl($api, $cmp, $slotset, $ctx) {
-    return [api_element("div", stc0)];
+    return [$hoisted1];
     /*LWC compiler vX.X.X*/
   }
   var _tmpl = lwc.registerTemplate(tmpl);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -9,12 +9,12 @@
   stylesheet.$scoped$ = true;
   var _implicitScopedStylesheets = [stylesheet];
 
-  const {h: api_element} = lwc.renderApi;
+  const {h: api_element, so: api_set_owner} = lwc.renderApi;
   const $hoisted1 = api_element("div", {
     key: 0
   }, [], true);
   function tmpl($api, $cmp, $slotset, $ctx) {
-    return [$hoisted1];
+    return [api_set_owner($hoisted1)];
     /*LWC compiler vX.X.X*/
   }
   var _tmpl = lwc.registerTemplate(tmpl);

--- a/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/fixtures/expected_default_config_simple_app_with_scoped_styles.js
@@ -12,7 +12,7 @@
   const {h: api_element, so: api_set_owner} = lwc.renderApi;
   const $hoisted1 = api_element("div", {
     key: 0
-  }, [], true);
+  }, []);
   function tmpl($api, $cmp, $slotset, $ctx) {
     return [api_set_owner($hoisted1)];
     /*LWC compiler vX.X.X*/

--- a/packages/@lwc/shared/src/keys.ts
+++ b/packages/@lwc/shared/src/keys.ts
@@ -7,6 +7,7 @@
 
 export const KEY__IS_NATIVE_SHADOW_ROOT_DEFINED = '$isNativeShadowRootDefined$';
 export const KEY__SHADOW_RESOLVER = '$shadowResolver$';
+export const KEY__IS_STATIC_NODE = '$isStaticNode$';
 export const KEY__SHADOW_RESOLVER_PRIVATE = '$$ShadowResolverKey$$';
 export const KEY__SHADOW_TOKEN = '$shadowToken$';
 export const KEY__SHADOW_TOKEN_PRIVATE = '$$ShadowTokenKey$$';

--- a/packages/@lwc/synthetic-shadow/src/env/document.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/document.ts
@@ -39,6 +39,7 @@ const {
     getElementsByClassName,
     getElementsByTagName,
     getElementsByTagNameNS,
+    createTreeWalker,
 } = Document.prototype;
 
 // In Firefox v57 and lower, getElementsByName is defined on HTMLDocument.prototype
@@ -57,4 +58,5 @@ export {
     getElementsByTagName,
     getElementsByTagNameNS,
     defaultViewGetter,
+    createTreeWalker,
 };

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -33,7 +33,7 @@ import {
 } from './traverse';
 import { getTextContent } from '../3rdparty/polymer/text-content';
 import { createStaticNodeList } from '../shared/static-node-list';
-import { DocumentPrototypeActiveElement, createComment } from '../env/document';
+import { DocumentPrototypeActiveElement, createComment, createTreeWalker } from '../env/document';
 import {
     compareDocumentPosition,
     DOCUMENT_POSITION_CONTAINED_BY,
@@ -87,9 +87,14 @@ defineProperty(Node.prototype, KEY__SHADOW_RESOLVER, {
         setNodeOwnerKey(this, (fn as any).nodeKey);
 
         if (isTrue((this as any)[KEY__IS_STATIC_NODE])) {
-            const treeWalker = document.createTreeWalker(
+            // Work around Internet Explorer wanting a function instead of an object. IE also *requires* this argument where
+            // other browsers don't.
+            const treeWalker = createTreeWalker.call(
+                getOwnerDocument(this),
                 this,
-                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT,
+                () => NodeFilter.FILTER_ACCEPT,
+                false
             );
             let currentNode: Node | null = treeWalker.nextNode();
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -17,6 +17,7 @@ import {
     KEY__IS_NATIVE_SHADOW_ROOT_DEFINED,
     KEY__SHADOW_RESOLVER,
     KEY__SHADOW_RESOLVER_PRIVATE,
+    KEY__IS_STATIC_NODE,
     setPrototypeOf,
     getPrototypeOf,
     isObject,
@@ -84,6 +85,20 @@ defineProperty(Node.prototype, KEY__SHADOW_RESOLVER, {
         (this as any)[KEY__SHADOW_RESOLVER_PRIVATE] = fn;
         // TODO [#1164]: temporary propagation of the key
         setNodeOwnerKey(this, (fn as any).nodeKey);
+
+        if (isTrue((this as any)[KEY__IS_STATIC_NODE])) {
+            const treeWalker = document.createTreeWalker(
+                this,
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT
+            );
+            let currentNode: Node | null = treeWalker.nextNode();
+
+            while (currentNode) {
+                (currentNode as any)[KEY__SHADOW_RESOLVER_PRIVATE] = fn;
+                setNodeOwnerKey(currentNode, (fn as any).nodeKey);
+                currentNode = treeWalker.nextNode();
+            }
+        }
     },
     get(this: Node): ShadowRootResolver | undefined {
         return (this as any)[KEY__SHADOW_RESOLVER_PRIVATE];

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -96,12 +96,11 @@ defineProperty(Node.prototype, KEY__SHADOW_RESOLVER, {
                 () => NodeFilter.FILTER_ACCEPT,
                 false
             );
-            let currentNode: Node | null = treeWalker.nextNode();
+            let currentNode: Node | null;
 
-            while (currentNode) {
+            while ((currentNode = treeWalker.nextNode())) {
                 (currentNode as any)[KEY__SHADOW_RESOLVER_PRIVATE] = fn;
                 setNodeOwnerKey(currentNode, (fn as any).nodeKey);
-                currentNode = treeWalker.nextNode();
             }
         }
     },

--- a/packages/@lwc/synthetic-shadow/tsconfig.json
+++ b/packages/@lwc/synthetic-shadow/tsconfig.json
@@ -9,5 +9,5 @@
         "declarationDir": null
     },
 
-    "include": ["src/"]
+    "include": ["src/", "typings"]
 }

--- a/packages/@lwc/synthetic-shadow/typings/documentOverrides.ts
+++ b/packages/@lwc/synthetic-shadow/typings/documentOverrides.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare interface Document {
+    createTreeWalker(
+        root: Node,
+        whatToShow?: number,
+        filter?: NodeFilter | null,
+        expandEntityReferences?: boolean
+    ): TreeWalker;
+}

--- a/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
@@ -73,7 +73,7 @@ it('should compile correctly simple components', () => {
         ['api_element#2', ['p', { key: expect.any(Number) }, ['#1']]],
         ['api_text#3', ['world!']],
         ['api_element#4', ['p', { key: expect.any(Number) }, ['#3']]],
-        ['api_element#5', ['div', { key: expect.any(Number) }, ['#2', '#4'], true]],
+        ['api_element#5', ['div', { key: expect.any(Number) }, ['#2', '#4']]],
         ['api_set_owner#6', ['#5']],
     ]);
 });

--- a/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/compileToFunction.spec.ts
@@ -23,6 +23,7 @@ function mockRenderApi() {
         t: mock('api_text'),
         h: mock('api_element'),
         c: mock('api_component'),
+        so: mock('api_set_owner'),
     };
 
     return {
@@ -72,7 +73,8 @@ it('should compile correctly simple components', () => {
         ['api_element#2', ['p', { key: expect.any(Number) }, ['#1']]],
         ['api_text#3', ['world!']],
         ['api_element#4', ['p', { key: expect.any(Number) }, ['#3']]],
-        ['api_element#5', ['div', { key: expect.any(Number) }, ['#2', '#4']]],
+        ['api_element#5', ['div', { key: expect.any(Number) }, ['#2', '#4'], true]],
+        ['api_set_owner#6', ['#5']],
     ]);
 });
 

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "iframe",
   {
@@ -12,7 +12,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -7,6 +7,7 @@ const $hoisted1 = api_element(
       allow: "geolocation https://google-developers.appspot.com",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -1,13 +1,18 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    allow: "geolocation https://google-developers.appspot.com",
+const $hoisted1 = api_element(
+  "iframe",
+  {
+    attrs: {
+      allow: "geolocation https://google-developers.appspot.com",
+    },
+    key: 0,
   },
-  key: 0,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("iframe", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -8,8 +8,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "img",
   {
@@ -37,7 +37,11 @@ const $hoisted3 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2, $hoisted3];
+  return [
+    api_set_owner($hoisted1),
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -9,8 +9,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "video",
@@ -21,8 +20,7 @@ const $hoisted2 = api_element(
     },
     key: 1,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "audio",
@@ -33,8 +31,7 @@ const $hoisted3 = api_element(
     },
     key: 2,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -8,6 +8,7 @@ const $hoisted1 = api_element(
       crossorigin: "anonymous",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -19,6 +20,7 @@ const $hoisted2 = api_element(
       crossorigin: "anonymous",
     },
     key: 1,
+    isStatic: true,
   },
   []
 );
@@ -30,6 +32,7 @@ const $hoisted3 = api_element(
       crossorigin: "anonymous",
     },
     key: 2,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -1,32 +1,43 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    src: "http://www.example.com/image.png",
-    crossorigin: "anonymous",
+const $hoisted1 = api_element(
+  "img",
+  {
+    attrs: {
+      src: "http://www.example.com/image.png",
+      crossorigin: "anonymous",
+    },
+    key: 0,
   },
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    src: "http://www.example.com/video.mp4",
-    crossorigin: "anonymous",
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "video",
+  {
+    attrs: {
+      src: "http://www.example.com/video.mp4",
+      crossorigin: "anonymous",
+    },
+    key: 1,
   },
-  key: 1,
-};
-const stc2 = {
-  attrs: {
-    src: "http://www.example.com/video.mp3",
-    crossorigin: "anonymous",
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "audio",
+  {
+    attrs: {
+      src: "http://www.example.com/video.mp3",
+      crossorigin: "anonymous",
+    },
+    key: 2,
   },
-  key: 2,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("img", stc0),
-    api_element("video", stc1),
-    api_element("audio", stc2),
-  ];
+  return [$hoisted1, $hoisted2, $hoisted3];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
@@ -6,8 +6,8 @@ const {
   h: api_element,
   gid: api_scoped_id,
 } = renderApi;
-const $hoisted1 = api_text("KIX", true);
-const $hoisted2 = api_text("Time to travel!", true);
+const $hoisted1 = api_text("KIX");
+const $hoisted2 = api_text("Time to travel!");
 const stc0 = {
   key: 1,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id-expression/expected.js
@@ -2,9 +2,12 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   fid: api_scoped_frag_id,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   gid: api_scoped_id,
 } = renderApi;
+const $hoisted1 = api_text("KIX", true);
+const $hoisted2 = api_text("Time to travel!", true);
 const stc0 = {
   key: 1,
 };
@@ -18,7 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 0,
       },
-      [api_text("KIX")]
+      [api_set_owner($hoisted1)]
     ),
     api_element("map", stc0, [
       api_element("area", {
@@ -42,7 +45,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 4,
       },
-      [api_text("Time to travel!")]
+      [api_set_owner($hoisted2)]
     ),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
@@ -2,9 +2,12 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   fid: api_scoped_frag_id,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   gid: api_scoped_id,
 } = renderApi;
+const $hoisted1 = api_text("KIX", true);
+const $hoisted2 = api_text("Don't forget your passport!", true);
 const stc0 = {
   key: 1,
 };
@@ -18,7 +21,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 0,
       },
-      [api_text("KIX")]
+      [api_set_owner($hoisted1)]
     ),
     api_element("map", stc0, [
       api_element("area", {
@@ -42,7 +45,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 4,
       },
-      [api_text("Don't forget your passport!")]
+      [api_set_owner($hoisted2)]
     ),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href-with-id/expected.js
@@ -6,8 +6,8 @@ const {
   h: api_element,
   gid: api_scoped_id,
 } = renderApi;
-const $hoisted1 = api_text("KIX", true);
-const $hoisted2 = api_text("Don't forget your passport!", true);
+const $hoisted1 = api_text("KIX");
+const $hoisted2 = api_text("Don't forget your passport!");
 const stc0 = {
   key: 1,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
@@ -1,5 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
+const $hoisted1 = api_text("Yasaka Taxi", true);
 const stc0 = {
   attrs: {
     href: "#yasaka-taxi",
@@ -23,7 +24,7 @@ const stc3 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("a", stc0, [api_text("Yasaka Taxi")]),
+    api_element("a", stc0, [api_set_owner($hoisted1)]),
     api_element("map", stc1, [
       api_element("area", stc2),
       api_element("area", stc3),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
-const $hoisted1 = api_text("Yasaka Taxi", true);
+const $hoisted1 = api_text("Yasaka Taxi");
 const stc0 = {
   attrs: {
     href: "#yasaka-taxi",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -14,8 +14,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [api_text("boolean present")],
-  true
+  [api_text("boolean present")]
 );
 const $hoisted2 = api_element(
   "p",
@@ -25,8 +24,7 @@ const $hoisted2 = api_element(
     },
     key: 1,
   },
-  [api_text("empty string, should be true")],
-  true
+  [api_text("empty string, should be true")]
 );
 const $hoisted3 = api_element(
   "p",
@@ -36,13 +34,9 @@ const $hoisted3 = api_element(
     },
     key: 2,
   },
-  [api_text("string value, should be true")],
-  true
+  [api_text("string value, should be true")]
 );
-const $hoisted4 = api_text(
-  "computed value, should be resolved in component",
-  true
-);
+const $hoisted4 = api_text("computed value, should be resolved in component");
 const $hoisted5 = api_element(
   "p",
   {
@@ -51,17 +45,13 @@ const $hoisted5 = api_element(
     },
     key: 4,
   },
-  [api_text("integer value, should be true")],
-  true
+  [api_text("integer value, should be true")]
 );
-const $hoisted6 = api_text("boolean present", true);
-const $hoisted7 = api_text("empty string, should be true", true);
-const $hoisted8 = api_text("string value, should be true", true);
-const $hoisted9 = api_text(
-  "computed value, should be resolved in component",
-  true
-);
-const $hoisted10 = api_text("integer value, should be true", true);
+const $hoisted6 = api_text("boolean present");
+const $hoisted7 = api_text("empty string, should be true");
+const $hoisted8 = api_text("string value, should be true");
+const $hoisted9 = api_text("computed value, should be resolved in component");
+const $hoisted10 = api_text("integer value, should be true");
 const stc0 = {
   props: {
     hidden: true,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -1,6 +1,11 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  c: api_custom_element,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -34,7 +39,11 @@ const $hoisted3 = api_element(
   [api_text("string value, should be true")],
   true
 );
-const $hoisted4 = api_element(
+const $hoisted4 = api_text(
+  "computed value, should be resolved in component",
+  true
+);
+const $hoisted5 = api_element(
   "p",
   {
     attrs: {
@@ -45,6 +54,14 @@ const $hoisted4 = api_element(
   [api_text("integer value, should be true")],
   true
 );
+const $hoisted6 = api_text("boolean present", true);
+const $hoisted7 = api_text("empty string, should be true", true);
+const $hoisted8 = api_text("string value, should be true", true);
+const $hoisted9 = api_text(
+  "computed value, should be resolved in component",
+  true
+);
+const $hoisted10 = api_text("integer value, should be true", true);
 const stc0 = {
   props: {
     hidden: true,
@@ -71,9 +88,9 @@ const stc3 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
-    $hoisted2,
-    $hoisted3,
+    api_set_owner($hoisted1),
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
     api_element(
       "p",
       {
@@ -82,16 +99,12 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 3,
       },
-      [api_text("computed value, should be resolved in component")]
+      [api_set_owner($hoisted4)]
     ),
-    $hoisted4,
-    api_custom_element("x-foo", _xFoo, stc0, [api_text("boolean present")]),
-    api_custom_element("x-foo", _xFoo, stc1, [
-      api_text("empty string, should be true"),
-    ]),
-    api_custom_element("x-foo", _xFoo, stc2, [
-      api_text("string value, should be true"),
-    ]),
+    api_set_owner($hoisted5),
+    api_custom_element("x-foo", _xFoo, stc0, [api_set_owner($hoisted6)]),
+    api_custom_element("x-foo", _xFoo, stc1, [api_set_owner($hoisted7)]),
+    api_custom_element("x-foo", _xFoo, stc2, [api_set_owner($hoisted8)]),
     api_custom_element(
       "x-foo",
       _xFoo,
@@ -101,11 +114,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 8,
       },
-      [api_text("computed value, should be resolved in component")]
+      [api_set_owner($hoisted9)]
     ),
-    api_custom_element("x-foo", _xFoo, stc3, [
-      api_text("integer value, should be true"),
-    ]),
+    api_custom_element("x-foo", _xFoo, stc3, [api_set_owner($hoisted10)]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -13,6 +13,7 @@ const $hoisted1 = api_element(
       hidden: "",
     },
     key: 0,
+    isStatic: true,
   },
   [api_text("boolean present")]
 );
@@ -23,6 +24,7 @@ const $hoisted2 = api_element(
       hidden: "",
     },
     key: 1,
+    isStatic: true,
   },
   [api_text("empty string, should be true")]
 );
@@ -33,6 +35,7 @@ const $hoisted3 = api_element(
       hidden: "other than true",
     },
     key: 2,
+    isStatic: true,
   },
   [api_text("string value, should be true")]
 );
@@ -44,6 +47,7 @@ const $hoisted5 = api_element(
       hidden: "3",
     },
     key: 4,
+    isStatic: true,
   },
   [api_text("integer value, should be true")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -1,49 +1,69 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "",
+    },
+    key: 0,
+  },
+  [api_text("boolean present")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "",
+    },
+    key: 1,
+  },
+  [api_text("empty string, should be true")],
+  true
+);
+const $hoisted3 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "other than true",
+    },
+    key: 2,
+  },
+  [api_text("string value, should be true")],
+  true
+);
+const $hoisted4 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "3",
+    },
+    key: 4,
+  },
+  [api_text("integer value, should be true")],
+  true
+);
 const stc0 = {
-  attrs: {
-    hidden: "",
-  },
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    hidden: "",
-  },
-  key: 1,
-};
-const stc2 = {
-  attrs: {
-    hidden: "other than true",
-  },
-  key: 2,
-};
-const stc3 = {
-  attrs: {
-    hidden: "3",
-  },
-  key: 4,
-};
-const stc4 = {
   props: {
     hidden: true,
   },
   key: 5,
 };
-const stc5 = {
+const stc1 = {
   props: {
     hidden: true,
   },
   key: 6,
 };
-const stc6 = {
+const stc2 = {
   props: {
     hidden: true,
   },
   key: 7,
 };
-const stc7 = {
+const stc3 = {
   props: {
     hidden: true,
   },
@@ -51,9 +71,9 @@ const stc7 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("p", stc0, [api_text("boolean present")]),
-    api_element("p", stc1, [api_text("empty string, should be true")]),
-    api_element("p", stc2, [api_text("string value, should be true")]),
+    $hoisted1,
+    $hoisted2,
+    $hoisted3,
     api_element(
       "p",
       {
@@ -64,12 +84,12 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       [api_text("computed value, should be resolved in component")]
     ),
-    api_element("p", stc3, [api_text("integer value, should be true")]),
-    api_custom_element("x-foo", _xFoo, stc4, [api_text("boolean present")]),
-    api_custom_element("x-foo", _xFoo, stc5, [
+    $hoisted4,
+    api_custom_element("x-foo", _xFoo, stc0, [api_text("boolean present")]),
+    api_custom_element("x-foo", _xFoo, stc1, [
       api_text("empty string, should be true"),
     ]),
-    api_custom_element("x-foo", _xFoo, stc6, [
+    api_custom_element("x-foo", _xFoo, stc2, [
       api_text("string value, should be true"),
     ]),
     api_custom_element(
@@ -83,7 +103,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       [api_text("computed value, should be resolved in component")]
     ),
-    api_custom_element("x-foo", _xFoo, stc7, [
+    api_custom_element("x-foo", _xFoo, stc3, [
       api_text("integer value, should be true"),
     ]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -1,64 +1,84 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element, t: api_text, c: api_custom_element } = renderApi;
+const $hoisted1 = api_element(
+  "input",
+  {
+    attrs: {
+      required: "",
+    },
+    props: {
+      value: "boolean present",
+    },
+    key: 0,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "input",
+  {
+    attrs: {
+      required: "",
+    },
+    props: {
+      value: "empty string",
+    },
+    key: 1,
+  },
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "input",
+  {
+    attrs: {
+      required: "other than true",
+    },
+    props: {
+      value: "string value",
+    },
+    key: 2,
+  },
+  [],
+  true
+);
+const $hoisted4 = api_element(
+  "input",
+  {
+    attrs: {
+      required: "3",
+    },
+    props: {
+      value: "integer value",
+    },
+    key: 4,
+  },
+  [],
+  true
+);
 const stc0 = {
-  attrs: {
-    required: "",
-  },
-  props: {
-    value: "boolean present",
-  },
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    required: "",
-  },
-  props: {
-    value: "empty string",
-  },
-  key: 1,
-};
-const stc2 = {
-  attrs: {
-    required: "other than true",
-  },
-  props: {
-    value: "string value",
-  },
-  key: 2,
-};
-const stc3 = {
   value: "computed value",
 };
-const stc4 = {
-  attrs: {
-    required: "3",
-  },
-  props: {
-    value: "integer value",
-  },
-  key: 4,
-};
-const stc5 = {
+const stc1 = {
   props: {
     required: true,
   },
   key: 5,
 };
-const stc6 = {
+const stc2 = {
   props: {
     required: "",
   },
   key: 6,
 };
-const stc7 = {
+const stc3 = {
   props: {
     required: "other than true",
   },
   key: 7,
 };
-const stc8 = {
+const stc4 = {
   props: {
     required: "3",
   },
@@ -66,20 +86,20 @@ const stc8 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("input", stc0),
-    api_element("input", stc1),
-    api_element("input", stc2),
+    $hoisted1,
+    $hoisted2,
+    $hoisted3,
     api_element("input", {
       attrs: {
         required: $cmp.computed ? "" : null,
       },
-      props: stc3,
+      props: stc0,
       key: 3,
     }),
-    api_element("input", stc4),
-    api_custom_element("x-foo", _xFoo, stc5, [api_text("boolean present")]),
-    api_custom_element("x-foo", _xFoo, stc6, [api_text("empty string")]),
-    api_custom_element("x-foo", _xFoo, stc7, [api_text("string value")]),
+    $hoisted4,
+    api_custom_element("x-foo", _xFoo, stc1, [api_text("boolean present")]),
+    api_custom_element("x-foo", _xFoo, stc2, [api_text("empty string")]),
+    api_custom_element("x-foo", _xFoo, stc3, [api_text("string value")]),
     api_custom_element(
       "x-foo",
       _xFoo,
@@ -91,7 +111,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       [api_text("computed value, should be resolved in component")]
     ),
-    api_custom_element("x-foo", _xFoo, stc8, [api_text("integer value")]),
+    api_custom_element("x-foo", _xFoo, stc4, [api_text("integer value")]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -16,6 +16,7 @@ const $hoisted1 = api_element(
       value: "boolean present",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -29,6 +30,7 @@ const $hoisted2 = api_element(
       value: "empty string",
     },
     key: 1,
+    isStatic: true,
   },
   []
 );
@@ -42,6 +44,7 @@ const $hoisted3 = api_element(
       value: "string value",
     },
     key: 2,
+    isStatic: true,
   },
   []
 );
@@ -55,6 +58,7 @@ const $hoisted4 = api_element(
       value: "integer value",
     },
     key: 4,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -17,8 +17,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "input",
@@ -31,8 +30,7 @@ const $hoisted2 = api_element(
     },
     key: 1,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "input",
@@ -45,8 +43,7 @@ const $hoisted3 = api_element(
     },
     key: 2,
   },
-  [],
-  true
+  []
 );
 const $hoisted4 = api_element(
   "input",
@@ -59,17 +56,13 @@ const $hoisted4 = api_element(
     },
     key: 4,
   },
-  [],
-  true
+  []
 );
-const $hoisted5 = api_text("boolean present", true);
-const $hoisted6 = api_text("empty string", true);
-const $hoisted7 = api_text("string value", true);
-const $hoisted8 = api_text(
-  "computed value, should be resolved in component",
-  true
-);
-const $hoisted9 = api_text("integer value", true);
+const $hoisted5 = api_text("boolean present");
+const $hoisted6 = api_text("empty string");
+const $hoisted7 = api_text("string value");
+const $hoisted8 = api_text("computed value, should be resolved in component");
+const $hoisted9 = api_text("integer value");
 const stc0 = {
   value: "computed value",
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -1,6 +1,11 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element, t: api_text, c: api_custom_element } = renderApi;
+const {
+  h: api_element,
+  so: api_set_owner,
+  t: api_text,
+  c: api_custom_element,
+} = renderApi;
 const $hoisted1 = api_element(
   "input",
   {
@@ -57,6 +62,14 @@ const $hoisted4 = api_element(
   [],
   true
 );
+const $hoisted5 = api_text("boolean present", true);
+const $hoisted6 = api_text("empty string", true);
+const $hoisted7 = api_text("string value", true);
+const $hoisted8 = api_text(
+  "computed value, should be resolved in component",
+  true
+);
+const $hoisted9 = api_text("integer value", true);
 const stc0 = {
   value: "computed value",
 };
@@ -86,9 +99,9 @@ const stc4 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
-    $hoisted2,
-    $hoisted3,
+    api_set_owner($hoisted1),
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
     api_element("input", {
       attrs: {
         required: $cmp.computed ? "" : null,
@@ -96,10 +109,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       props: stc0,
       key: 3,
     }),
-    $hoisted4,
-    api_custom_element("x-foo", _xFoo, stc1, [api_text("boolean present")]),
-    api_custom_element("x-foo", _xFoo, stc2, [api_text("empty string")]),
-    api_custom_element("x-foo", _xFoo, stc3, [api_text("string value")]),
+    api_set_owner($hoisted4),
+    api_custom_element("x-foo", _xFoo, stc1, [api_set_owner($hoisted5)]),
+    api_custom_element("x-foo", _xFoo, stc2, [api_set_owner($hoisted6)]),
+    api_custom_element("x-foo", _xFoo, stc3, [api_set_owner($hoisted7)]),
     api_custom_element(
       "x-foo",
       _xFoo,
@@ -109,9 +122,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 8,
       },
-      [api_text("computed value, should be resolved in component")]
+      [api_set_owner($hoisted8)]
     ),
-    api_custom_element("x-foo", _xFoo, stc4, [api_text("integer value")]),
+    api_custom_element("x-foo", _xFoo, stc4, [api_set_owner($hoisted9)]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -14,8 +14,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [api_text("x")],
-  true
+  [api_text("x")]
 );
 const stc0 = {
   props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -1,6 +1,11 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  c: api_custom_element,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -34,7 +39,7 @@ const stc0 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
+    api_set_owner($hoisted1),
     api_custom_element("x-foo", _xFoo, stc0),
     api_element("input", {
       attrs: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -13,6 +13,7 @@ const $hoisted1 = api_element(
       hidden: "",
     },
     key: 0,
+    isStatic: true,
   },
   [api_text("x")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -1,13 +1,18 @@
 import _xFoo from "x/foo";
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
-const stc0 = {
-  attrs: {
-    hidden: "",
+const $hoisted1 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "",
+    },
+    key: 0,
   },
-  key: 0,
-};
-const stc1 = {
+  [api_text("x")],
+  true
+);
+const stc0 = {
   props: {
     autofocus: "true",
     autoplay: "true",
@@ -29,8 +34,8 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("p", stc0, [api_text("x")]),
-    api_custom_element("x-foo", _xFoo, stc1),
+    $hoisted1,
+    api_custom_element("x-foo", _xFoo, stc0),
     api_element("input", {
       attrs: {
         readonly: $cmp.getReadOnly ? "" : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -13,7 +13,7 @@ const $hoisted1 = api_element(
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
+    api_set_owner($hoisted1),
     api_element("input", {
       attrs: {
         readonly: $cmp.getReadOnly ? "" : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -1,14 +1,19 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    hidden: "",
+const $hoisted1 = api_element(
+  "p",
+  {
+    attrs: {
+      hidden: "",
+    },
+    key: 0,
   },
-  key: 0,
-};
+  [api_text("x")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("p", stc0, [api_text("x")]),
+    $hoisted1,
     api_element("input", {
       attrs: {
         readonly: $cmp.getReadOnly ? "" : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -8,8 +8,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [api_text("x")],
-  true
+  [api_text("x")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -7,6 +7,7 @@ const $hoisted1 = api_element(
       hidden: "",
     },
     key: 0,
+    isStatic: true,
   },
   [api_text("x")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -8,8 +8,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "div",
@@ -20,8 +19,7 @@ const $hoisted2 = api_element(
     },
     key: 1,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "div",
@@ -32,8 +30,7 @@ const $hoisted3 = api_element(
     },
     key: 2,
   },
-  [],
-  true
+  []
 );
 const $hoisted4 = api_element(
   "div",
@@ -44,8 +41,7 @@ const $hoisted4 = api_element(
     },
     key: 3,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -7,6 +7,7 @@ const $hoisted1 = api_element(
       foo: true,
     },
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -18,6 +19,7 @@ const $hoisted2 = api_element(
       bar: true,
     },
     key: 1,
+    isStatic: true,
   },
   []
 );
@@ -29,6 +31,7 @@ const $hoisted3 = api_element(
       bar: true,
     },
     key: 2,
+    isStatic: true,
   },
   []
 );
@@ -40,6 +43,7 @@ const $hoisted4 = api_element(
       bar: true,
     },
     key: 3,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -1,39 +1,54 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  classMap: {
-    foo: true,
+const $hoisted1 = api_element(
+  "div",
+  {
+    classMap: {
+      foo: true,
+    },
+    key: 0,
   },
-  key: 0,
-};
-const stc1 = {
-  classMap: {
-    foo: true,
-    bar: true,
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "div",
+  {
+    classMap: {
+      foo: true,
+      bar: true,
+    },
+    key: 1,
   },
-  key: 1,
-};
-const stc2 = {
-  classMap: {
-    foo: true,
-    bar: true,
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "div",
+  {
+    classMap: {
+      foo: true,
+      bar: true,
+    },
+    key: 2,
   },
-  key: 2,
-};
-const stc3 = {
-  classMap: {
-    foo: true,
-    bar: true,
+  [],
+  true
+);
+const $hoisted4 = api_element(
+  "div",
+  {
+    classMap: {
+      foo: true,
+      bar: true,
+    },
+    key: 3,
   },
-  key: 3,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("div", stc0),
-    api_element("div", stc1),
-    api_element("div", stc2),
-    api_element("div", stc3),
-  ];
+  return [$hoisted1, $hoisted2, $hoisted3, $hoisted4];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -48,7 +48,12 @@ const $hoisted4 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2, $hoisted3, $hoisted4];
+  return [
+    api_set_owner($hoisted1),
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
+    api_set_owner($hoisted4),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "section",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element("p", {
@@ -11,6 +12,7 @@ const $hoisted1 = api_element(
         "data--bar-baz": "xyz",
       },
       key: 1,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -1,16 +1,22 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    "data--bar-baz": "xyz",
+const $hoisted1 = api_element(
+  "section",
+  {
+    key: 0,
   },
-  key: 1,
-};
+  [
+    api_element("p", {
+      attrs: {
+        "data--bar-baz": "xyz",
+      },
+      key: 1,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("section", stc0, [api_element("p", stc1)])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -16,7 +16,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -12,8 +12,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -13,8 +13,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -1,17 +1,23 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    "data-foo": "1",
-    "data-bar-baz": "xyz",
+const $hoisted1 = api_element(
+  "section",
+  {
+    key: 0,
   },
-  key: 1,
-};
+  [
+    api_element("p", {
+      attrs: {
+        "data-foo": "1",
+        "data-bar-baz": "xyz",
+      },
+      key: 1,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("section", stc0, [api_element("p", stc1)])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "section",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element("p", {
@@ -12,6 +13,7 @@ const $hoisted1 = api_element(
         "data-bar-baz": "xyz",
       },
       key: 1,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -17,7 +17,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -8,6 +8,7 @@ const $hoisted1 = api_element(
       title: "",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -1,13 +1,18 @@
 import _fooBar from "foo/bar";
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element, c: api_custom_element } = renderApi;
-const stc0 = {
-  attrs: {
-    title: "",
+const $hoisted1 = api_element(
+  "p",
+  {
+    attrs: {
+      title: "",
+    },
+    key: 0,
   },
-  key: 0,
-};
-const stc1 = {
+  [],
+  true
+);
+const stc0 = {
   props: {
     content: "",
     visible: true,
@@ -15,7 +20,7 @@ const stc1 = {
   key: 1,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("p", stc0), api_custom_element("foo-bar", _fooBar, stc1)];
+  return [$hoisted1, api_custom_element("foo-bar", _fooBar, stc0)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -1,6 +1,6 @@
 import _fooBar from "foo/bar";
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element, c: api_custom_element } = renderApi;
+const { h: api_element, so: api_set_owner, c: api_custom_element } = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -20,7 +20,10 @@ const stc0 = {
   key: 1,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, api_custom_element("foo-bar", _fooBar, stc0)];
+  return [
+    api_set_owner($hoisted1),
+    api_custom_element("foo-bar", _fooBar, stc0),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -9,8 +9,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 const stc0 = {
   props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "input",
   {
@@ -19,7 +19,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -1,20 +1,25 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    type: "checkbox",
-    required: "",
-    readonly: "",
-    minlength: "5",
-    maxlength: "10",
+const $hoisted1 = api_element(
+  "input",
+  {
+    attrs: {
+      type: "checkbox",
+      required: "",
+      readonly: "",
+      minlength: "5",
+      maxlength: "10",
+    },
+    props: {
+      checked: true,
+    },
+    key: 0,
   },
-  props: {
-    checked: true,
-  },
-  key: 0,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("input", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -14,6 +14,7 @@ const $hoisted1 = api_element(
       checked: true,
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -15,8 +15,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -22,7 +22,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "section",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element(
@@ -15,6 +16,7 @@ const $hoisted1 = api_element(
           "unknown-attr": "should-error",
         },
         key: 1,
+        isStatic: true,
       },
       [api_text("x")]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -1,22 +1,28 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    minlength: "1",
-    maxlength: "5",
-    "unknown-attr": "should-error",
+const $hoisted1 = api_element(
+  "section",
+  {
+    key: 0,
   },
-  key: 1,
-};
+  [
+    api_element(
+      "textarea",
+      {
+        attrs: {
+          minlength: "1",
+          maxlength: "5",
+          "unknown-attr": "should-error",
+        },
+        key: 1,
+      },
+      [api_text("x")]
+    ),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("section", stc0, [
-      api_element("textarea", stc1, [api_text("x")]),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -18,8 +18,7 @@ const $hoisted1 = api_element(
       },
       [api_text("x")]
     ),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -17,8 +17,7 @@ const $hoisted1 = api_element(
       },
       [api_text("x")]
     ),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -1,19 +1,27 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    title: "x",
-    "aria-hidden": "x",
+const $hoisted1 = api_element(
+  "section",
+  {
+    key: 0,
   },
-  key: 1,
-};
+  [
+    api_element(
+      "p",
+      {
+        attrs: {
+          title: "x",
+          "aria-hidden": "x",
+        },
+        key: 1,
+      },
+      [api_text("x")]
+    ),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("section", stc0, [api_element("p", stc1, [api_text("x")])]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "section",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element(
@@ -14,6 +15,7 @@ const $hoisted1 = api_element(
           "aria-hidden": "x",
         },
         key: 1,
+        isStatic: true,
       },
       [api_text("x")]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -21,7 +21,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -12,8 +12,8 @@ const {
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
-const $hoisted1 = api_text("label text", true);
-const $hoisted2 = api_text("description text", true);
+const $hoisted1 = api_text("label text");
+const $hoisted2 = api_text("description text");
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_custom_element("x-subject", _xSubject, {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -6,11 +6,14 @@ const {
   gid: api_scoped_id,
   c: api_custom_element,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   k: api_key,
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
+const $hoisted1 = api_text("label text", true);
+const $hoisted2 = api_text("description text", true);
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
     api_custom_element("x-subject", _xSubject, {
@@ -46,7 +49,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 4,
       },
-      [api_text("label text")]
+      [api_set_owner($hoisted1)]
     ),
     api_element("input", {
       attrs: {
@@ -64,7 +67,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             },
             key: api_key(6, thing.key),
           },
-          [api_text("description text")]
+          [api_set_owner($hoisted2)]
         ),
         api_element("input", {
           attrs: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -23,8 +23,7 @@ const $hoisted1 = api_element(
     },
     key: 1,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "svg",
@@ -51,8 +50,7 @@ const $hoisted2 = api_element(
       key: 4,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted3 = api_element(
   "table",
@@ -62,8 +60,7 @@ const $hoisted3 = api_element(
     },
     key: 5,
   },
-  [],
-  true
+  []
 );
 const stc0 = {
   r: true,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -22,6 +22,7 @@ const $hoisted1 = api_element(
       tabindex: "-1",
     },
     key: 1,
+    isStatic: true,
   },
   []
 );
@@ -36,6 +37,7 @@ const $hoisted2 = api_element(
     },
     key: 3,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("use", {
@@ -49,6 +51,7 @@ const $hoisted2 = api_element(
       },
       key: 4,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -59,6 +62,7 @@ const $hoisted3 = api_element(
       bgcolor: "x",
     },
     key: 5,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -1,7 +1,12 @@
 import _nsFoo from "ns/foo";
 import _nsBar from "ns/bar";
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
-const { gid: api_scoped_id, c: api_custom_element, h: api_element } = renderApi;
+const {
+  gid: api_scoped_id,
+  c: api_custom_element,
+  h: api_element,
+  so: api_set_owner,
+} = renderApi;
 const $hoisted1 = api_element(
   "a",
   {
@@ -78,7 +83,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       key: 0,
     }),
-    $hoisted1,
+    api_set_owner($hoisted1),
     api_custom_element("ns-bar", _nsBar, {
       classMap: stc0,
       attrs: stc1,
@@ -93,8 +98,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       key: 2,
     }),
-    $hoisted2,
-    $hoisted3,
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
     api_element("div", {
       className: $cmp.foo,
       attrs: stc2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -2,43 +2,71 @@ import _nsFoo from "ns/foo";
 import _nsBar from "ns/bar";
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
 const { gid: api_scoped_id, c: api_custom_element, h: api_element } = renderApi;
+const $hoisted1 = api_element(
+  "a",
+  {
+    classMap: {
+      test: true,
+    },
+    attrs: {
+      "data-foo": "datafoo",
+      "aria-hidden": "h",
+      role: "presentation",
+      href: "/foo",
+      title: "test",
+      tabindex: "-1",
+    },
+    key: 1,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "svg",
+  {
+    classMap: {
+      cubano: true,
+    },
+    attrs: {
+      focusable: "true",
+    },
+    key: 3,
+    svg: true,
+  },
+  [
+    api_element("use", {
+      attrs: {
+        "xlink:href": sanitizeAttribute(
+          "use",
+          "http://www.w3.org/2000/svg",
+          "xlink:href",
+          "xx"
+        ),
+      },
+      key: 4,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted3 = api_element(
+  "table",
+  {
+    attrs: {
+      bgcolor: "x",
+    },
+    key: 5,
+  },
+  [],
+  true
+);
 const stc0 = {
-  classMap: {
-    test: true,
-  },
-  attrs: {
-    "data-foo": "datafoo",
-    "aria-hidden": "h",
-    role: "presentation",
-    href: "/foo",
-    title: "test",
-    tabindex: "-1",
-  },
-  key: 1,
-};
-const stc1 = {
   r: true,
 };
-const stc2 = {
+const stc1 = {
   "data-xx": "foo",
 };
-const stc3 = {
-  classMap: {
-    cubano: true,
-  },
-  attrs: {
-    focusable: "true",
-  },
-  key: 3,
-  svg: true,
-};
-const stc4 = {
-  attrs: {
-    bgcolor: "x",
-  },
-  key: 5,
-};
-const stc5 = {
+const stc2 = {
   "aria-hidden": "hidden",
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
@@ -50,10 +78,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       key: 0,
     }),
-    api_element("a", stc0),
+    $hoisted1,
     api_custom_element("ns-bar", _nsBar, {
-      classMap: stc1,
-      attrs: stc2,
+      classMap: stc0,
+      attrs: stc1,
       props: {
         ariaDescribedBy: api_scoped_id("ns-foo"),
         ariaHidden: "hidden",
@@ -65,24 +93,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       key: 2,
     }),
-    api_element("svg", stc3, [
-      api_element("use", {
-        attrs: {
-          "xlink:href": sanitizeAttribute(
-            "use",
-            "http://www.w3.org/2000/svg",
-            "xlink:href",
-            "xx"
-          ),
-        },
-        key: 4,
-        svg: true,
-      }),
-    ]),
-    api_element("table", stc4),
+    $hoisted2,
+    $hoisted3,
     api_element("div", {
       className: $cmp.foo,
-      attrs: stc5,
+      attrs: stc2,
       key: 6,
     }),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -6,8 +6,7 @@ const $hoisted1 = api_element(
     styleDecls: [["color", "blue", false]],
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "div",
@@ -15,8 +14,7 @@ const $hoisted2 = api_element(
     styleDecls: [["color", "blue", false]],
     key: 1,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "div",
@@ -24,8 +22,7 @@ const $hoisted3 = api_element(
     styleDecls: [["color", "blue", false]],
     key: 2,
   },
-  [],
-  true
+  []
 );
 const $hoisted4 = api_element(
   "div",
@@ -33,8 +30,7 @@ const $hoisted4 = api_element(
     styleDecls: [["box-shadow", "10px 5px 5px black", false]],
     key: 3,
   },
-  [],
-  true
+  []
 );
 const $hoisted5 = api_element(
   "div",
@@ -46,8 +42,7 @@ const $hoisted5 = api_element(
     ],
     key: 4,
   },
-  [],
-  true
+  []
 );
 const $hoisted6 = api_element(
   "div",
@@ -59,8 +54,7 @@ const $hoisted6 = api_element(
     ],
     key: 5,
   },
-  [],
-  true
+  []
 );
 const $hoisted7 = api_element(
   "div",
@@ -68,8 +62,7 @@ const $hoisted7 = api_element(
     styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
     key: 6,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -5,6 +5,7 @@ const $hoisted1 = api_element(
   {
     styleDecls: [["color", "blue", false]],
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -13,6 +14,7 @@ const $hoisted2 = api_element(
   {
     styleDecls: [["color", "blue", false]],
     key: 1,
+    isStatic: true,
   },
   []
 );
@@ -21,6 +23,7 @@ const $hoisted3 = api_element(
   {
     styleDecls: [["color", "blue", false]],
     key: 2,
+    isStatic: true,
   },
   []
 );
@@ -29,6 +32,7 @@ const $hoisted4 = api_element(
   {
     styleDecls: [["box-shadow", "10px 5px 5px black", false]],
     key: 3,
+    isStatic: true,
   },
   []
 );
@@ -41,6 +45,7 @@ const $hoisted5 = api_element(
       ["color", "red", false],
     ],
     key: 4,
+    isStatic: true,
   },
   []
 );
@@ -53,6 +58,7 @@ const $hoisted6 = api_element(
       ["color", "red", false],
     ],
     key: 5,
+    isStatic: true,
   },
   []
 );
@@ -61,6 +67,7 @@ const $hoisted7 = api_element(
   {
     styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
     key: 6,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -73,13 +73,13 @@ const $hoisted7 = api_element(
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
-    $hoisted2,
-    $hoisted3,
-    $hoisted4,
-    $hoisted5,
-    $hoisted6,
-    $hoisted7,
+    api_set_owner($hoisted1),
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
+    api_set_owner($hoisted4),
+    api_set_owner($hoisted5),
+    api_set_owner($hoisted6),
+    api_set_owner($hoisted7),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -1,50 +1,85 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  styleDecls: [["color", "blue", false]],
-  key: 0,
-};
-const stc1 = {
-  styleDecls: [["color", "blue", false]],
-  key: 1,
-};
-const stc2 = {
-  styleDecls: [["color", "blue", false]],
-  key: 2,
-};
-const stc3 = {
-  styleDecls: [["box-shadow", "10px 5px 5px black", false]],
-  key: 3,
-};
-const stc4 = {
-  styleDecls: [
-    ["font-size", "12px", false],
-    ["background", "blue", false],
-    ["color", "red", false],
-  ],
-  key: 4,
-};
-const stc5 = {
-  styleDecls: [
-    ["font-size", "12px", false],
-    ["background", "blue", false],
-    ["color", "red", false],
-  ],
-  key: 5,
-};
-const stc6 = {
-  styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
-  key: 6,
-};
+const $hoisted1 = api_element(
+  "div",
+  {
+    styleDecls: [["color", "blue", false]],
+    key: 0,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "div",
+  {
+    styleDecls: [["color", "blue", false]],
+    key: 1,
+  },
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "div",
+  {
+    styleDecls: [["color", "blue", false]],
+    key: 2,
+  },
+  [],
+  true
+);
+const $hoisted4 = api_element(
+  "div",
+  {
+    styleDecls: [["box-shadow", "10px 5px 5px black", false]],
+    key: 3,
+  },
+  [],
+  true
+);
+const $hoisted5 = api_element(
+  "div",
+  {
+    styleDecls: [
+      ["font-size", "12px", false],
+      ["background", "blue", false],
+      ["color", "red", false],
+    ],
+    key: 4,
+  },
+  [],
+  true
+);
+const $hoisted6 = api_element(
+  "div",
+  {
+    styleDecls: [
+      ["font-size", "12px", false],
+      ["background", "blue", false],
+      ["color", "red", false],
+    ],
+    key: 5,
+  },
+  [],
+  true
+);
+const $hoisted7 = api_element(
+  "div",
+  {
+    styleDecls: [["background-color", "rgba(255,0,0,0.3)", false]],
+    key: 6,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("div", stc0),
-    api_element("div", stc1),
-    api_element("div", stc2),
-    api_element("div", stc3),
-    api_element("div", stc4),
-    api_element("div", stc5),
-    api_element("div", stc6),
+    $hoisted1,
+    $hoisted2,
+    $hoisted3,
+    $hoisted4,
+    $hoisted5,
+    $hoisted6,
+    $hoisted7,
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
@@ -7,7 +7,7 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_text("valid", true);
+const $hoisted1 = api_text("valid");
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
@@ -3,9 +3,11 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   ti: api_tab_index,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   c: api_custom_element,
 } = renderApi;
+const $hoisted1 = api_text("valid", true);
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element(
@@ -16,7 +18,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         },
         key: 0,
       },
-      [api_text("valid")]
+      [api_set_owner($hoisted1)]
     ),
     api_custom_element("x-foo", _xFoo, {
       props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -7,6 +7,7 @@ const $hoisted1 = api_element(
       min: "4",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "somefancytag",
   {
@@ -12,7 +12,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -1,13 +1,18 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    min: "4",
+const $hoisted1 = api_element(
+  "somefancytag",
+  {
+    attrs: {
+      min: "4",
+    },
+    key: 0,
   },
-  key: 0,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("somefancytag", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -8,8 +8,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
       "baz-fiz": true,
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -14,7 +14,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -1,15 +1,20 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  classMap: {
-    foo: true,
-    bar: true,
-    "baz-fiz": true,
+const $hoisted1 = api_element(
+  "section",
+  {
+    classMap: {
+      foo: true,
+      bar: true,
+      "baz-fiz": true,
+    },
+    key: 0,
   },
-  key: 0,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("section", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner } = renderApi;
-const $hoisted1 = api_text("Hello world", true);
+const $hoisted1 = api_text("Hello world");
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
@@ -1,7 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text } = renderApi;
+const { t: api_text, so: api_set_owner } = renderApi;
+const $hoisted1 = api_text("Hello world", true);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_text("Hello world")];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -14,7 +14,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
       ["opacity", "0.5", true],
     ],
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
     ],
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -1,15 +1,20 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  styleDecls: [
-    ["background", "blue", true],
-    ["color", "red", false],
-    ["opacity", "0.5", true],
-  ],
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "div",
+  {
+    styleDecls: [
+      ["background", "blue", true],
+      ["color", "red", false],
+      ["opacity", "0.5", true],
+    ],
+    key: 0,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("div", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
       ["margin", "10px 5px 10px", false],
     ],
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -20,6 +21,7 @@ const $hoisted2 = api_element(
       ["color", "var(--my-color)", false],
     ],
     key: 1,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -1,22 +1,32 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  styleDecls: [
-    ["font-size", "12px", false],
-    ["color", "red", false],
-    ["margin", "10px 5px 10px", false],
-  ],
-  key: 0,
-};
-const stc1 = {
-  styleDecls: [
-    ["--my-color", "blue", false],
-    ["color", "var(--my-color)", false],
-  ],
-  key: 1,
-};
+const $hoisted1 = api_element(
+  "section",
+  {
+    styleDecls: [
+      ["font-size", "12px", false],
+      ["color", "red", false],
+      ["margin", "10px 5px 10px", false],
+    ],
+    key: 0,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "section",
+  {
+    styleDecls: [
+      ["--my-color", "blue", false],
+      ["color", "var(--my-color)", false],
+    ],
+    key: 1,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("section", stc0), api_element("section", stc1)];
+  return [$hoisted1, $hoisted2];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
     ],
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "section",
@@ -22,8 +21,7 @@ const $hoisted2 = api_element(
     ],
     key: 1,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1), api_set_owner($hoisted2)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -26,7 +26,7 @@ const $hoisted2 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2];
+  return [api_set_owner($hoisted1), api_set_owner($hoisted2)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -1,33 +1,36 @@
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  classMap: {
-    "slds-button__icon": true,
+const $hoisted1 = api_element(
+  "svg",
+  {
+    classMap: {
+      "slds-button__icon": true,
+    },
+    attrs: {
+      viewBox: "0 0 5 5",
+      "aria-hidden": "true",
+    },
+    key: 0,
+    svg: true,
   },
-  attrs: {
-    viewBox: "0 0 5 5",
-    "aria-hidden": "true",
-  },
-  key: 0,
-  svg: true,
-};
+  [
+    api_element("use", {
+      attrs: {
+        "xlink:href": sanitizeAttribute(
+          "use",
+          "http://www.w3.org/2000/svg",
+          "xlink:href",
+          "/x"
+        ),
+      },
+      key: 1,
+      svg: true,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("svg", stc0, [
-      api_element("use", {
-        attrs: {
-          "xlink:href": sanitizeAttribute(
-            "use",
-            "http://www.w3.org/2000/svg",
-            "xlink:href",
-            "/x"
-          ),
-        },
-        key: 1,
-        svg: true,
-      }),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -26,8 +26,7 @@ const $hoisted1 = api_element(
       key: 1,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -30,7 +30,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -12,6 +12,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("use", {
@@ -25,6 +26,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("Root")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -1,10 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 0,
+  },
+  [api_text("Root")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("p", stc0, [api_text("Root")])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -5,8 +5,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("Root")],
-  true
+  [api_text("Root")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -9,7 +9,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
@@ -1,7 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text } = renderApi;
+const { t: api_text, so: api_set_owner } = renderApi;
+const $hoisted1 = api_text("foo", true);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_text("foo")];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner } = renderApi;
-const $hoisted1 = api_text("foo", true);
+const $hoisted1 = api_text("foo");
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { co: api_comment, t: api_text, h: api_element } = renderApi;
+const {
+  co: api_comment,
+  so: api_set_owner,
+  t: api_text,
+  h: api_element,
+} = renderApi;
 const $hoisted1 = api_comment(" This is an HTML comment ", true);
 const $hoisted2 = api_element(
   "button",
@@ -10,7 +15,7 @@ const $hoisted2 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2];
+  return [api_set_owner($hoisted1), api_set_owner($hoisted2)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -1,13 +1,16 @@
 import { registerTemplate, renderApi } from "lwc";
 const { co: api_comment, t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_comment(" This is an HTML comment ", true);
+const $hoisted2 = api_element(
+  "button",
+  {
+    key: 0,
+  },
+  [api_text("click me")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_comment(" This is an HTML comment "),
-    api_element("button", stc0, [api_text("click me")]),
-  ];
+  return [$hoisted1, $hoisted2];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -5,14 +5,13 @@ const {
   t: api_text,
   h: api_element,
 } = renderApi;
-const $hoisted1 = api_comment(" This is an HTML comment ", true);
+const $hoisted1 = api_comment(" This is an HTML comment ");
 const $hoisted2 = api_element(
   "button",
   {
     key: 0,
   },
-  [api_text("click me")],
-  true
+  [api_text("click me")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1), api_set_owner($hoisted2)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -10,6 +10,7 @@ const $hoisted2 = api_element(
   "button",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("click me")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -8,7 +8,7 @@ const {
   h: api_element,
   i: api_iterator,
 } = renderApi;
-const $hoisted1 = api_comment(" color ", true);
+const $hoisted1 = api_comment(" color ");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -1,6 +1,7 @@
 import { registerTemplate, renderApi } from "lwc";
 const {
   co: api_comment,
+  so: api_set_owner,
   k: api_key,
   d: api_dynamic_text,
   t: api_text,
@@ -18,7 +19,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       stc0,
       api_iterator($cmp.colors, function (color) {
         return [
-          $hoisted1,
+          api_set_owner($hoisted1),
           api_element(
             "li",
             {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -7,6 +7,7 @@ const {
   h: api_element,
   i: api_iterator,
 } = renderApi;
+const $hoisted1 = api_comment(" color ", true);
 const stc0 = {
   key: 0,
 };
@@ -17,7 +18,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       stc0,
       api_iterator($cmp.colors, function (color) {
         return [
-          api_comment(" color "),
+          $hoisted1,
           api_element(
             "li",
             {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -1,7 +1,14 @@
 import { registerTemplate, renderApi } from "lwc";
-const { co: api_comment, t: api_text, h: api_element } = renderApi;
+const {
+  co: api_comment,
+  so: api_set_owner,
+  t: api_text,
+  h: api_element,
+} = renderApi;
 const $hoisted1 = api_comment(" HTML comment inside if:true ", true);
-const $hoisted2 = api_comment(" HTML comment inside if:false ", true);
+const $hoisted2 = api_text("true branch", true);
+const $hoisted3 = api_comment(" HTML comment inside if:false ", true);
+const $hoisted4 = api_text("false branch", true);
 const stc0 = {
   key: 0,
 };
@@ -10,11 +17,13 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $cmp.truthyValue ? $hoisted1 : null,
-    $cmp.truthyValue ? api_element("p", stc0, [api_text("true branch")]) : null,
-    !$cmp.truthyValue ? $hoisted2 : null,
+    $cmp.truthyValue ? api_set_owner($hoisted1) : null,
+    $cmp.truthyValue
+      ? api_element("p", stc0, [api_set_owner($hoisted2)])
+      : null,
+    !$cmp.truthyValue ? api_set_owner($hoisted3) : null,
     !$cmp.truthyValue
-      ? api_element("p", stc1, [api_text("false branch")])
+      ? api_element("p", stc1, [api_set_owner($hoisted4)])
       : null,
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -5,10 +5,10 @@ const {
   t: api_text,
   h: api_element,
 } = renderApi;
-const $hoisted1 = api_comment(" HTML comment inside if:true ", true);
-const $hoisted2 = api_text("true branch", true);
-const $hoisted3 = api_comment(" HTML comment inside if:false ", true);
-const $hoisted4 = api_text("false branch", true);
+const $hoisted1 = api_comment(" HTML comment inside if:true ");
+const $hoisted2 = api_text("true branch");
+const $hoisted3 = api_comment(" HTML comment inside if:false ");
+const $hoisted4 = api_text("false branch");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -1,5 +1,7 @@
 import { registerTemplate, renderApi } from "lwc";
 const { co: api_comment, t: api_text, h: api_element } = renderApi;
+const $hoisted1 = api_comment(" HTML comment inside if:true ", true);
+const $hoisted2 = api_comment(" HTML comment inside if:false ", true);
 const stc0 = {
   key: 0,
 };
@@ -8,9 +10,9 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $cmp.truthyValue ? api_comment(" HTML comment inside if:true ") : null,
+    $cmp.truthyValue ? $hoisted1 : null,
     $cmp.truthyValue ? api_element("p", stc0, [api_text("true branch")]) : null,
-    !$cmp.truthyValue ? api_comment(" HTML comment inside if:false ") : null,
+    !$cmp.truthyValue ? $hoisted2 : null,
     !$cmp.truthyValue
       ? api_element("p", stc1, [api_text("false branch")])
       : null,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { co: api_comment, t: api_text, h: api_element } = renderApi;
+const {
+  co: api_comment,
+  so: api_set_owner,
+  t: api_text,
+  h: api_element,
+} = renderApi;
 const $hoisted1 = api_comment(" This is an HTML comment ", true);
 const $hoisted2 = api_element(
   "button",
@@ -10,7 +15,7 @@ const $hoisted2 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2];
+  return [api_set_owner($hoisted1), api_set_owner($hoisted2)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -1,13 +1,16 @@
 import { registerTemplate, renderApi } from "lwc";
 const { co: api_comment, t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_comment(" This is an HTML comment ", true);
+const $hoisted2 = api_element(
+  "button",
+  {
+    key: 0,
+  },
+  [api_text("click me")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_comment(" This is an HTML comment "),
-    api_element("button", stc0, [api_text("click me")]),
-  ];
+  return [$hoisted1, $hoisted2];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -5,14 +5,13 @@ const {
   t: api_text,
   h: api_element,
 } = renderApi;
-const $hoisted1 = api_comment(" This is an HTML comment ", true);
+const $hoisted1 = api_comment(" This is an HTML comment ");
 const $hoisted2 = api_element(
   "button",
   {
     key: 0,
   },
-  [api_text("click me")],
-  true
+  [api_text("click me")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1), api_set_owner($hoisted2)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -10,6 +10,7 @@ const $hoisted2 = api_element(
   "button",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("click me")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -2,6 +2,7 @@ import _xChild from "x/child";
 import { registerTemplate, renderApi } from "lwc";
 const {
   co: api_comment,
+  so: api_set_owner,
   t: api_text,
   h: api_element,
   c: api_custom_element,
@@ -19,7 +20,12 @@ const stc0 = {
   key: 0,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_custom_element("x-child", _xChild, stc0, [$hoisted1, $hoisted2])];
+  return [
+    api_custom_element("x-child", _xChild, stc0, [
+      api_set_owner($hoisted1),
+      api_set_owner($hoisted2),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -8,21 +8,18 @@ const {
   c: api_custom_element,
 } = renderApi;
 const $hoisted1 = api_comment(" HTML comment inside slot ");
-const $hoisted2 = api_element(
-  "p",
-  {
-    key: 1,
-  },
-  [api_text("slot content")]
-);
+const $hoisted2 = api_text("slot content");
 const stc0 = {
   key: 0,
+};
+const stc1 = {
+  key: 1,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_custom_element("x-child", _xChild, stc0, [
       api_set_owner($hoisted1),
-      api_set_owner($hoisted2),
+      api_element("p", stc1, [api_set_owner($hoisted2)]),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -7,14 +7,13 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_comment(" HTML comment inside slot ", true);
+const $hoisted1 = api_comment(" HTML comment inside slot ");
 const $hoisted2 = api_element(
   "p",
   {
     key: 1,
   },
-  [api_text("slot content")],
-  true
+  [api_text("slot content")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -6,19 +6,20 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
+const $hoisted1 = api_comment(" HTML comment inside slot ", true);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("slot content")],
+  true
+);
 const stc0 = {
   key: 0,
 };
-const stc1 = {
-  key: 1,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_custom_element("x-child", _xChild, stc0, [
-      api_comment(" HTML comment inside slot "),
-      api_element("p", stc1, [api_text("slot content")]),
-    ]),
-  ];
+  return [api_custom_element("x-child", _xChild, stc0, [$hoisted1, $hoisted2])];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -5,16 +5,21 @@ const {
   dc: api_dynamic_component,
   f: api_flatten,
 } = renderApi;
+const $hoisted1 = api_element(
+  "div",
+  {
+    key: 0,
+  },
+  [api_text("sibling")],
+  true
+);
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   key: 1,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
-    api_element("div", stc0, [api_text("sibling")]),
-    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc1),
+    $hoisted1,
+    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
   ]);
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -10,6 +10,7 @@ const $hoisted1 = api_element(
   "div",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("sibling")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -2,6 +2,7 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   t: api_text,
   h: api_element,
+  so: api_set_owner,
   dc: api_dynamic_component,
   f: api_flatten,
 } = renderApi;
@@ -18,7 +19,7 @@ const stc0 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
-    $hoisted1,
+    api_set_owner($hoisted1),
     api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
   ]);
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -11,8 +11,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("sibling")],
-  true
+  [api_text("sibling")]
 );
 const stc0 = {
   key: 1,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -13,6 +13,7 @@ const $hoisted3 = api_element(
   "p",
   {
     key: 1,
+    isStatic: true,
   },
   [api_text("Last child")]
 );
@@ -23,6 +24,7 @@ const $hoisted7 = api_element(
   "p",
   {
     key: 6,
+    isStatic: true,
   },
   [api_text("Last child")]
 );
@@ -33,12 +35,14 @@ const $hoisted8 = api_element(
       s4: true,
     },
     key: 8,
+    isStatic: true,
   },
   [
     api_element(
       "p",
       {
         key: 9,
+        isStatic: true,
       },
       [api_text("Other child1")]
     ),
@@ -46,6 +50,7 @@ const $hoisted8 = api_element(
       "p",
       {
         key: 10,
+        isStatic: true,
       },
       [api_text("Other child2")]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -7,26 +7,24 @@ const {
   f: api_flatten,
   k: api_key,
 } = renderApi;
-const $hoisted1 = api_text("Other Child", true);
-const $hoisted2 = api_text("X", true);
+const $hoisted1 = api_text("Other Child");
+const $hoisted2 = api_text("X");
 const $hoisted3 = api_element(
   "p",
   {
     key: 1,
   },
-  [api_text("Last child")],
-  true
+  [api_text("Last child")]
 );
-const $hoisted4 = api_text("Other Child", true);
-const $hoisted5 = api_text("X1", true);
-const $hoisted6 = api_text("X2", true);
+const $hoisted4 = api_text("Other Child");
+const $hoisted5 = api_text("X1");
+const $hoisted6 = api_text("X2");
 const $hoisted7 = api_element(
   "p",
   {
     key: 6,
   },
-  [api_text("Last child")],
-  true
+  [api_text("Last child")]
 );
 const $hoisted8 = api_element(
   "section",
@@ -51,8 +49,7 @@ const $hoisted8 = api_element(
       },
       [api_text("Other child2")]
     ),
-  ],
-  true
+  ]
 );
 const stc0 = {
   classMap: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -1,12 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const {
   t: api_text,
+  so: api_set_owner,
   i: api_iterator,
   h: api_element,
   f: api_flatten,
   k: api_key,
 } = renderApi;
-const $hoisted1 = api_element(
+const $hoisted1 = api_text("Other Child", true);
+const $hoisted2 = api_text("X", true);
+const $hoisted3 = api_element(
   "p",
   {
     key: 1,
@@ -14,7 +17,10 @@ const $hoisted1 = api_element(
   [api_text("Last child")],
   true
 );
-const $hoisted2 = api_element(
+const $hoisted4 = api_text("Other Child", true);
+const $hoisted5 = api_text("X1", true);
+const $hoisted6 = api_text("X2", true);
+const $hoisted7 = api_element(
   "p",
   {
     key: 6,
@@ -22,7 +28,7 @@ const $hoisted2 = api_element(
   [api_text("Last child")],
   true
 );
-const $hoisted3 = api_element(
+const $hoisted8 = api_element(
   "section",
   {
     classMap: {
@@ -73,18 +79,18 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "section",
       stc0,
       api_flatten([
-        api_text("Other Child"),
+        api_set_owner($hoisted1),
         api_iterator($cmp.items, function (item) {
-          return api_text("X");
+          return api_set_owner($hoisted2);
         }),
-        $hoisted1,
+        api_set_owner($hoisted3),
       ])
     ),
     api_element(
       "section",
       stc1,
       api_flatten([
-        api_text("Other Child"),
+        api_set_owner($hoisted4),
         $cmp.isTrue
           ? api_iterator($cmp.items, function (item) {
               return [
@@ -93,14 +99,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   {
                     key: api_key(3, item.id),
                   },
-                  [api_text("X1")]
+                  [api_set_owner($hoisted5)]
                 ),
                 api_element(
                   "p",
                   {
                     key: api_key(4, item.id),
                   },
-                  [api_text("X2")]
+                  [api_set_owner($hoisted6)]
                 ),
               ];
             })
@@ -111,7 +117,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       "section",
       stc3,
       api_flatten([
-        $hoisted2,
+        api_set_owner($hoisted7),
         api_iterator($cmp.items, function (item) {
           return api_element("div", {
             key: api_key(7, item.id),
@@ -119,7 +125,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         }),
       ])
     ),
-    $hoisted3,
+    api_set_owner($hoisted8),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -6,6 +6,48 @@ const {
   f: api_flatten,
   k: api_key,
 } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("Last child")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 6,
+  },
+  [api_text("Last child")],
+  true
+);
+const $hoisted3 = api_element(
+  "section",
+  {
+    classMap: {
+      s4: true,
+    },
+    key: 8,
+  },
+  [
+    api_element(
+      "p",
+      {
+        key: 9,
+      },
+      [api_text("Other child1")]
+    ),
+    api_element(
+      "p",
+      {
+        key: 10,
+      },
+      [api_text("Other child2")]
+    ),
+  ],
+  true
+);
 const stc0 = {
   classMap: {
     s1: true,
@@ -13,35 +55,17 @@ const stc0 = {
   key: 0,
 };
 const stc1 = {
-  key: 1,
-};
-const stc2 = {
   classMap: {
     s2: true,
   },
   key: 2,
 };
-const stc3 = [];
-const stc4 = {
+const stc2 = [];
+const stc3 = {
   classMap: {
     s3: true,
   },
   key: 5,
-};
-const stc5 = {
-  key: 6,
-};
-const stc6 = {
-  classMap: {
-    s4: true,
-  },
-  key: 8,
-};
-const stc7 = {
-  key: 9,
-};
-const stc8 = {
-  key: 10,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
@@ -53,12 +77,12 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         api_iterator($cmp.items, function (item) {
           return api_text("X");
         }),
-        api_element("p", stc1, [api_text("Last child")]),
+        $hoisted1,
       ])
     ),
     api_element(
       "section",
-      stc2,
+      stc1,
       api_flatten([
         api_text("Other Child"),
         $cmp.isTrue
@@ -80,14 +104,14 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 ),
               ];
             })
-          : stc3,
+          : stc2,
       ])
     ),
     api_element(
       "section",
-      stc4,
+      stc3,
       api_flatten([
-        api_element("p", stc5, [api_text("Last child")]),
+        $hoisted2,
         api_iterator($cmp.items, function (item) {
           return api_element("div", {
             key: api_key(7, item.id),
@@ -95,10 +119,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         }),
       ])
     ),
-    api_element("section", stc6, [
-      api_element("p", stc7, [api_text("Other child1")]),
-      api_element("p", stc8, [api_text("Other child2")]),
-    ]),
+    $hoisted3,
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -5,6 +5,7 @@ const {
   t: api_text,
   h: api_element,
   i: api_iterator,
+  so: api_set_owner,
   f: api_flatten,
 } = renderApi;
 const $hoisted1 = api_element(
@@ -34,7 +35,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             [api_text(api_dynamic_text(item))]
           );
         }),
-        $hoisted1,
+        api_set_owner($hoisted1),
       ])
     ),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -12,6 +12,7 @@ const $hoisted1 = api_element(
   "li",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("Last")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -7,11 +7,16 @@ const {
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
+const $hoisted1 = api_element(
+  "li",
+  {
+    key: 2,
+  },
+  [api_text("Last")],
+  true
+);
 const stc0 = {
   key: 0,
-};
-const stc1 = {
-  key: 2,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
@@ -29,7 +34,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             [api_text(api_dynamic_text(item))]
           );
         }),
-        api_element("li", stc1, [api_text("Last")]),
+        $hoisted1,
       ])
     ),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -13,8 +13,7 @@ const $hoisted1 = api_element(
   {
     key: 2,
   },
-  [api_text("Last")],
-  true
+  [api_text("Last")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -1,5 +1,11 @@
 import { registerTemplate, renderApi } from "lwc";
-const { k: api_key, t: api_text, h: api_element, i: api_iterator } = renderApi;
+const {
+  k: api_key,
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  i: api_iterator,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -26,7 +32,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             classMap: stc1,
             key: api_key(1, item.id),
           },
-          [$hoisted1]
+          [api_set_owner($hoisted1)]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -11,8 +11,7 @@ const $hoisted1 = api_element(
   {
     key: 2,
   },
-  [api_text("items")],
-  true
+  [api_text("items")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -1,13 +1,18 @@
 import { registerTemplate, renderApi } from "lwc";
 const { k: api_key, t: api_text, h: api_element, i: api_iterator } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 2,
+  },
+  [api_text("items")],
+  true
+);
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   "my-list": true,
-};
-const stc2 = {
-  key: 2,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
@@ -21,7 +26,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             classMap: stc1,
             key: api_key(1, item.id),
           },
-          [api_element("p", stc2, [api_text("items")])]
+          [$hoisted1]
         );
       })
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -10,6 +10,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("items")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
@@ -1,8 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
-const $hoisted1 = api_text("1", true);
-const $hoisted2 = api_text("2", true);
-const $hoisted3 = api_text("3", true);
+const $hoisted1 = api_text("1");
+const $hoisted2 = api_text("2");
+const $hoisted3 = api_text("3");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
@@ -1,5 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
+const $hoisted1 = api_text("1", true);
+const $hoisted2 = api_text("2", true);
+const $hoisted3 = api_text("3", true);
 const stc0 = {
   key: 0,
 };
@@ -15,9 +18,9 @@ const stc3 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,
-      $cmp.isTrue ? api_element("p", stc2, [api_text("2")]) : null,
-      $cmp.isTrue ? api_element("p", stc3, [api_text("3")]) : null,
+      $cmp.isTrue ? api_element("p", stc1, [api_set_owner($hoisted1)]) : null,
+      $cmp.isTrue ? api_element("p", stc2, [api_set_owner($hoisted2)]) : null,
+      $cmp.isTrue ? api_element("p", stc3, [api_set_owner($hoisted3)]) : null,
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -1,5 +1,12 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, d: api_dynamic_text } = renderApi;
+const {
+  t: api_text,
+  so: api_set_owner,
+  h: api_element,
+  d: api_dynamic_text,
+} = renderApi;
+const $hoisted1 = api_text("1", true);
+const $hoisted2 = api_text("3", true);
 const stc0 = {
   key: 0,
 };
@@ -12,9 +19,9 @@ const stc2 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $cmp.isTrue ? api_element("p", stc1, [api_text("1")]) : null,
+      $cmp.isTrue ? api_element("p", stc1, [api_set_owner($hoisted1)]) : null,
       api_text(api_dynamic_text($cmp.foo)),
-      $cmp.isTrue ? api_element("p", stc2, [api_text("3")]) : null,
+      $cmp.isTrue ? api_element("p", stc2, [api_set_owner($hoisted2)]) : null,
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -5,8 +5,8 @@ const {
   h: api_element,
   d: api_dynamic_text,
 } = renderApi;
-const $hoisted1 = api_text("1", true);
-const $hoisted2 = api_text("3", true);
+const $hoisted1 = api_text("1");
+const $hoisted2 = api_text("3");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
@@ -1,6 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
-const $hoisted1 = api_text("1", true);
+const $hoisted1 = api_text("1");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
@@ -1,5 +1,6 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
+const $hoisted1 = api_text("1", true);
 const stc0 = {
   key: 0,
 };
@@ -9,7 +10,9 @@ const stc1 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $cmp.isTrue === true ? api_element("p", stc1, [api_text("1")]) : null,
+      $cmp.isTrue === true
+        ? api_element("p", stc1, [api_set_owner($hoisted1)])
+        : null,
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
@@ -1,5 +1,7 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
+const $hoisted1 = api_text("1", true);
+const $hoisted2 = api_text("2", true);
 const stc0 = {
   key: 0,
 };
@@ -8,8 +10,8 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
-    !$cmp.isTrue2 ? api_element("p", stc1, [api_text("2")]) : null,
+    $cmp.isTrue ? api_element("p", stc0, [api_set_owner($hoisted1)]) : null,
+    !$cmp.isTrue2 ? api_element("p", stc1, [api_set_owner($hoisted2)]) : null,
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
@@ -1,7 +1,7 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
-const $hoisted1 = api_text("1", true);
-const $hoisted2 = api_text("2", true);
+const $hoisted1 = api_text("1");
+const $hoisted2 = api_text("2");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
@@ -1,5 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
+const $hoisted1 = api_text("1", true);
+const $hoisted2 = api_text("2", true);
+const $hoisted3 = api_text("3", true);
 const stc0 = {
   key: 0,
 };
@@ -11,9 +14,9 @@ const stc2 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $cmp.isTrue ? api_element("p", stc0, [api_text("1")]) : null,
-    $cmp.isTrue ? api_element("p", stc1, [api_text("2")]) : null,
-    $cmp.isTrue ? api_element("p", stc2, [api_text("3")]) : null,
+    $cmp.isTrue ? api_element("p", stc0, [api_set_owner($hoisted1)]) : null,
+    $cmp.isTrue ? api_element("p", stc1, [api_set_owner($hoisted2)]) : null,
+    $cmp.isTrue ? api_element("p", stc2, [api_set_owner($hoisted3)]) : null,
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
@@ -1,8 +1,8 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, so: api_set_owner, h: api_element } = renderApi;
-const $hoisted1 = api_text("1", true);
-const $hoisted2 = api_text("2", true);
-const $hoisted3 = api_text("3", true);
+const $hoisted1 = api_text("1");
+const $hoisted2 = api_text("2");
+const $hoisted3 = api_text("3");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -5,17 +5,15 @@ const $hoisted1 = api_element(
   {
     key: 1,
   },
-  [api_text("1")],
-  true
+  [api_text("1")]
 );
-const $hoisted2 = api_text("2", true);
+const $hoisted2 = api_text("2");
 const $hoisted3 = api_element(
   "p",
   {
     key: 3,
   },
-  [api_text("3")],
-  true
+  [api_text("3")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -8,7 +8,8 @@ const $hoisted1 = api_element(
   [api_text("1")],
   true
 );
-const $hoisted2 = api_element(
+const $hoisted2 = api_text("2", true);
+const $hoisted3 = api_element(
   "p",
   {
     key: 3,
@@ -25,9 +26,9 @@ const stc1 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $hoisted1,
-      $cmp.bar ? api_element("p", stc1, [api_text("2")]) : null,
-      $hoisted2,
+      api_set_owner($hoisted1),
+      $cmp.bar ? api_element("p", stc1, [api_set_owner($hoisted2)]) : null,
+      api_set_owner($hoisted3),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -1,23 +1,33 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("1")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 3,
+  },
+  [api_text("3")],
+  true
+);
 const stc0 = {
   key: 0,
 };
 const stc1 = {
-  key: 1,
-};
-const stc2 = {
   key: 2,
-};
-const stc3 = {
-  key: 3,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_element("p", stc1, [api_text("1")]),
-      $cmp.bar ? api_element("p", stc2, [api_text("2")]) : null,
-      api_element("p", stc3, [api_text("3")]),
+      $hoisted1,
+      $cmp.bar ? api_element("p", stc1, [api_text("2")]) : null,
+      $hoisted2,
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 1,
+    isStatic: true,
   },
   [api_text("1")]
 );
@@ -12,6 +13,7 @@ const $hoisted3 = api_element(
   "p",
   {
     key: 3,
+    isStatic: true,
   },
   [api_text("3")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -4,8 +4,10 @@ const {
   d: api_dynamic_text,
   t: api_text,
   h: api_element,
+  so: api_set_owner,
   i: api_iterator,
 } = renderApi;
+const $hoisted1 = api_text("Text", true);
 const stc0 = {
   key: 0,
 };
@@ -47,7 +49,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                 {
                   key: api_key(3, x.value.key),
                 },
-                [api_text("Text")]
+                [api_set_owner($hoisted1)]
               )
             : null,
         ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -7,7 +7,7 @@ const {
   so: api_set_owner,
   i: api_iterator,
 } = renderApi;
-const $hoisted1 = api_text("Text", true);
+const $hoisted1 = api_text("Text");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -5,8 +5,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -1,10 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "div",
+  {
+    key: 0,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("div", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "div",
   {
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -9,7 +9,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("Root")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -1,10 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 0,
+  },
+  [api_text("Root")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("p", stc0, [api_text("Root")])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -5,8 +5,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("Root")],
-  true
+  [api_text("Root")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -9,7 +9,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -1,5 +1,11 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot, f: api_flatten } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+  f: api_flatten,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -8,6 +14,8 @@ const $hoisted1 = api_element(
   [api_text("Root")],
   true
 );
+const $hoisted2 = api_text("Default", true);
+const $hoisted3 = api_text("Named", true);
 const stc0 = {
   key: 1,
 };
@@ -19,9 +27,9 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
-    $hoisted1,
-    api_slot("", stc0, [api_text("Default")], $slotset),
-    api_slot("named", stc1, [api_text("Named")], $slotset),
+    api_set_owner($hoisted1),
+    api_slot("", stc0, [api_set_owner($hoisted2)], $slotset),
+    api_slot("named", stc1, [api_set_owner($hoisted3)], $slotset),
   ]);
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -10,6 +10,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("Root")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -11,11 +11,10 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("Root")],
-  true
+  [api_text("Root")]
 );
-const $hoisted2 = api_text("Default", true);
-const $hoisted3 = api_text("Named", true);
+const $hoisted2 = api_text("Default");
+const $hoisted3 = api_text("Named");
 const stc0 = {
   key: 1,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -1,12 +1,17 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot, f: api_flatten } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 0,
+  },
+  [api_text("Root")],
+  true
+);
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   key: 1,
 };
-const stc2 = {
+const stc1 = {
   attrs: {
     name: "named",
   },
@@ -14,9 +19,9 @@ const stc2 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return api_flatten([
-    api_element("p", stc0, [api_text("Root")]),
-    api_slot("", stc1, [api_text("Default")], $slotset),
-    api_slot("named", stc2, [api_text("Named")], $slotset),
+    $hoisted1,
+    api_slot("", stc0, [api_text("Default")], $slotset),
+    api_slot("named", stc1, [api_text("Named")], $slotset),
   ]);
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
@@ -5,8 +5,8 @@ const {
   so: api_set_owner,
   h: api_element,
 } = renderApi;
-const $hoisted1 = api_text("x", true);
-const $hoisted2 = api_text("x", true);
+const $hoisted1 = api_text("x");
+const $hoisted2 = api_text("x");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
@@ -1,5 +1,12 @@
 import { registerTemplate, renderApi } from "lwc";
-const { b: api_bind, t: api_text, h: api_element } = renderApi;
+const {
+  b: api_bind,
+  t: api_text,
+  so: api_set_owner,
+  h: api_element,
+} = renderApi;
+const $hoisted1 = api_text("x", true);
+const $hoisted2 = api_text("x", true);
 const stc0 = {
   key: 0,
 };
@@ -15,7 +22,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             click: _m0 || ($ctx._m0 = api_bind($cmp.handleClick)),
           },
         },
-        [api_text("x")]
+        [api_set_owner($hoisted1)]
       ),
       api_element(
         "div",
@@ -25,7 +32,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             press: _m1 || ($ctx._m1 = api_bind($cmp.handlePress)),
           },
         },
-        [api_text("x")]
+        [api_set_owner($hoisted2)]
       ),
     ]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
@@ -5,10 +5,10 @@ const {
   so: api_set_owner,
   h: api_element,
 } = renderApi;
-const $hoisted1 = api_text("Click", true);
-const $hoisted2 = api_text("Click", true);
-const $hoisted3 = api_text("Click", true);
-const $hoisted4 = api_text("Click", true);
+const $hoisted1 = api_text("Click");
+const $hoisted2 = api_text("Click");
+const $hoisted3 = api_text("Click");
+const $hoisted4 = api_text("Click");
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0, _m1, _m2, _m3 } = $ctx;
   return [

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
@@ -1,5 +1,14 @@
 import { registerTemplate, renderApi } from "lwc";
-const { b: api_bind, t: api_text, h: api_element } = renderApi;
+const {
+  b: api_bind,
+  t: api_text,
+  so: api_set_owner,
+  h: api_element,
+} = renderApi;
+const $hoisted1 = api_text("Click", true);
+const $hoisted2 = api_text("Click", true);
+const $hoisted3 = api_text("Click", true);
+const $hoisted4 = api_text("Click", true);
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { _m0, _m1, _m2, _m3 } = $ctx;
   return [
@@ -11,7 +20,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           a123: _m0 || ($ctx._m0 = api_bind($cmp.handleClick)),
         },
       },
-      [api_text("Click")]
+      [api_set_owner($hoisted1)]
     ),
     api_element(
       "div",
@@ -21,7 +30,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           foo_bar: _m1 || ($ctx._m1 = api_bind($cmp.handleClick)),
         },
       },
-      [api_text("Click")]
+      [api_set_owner($hoisted2)]
     ),
     api_element(
       "div",
@@ -31,7 +40,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           foo_: _m2 || ($ctx._m2 = api_bind($cmp.handleClick)),
         },
       },
-      [api_text("Click")]
+      [api_set_owner($hoisted3)]
     ),
     api_element(
       "div",
@@ -41,7 +50,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           a123: _m3 || ($ctx._m3 = api_bind($cmp.handleClick)),
         },
       },
-      [api_text("Click")]
+      [api_set_owner($hoisted4)]
     ),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -1,13 +1,18 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  props: {
-    value: "{value}",
+const $hoisted1 = api_element(
+  "input",
+  {
+    props: {
+      value: "{value}",
+    },
+    key: 0,
   },
-  key: 0,
-};
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("input", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -7,6 +7,7 @@ const $hoisted1 = api_element(
       value: "{value}",
     },
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "input",
   {
@@ -12,7 +12,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -8,8 +8,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -1,6 +1,11 @@
 import _xCustomComponent from "x/customComponent";
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element, c: api_custom_element, t: api_text } = renderApi;
+const {
+  h: api_element,
+  so: api_set_owner,
+  c: api_custom_element,
+  t: api_text,
+} = renderApi;
 const $hoisted1 = api_element(
   "unknonwtag",
   {
@@ -33,10 +38,10 @@ const stc0 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    $hoisted1,
+    api_set_owner($hoisted1),
     api_custom_element("x-custom-component", _xCustomComponent, stc0),
-    $hoisted2,
-    $hoisted3,
+    api_set_owner($hoisted2),
+    api_set_owner($hoisted3),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -1,27 +1,42 @@
 import _xCustomComponent from "x/customComponent";
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element, c: api_custom_element, t: api_text } = renderApi;
+const $hoisted1 = api_element(
+  "unknonwtag",
+  {
+    key: 0,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "span",
+  {
+    key: 2,
+  },
+  [api_text("valid tags should not warn")],
+  true
+);
+const $hoisted3 = api_element(
+  "spam",
+  {
+    key: 3,
+  },
+  [api_text("this tag has a typo")],
+  true
+);
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   props: {
     someTruthyValue: true,
   },
   key: 1,
 };
-const stc2 = {
-  key: 2,
-};
-const stc3 = {
-  key: 3,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("unknonwtag", stc0),
-    api_custom_element("x-custom-component", _xCustomComponent, stc1),
-    api_element("span", stc2, [api_text("valid tags should not warn")]),
-    api_element("spam", stc3, [api_text("this tag has a typo")]),
+    $hoisted1,
+    api_custom_element("x-custom-component", _xCustomComponent, stc0),
+    $hoisted2,
+    $hoisted3,
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -11,24 +11,21 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "span",
   {
     key: 2,
   },
-  [api_text("valid tags should not warn")],
-  true
+  [api_text("valid tags should not warn")]
 );
 const $hoisted3 = api_element(
   "spam",
   {
     key: 3,
   },
-  [api_text("this tag has a typo")],
-  true
+  [api_text("this tag has a typo")]
 );
 const stc0 = {
   props: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -10,6 +10,7 @@ const $hoisted1 = api_element(
   "unknonwtag",
   {
     key: 0,
+    isStatic: true,
   },
   []
 );
@@ -17,6 +18,7 @@ const $hoisted2 = api_element(
   "span",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("valid tags should not warn")]
 );
@@ -24,6 +26,7 @@ const $hoisted3 = api_element(
   "spam",
   {
     key: 3,
+    isStatic: true,
   },
   [api_text("this tag has a typo")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -5,8 +5,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -1,10 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "div",
+  {
+    key: 0,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("div", stc0)];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "div",
   {
     key: 0,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -9,7 +9,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -5,8 +5,7 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("hello")],
-  true
+  [api_text("hello")]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "h1",
   {
@@ -9,7 +9,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "h1",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("hello")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-template/expected.js
@@ -1,10 +1,15 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
+const $hoisted1 = api_element(
+  "h1",
+  {
+    key: 0,
+  },
+  [api_text("hello")],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("h1", stc0, [api_text("hello")])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "section",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element("color-profile", {
@@ -11,6 +12,7 @@ const $hoisted1 = api_element(
         local: "x",
       },
       key: 1,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "section",
   {
@@ -16,7 +16,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -1,16 +1,22 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    local: "x",
+const $hoisted1 = api_element(
+  "section",
+  {
+    key: 0,
   },
-  key: 1,
-};
+  [
+    api_element("color-profile", {
+      attrs: {
+        local: "x",
+      },
+      key: 1,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("section", stc0, [api_element("color-profile", stc1)])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -12,8 +12,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -2,11 +2,14 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   b: api_bind,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   k: api_key,
   d: api_dynamic_text,
   i: api_iterator,
 } = renderApi;
+const $hoisted1 = api_text("New", true);
+const $hoisted2 = api_text("[X]", true);
 const stc0 = {
   key: 1,
 };
@@ -21,7 +24,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           click: _m0 || ($ctx._m0 = api_bind($cmp.create)),
         },
       },
-      [api_text("New")]
+      [api_set_owner($hoisted1)]
     ),
     api_element(
       "ul",
@@ -42,7 +45,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
                   click: api_bind(task.delete),
                 },
               },
-              [api_text("[X]")]
+              [api_set_owner($hoisted2)]
             ),
           ]
         );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -8,8 +8,8 @@ const {
   d: api_dynamic_text,
   i: api_iterator,
 } = renderApi;
-const $hoisted1 = api_text("New", true);
-const $hoisted2 = api_text("[X]", true);
+const $hoisted1 = api_text("New");
+const $hoisted2 = api_text("[X]");
 const stc0 = {
   key: 1,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "h1",
   {
     key: 0,
+    isStatic: true,
   },
   [api_text("hello")]
 );
@@ -11,6 +12,7 @@ const $hoisted2 = api_element(
   "br",
   {
     key: 1,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "h1",
   {
@@ -17,7 +17,7 @@ const $hoisted2 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1, $hoisted2];
+  return [api_set_owner($hoisted1), api_set_owner($hoisted2)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -5,16 +5,14 @@ const $hoisted1 = api_element(
   {
     key: 0,
   },
-  [api_text("hello")],
-  true
+  [api_text("hello")]
 );
 const $hoisted2 = api_element(
   "br",
   {
     key: 1,
   },
-  [],
-  true
+  []
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1), api_set_owner($hoisted2)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -1,16 +1,23 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  key: 1,
-};
+const $hoisted1 = api_element(
+  "h1",
+  {
+    key: 0,
+  },
+  [api_text("hello")],
+  true
+);
+const $hoisted2 = api_element(
+  "br",
+  {
+    key: 1,
+  },
+  [],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("h1", stc0, [api_text("hello")]),
-    api_element("br", stc1),
-  ];
+  return [$hoisted1, $hoisted2];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -1,23 +1,26 @@
 import { registerTemplate, renderApi } from "lwc";
 const {
   t: api_text,
+  so: api_set_owner,
   k: api_key,
   h: api_element,
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
+const $hoisted1 = api_text("Outer", true);
+const $hoisted2 = api_text("Inner", true);
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
   return $cmp.isTrue
     ? api_flatten([
-        api_text("Outer"),
+        api_set_owner($hoisted1),
         api_iterator($cmp.items, function (item) {
           return api_element(
             "p",
             {
               key: api_key(0, item.id),
             },
-            [api_text("Inner")]
+            [api_set_owner($hoisted2)]
           );
         }),
       ])

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -7,8 +7,8 @@ const {
   i: api_iterator,
   f: api_flatten,
 } = renderApi;
-const $hoisted1 = api_text("Outer", true);
-const $hoisted2 = api_text("Inner", true);
+const $hoisted1 = api_text("Outer");
+const $hoisted2 = api_text("Inner");
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
   return $cmp.isTrue

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 1,
+    isStatic: true,
   },
   [api_text("Test slot content")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
   {
     key: 1,
   },
-  [api_text("Test slot content")],
-  true
+  [api_text("Test slot content")]
 );
 const stc0 = {
   attrs: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -1,23 +1,21 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("Test slot content")],
+  true
+);
 const stc0 = {
   attrs: {
     name: "secret-slot",
   },
   key: 0,
 };
-const stc1 = {
-  key: 1,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_slot(
-      "secret-slot",
-      stc0,
-      [api_element("p", stc1, [api_text("Test slot content")])],
-      $slotset
-    ),
-  ];
+  return [api_slot("secret-slot", stc0, [$hoisted1], $slotset)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -15,7 +20,7 @@ const stc0 = {
   key: 0,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_slot("secret-slot", stc0, [$hoisted1], $slotset)];
+  return [api_slot("secret-slot", stc0, [api_set_owner($hoisted1)], $slotset)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -4,16 +4,19 @@ const $hoisted1 = api_element(
   "table",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element(
       "tbody",
       {
         key: 1,
+        isStatic: true,
       },
       [
         api_element("tr", {
           key: 2,
+          isStatic: true,
         }),
       ]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -1,20 +1,27 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  key: 1,
-};
-const stc2 = {
-  key: 2,
-};
+const $hoisted1 = api_element(
+  "table",
+  {
+    key: 0,
+  },
+  [
+    api_element(
+      "tbody",
+      {
+        key: 1,
+      },
+      [
+        api_element("tr", {
+          key: 2,
+        }),
+      ]
+    ),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("table", stc0, [
-      api_element("tbody", stc1, [api_element("tr", stc2)]),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "table",
   {
@@ -21,7 +21,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -17,8 +17,7 @@ const $hoisted1 = api_element(
         }),
       ]
     ),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -1,5 +1,21 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 2,
+  },
+  [api_text("Default slot other content")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 4,
+  },
+  [api_text("Default slot content")],
+  true
+);
 const stc0 = {
   key: 0,
 };
@@ -10,29 +26,13 @@ const stc1 = {
   key: 1,
 };
 const stc2 = {
-  key: 2,
-};
-const stc3 = {
   key: 3,
-};
-const stc4 = {
-  key: 4,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_slot(
-        "other",
-        stc1,
-        [api_element("p", stc2, [api_text("Default slot other content")])],
-        $slotset
-      ),
-      api_slot(
-        "",
-        stc3,
-        [api_element("p", stc4, [api_text("Default slot content")])],
-        $slotset
-      ),
+      api_slot("other", stc1, [$hoisted1], $slotset),
+      api_slot("", stc2, [$hoisted2], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -31,8 +36,8 @@ const stc2 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_slot("other", stc1, [$hoisted1], $slotset),
-      api_slot("", stc2, [$hoisted2], $slotset),
+      api_slot("other", stc1, [api_set_owner($hoisted1)], $slotset),
+      api_slot("", stc2, [api_set_owner($hoisted2)], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -10,16 +10,14 @@ const $hoisted1 = api_element(
   {
     key: 2,
   },
-  [api_text("Default slot other content")],
-  true
+  [api_text("Default slot other content")]
 );
 const $hoisted2 = api_element(
   "p",
   {
     key: 4,
   },
-  [api_text("Default slot content")],
-  true
+  [api_text("Default slot content")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("Default slot other content")]
 );
@@ -16,6 +17,7 @@ const $hoisted2 = api_element(
   "p",
   {
     key: 4,
+    isStatic: true,
   },
   [api_text("Default slot content")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 1,
+    isStatic: true,
   },
   [api_text("Sibling")]
 );
@@ -16,6 +17,7 @@ const $hoisted2 = api_element(
   "p",
   {
     key: 3,
+    isStatic: true,
   },
   [api_text("Default slot content")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -1,27 +1,32 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("Sibling")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 3,
+  },
+  [api_text("Default slot content")],
+  true
+);
 const stc0 = {
   key: 0,
 };
 const stc1 = {
-  key: 1,
-};
-const stc2 = {
   key: 2,
-};
-const stc3 = {
-  key: 3,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_element("p", stc1, [api_text("Sibling")]),
-      api_slot(
-        "",
-        stc2,
-        [api_element("p", stc3, [api_text("Default slot content")])],
-        $slotset
-      ),
+      $hoisted1,
+      api_slot("", stc1, [$hoisted2], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -10,16 +10,14 @@ const $hoisted1 = api_element(
   {
     key: 1,
   },
-  [api_text("Sibling")],
-  true
+  [api_text("Sibling")]
 );
 const $hoisted2 = api_element(
   "p",
   {
     key: 3,
   },
-  [api_text("Default slot content")],
-  true
+  [api_text("Default slot content")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -25,8 +30,8 @@ const stc1 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $hoisted1,
-      api_slot("", stc1, [$hoisted2], $slotset),
+      api_set_owner($hoisted1),
+      api_slot("", stc1, [api_set_owner($hoisted2)], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -1,24 +1,22 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 2,
+  },
+  [api_text("Default slot content")],
+  true
+);
 const stc0 = {
   key: 0,
 };
 const stc1 = {
   key: 1,
 };
-const stc2 = {
-  key: 2,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("section", stc0, [
-      api_slot(
-        "",
-        stc1,
-        [api_element("p", stc2, [api_text("Default slot content")])],
-        $slotset
-      ),
-    ]),
+    api_element("section", stc0, [api_slot("", stc1, [$hoisted1], $slotset)]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("Default slot content")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -16,7 +21,9 @@ const stc1 = {
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
-    api_element("section", stc0, [api_slot("", stc1, [$hoisted1], $slotset)]),
+    api_element("section", stc0, [
+      api_slot("", stc1, [api_set_owner($hoisted1)], $slotset),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
   {
     key: 2,
   },
-  [api_text("Default slot content")],
-  true
+  [api_text("Default slot content")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 1,
+    isStatic: true,
   },
   [api_text("Before header")]
 );
@@ -17,6 +18,7 @@ const $hoisted3 = api_element(
   "p",
   {
     key: 3,
+    isStatic: true,
   },
   [api_text("In")]
 );
@@ -24,6 +26,7 @@ const $hoisted4 = api_element(
   "p",
   {
     key: 4,
+    isStatic: true,
   },
   [api_text("between")]
 );
@@ -31,6 +34,7 @@ const $hoisted5 = api_element(
   "p",
   {
     key: 6,
+    isStatic: true,
   },
   [api_text("Default body")]
 );
@@ -38,6 +42,7 @@ const $hoisted6 = api_element(
   "p",
   {
     key: 8,
+    isStatic: true,
   },
   [api_text("Default footer")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -8,7 +13,8 @@ const $hoisted1 = api_element(
   [api_text("Before header")],
   true
 );
-const $hoisted2 = api_element(
+const $hoisted2 = api_text("Default header", true);
+const $hoisted3 = api_element(
   "p",
   {
     key: 3,
@@ -16,7 +22,7 @@ const $hoisted2 = api_element(
   [api_text("In")],
   true
 );
-const $hoisted3 = api_element(
+const $hoisted4 = api_element(
   "p",
   {
     key: 4,
@@ -24,7 +30,7 @@ const $hoisted3 = api_element(
   [api_text("between")],
   true
 );
-const $hoisted4 = api_element(
+const $hoisted5 = api_element(
   "p",
   {
     key: 6,
@@ -32,7 +38,7 @@ const $hoisted4 = api_element(
   [api_text("Default body")],
   true
 );
-const $hoisted5 = api_element(
+const $hoisted6 = api_element(
   "p",
   {
     key: 8,
@@ -61,12 +67,12 @@ const stc3 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      $hoisted1,
-      api_slot("header", stc1, [api_text("Default header")], $slotset),
-      $hoisted2,
-      $hoisted3,
-      api_slot("", stc2, [$hoisted4], $slotset),
-      api_slot("footer", stc3, [$hoisted5], $slotset),
+      api_set_owner($hoisted1),
+      api_slot("header", stc1, [api_set_owner($hoisted2)], $slotset),
+      api_set_owner($hoisted3),
+      api_set_owner($hoisted4),
+      api_slot("", stc2, [api_set_owner($hoisted5)], $slotset),
+      api_slot("footer", stc3, [api_set_owner($hoisted6)], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -10,41 +10,36 @@ const $hoisted1 = api_element(
   {
     key: 1,
   },
-  [api_text("Before header")],
-  true
+  [api_text("Before header")]
 );
-const $hoisted2 = api_text("Default header", true);
+const $hoisted2 = api_text("Default header");
 const $hoisted3 = api_element(
   "p",
   {
     key: 3,
   },
-  [api_text("In")],
-  true
+  [api_text("In")]
 );
 const $hoisted4 = api_element(
   "p",
   {
     key: 4,
   },
-  [api_text("between")],
-  true
+  [api_text("between")]
 );
 const $hoisted5 = api_element(
   "p",
   {
     key: 6,
   },
-  [api_text("Default body")],
-  true
+  [api_text("Default body")]
 );
 const $hoisted6 = api_element(
   "p",
   {
     key: 8,
   },
-  [api_text("Default footer")],
-  true
+  [api_text("Default footer")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -1,57 +1,72 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 1,
+  },
+  [api_text("Before header")],
+  true
+);
+const $hoisted2 = api_element(
+  "p",
+  {
+    key: 3,
+  },
+  [api_text("In")],
+  true
+);
+const $hoisted3 = api_element(
+  "p",
+  {
+    key: 4,
+  },
+  [api_text("between")],
+  true
+);
+const $hoisted4 = api_element(
+  "p",
+  {
+    key: 6,
+  },
+  [api_text("Default body")],
+  true
+);
+const $hoisted5 = api_element(
+  "p",
+  {
+    key: 8,
+  },
+  [api_text("Default footer")],
+  true
+);
 const stc0 = {
   key: 0,
 };
 const stc1 = {
-  key: 1,
-};
-const stc2 = {
   attrs: {
     name: "header",
   },
   key: 2,
 };
-const stc3 = {
-  key: 3,
-};
-const stc4 = {
-  key: 4,
-};
-const stc5 = {
+const stc2 = {
   key: 5,
 };
-const stc6 = {
-  key: 6,
-};
-const stc7 = {
+const stc3 = {
   attrs: {
     name: "footer",
   },
   key: 7,
 };
-const stc8 = {
-  key: 8,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_element("p", stc1, [api_text("Before header")]),
-      api_slot("header", stc2, [api_text("Default header")], $slotset),
-      api_element("p", stc3, [api_text("In")]),
-      api_element("p", stc4, [api_text("between")]),
-      api_slot(
-        "",
-        stc5,
-        [api_element("p", stc6, [api_text("Default body")])],
-        $slotset
-      ),
-      api_slot(
-        "footer",
-        stc7,
-        [api_element("p", stc8, [api_text("Default footer")])],
-        $slotset
-      ),
+      $hoisted1,
+      api_slot("header", stc1, [api_text("Default header")], $slotset),
+      $hoisted2,
+      $hoisted3,
+      api_slot("", stc2, [$hoisted4], $slotset),
+      api_slot("footer", stc3, [$hoisted5], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -3,10 +3,12 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   h: api_element,
   t: api_text,
+  so: api_set_owner,
   i: api_iterator,
   f: api_flatten,
   c: api_custom_element,
 } = renderApi;
+const $hoisted1 = api_text("x", true);
 const stc0 = {
   key: 0,
 };
@@ -28,7 +30,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           $cmp.isLoading ? api_element("div", stc2) : null,
           $cmp.haveLoadedItems
             ? api_iterator($cmp.menuItems, function (item) {
-                return api_text("x");
+                return api_set_owner($hoisted1);
               })
             : stc3,
         ])

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -8,7 +8,7 @@ const {
   f: api_flatten,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_text("x", true);
+const $hoisted1 = api_text("x");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -3,10 +3,12 @@ import { registerTemplate, renderApi } from "lwc";
 const {
   k: api_key,
   t: api_text,
+  so: api_set_owner,
   h: api_element,
   i: api_iterator,
   c: api_custom_element,
 } = renderApi;
+const $hoisted1 = api_text("X", true);
 const stc0 = {
   classMap: {
     s2: true,
@@ -27,7 +29,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               {
                 key: api_key(1, item.id),
               },
-              [api_text("X")]
+              [api_set_owner($hoisted1)]
             );
           })
         : stc1

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -8,7 +8,7 @@ const {
   i: api_iterator,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_text("X", true);
+const $hoisted1 = api_text("X");
 const stc0 = {
   classMap: {
     s2: true,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
@@ -6,8 +6,8 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_text("S1", true);
-const $hoisted2 = api_text("S2", true);
+const $hoisted1 = api_text("S1");
+const $hoisted2 = api_text("S2");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
@@ -1,6 +1,13 @@
 import _nsCmp from "ns/cmp";
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
+const {
+  t: api_text,
+  so: api_set_owner,
+  h: api_element,
+  c: api_custom_element,
+} = renderApi;
+const $hoisted1 = api_text("S1", true);
+const $hoisted2 = api_text("S2", true);
 const stc0 = {
   key: 0,
 };
@@ -23,8 +30,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [
-        $cmp.isTrue ? api_element("p", stc2, [api_text("S1")]) : null,
-        api_element("p", stc3, [api_text("S2")]),
+        $cmp.isTrue ? api_element("p", stc2, [api_set_owner($hoisted1)]) : null,
+        api_element("p", stc3, [api_set_owner($hoisted2)]),
       ]),
     ]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
   "p",
   {
     key: 2,
+    isStatic: true,
   },
   [api_text("Test slot content")]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -10,8 +10,7 @@ const $hoisted1 = api_element(
   {
     key: 2,
   },
-  [api_text("Test slot content")],
-  true
+  [api_text("Test slot content")]
 );
 const stc0 = {
   key: 0,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -1,5 +1,13 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const $hoisted1 = api_element(
+  "p",
+  {
+    key: 2,
+  },
+  [api_text("Test slot content")],
+  true
+);
 const stc0 = {
   key: 0,
 };
@@ -9,18 +17,10 @@ const stc1 = {
   },
   key: 1,
 };
-const stc2 = {
-  key: 2,
-};
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_slot(
-        "test",
-        stc1,
-        [api_element("p", stc2, [api_text("Test slot content")])],
-        $slotset
-      ),
+      api_slot("test", stc1, [$hoisted1], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, s: api_slot } = renderApi;
+const {
+  t: api_text,
+  h: api_element,
+  so: api_set_owner,
+  s: api_slot,
+} = renderApi;
 const $hoisted1 = api_element(
   "p",
   {
@@ -20,7 +25,7 @@ const stc1 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
-      api_slot("test", stc1, [$hoisted1], $slotset),
+      api_slot("test", stc1, [api_set_owner($hoisted1)], $slotset),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
@@ -6,8 +6,8 @@ const {
   h: api_element,
   c: api_custom_element,
 } = renderApi;
-const $hoisted1 = api_text("Header Slot Content", true);
-const $hoisted2 = api_text("Default Content", true);
+const $hoisted1 = api_text("Header Slot Content");
+const $hoisted2 = api_text("Default Content");
 const stc0 = {
   key: 0,
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
@@ -1,6 +1,13 @@
 import _nsCmp from "ns/cmp";
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element, c: api_custom_element } = renderApi;
+const {
+  t: api_text,
+  so: api_set_owner,
+  h: api_element,
+  c: api_custom_element,
+} = renderApi;
+const $hoisted1 = api_text("Header Slot Content", true);
+const $hoisted2 = api_text("Default Content", true);
 const stc0 = {
   key: 0,
 };
@@ -23,8 +30,8 @@ function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_custom_element("ns-cmp", _nsCmp, stc1, [
-        api_element("p", stc2, [api_text("Header Slot Content")]),
-        api_element("p", stc3, [api_text("Default Content")]),
+        api_element("p", stc2, [api_set_owner($hoisted1)]),
+        api_element("p", stc3, [api_set_owner($hoisted2)]),
       ]),
     ]),
   ];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -1,5 +1,10 @@
 import { registerTemplate, renderApi } from "lwc";
-const { gid: api_scoped_id, h: api_element, t: api_text } = renderApi;
+const {
+  gid: api_scoped_id,
+  h: api_element,
+  so: api_set_owner,
+  t: api_text,
+} = renderApi;
 const $hoisted1 = api_element(
   "feFlood",
   {
@@ -505,7 +510,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [$hoisted1]
+          [api_set_owner($hoisted1)]
         ),
         api_element(
           "filter",
@@ -517,7 +522,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 4,
             svg: true,
           },
-          [$hoisted2]
+          [api_set_owner($hoisted2)]
         ),
         api_element(
           "filter",
@@ -529,17 +534,17 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 6,
             svg: true,
           },
-          [$hoisted3]
+          [api_set_owner($hoisted3)]
         ),
       ]),
-      $hoisted4,
-      $hoisted5,
-      $hoisted6,
-      $hoisted7,
+      api_set_owner($hoisted4),
+      api_set_owner($hoisted5),
+      api_set_owner($hoisted6),
+      api_set_owner($hoisted7),
     ]),
     api_element("svg", stc2, [
-      $hoisted8,
-      $hoisted9,
+      api_set_owner($hoisted8),
+      api_set_owner($hoisted9),
       api_element(
         "filter",
         {
@@ -555,13 +560,13 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           svg: true,
         },
         [
-          $hoisted10,
-          $hoisted11,
-          $hoisted12,
-          $hoisted13,
-          $hoisted14,
-          $hoisted15,
-          $hoisted16,
+          api_set_owner($hoisted10),
+          api_set_owner($hoisted11),
+          api_set_owner($hoisted12),
+          api_set_owner($hoisted13),
+          api_set_owner($hoisted14),
+          api_set_owner($hoisted15),
+          api_set_owner($hoisted16),
         ]
       ),
     ]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -1,5 +1,468 @@
 import { registerTemplate, renderApi } from "lwc";
 const { gid: api_scoped_id, h: api_element, t: api_text } = renderApi;
+const $hoisted1 = api_element(
+  "feFlood",
+  {
+    attrs: {
+      x: "25%",
+      y: "25%",
+      width: "50%",
+      height: "50%",
+      "flood-color": "green",
+      "flood-opacity": "0.75",
+    },
+    key: 3,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "feBlend",
+  {
+    attrs: {
+      x: "25%",
+      y: "25%",
+      width: "50%",
+      height: "50%",
+      in2: "SourceGraphic",
+      mode: "multiply",
+    },
+    key: 5,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "feMerge",
+  {
+    attrs: {
+      x: "25%",
+      y: "25%",
+      width: "50%",
+      height: "50%",
+    },
+    key: 7,
+    svg: true,
+  },
+  [
+    api_element("feMergeNode", {
+      attrs: {
+        in: "SourceGraphic",
+      },
+      key: 8,
+      svg: true,
+    }),
+    api_element("feMergeNode", {
+      attrs: {
+        in: "FillPaint",
+      },
+      key: 9,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted4 = api_element(
+  "g",
+  {
+    attrs: {
+      fill: "none",
+      stroke: "blue",
+      "stroke-width": "4",
+    },
+    key: 10,
+    svg: true,
+  },
+  [
+    api_element("rect", {
+      attrs: {
+        width: "200",
+        height: "200",
+      },
+      key: 11,
+      svg: true,
+    }),
+    api_element("line", {
+      attrs: {
+        x2: "200",
+        y2: "200",
+      },
+      key: 12,
+      svg: true,
+    }),
+    api_element("line", {
+      attrs: {
+        x1: "200",
+        y2: "200",
+      },
+      key: 13,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted5 = api_element(
+  "circle",
+  {
+    attrs: {
+      fill: "green",
+      filter: "url(#flood)",
+      cx: "100",
+      cy: "100",
+      r: "90",
+    },
+    key: 14,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted6 = api_element(
+  "g",
+  {
+    attrs: {
+      transform: "translate(200 0)",
+    },
+    key: 15,
+    svg: true,
+  },
+  [
+    api_element(
+      "g",
+      {
+        attrs: {
+          fill: "none",
+          stroke: "blue",
+          "stroke-width": "4",
+        },
+        key: 16,
+        svg: true,
+      },
+      [
+        api_element("rect", {
+          attrs: {
+            width: "200",
+            height: "200",
+          },
+          key: 17,
+          svg: true,
+        }),
+        api_element("line", {
+          attrs: {
+            x2: "200",
+            y2: "200",
+          },
+          key: 18,
+          svg: true,
+        }),
+        api_element("line", {
+          attrs: {
+            x1: "200",
+            y2: "200",
+          },
+          key: 19,
+          svg: true,
+        }),
+      ]
+    ),
+    api_element("circle", {
+      attrs: {
+        fill: "green",
+        filter: "url(#blend)",
+        cx: "100",
+        cy: "100",
+        r: "90",
+      },
+      key: 20,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted7 = api_element(
+  "g",
+  {
+    attrs: {
+      transform: "translate(0 200)",
+    },
+    key: 21,
+    svg: true,
+  },
+  [
+    api_element(
+      "g",
+      {
+        attrs: {
+          fill: "none",
+          stroke: "blue",
+          "stroke-width": "4",
+        },
+        key: 22,
+        svg: true,
+      },
+      [
+        api_element("rect", {
+          attrs: {
+            width: "200",
+            height: "200",
+          },
+          key: 23,
+          svg: true,
+        }),
+        api_element("line", {
+          attrs: {
+            x2: "200",
+            y2: "200",
+          },
+          key: 24,
+          svg: true,
+        }),
+        api_element("line", {
+          attrs: {
+            x1: "200",
+            y2: "200",
+          },
+          key: 25,
+          svg: true,
+        }),
+      ]
+    ),
+    api_element("circle", {
+      attrs: {
+        fill: "green",
+        "fill-opacity": "0.5",
+        filter: "url(#merge)",
+        cx: "100",
+        cy: "100",
+        r: "90",
+      },
+      key: 26,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted8 = api_element(
+  "rect",
+  {
+    attrs: {
+      fill: "none",
+      stroke: "blue",
+      x: "1",
+      y: "1",
+      width: "598",
+      height: "248",
+    },
+    key: 28,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted9 = api_element(
+  "g",
+  {
+    key: 29,
+    svg: true,
+  },
+  [
+    api_element("rect", {
+      attrs: {
+        x: "50",
+        y: "25",
+        width: "100",
+        height: "200",
+        filter: "url(#Default)",
+      },
+      key: 30,
+      svg: true,
+    }),
+    api_element("rect", {
+      attrs: {
+        x: "50",
+        y: "25",
+        width: "100",
+        height: "200",
+        fill: "none",
+        stroke: "green",
+      },
+      key: 31,
+      svg: true,
+    }),
+    api_element("rect", {
+      attrs: {
+        x: "250",
+        y: "25",
+        width: "100",
+        height: "200",
+        filter: "url(#Fitted)",
+      },
+      key: 32,
+      svg: true,
+    }),
+    api_element("rect", {
+      attrs: {
+        x: "250",
+        y: "25",
+        width: "100",
+        height: "200",
+        fill: "none",
+        stroke: "green",
+      },
+      key: 33,
+      svg: true,
+    }),
+    api_element("rect", {
+      attrs: {
+        x: "450",
+        y: "25",
+        width: "100",
+        height: "200",
+        filter: "url(#Shifted)",
+      },
+      key: 34,
+      svg: true,
+    }),
+    api_element("rect", {
+      attrs: {
+        x: "450",
+        y: "25",
+        width: "100",
+        height: "200",
+        fill: "none",
+        stroke: "green",
+      },
+      key: 35,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted10 = api_element(
+  "desc",
+  {
+    key: 37,
+    svg: true,
+  },
+  [api_text("Produces a 3D lighting effect.")],
+  true
+);
+const $hoisted11 = api_element(
+  "feGaussianBlur",
+  {
+    attrs: {
+      in: "SourceAlpha",
+      stdDeviation: "4",
+      result: "blur",
+    },
+    key: 38,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted12 = api_element(
+  "feOffset",
+  {
+    attrs: {
+      in: "blur",
+      dx: "4",
+      dy: "4",
+      result: "offsetBlur",
+    },
+    key: 39,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted13 = api_element(
+  "feSpecularLighting",
+  {
+    attrs: {
+      in: "blur",
+      surfaceScale: "5",
+      specularConstant: ".75",
+      specularExponent: "20",
+      "lighting-color": "#bbbbbb",
+      result: "specOut",
+    },
+    key: 40,
+    svg: true,
+  },
+  [
+    api_element("fePointLight", {
+      attrs: {
+        x: "-5000",
+        y: "-10000",
+        z: "20000",
+      },
+      key: 41,
+      svg: true,
+    }),
+  ],
+  true
+);
+const $hoisted14 = api_element(
+  "feComposite",
+  {
+    attrs: {
+      in: "specOut",
+      in2: "SourceAlpha",
+      operator: "in",
+      result: "specOut",
+    },
+    key: 42,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted15 = api_element(
+  "feComposite",
+  {
+    attrs: {
+      in: "SourceGraphic",
+      in2: "specOut",
+      operator: "arithmetic",
+      k1: "0",
+      k2: "1",
+      k3: "1",
+      k4: "0",
+      result: "litPaint",
+    },
+    key: 43,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted16 = api_element(
+  "feMerge",
+  {
+    key: 44,
+    svg: true,
+  },
+  [
+    api_element("feMergeNode", {
+      attrs: {
+        in: "offsetBlur",
+      },
+      key: 45,
+      svg: true,
+    }),
+    api_element("feMergeNode", {
+      attrs: {
+        in: "litPaint",
+      },
+      key: 46,
+      svg: true,
+    }),
+  ],
+  true
+);
 const stc0 = {
   attrs: {
     width: "400",
@@ -15,201 +478,6 @@ const stc1 = {
 };
 const stc2 = {
   attrs: {
-    x: "25%",
-    y: "25%",
-    width: "50%",
-    height: "50%",
-    "flood-color": "green",
-    "flood-opacity": "0.75",
-  },
-  key: 3,
-  svg: true,
-};
-const stc3 = {
-  attrs: {
-    x: "25%",
-    y: "25%",
-    width: "50%",
-    height: "50%",
-    in2: "SourceGraphic",
-    mode: "multiply",
-  },
-  key: 5,
-  svg: true,
-};
-const stc4 = {
-  attrs: {
-    x: "25%",
-    y: "25%",
-    width: "50%",
-    height: "50%",
-  },
-  key: 7,
-  svg: true,
-};
-const stc5 = {
-  attrs: {
-    in: "SourceGraphic",
-  },
-  key: 8,
-  svg: true,
-};
-const stc6 = {
-  attrs: {
-    in: "FillPaint",
-  },
-  key: 9,
-  svg: true,
-};
-const stc7 = {
-  attrs: {
-    fill: "none",
-    stroke: "blue",
-    "stroke-width": "4",
-  },
-  key: 10,
-  svg: true,
-};
-const stc8 = {
-  attrs: {
-    width: "200",
-    height: "200",
-  },
-  key: 11,
-  svg: true,
-};
-const stc9 = {
-  attrs: {
-    x2: "200",
-    y2: "200",
-  },
-  key: 12,
-  svg: true,
-};
-const stc10 = {
-  attrs: {
-    x1: "200",
-    y2: "200",
-  },
-  key: 13,
-  svg: true,
-};
-const stc11 = {
-  attrs: {
-    fill: "green",
-    filter: "url(#flood)",
-    cx: "100",
-    cy: "100",
-    r: "90",
-  },
-  key: 14,
-  svg: true,
-};
-const stc12 = {
-  attrs: {
-    transform: "translate(200 0)",
-  },
-  key: 15,
-  svg: true,
-};
-const stc13 = {
-  attrs: {
-    fill: "none",
-    stroke: "blue",
-    "stroke-width": "4",
-  },
-  key: 16,
-  svg: true,
-};
-const stc14 = {
-  attrs: {
-    width: "200",
-    height: "200",
-  },
-  key: 17,
-  svg: true,
-};
-const stc15 = {
-  attrs: {
-    x2: "200",
-    y2: "200",
-  },
-  key: 18,
-  svg: true,
-};
-const stc16 = {
-  attrs: {
-    x1: "200",
-    y2: "200",
-  },
-  key: 19,
-  svg: true,
-};
-const stc17 = {
-  attrs: {
-    fill: "green",
-    filter: "url(#blend)",
-    cx: "100",
-    cy: "100",
-    r: "90",
-  },
-  key: 20,
-  svg: true,
-};
-const stc18 = {
-  attrs: {
-    transform: "translate(0 200)",
-  },
-  key: 21,
-  svg: true,
-};
-const stc19 = {
-  attrs: {
-    fill: "none",
-    stroke: "blue",
-    "stroke-width": "4",
-  },
-  key: 22,
-  svg: true,
-};
-const stc20 = {
-  attrs: {
-    width: "200",
-    height: "200",
-  },
-  key: 23,
-  svg: true,
-};
-const stc21 = {
-  attrs: {
-    x2: "200",
-    y2: "200",
-  },
-  key: 24,
-  svg: true,
-};
-const stc22 = {
-  attrs: {
-    x1: "200",
-    y2: "200",
-  },
-  key: 25,
-  svg: true,
-};
-const stc23 = {
-  attrs: {
-    fill: "green",
-    "fill-opacity": "0.5",
-    filter: "url(#merge)",
-    cx: "100",
-    cy: "100",
-    r: "90",
-  },
-  key: 26,
-  svg: true,
-};
-const stc24 = {
-  attrs: {
     width: "600",
     height: "250",
     viewBox: "0 0 600 250",
@@ -217,177 +485,6 @@ const stc24 = {
     "xmlns:xlink": "http://www.w3.org/1999/xlink",
   },
   key: 27,
-  svg: true,
-};
-const stc25 = {
-  attrs: {
-    fill: "none",
-    stroke: "blue",
-    x: "1",
-    y: "1",
-    width: "598",
-    height: "248",
-  },
-  key: 28,
-  svg: true,
-};
-const stc26 = {
-  key: 29,
-  svg: true,
-};
-const stc27 = {
-  attrs: {
-    x: "50",
-    y: "25",
-    width: "100",
-    height: "200",
-    filter: "url(#Default)",
-  },
-  key: 30,
-  svg: true,
-};
-const stc28 = {
-  attrs: {
-    x: "50",
-    y: "25",
-    width: "100",
-    height: "200",
-    fill: "none",
-    stroke: "green",
-  },
-  key: 31,
-  svg: true,
-};
-const stc29 = {
-  attrs: {
-    x: "250",
-    y: "25",
-    width: "100",
-    height: "200",
-    filter: "url(#Fitted)",
-  },
-  key: 32,
-  svg: true,
-};
-const stc30 = {
-  attrs: {
-    x: "250",
-    y: "25",
-    width: "100",
-    height: "200",
-    fill: "none",
-    stroke: "green",
-  },
-  key: 33,
-  svg: true,
-};
-const stc31 = {
-  attrs: {
-    x: "450",
-    y: "25",
-    width: "100",
-    height: "200",
-    filter: "url(#Shifted)",
-  },
-  key: 34,
-  svg: true,
-};
-const stc32 = {
-  attrs: {
-    x: "450",
-    y: "25",
-    width: "100",
-    height: "200",
-    fill: "none",
-    stroke: "green",
-  },
-  key: 35,
-  svg: true,
-};
-const stc33 = {
-  key: 37,
-  svg: true,
-};
-const stc34 = {
-  attrs: {
-    in: "SourceAlpha",
-    stdDeviation: "4",
-    result: "blur",
-  },
-  key: 38,
-  svg: true,
-};
-const stc35 = {
-  attrs: {
-    in: "blur",
-    dx: "4",
-    dy: "4",
-    result: "offsetBlur",
-  },
-  key: 39,
-  svg: true,
-};
-const stc36 = {
-  attrs: {
-    in: "blur",
-    surfaceScale: "5",
-    specularConstant: ".75",
-    specularExponent: "20",
-    "lighting-color": "#bbbbbb",
-    result: "specOut",
-  },
-  key: 40,
-  svg: true,
-};
-const stc37 = {
-  attrs: {
-    x: "-5000",
-    y: "-10000",
-    z: "20000",
-  },
-  key: 41,
-  svg: true,
-};
-const stc38 = {
-  attrs: {
-    in: "specOut",
-    in2: "SourceAlpha",
-    operator: "in",
-    result: "specOut",
-  },
-  key: 42,
-  svg: true,
-};
-const stc39 = {
-  attrs: {
-    in: "SourceGraphic",
-    in2: "specOut",
-    operator: "arithmetic",
-    k1: "0",
-    k2: "1",
-    k3: "1",
-    k4: "0",
-    result: "litPaint",
-  },
-  key: 43,
-  svg: true,
-};
-const stc40 = {
-  key: 44,
-  svg: true,
-};
-const stc41 = {
-  attrs: {
-    in: "offsetBlur",
-  },
-  key: 45,
-  svg: true,
-};
-const stc42 = {
-  attrs: {
-    in: "litPaint",
-  },
-  key: 46,
   svg: true,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
@@ -408,7 +505,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [api_element("feFlood", stc2)]
+          [$hoisted1]
         ),
         api_element(
           "filter",
@@ -420,7 +517,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 4,
             svg: true,
           },
-          [api_element("feBlend", stc3)]
+          [$hoisted2]
         ),
         api_element(
           "filter",
@@ -432,47 +529,17 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 6,
             svg: true,
           },
-          [
-            api_element("feMerge", stc4, [
-              api_element("feMergeNode", stc5),
-              api_element("feMergeNode", stc6),
-            ]),
-          ]
+          [$hoisted3]
         ),
       ]),
-      api_element("g", stc7, [
-        api_element("rect", stc8),
-        api_element("line", stc9),
-        api_element("line", stc10),
-      ]),
-      api_element("circle", stc11),
-      api_element("g", stc12, [
-        api_element("g", stc13, [
-          api_element("rect", stc14),
-          api_element("line", stc15),
-          api_element("line", stc16),
-        ]),
-        api_element("circle", stc17),
-      ]),
-      api_element("g", stc18, [
-        api_element("g", stc19, [
-          api_element("rect", stc20),
-          api_element("line", stc21),
-          api_element("line", stc22),
-        ]),
-        api_element("circle", stc23),
-      ]),
+      $hoisted4,
+      $hoisted5,
+      $hoisted6,
+      $hoisted7,
     ]),
-    api_element("svg", stc24, [
-      api_element("rect", stc25),
-      api_element("g", stc26, [
-        api_element("rect", stc27),
-        api_element("rect", stc28),
-        api_element("rect", stc29),
-        api_element("rect", stc30),
-        api_element("rect", stc31),
-        api_element("rect", stc32),
-      ]),
+    api_element("svg", stc2, [
+      $hoisted8,
+      $hoisted9,
       api_element(
         "filter",
         {
@@ -488,20 +555,13 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           svg: true,
         },
         [
-          api_element("desc", stc33, [
-            api_text("Produces a 3D lighting effect."),
-          ]),
-          api_element("feGaussianBlur", stc34),
-          api_element("feOffset", stc35),
-          api_element("feSpecularLighting", stc36, [
-            api_element("fePointLight", stc37),
-          ]),
-          api_element("feComposite", stc38),
-          api_element("feComposite", stc39),
-          api_element("feMerge", stc40, [
-            api_element("feMergeNode", stc41),
-            api_element("feMergeNode", stc42),
-          ]),
+          $hoisted10,
+          $hoisted11,
+          $hoisted12,
+          $hoisted13,
+          $hoisted14,
+          $hoisted15,
+          $hoisted16,
         ]
       ),
     ]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -18,6 +18,7 @@ const $hoisted1 = api_element(
     },
     key: 3,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -34,6 +35,7 @@ const $hoisted2 = api_element(
     },
     key: 5,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -48,6 +50,7 @@ const $hoisted3 = api_element(
     },
     key: 7,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("feMergeNode", {
@@ -56,6 +59,7 @@ const $hoisted3 = api_element(
       },
       key: 8,
       svg: true,
+      isStatic: true,
     }),
     api_element("feMergeNode", {
       attrs: {
@@ -63,6 +67,7 @@ const $hoisted3 = api_element(
       },
       key: 9,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -76,6 +81,7 @@ const $hoisted4 = api_element(
     },
     key: 10,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("rect", {
@@ -85,6 +91,7 @@ const $hoisted4 = api_element(
       },
       key: 11,
       svg: true,
+      isStatic: true,
     }),
     api_element("line", {
       attrs: {
@@ -93,6 +100,7 @@ const $hoisted4 = api_element(
       },
       key: 12,
       svg: true,
+      isStatic: true,
     }),
     api_element("line", {
       attrs: {
@@ -101,6 +109,7 @@ const $hoisted4 = api_element(
       },
       key: 13,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -116,6 +125,7 @@ const $hoisted5 = api_element(
     },
     key: 14,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -127,6 +137,7 @@ const $hoisted6 = api_element(
     },
     key: 15,
     svg: true,
+    isStatic: true,
   },
   [
     api_element(
@@ -139,6 +150,7 @@ const $hoisted6 = api_element(
         },
         key: 16,
         svg: true,
+        isStatic: true,
       },
       [
         api_element("rect", {
@@ -148,6 +160,7 @@ const $hoisted6 = api_element(
           },
           key: 17,
           svg: true,
+          isStatic: true,
         }),
         api_element("line", {
           attrs: {
@@ -156,6 +169,7 @@ const $hoisted6 = api_element(
           },
           key: 18,
           svg: true,
+          isStatic: true,
         }),
         api_element("line", {
           attrs: {
@@ -164,6 +178,7 @@ const $hoisted6 = api_element(
           },
           key: 19,
           svg: true,
+          isStatic: true,
         }),
       ]
     ),
@@ -177,6 +192,7 @@ const $hoisted6 = api_element(
       },
       key: 20,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -188,6 +204,7 @@ const $hoisted7 = api_element(
     },
     key: 21,
     svg: true,
+    isStatic: true,
   },
   [
     api_element(
@@ -200,6 +217,7 @@ const $hoisted7 = api_element(
         },
         key: 22,
         svg: true,
+        isStatic: true,
       },
       [
         api_element("rect", {
@@ -209,6 +227,7 @@ const $hoisted7 = api_element(
           },
           key: 23,
           svg: true,
+          isStatic: true,
         }),
         api_element("line", {
           attrs: {
@@ -217,6 +236,7 @@ const $hoisted7 = api_element(
           },
           key: 24,
           svg: true,
+          isStatic: true,
         }),
         api_element("line", {
           attrs: {
@@ -225,6 +245,7 @@ const $hoisted7 = api_element(
           },
           key: 25,
           svg: true,
+          isStatic: true,
         }),
       ]
     ),
@@ -239,6 +260,7 @@ const $hoisted7 = api_element(
       },
       key: 26,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -255,6 +277,7 @@ const $hoisted8 = api_element(
     },
     key: 28,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -263,6 +286,7 @@ const $hoisted9 = api_element(
   {
     key: 29,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("rect", {
@@ -275,6 +299,7 @@ const $hoisted9 = api_element(
       },
       key: 30,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       attrs: {
@@ -287,6 +312,7 @@ const $hoisted9 = api_element(
       },
       key: 31,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       attrs: {
@@ -298,6 +324,7 @@ const $hoisted9 = api_element(
       },
       key: 32,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       attrs: {
@@ -310,6 +337,7 @@ const $hoisted9 = api_element(
       },
       key: 33,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       attrs: {
@@ -321,6 +349,7 @@ const $hoisted9 = api_element(
       },
       key: 34,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       attrs: {
@@ -333,6 +362,7 @@ const $hoisted9 = api_element(
       },
       key: 35,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -341,6 +371,7 @@ const $hoisted10 = api_element(
   {
     key: 37,
     svg: true,
+    isStatic: true,
   },
   [api_text("Produces a 3D lighting effect.")]
 );
@@ -354,6 +385,7 @@ const $hoisted11 = api_element(
     },
     key: 38,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -368,6 +400,7 @@ const $hoisted12 = api_element(
     },
     key: 39,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -384,6 +417,7 @@ const $hoisted13 = api_element(
     },
     key: 40,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("fePointLight", {
@@ -394,6 +428,7 @@ const $hoisted13 = api_element(
       },
       key: 41,
       svg: true,
+      isStatic: true,
     }),
   ]
 );
@@ -408,6 +443,7 @@ const $hoisted14 = api_element(
     },
     key: 42,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -426,6 +462,7 @@ const $hoisted15 = api_element(
     },
     key: 43,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -434,6 +471,7 @@ const $hoisted16 = api_element(
   {
     key: 44,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("feMergeNode", {
@@ -442,6 +480,7 @@ const $hoisted16 = api_element(
       },
       key: 45,
       svg: true,
+      isStatic: true,
     }),
     api_element("feMergeNode", {
       attrs: {
@@ -449,6 +488,7 @@ const $hoisted16 = api_element(
       },
       key: 46,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -19,8 +19,7 @@ const $hoisted1 = api_element(
     key: 3,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "feBlend",
@@ -36,8 +35,7 @@ const $hoisted2 = api_element(
     key: 5,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "feMerge",
@@ -66,8 +64,7 @@ const $hoisted3 = api_element(
       key: 9,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted4 = api_element(
   "g",
@@ -105,8 +102,7 @@ const $hoisted4 = api_element(
       key: 13,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted5 = api_element(
   "circle",
@@ -121,8 +117,7 @@ const $hoisted5 = api_element(
     key: 14,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted6 = api_element(
   "g",
@@ -183,8 +178,7 @@ const $hoisted6 = api_element(
       key: 20,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted7 = api_element(
   "g",
@@ -246,8 +240,7 @@ const $hoisted7 = api_element(
       key: 26,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted8 = api_element(
   "rect",
@@ -263,8 +256,7 @@ const $hoisted8 = api_element(
     key: 28,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted9 = api_element(
   "g",
@@ -342,8 +334,7 @@ const $hoisted9 = api_element(
       key: 35,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted10 = api_element(
   "desc",
@@ -351,8 +342,7 @@ const $hoisted10 = api_element(
     key: 37,
     svg: true,
   },
-  [api_text("Produces a 3D lighting effect.")],
-  true
+  [api_text("Produces a 3D lighting effect.")]
 );
 const $hoisted11 = api_element(
   "feGaussianBlur",
@@ -365,8 +355,7 @@ const $hoisted11 = api_element(
     key: 38,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted12 = api_element(
   "feOffset",
@@ -380,8 +369,7 @@ const $hoisted12 = api_element(
     key: 39,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted13 = api_element(
   "feSpecularLighting",
@@ -407,8 +395,7 @@ const $hoisted13 = api_element(
       key: 41,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const $hoisted14 = api_element(
   "feComposite",
@@ -422,8 +409,7 @@ const $hoisted14 = api_element(
     key: 42,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted15 = api_element(
   "feComposite",
@@ -441,8 +427,7 @@ const $hoisted15 = api_element(
     key: 43,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted16 = api_element(
   "feMerge",
@@ -465,8 +450,7 @@ const $hoisted16 = api_element(
       key: 46,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 const stc0 = {
   attrs: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -1,56 +1,74 @@
 import { registerTemplate, renderApi } from "lwc";
 const { t: api_text, h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-};
-const stc1 = {
-  attrs: {
-    width: "706",
-    height: "180",
+const $hoisted1 = api_element(
+  "div",
+  {
+    key: 0,
   },
-  key: 1,
-  svg: true,
-};
-const stc2 = {
-  attrs: {
-    transform: "translate(3,3)",
-  },
-  key: 2,
-  svg: true,
-};
-const stc3 = {
-  attrs: {
-    transform: "translate(250,0)",
-  },
-  key: 3,
-  svg: true,
-};
-const stc4 = {
-  attrs: {
-    width: "200",
-    height: "36",
-    "xlink:href": "javascript:alert(1)",
-  },
-  key: 4,
-  svg: true,
-};
-const stc5 = {
-  key: 5,
-};
+  [
+    api_element(
+      "svg",
+      {
+        attrs: {
+          width: "706",
+          height: "180",
+        },
+        key: 1,
+        svg: true,
+      },
+      [
+        api_element(
+          "g",
+          {
+            attrs: {
+              transform: "translate(3,3)",
+            },
+            key: 2,
+            svg: true,
+          },
+          [
+            api_element(
+              "g",
+              {
+                attrs: {
+                  transform: "translate(250,0)",
+                },
+                key: 3,
+                svg: true,
+              },
+              [
+                api_element(
+                  "foreignObject",
+                  {
+                    attrs: {
+                      width: "200",
+                      height: "36",
+                      "xlink:href": "javascript:alert(1)",
+                    },
+                    key: 4,
+                    svg: true,
+                  },
+                  [
+                    api_element(
+                      "a",
+                      {
+                        key: 5,
+                      },
+                      [api_text("x")]
+                    ),
+                  ]
+                ),
+              ]
+            ),
+          ]
+        ),
+      ]
+    ),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("div", stc0, [
-      api_element("svg", stc1, [
-        api_element("g", stc2, [
-          api_element("g", stc3, [
-            api_element("foreignObject", stc4, [
-              api_element("a", stc5, [api_text("x")]),
-            ]),
-          ]),
-        ]),
-      ]),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -64,8 +64,7 @@ const $hoisted1 = api_element(
         ),
       ]
     ),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -4,6 +4,7 @@ const $hoisted1 = api_element(
   "div",
   {
     key: 0,
+    isStatic: true,
   },
   [
     api_element(
@@ -15,6 +16,7 @@ const $hoisted1 = api_element(
         },
         key: 1,
         svg: true,
+        isStatic: true,
       },
       [
         api_element(
@@ -25,6 +27,7 @@ const $hoisted1 = api_element(
             },
             key: 2,
             svg: true,
+            isStatic: true,
           },
           [
             api_element(
@@ -35,6 +38,7 @@ const $hoisted1 = api_element(
                 },
                 key: 3,
                 svg: true,
+                isStatic: true,
               },
               [
                 api_element(
@@ -47,12 +51,14 @@ const $hoisted1 = api_element(
                     },
                     key: 4,
                     svg: true,
+                    isStatic: true,
                   },
                   [
                     api_element(
                       "a",
                       {
                         key: 5,
+                        isStatic: true,
                       },
                       [api_text("x")]
                     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { t: api_text, h: api_element } = renderApi;
+const { t: api_text, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "div",
   {
@@ -68,7 +68,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { gid: api_scoped_id, h: api_element } = renderApi;
+const { gid: api_scoped_id, h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "stop",
   {
@@ -77,10 +77,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [$hoisted1, $hoisted2]
+          [api_set_owner($hoisted1), api_set_owner($hoisted2)]
         ),
       ]),
-      $hoisted3,
+      api_set_owner($hoisted3),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -1,5 +1,53 @@
 import { registerTemplate, renderApi } from "lwc";
 const { gid: api_scoped_id, h: api_element } = renderApi;
+const $hoisted1 = api_element(
+  "stop",
+  {
+    styleDecls: [
+      ["stop-color", "rgb(255,255,0)", false],
+      ["stop-opacity", "1", false],
+    ],
+    attrs: {
+      offset: "0%",
+    },
+    key: 3,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted2 = api_element(
+  "stop",
+  {
+    styleDecls: [
+      ["stop-color", "rgb(255,0,0)", false],
+      ["stop-opacity", "1", false],
+    ],
+    attrs: {
+      offset: "100%",
+    },
+    key: 4,
+    svg: true,
+  },
+  [],
+  true
+);
+const $hoisted3 = api_element(
+  "ellipse",
+  {
+    attrs: {
+      cx: "200",
+      cy: "70",
+      rx: "85",
+      ry: "55",
+      fill: "url(#grad1)",
+    },
+    key: 5,
+    svg: true,
+  },
+  [],
+  true
+);
 const stc0 = {
   attrs: {
     height: "150",
@@ -10,39 +58,6 @@ const stc0 = {
 };
 const stc1 = {
   key: 1,
-  svg: true,
-};
-const stc2 = {
-  styleDecls: [
-    ["stop-color", "rgb(255,255,0)", false],
-    ["stop-opacity", "1", false],
-  ],
-  attrs: {
-    offset: "0%",
-  },
-  key: 3,
-  svg: true,
-};
-const stc3 = {
-  styleDecls: [
-    ["stop-color", "rgb(255,0,0)", false],
-    ["stop-opacity", "1", false],
-  ],
-  attrs: {
-    offset: "100%",
-  },
-  key: 4,
-  svg: true,
-};
-const stc4 = {
-  attrs: {
-    cx: "200",
-    cy: "70",
-    rx: "85",
-    ry: "55",
-    fill: "url(#grad1)",
-  },
-  key: 5,
   svg: true,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
@@ -62,10 +77,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [api_element("stop", stc2), api_element("stop", stc3)]
+          [$hoisted1, $hoisted2]
         ),
       ]),
-      api_element("ellipse", stc4),
+      $hoisted3,
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -12,6 +12,7 @@ const $hoisted1 = api_element(
     },
     key: 3,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -27,6 +28,7 @@ const $hoisted2 = api_element(
     },
     key: 4,
     svg: true,
+    isStatic: true,
   },
   []
 );
@@ -42,6 +44,7 @@ const $hoisted3 = api_element(
     },
     key: 5,
     svg: true,
+    isStatic: true,
   },
   []
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -13,8 +13,7 @@ const $hoisted1 = api_element(
     key: 3,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted2 = api_element(
   "stop",
@@ -29,8 +28,7 @@ const $hoisted2 = api_element(
     key: 4,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const $hoisted3 = api_element(
   "ellipse",
@@ -45,8 +43,7 @@ const $hoisted3 = api_element(
     key: 5,
     svg: true,
   },
-  [],
-  true
+  []
 );
 const stc0 = {
   attrs: {

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -1,54 +1,58 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element, t: api_text } = renderApi;
-const stc0 = {
-  attrs: {
-    version: "1.1",
-    baseProfile: "full",
-    width: "300",
-    height: "200",
-    xmlns: "http://www.w3.org/2000/svg",
+const $hoisted1 = api_element(
+  "svg",
+  {
+    attrs: {
+      version: "1.1",
+      baseProfile: "full",
+      width: "300",
+      height: "200",
+      xmlns: "http://www.w3.org/2000/svg",
+    },
+    key: 0,
+    svg: true,
   },
-  key: 0,
-  svg: true,
-};
-const stc1 = {
-  attrs: {
-    width: "100%",
-    height: "100%",
-    fill: "red",
-  },
-  key: 1,
-  svg: true,
-};
-const stc2 = {
-  attrs: {
-    cx: "150",
-    cy: "100",
-    r: "80",
-    fill: "green",
-  },
-  key: 2,
-  svg: true,
-};
-const stc3 = {
-  attrs: {
-    x: "150",
-    y: "125",
-    "font-size": "60",
-    "text-anchor": "middle",
-    fill: "white",
-  },
-  key: 3,
-  svg: true,
-};
+  [
+    api_element("rect", {
+      attrs: {
+        width: "100%",
+        height: "100%",
+        fill: "red",
+      },
+      key: 1,
+      svg: true,
+    }),
+    api_element("circle", {
+      attrs: {
+        cx: "150",
+        cy: "100",
+        r: "80",
+        fill: "green",
+      },
+      key: 2,
+      svg: true,
+    }),
+    api_element(
+      "text",
+      {
+        attrs: {
+          x: "150",
+          y: "125",
+          "font-size": "60",
+          "text-anchor": "middle",
+          fill: "white",
+        },
+        key: 3,
+        svg: true,
+      },
+      [api_text("SVG")]
+    ),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("svg", stc0, [
-      api_element("rect", stc1),
-      api_element("circle", stc2),
-      api_element("text", stc3, [api_text("SVG")]),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element, t: api_text } = renderApi;
+const { h: api_element, t: api_text, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -52,7 +52,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -12,6 +12,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("rect", {
@@ -22,6 +23,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
       svg: true,
+      isStatic: true,
     }),
     api_element("circle", {
       attrs: {
@@ -32,6 +34,7 @@ const $hoisted1 = api_element(
       },
       key: 2,
       svg: true,
+      isStatic: true,
     }),
     api_element(
       "text",
@@ -45,6 +48,7 @@ const $hoisted1 = api_element(
         },
         key: 3,
         svg: true,
+        isStatic: true,
       },
       [api_text("SVG")]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -48,8 +48,7 @@ const $hoisted1 = api_element(
       },
       [api_text("SVG")]
     ),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -8,11 +8,13 @@ const $hoisted1 = api_element(
     },
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("path", {
       key: 1,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -18,7 +18,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -1,18 +1,24 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    xmlns: "http://www.w3.org/2000/svg",
+const $hoisted1 = api_element(
+  "svg",
+  {
+    attrs: {
+      xmlns: "http://www.w3.org/2000/svg",
+    },
+    key: 0,
+    svg: true,
   },
-  key: 0,
-  svg: true,
-};
-const stc1 = {
-  key: 1,
-  svg: true,
-};
+  [
+    api_element("path", {
+      key: 1,
+      svg: true,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("svg", stc0, [api_element("path", stc1)])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -14,8 +14,7 @@ const $hoisted1 = api_element(
       key: 1,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -9,6 +9,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("image", {
@@ -21,6 +22,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -22,8 +22,7 @@ const $hoisted1 = api_element(
       key: 1,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -1,26 +1,32 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  attrs: {
-    width: "200",
-    height: "200",
+const $hoisted1 = api_element(
+  "svg",
+  {
+    attrs: {
+      width: "200",
+      height: "200",
+    },
+    key: 0,
+    svg: true,
   },
-  key: 0,
-  svg: true,
-};
-const stc1 = {
-  attrs: {
-    "xlink:href": "/foo.png",
-    x: "1",
-    y: "2",
-    height: "200",
-    width: "200",
-  },
-  key: 1,
-  svg: true,
-};
+  [
+    api_element("image", {
+      attrs: {
+        "xlink:href": "/foo.png",
+        x: "1",
+        y: "2",
+        height: "200",
+        width: "200",
+      },
+      key: 1,
+      svg: true,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [api_element("svg", stc0, [api_element("image", stc1)])];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -26,7 +26,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -5,91 +5,113 @@ const $hoisted1 = api_element(
   {
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("a", {
       key: 1,
       svg: true,
+      isStatic: true,
     }),
     api_element("circle", {
       key: 2,
       svg: true,
+      isStatic: true,
     }),
     api_element("defs", {
       key: 3,
       svg: true,
+      isStatic: true,
     }),
     api_element("desc", {
       key: 4,
       svg: true,
+      isStatic: true,
     }),
     api_element("ellipse", {
       key: 5,
       svg: true,
+      isStatic: true,
     }),
     api_element("filter", {
       key: 6,
       svg: true,
+      isStatic: true,
     }),
     api_element("g", {
       key: 7,
       svg: true,
+      isStatic: true,
     }),
     api_element("line", {
       key: 8,
       svg: true,
+      isStatic: true,
     }),
     api_element("marker", {
       key: 9,
       svg: true,
+      isStatic: true,
     }),
     api_element("mask", {
       key: 10,
       svg: true,
+      isStatic: true,
     }),
     api_element("path", {
       key: 11,
       svg: true,
+      isStatic: true,
     }),
     api_element("pattern", {
       key: 12,
       svg: true,
+      isStatic: true,
     }),
     api_element("polygon", {
       key: 13,
       svg: true,
+      isStatic: true,
     }),
     api_element("polyline", {
       key: 14,
       svg: true,
+      isStatic: true,
     }),
     api_element("rect", {
       key: 15,
       svg: true,
+      isStatic: true,
     }),
     api_element("stop", {
       key: 16,
       svg: true,
+      isStatic: true,
     }),
     api_element("symbol", {
       key: 17,
       svg: true,
+      isStatic: true,
     }),
     api_element("text", {
       key: 18,
       svg: true,
+      isStatic: true,
     }),
     api_element("title", {
       key: 19,
       svg: true,
+      isStatic: true,
     }),
     api_element("tspan", {
       key: 20,
       svg: true,
+      isStatic: true,
     }),
     api_element("use", {
       key: 21,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -95,7 +95,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -1,119 +1,101 @@
 import { registerTemplate, renderApi } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  key: 0,
-  svg: true,
-};
-const stc1 = {
-  key: 1,
-  svg: true,
-};
-const stc2 = {
-  key: 2,
-  svg: true,
-};
-const stc3 = {
-  key: 3,
-  svg: true,
-};
-const stc4 = {
-  key: 4,
-  svg: true,
-};
-const stc5 = {
-  key: 5,
-  svg: true,
-};
-const stc6 = {
-  key: 6,
-  svg: true,
-};
-const stc7 = {
-  key: 7,
-  svg: true,
-};
-const stc8 = {
-  key: 8,
-  svg: true,
-};
-const stc9 = {
-  key: 9,
-  svg: true,
-};
-const stc10 = {
-  key: 10,
-  svg: true,
-};
-const stc11 = {
-  key: 11,
-  svg: true,
-};
-const stc12 = {
-  key: 12,
-  svg: true,
-};
-const stc13 = {
-  key: 13,
-  svg: true,
-};
-const stc14 = {
-  key: 14,
-  svg: true,
-};
-const stc15 = {
-  key: 15,
-  svg: true,
-};
-const stc16 = {
-  key: 16,
-  svg: true,
-};
-const stc17 = {
-  key: 17,
-  svg: true,
-};
-const stc18 = {
-  key: 18,
-  svg: true,
-};
-const stc19 = {
-  key: 19,
-  svg: true,
-};
-const stc20 = {
-  key: 20,
-  svg: true,
-};
-const stc21 = {
-  key: 21,
-  svg: true,
-};
+const $hoisted1 = api_element(
+  "svg",
+  {
+    key: 0,
+    svg: true,
+  },
+  [
+    api_element("a", {
+      key: 1,
+      svg: true,
+    }),
+    api_element("circle", {
+      key: 2,
+      svg: true,
+    }),
+    api_element("defs", {
+      key: 3,
+      svg: true,
+    }),
+    api_element("desc", {
+      key: 4,
+      svg: true,
+    }),
+    api_element("ellipse", {
+      key: 5,
+      svg: true,
+    }),
+    api_element("filter", {
+      key: 6,
+      svg: true,
+    }),
+    api_element("g", {
+      key: 7,
+      svg: true,
+    }),
+    api_element("line", {
+      key: 8,
+      svg: true,
+    }),
+    api_element("marker", {
+      key: 9,
+      svg: true,
+    }),
+    api_element("mask", {
+      key: 10,
+      svg: true,
+    }),
+    api_element("path", {
+      key: 11,
+      svg: true,
+    }),
+    api_element("pattern", {
+      key: 12,
+      svg: true,
+    }),
+    api_element("polygon", {
+      key: 13,
+      svg: true,
+    }),
+    api_element("polyline", {
+      key: 14,
+      svg: true,
+    }),
+    api_element("rect", {
+      key: 15,
+      svg: true,
+    }),
+    api_element("stop", {
+      key: 16,
+      svg: true,
+    }),
+    api_element("symbol", {
+      key: 17,
+      svg: true,
+    }),
+    api_element("text", {
+      key: 18,
+      svg: true,
+    }),
+    api_element("title", {
+      key: 19,
+      svg: true,
+    }),
+    api_element("tspan", {
+      key: 20,
+      svg: true,
+    }),
+    api_element("use", {
+      key: 21,
+      svg: true,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("svg", stc0, [
-      api_element("a", stc1),
-      api_element("circle", stc2),
-      api_element("defs", stc3),
-      api_element("desc", stc4),
-      api_element("ellipse", stc5),
-      api_element("filter", stc6),
-      api_element("g", stc7),
-      api_element("line", stc8),
-      api_element("marker", stc9),
-      api_element("mask", stc10),
-      api_element("path", stc11),
-      api_element("pattern", stc12),
-      api_element("polygon", stc13),
-      api_element("polyline", stc14),
-      api_element("rect", stc15),
-      api_element("stop", stc16),
-      api_element("symbol", stc17),
-      api_element("text", stc18),
-      api_element("title", stc19),
-      api_element("tspan", stc20),
-      api_element("use", stc21),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -91,8 +91,7 @@ const $hoisted1 = api_element(
       key: 21,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -26,8 +26,7 @@ const $hoisted1 = api_element(
       key: 1,
       svg: true,
     }),
-  ],
-  true
+  ]
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
   return [api_set_owner($hoisted1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -1,5 +1,5 @@
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
-const { h: api_element } = renderApi;
+const { h: api_element, so: api_set_owner } = renderApi;
 const $hoisted1 = api_element(
   "svg",
   {
@@ -30,7 +30,7 @@ const $hoisted1 = api_element(
   true
 );
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [$hoisted1];
+  return [api_set_owner($hoisted1)];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -1,33 +1,36 @@
 import { registerTemplate, renderApi, sanitizeAttribute } from "lwc";
 const { h: api_element } = renderApi;
-const stc0 = {
-  classMap: {
-    "slds-icon": true,
+const $hoisted1 = api_element(
+  "svg",
+  {
+    classMap: {
+      "slds-icon": true,
+    },
+    attrs: {
+      "aria-hidden": "true",
+      title: "when needed",
+    },
+    key: 0,
+    svg: true,
   },
-  attrs: {
-    "aria-hidden": "true",
-    title: "when needed",
-  },
-  key: 0,
-  svg: true,
-};
+  [
+    api_element("use", {
+      attrs: {
+        "xlink:href": sanitizeAttribute(
+          "use",
+          "http://www.w3.org/2000/svg",
+          "xlink:href",
+          "/assets/icons/standard-sprite/svg/symbols.svg#case"
+        ),
+      },
+      key: 1,
+      svg: true,
+    }),
+  ],
+  true
+);
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return [
-    api_element("svg", stc0, [
-      api_element("use", {
-        attrs: {
-          "xlink:href": sanitizeAttribute(
-            "use",
-            "http://www.w3.org/2000/svg",
-            "xlink:href",
-            "/assets/icons/standard-sprite/svg/symbols.svg#case"
-          ),
-        },
-        key: 1,
-        svg: true,
-      }),
-    ]),
-  ];
+  return [$hoisted1];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink-with-literal-value/expected.js
@@ -12,6 +12,7 @@ const $hoisted1 = api_element(
     },
     key: 0,
     svg: true,
+    isStatic: true,
   },
   [
     api_element("use", {
@@ -25,6 +26,7 @@ const $hoisted1 = api_element(
       },
       key: 1,
       svg: true,
+      isStatic: true,
     }),
   ]
 );

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -117,7 +117,7 @@ function getStaticNodes(root: Root): Set<ChildNode> {
             );
         }); // all attrs are static
         result &&= directives.length === 0; // do not have any directive
-        result &&= !properties.some((prop) => isLiteral(prop.value)); // all properties are static
+        result &&= !properties.some((prop) => !isLiteral(prop.value)); // all properties are static
         result &&= listeners.length === 0; // do not have any event listener
 
         // Notes:

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -107,7 +107,7 @@ function getStaticNodes(root: Root): {
         //   2. An element inside a foreach can be static because it will have a parent that it is dynamic (the keyed element)
         //   3. Slotted content can be static if:
         //        - the parent is dynamic and not a component. In light dom, if the slot is wrapped with if, then the node will
-        //          be directly removed. @todo: make a test.
+        //          be directly removed.
 
         result &&= !isIf(parent); // when parent node is an if, this element may be removed directly.
         result &&= !isSlot(node); // slot element can't be static.

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -130,7 +130,7 @@ function getStaticNodes(root: Root): {
             );
         }); // all attrs are static
         result &&= directives.length === 0; // do not have any directive
-        result &&= !properties.some((prop) => !isLiteral(prop.value)); // all properties are static
+        result &&= properties.every((prop) => isLiteral(prop.value)); // all properties are static
         result &&= listeners.length === 0; // do not have any event listener
 
         return result;

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -245,12 +245,8 @@ export default class CodeGen {
             args.push(children); // only generate children if non-empty or if hoisted
         }
 
-        if (isHoisted) {
-            args.push(t.literal(true));
-        }
-
-        const expr = this._renderApiCall(RENDER_APIS.element, args);
-        return isHoisted ? this.genHoistedNode(expr) : expr;
+        const apiCall = this._renderApiCall(RENDER_APIS.element, args);
+        return isHoisted ? this.genHoistedNode(apiCall) : apiCall;
     }
 
     genCustomElement(
@@ -295,13 +291,9 @@ export default class CodeGen {
             textConcatenation = t.binaryExpression('+', textConcatenation, mappedValues[i]);
         }
 
-        if (isHoisted) {
-            return this.genHoistedNode(
-                this._renderApiCall(RENDER_APIS.text, [textConcatenation, t.literal(true)])
-            );
-        }
+        const apiCall = this._renderApiCall(RENDER_APIS.text, [textConcatenation]);
 
-        return this._renderApiCall(RENDER_APIS.text, [textConcatenation]);
+        return isHoisted ? this.genHoistedNode(apiCall) : apiCall;
     }
 
     genHoistedNode(expr: t.Expression): t.CallExpression {
@@ -313,11 +305,9 @@ export default class CodeGen {
     }
 
     genComment(value: string, isHoisted: boolean): t.Expression {
-        return isHoisted
-            ? this.genHoistedNode(
-                  this._renderApiCall(RENDER_APIS.comment, [t.literal(value), t.literal(true)])
-              )
-            : this._renderApiCall(RENDER_APIS.comment, [t.literal(value)]);
+        const apiCall = this._renderApiCall(RENDER_APIS.comment, [t.literal(value)]);
+
+        return isHoisted ? this.genHoistedNode(apiCall) : apiCall;
     }
 
     genSanitizeHtmlContent(content: t.Expression): t.Expression {

--- a/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/function.ts
@@ -13,6 +13,7 @@ import {
     identifierFromComponentName,
     generateTemplateMetadata,
     generateApisInitialization,
+    generateHoistedNodes,
 } from '../helpers';
 import { optimizeStaticExpressions } from '../optimize';
 
@@ -37,6 +38,8 @@ import { optimizeStaticExpressions } from '../optimize';
  */
 export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
     const apisInit = generateApisInitialization(codeGen);
+    const hoistedNodes = generateHoistedNodes(codeGen);
+
     const lookups = Array.from(codeGen.referencedComponents)
         .sort()
         .map((name) => {
@@ -58,6 +61,7 @@ export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.P
 
     return t.program([
         ...apisInit,
+        ...hoistedNodes,
         ...lookups,
         ...optimizedTemplateDeclarations,
         ...metadata,

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -17,6 +17,7 @@ import {
     identifierFromComponentName,
     generateTemplateMetadata,
     generateApisInitialization,
+    generateHoistedNodes,
 } from '../helpers';
 import { optimizeStaticExpressions } from '../optimize';
 
@@ -39,14 +40,6 @@ function generateLwcApisImport(codeGen: CodeGen): t.ImportDeclaration {
         });
 
     return t.importDeclaration(imports, t.literal(LWC_MODULE_NAME));
-}
-
-function generateHoistedNodes(codegen: CodeGen): t.VariableDeclaration[] {
-    return codegen.hoistedNodes.map((value, index) => {
-        return t.variableDeclaration('const', [
-            t.variableDeclarator(t.identifier(`$hoisted${index + 1}`), value),
-        ]);
-    });
 }
 
 /**

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -41,6 +41,14 @@ function generateLwcApisImport(codeGen: CodeGen): t.ImportDeclaration {
     return t.importDeclaration(imports, t.literal(LWC_MODULE_NAME));
 }
 
+function generateHoistedNodes(codegen: CodeGen): t.VariableDeclaration[] {
+    return codegen.hoistedNodes.map((value, index) => {
+        return t.variableDeclaration('const', [
+            t.variableDeclarator(t.identifier(`$hoisted${index + 1}`), value),
+        ]);
+    });
+}
+
 /**
  * Generate an ES module AST from a template ESTree AST. The generated module imports the dependent
  * LWC components via import statements and expose the template function via a default export
@@ -62,6 +70,7 @@ function generateLwcApisImport(codeGen: CodeGen): t.ImportDeclaration {
  */
 export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.Program {
     const apisInit = generateApisInitialization(codeGen);
+    const hoistedNodes = generateHoistedNodes(codeGen);
 
     codeGen.usedLwcApis.add(SECURE_REGISTER_TEMPLATE_METHOD_NAME);
 
@@ -73,6 +82,7 @@ export function format(templateFn: t.FunctionDeclaration, codeGen: CodeGen): t.P
 
     const templateBody = [
         ...apisInit,
+        ...hoistedNodes,
         ...optimizedTemplateDeclarations,
         t.exportDefaultDeclaration(
             t.callExpression(t.identifier(SECURE_REGISTER_TEMPLATE_METHOD_NAME), [

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -100,6 +100,14 @@ export function hasIdAttribute(node: Node): boolean {
     return false;
 }
 
+export function generateHoistedNodes(codegen: CodeGen): t.VariableDeclaration[] {
+    return codegen.hoistedNodes.map((value, index) => {
+        return t.variableDeclaration('const', [
+            t.variableDeclarator(t.identifier(`$hoisted${index + 1}`), value),
+        ]);
+    });
+}
+
 export function memorizeHandler(
     codeGen: CodeGen,
     componentHandler: t.Expression,

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -95,22 +95,24 @@ function transform(codeGen: CodeGen): t.Expression {
 
             res = codeGen.getSlot(element.slotName, databag, defaultSlot);
         } else {
-            res = codeGen.genElement(name, databag, children);
+            res = codeGen.genElement(name, databag, children, codeGen.isStaticNode(element));
         }
 
         return res;
     }
 
     function transformText(consecutiveText: Text[]): t.Expression {
+        const mustHoistText = !consecutiveText.some((txt) => !codeGen.isStaticNode(txt));
         return codeGen.genText(
             consecutiveText.map(({ value }) => {
                 return isStringLiteral(value) ? value.value : codeGen.bindExpression(value);
-            })
+            }),
+            mustHoistText
         );
     }
 
     function transformComment(comment: Comment): t.Expression {
-        return codeGen.genComment(comment.value);
+        return codeGen.genComment(comment.value, codeGen.isStaticNode(comment));
     }
 
     function transformChildren(parent: ParentNode): t.Expression {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -105,7 +105,7 @@ function transform(codeGen: CodeGen): t.Expression {
     }
 
     function transformText(consecutiveText: Text[]): t.Expression {
-        const mustHoistText = !consecutiveText.some((txt) => !codeGen.isHoistedNode(txt));
+        const mustHoistText = consecutiveText.every((txt) => codeGen.isHoistedNode(txt));
         return codeGen.genText(
             consecutiveText.map(({ value }) => {
                 return isStringLiteral(value) ? value.value : codeGen.bindExpression(value);

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -95,14 +95,17 @@ function transform(codeGen: CodeGen): t.Expression {
 
             res = codeGen.getSlot(element.slotName, databag, defaultSlot);
         } else {
-            res = codeGen.genElement(name, databag, children, codeGen.isStaticNode(element));
+            if (codeGen.isStaticNode(element)) {
+                databag.properties.push(t.property(t.literal('isStatic'), t.literal(true)));
+            }
+            res = codeGen.genElement(name, databag, children, codeGen.isHoistedNode(element));
         }
 
         return res;
     }
 
     function transformText(consecutiveText: Text[]): t.Expression {
-        const mustHoistText = !consecutiveText.some((txt) => !codeGen.isStaticNode(txt));
+        const mustHoistText = !consecutiveText.some((txt) => !codeGen.isHoistedNode(txt));
         return codeGen.genText(
             consecutiveText.map(({ value }) => {
                 return isStringLiteral(value) ? value.value : codeGen.bindExpression(value);
@@ -112,7 +115,7 @@ function transform(codeGen: CodeGen): t.Expression {
     }
 
     function transformComment(comment: Comment): t.Expression {
-        return codeGen.genComment(comment.value, codeGen.isStaticNode(comment));
+        return codeGen.genComment(comment.value, codeGen.isHoistedNode(comment));
     }
 
     function transformChildren(parent: ParentNode): t.Expression {

--- a/packages/integration-karma/test/api/sanitizeAttribute/x/xlink/xlink.html
+++ b/packages/integration-karma/test/api/sanitizeAttribute/x/xlink/xlink.html
@@ -1,5 +1,5 @@
 <template>
     <svg>
-        <use xlink:href="/foo"></use>
+        <use xlink:href={xLink}></use>
     </svg>
 </template>

--- a/packages/integration-karma/test/api/sanitizeAttribute/x/xlink/xlink.js
+++ b/packages/integration-karma/test/api/sanitizeAttribute/x/xlink/xlink.js
@@ -1,3 +1,7 @@
 import { LightningElement } from 'lwc';
 
-export default class Xlink extends LightningElement {}
+export default class Xlink extends LightningElement {
+    get xLink() {
+        return '/foo';
+    }
+}

--- a/packages/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/integration-karma/test/light-dom/slotting/index.spec.js
@@ -7,6 +7,7 @@ import LightConsumer from 'x/lightConsumer';
 import ShadowConsumer from 'x/shadowConsumer';
 import ConditionalSlot from 'x/conditionalSlot';
 import ConditionalSlotted from 'x/conditionalSlotted';
+import StaticSlotContent from 'x/staticSlotContent';
 
 function createTestElement(tag, component) {
     const elm = createElement(tag, { is: component });
@@ -90,6 +91,23 @@ describe('Slotting', () => {
         const elm = nodes['x-conditional-slotted'];
         expect(elm.innerHTML).toEqual(
             '<x-conditional-slot data-id="conditional-slot"><p data-id="slotted-text">Slotted content</p><button data-id="button">Toggle</button></x-conditional-slot>'
+        );
+        nodes.button.click();
+        await Promise.resolve();
+        expect(elm.innerHTML).toEqual(
+            '<x-conditional-slot data-id="conditional-slot"><button data-id="button">Toggle</button></x-conditional-slot>'
+        );
+    });
+
+    it('removes slotted static content properly', async () => {
+        const nodes = createTestElement('x-static-slot-content', StaticSlotContent);
+
+        // creates another component instance so it losses track of the elm we want to remove.
+        createTestElement('x-static-slot-content', StaticSlotContent);
+
+        const elm = nodes['x-static-slot-content'];
+        expect(elm.innerHTML).toEqual(
+            '<x-conditional-slot data-id="conditional-slot"><p data-id="slotted-text">static slotted content</p><button data-id="button">Toggle</button></x-conditional-slot>'
         );
         nodes.button.click();
         await Promise.resolve();

--- a/packages/integration-karma/test/light-dom/slotting/x/staticSlotContent/staticSlotContent.html
+++ b/packages/integration-karma/test/light-dom/slotting/x/staticSlotContent/staticSlotContent.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <x-conditional-slot data-id="conditional-slot">
+        <p data-id="slotted-text">static slotted content</p>
+    </x-conditional-slot>
+</template>

--- a/packages/integration-karma/test/light-dom/slotting/x/staticSlotContent/staticSlotContent.js
+++ b/packages/integration-karma/test/light-dom/slotting/x/staticSlotContent/staticSlotContent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class StaticSlotContent extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -42,6 +42,7 @@ function createDisconnectedTestElement() {
 describe('event propagation', () => {
     describe('dispatched on native element', () => {
         it('{bubbles: true, composed: true}', () => {
+            debugger;
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: true, composed: true });
             const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);

--- a/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -42,7 +42,6 @@ function createDisconnectedTestElement() {
 describe('event propagation', () => {
     describe('dispatched on native element', () => {
         it('{bubbles: true, composed: true}', () => {
-            debugger;
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: true, composed: true });
             const actualLogs = dispatchEventWithLog(nodes.button, nodes, event);


### PR DESCRIPTION
## Details

Note: this PR base branch is against #2758 for it to only include changes related to hoist static vnodes.

### Performance

With the performance test as they are, these are the results:

<img width="721" alt="image" src="https://user-images.githubusercontent.com/534821/160179121-e26ef7ea-0124-4f66-9ce7-1f2a2379ed3b.png">

There's so much improvement in the `styled-component` tests, because the component has a static node `<div class="cmp-${i}">Hello world</div>`.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
