### PR TITLE
chore: update nucleus config to add summer22 and remove winter22

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -24,10 +24,10 @@ branches:
     pull-request:
       <<: *branch-definition
       merge-method: force-push # release branch should always be in sync with master branch (linear history)
-  winter22:
+  spring22:
     pull-request:
       <<: *branch-definition
-  spring22:
+  summer22:
     pull-request:
       <<: *branch-definition
 steps:


### PR DESCRIPTION
## Details
Add 238/patch code line and remove 234/patch from nucleus config

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
