### PR TITLE
test: increase jest test timeout

### DIFF
--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 module.exports = {
+    testTimeout: 60000, // Default timeout for all tests in  ms. Jest's default is 5000ms
     rootDir: '../..',
     projects: ['<rootDir>/packages/@lwc/*'],
     coverageThreshold: {

--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 module.exports = {
-    testTimeout: 60000, // Default timeout for all tests in  ms. Jest's default is 5000ms
+    testTimeout: 60000, // Default timeout for all tests in ms. Jest's default is 5000ms
     rootDir: '../..',
     projects: ['<rootDir>/packages/@lwc/*'],
     coverageThreshold: {


### PR DESCRIPTION
I noticed some test failures in Nucleus due to exceeding Jest's default timeout of 5000ms.

Rather than have random test failures, let's bump it up higher. 🙂 

```
FAIL rollup-plugin-lwc-compiler packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts (25.916 s)
  ● integration › compat › should be compatible with compat plugin
    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
      31 |
      32 |     describe('compat', () => {
    > 33 |         it('should be compatible with compat plugin', async () => {
         |         ^
      34 |             const bundle = await rollup({
      35 |                 input: path.resolve(__dirname, 'fixtures/javascript/javascript.js'),
      36 |                 plugins: [lwc(), compat()],
      at src/__tests__/integrations/integrations.spec.ts:33:9
      at src/__tests__/integrations/integrations.spec.ts:32:5
      at Object.<anonymous> (src/__tests__/integrations/integrations.spec.ts:14:1)
PASS lwc-template-compiler packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts (14.949 s)
PASS lwc-engine-server packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts (27.534 s)
PASS rollup-plugin-lwc-compiler packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts (28.099 s)
Summary of all failing tests
FAIL packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts (25.916 s)
  ● integration › compat › should be compatible with compat plugin
    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
      31 |
      32 |     describe('compat', () => {
    > 33 |         it('should be compatible with compat plugin', async () => {
         |         ^
      34 |             const bundle = await rollup({
      35 |                 input: path.resolve(__dirname, 'fixtures/javascript/javascript.js'),
      36 |                 plugins: [lwc(), compat()],
      at src/__tests__/integrations/integrations.spec.ts:33:9
      at src/__tests__/integrations/integrations.spec.ts:32:5
      at Object.<anonymous> (src/__tests__/integrations/integrations.spec.ts:14:1)
```