### PR TITLE
test: Update tests to use `lwc` restricted imports

### DIFF
--- a/packages/integration-karma/test/act/index.spec.js
+++ b/packages/integration-karma/test/act/index.spec.js
@@ -1,4 +1,11 @@
-import { createElement, LightningElement } from 'lwc';
+import {
+    createElement,
+    LightningElement,
+    registerComponent,
+    registerTemplate,
+    registerDecorators,
+} from 'lwc';
+
 import HtmlTags from 'html/tags';
 import UiSomething from 'ui/something';
 import UiSomethingElse from 'ui/somethingElse';
@@ -29,9 +36,6 @@ import testStyleAttr from './act-components/test-style-attr';
 // Tests that confirm that the runtime LWC engine-dom is compatible with the compiled templates
 // from the ACTCompiler
 describe('ACTCompiler', () => {
-    // These can't be imported from 'lwc'` because @lwc/rollup-plugin won't allow it
-    const { registerComponent, registerTemplate, registerDecorators } = LWC;
-
     function createComponentFromTemplate(
         template,
         { props = {}, propsToTrack = [], methods = {} } = {}

--- a/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -1,7 +1,4 @@
-// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
-const { isNodeFromTemplate } = LWC;
-
-import { createElement } from 'lwc';
+import { createElement, isNodeFromTemplate } from 'lwc';
 import Test from 'x/test';
 
 function testNonNodes(type, obj) {

--- a/packages/integration-karma/test/api/registerTemplate/index.spec.js
+++ b/packages/integration-karma/test/api/registerTemplate/index.spec.js
@@ -1,7 +1,4 @@
-// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
-const { registerTemplate } = LWC;
-
-import { createElement } from 'lwc';
+import { createElement, registerTemplate } from 'lwc';
 import { LightningElement } from 'lwc';
 
 it('should accepts a function return the same value', () => {

--- a/packages/integration-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/integration-karma/test/component/LightningElement.render/index.spec.js
@@ -1,10 +1,7 @@
-import { createElement } from 'lwc';
+import { createElement, registerTemplate } from 'lwc';
 
 import DynamicTemplate, { template1, template2 } from 'x/dynamicTemplate';
 import RenderThrow from 'x/renderThrow';
-
-// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
-const { registerTemplate } = LWC;
 
 function testInvalidTemplate(type, template) {
     it(`throws an error if returns ${type}`, () => {

--- a/packages/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -1,10 +1,7 @@
-import { createElement, LightningElement } from 'lwc';
+import { createElement, LightningElement, registerTemplate, registerComponent } from 'lwc';
 import Component from 'x/component';
 import ComponentWithProp from 'x/componentWithProp';
 import ComponentWithTemplateAndStylesheet from 'x/componentWithTemplateAndStylesheet';
-
-// TODO [#1284]: Import this from the lwc module once we move validation from compiler to linter
-const { registerTemplate, registerComponent } = LWC;
 
 if (!process.env.COMPAT) {
     describe('compiler version mismatch', () => {

--- a/packages/integration-karma/test/services/hooks/index.spec.js
+++ b/packages/integration-karma/test/services/hooks/index.spec.js
@@ -1,8 +1,6 @@
-import { createElement } from 'lwc';
+import { createElement, register } from 'lwc';
 
 import XHooks from 'x/hooks';
-
-const { register } = LWC;
 
 describe('Service hooks', () => {
     let entries = [];

--- a/packages/integration-karma/test/swapping/components/index.spec.js
+++ b/packages/integration-karma/test/swapping/components/index.spec.js
@@ -1,7 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
-
-// TODO [#1869]: getting the global API from global LWC in tests until it is allowed in compiler
-const { swapComponent } = LWC;
+import { createElement, setFeatureFlagForTest, swapComponent } from 'lwc';
 
 import Container from 'base/container';
 import A from 'base/a';

--- a/packages/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/integration-karma/test/swapping/styles/index.spec.js
@@ -1,9 +1,6 @@
-import { createElement } from 'lwc';
-
-// TODO [#1869]: getting the global API from global LWC in tests until it is allowed in compiler
-const { swapStyle } = LWC;
-
+import { createElement, swapStyle } from 'lwc';
 import Simple from 'base/simple';
+
 const { blockStyle, inlineStyle, noneStyle } = Simple;
 
 describe('style swapping', () => {

--- a/packages/integration-karma/test/swapping/templates/index.spec.js
+++ b/packages/integration-karma/test/swapping/templates/index.spec.js
@@ -1,7 +1,4 @@
-import { createElement } from 'lwc';
-
-// TODO [#1869]: getting the global API from global LWC in tests until it is allowed in compiler
-const { swapTemplate } = LWC;
+import { createElement, swapTemplate } from 'lwc';
 
 import Simple from 'base/simple';
 import Advanced from 'base/advanced';


### PR DESCRIPTION
## Details

This PR is a follow-up of #2719. It updates all the tests to use import restricted APIs from `lwc`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.