### PR TITLE
chore: run karma and integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
               <<# parameters.force_native_shadow_mode >> FORCE_NATIVE_SHADOW_MODE_FOR_TEST=1 <</ parameters.force_native_shadow_mode >>
               <<# parameters.compat >> COMPAT=1 <</ parameters.compat >>
               <<# parameters.coverage >> COVERAGE=1 <</ parameters.coverage >>
-              yarn sauce
+              yarn sauce --log-level debug
 
 
 # Jobs definition
@@ -219,21 +219,19 @@ workflows:
           filters:
             <<: *ignore_forks
           requires:
-            - build
+            - test_unit
 
       - test_integration:
           filters:
             <<: *ignore_forks
           requires:
             - test_unit
-            - test_karma
 
       - test_integration_compat:
           filters:
             <<: *ignore_forks
           requires:
             - test_unit
-            - test_karma
 
   build_and_test_for_forked_repos:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
               <<# parameters.force_native_shadow_mode >> FORCE_NATIVE_SHADOW_MODE_FOR_TEST=1 <</ parameters.force_native_shadow_mode >>
               <<# parameters.compat >> COMPAT=1 <</ parameters.compat >>
               <<# parameters.coverage >> COVERAGE=1 <</ parameters.coverage >>
-              yarn sauce --log-level debug
+              yarn sauce
 
 
 # Jobs definition


### PR DESCRIPTION
## Details
This PR makes the karma and integration jobs run in parallel. The build time went down from 13m to 9m.

Observations:
**Karma Tests**
1. Running `yarn test` locally takes <15s but it runs the tests in 1 browser. `yarn sauce` typically runs in 3 browsers and takes about 45s.
      1. The time to bundle the test files using rollout is about 5s locally. On circleci, this time goes up 9s. It processes 229 spec.js files.
      2. Karma executes the tests simultaneously in selected browsers.
2. Sauce accounts provided to dev team has a high concurrency limit(1520).

**Integration tests** 
1. Time spent in bundling is about 2 seconds locally. It processes 58 spec.js files.
2. Total execution of this time is about 4m in non-compat, 6m in compat mode.
3. Unlike karma, wdio spins up a new sauce session per spec. This is the main contributor to the higher execution time for this job.
4. Karma executes spec.js in parallel and all the test case with in a spec.js are executed in sequence

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
