### PR TITLE
test: fix Node warning about event emitters

### DIFF
--- a/packages/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/integration-karma/scripts/karma-plugins/lwc.js
@@ -20,6 +20,12 @@ const compatRollupPlugin = require('rollup-plugin-compat');
 const { COMPAT } = require('../shared/options');
 const Watcher = require('./Watcher');
 
+// Fix Node warning about >10 event listeners ("Possible EventEmitter memory leak detected").
+// This is due to the fact that we are running so many simultaneous rollup commands
+// on so many files. For every `*.spec.js` file, Rollup adds a listener at
+// this line: https://github.com/rollup/rollup/blob/35cbfae/src/utils/hookActions.ts#L37
+process.setMaxListeners(1000);
+
 function createPreprocessor(config, emitter, logger) {
     const { basePath } = config;
 


### PR DESCRIPTION
## Details

The Node event emitter listener limit is 10. We are adding 228 due to running Rollup simultaneously on 228 files here:

https://github.com/salesforce/lwc/blob/7589da0ab0608ca440f4d08b0d8e714d72574317/packages/integration-karma/scripts/karma-plugins/lwc.js#L64

Rollup adds the listener [here](https://github.com/rollup/rollup/blob/35cbfae/src/utils/hookActions.ts#L37).

This causes the warning:

    (node:52671) MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
    11 beforeExit listeners added to [process]. Use emitter.setMaxListeners() to increase limit

Bumping the limit is harmless, and avoids an annoying warning message when running the Karma tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->