### PR TITLE
test: remove flakey IE integration test

### DIFF
--- a/packages/integration-tests/src/components/events/test-mouseover/integration/mouseover.spec.js
+++ b/packages/integration-tests/src/components/events/test-mouseover/integration/mouseover.spec.js
@@ -7,18 +7,18 @@
 const assert = require('assert');
 const URL = '/mouseover';
 
-describe('mouseover', () => {
-    beforeEach(async () => {
-        await browser.url(URL);
-    });
+if (process.env.COMPAT === 'false') {
+    describe('mouseover', () => {
+        beforeEach(async () => {
+            await browser.url(URL);
+        });
 
-    it('should be able to trigger programmatic mouseover', async () => {
-        const component = await browser.$('integration-mouseover');
-        const elementToHover = await component.shadow$('.mouseover');
-        // This might seem like a roundabout way to mouse over an element, but this puts ChromeDriver into the
-        // code path where it calls elementsFromPoint, which is what we're trying to test:
-        // https://github.com/bayandin/chromedriver/blob/ad6ede8/js/get_element_location.js#L122
-        if (typeof browser.performActions === 'function') {
+        it('should be able to trigger programmatic mouseover', async () => {
+            const component = await browser.$('integration-mouseover');
+            const elementToHover = await component.shadow$('.mouseover');
+            // This might seem like a roundabout way to mouse over an element, but this puts ChromeDriver into the
+            // code path where it calls elementsFromPoint, which is what we're trying to test:
+            // https://github.com/bayandin/chromedriver/blob/ad6ede8/js/get_element_location.js#L122
             await browser.performActions([
                 {
                     type: 'pointer',
@@ -37,13 +37,10 @@ describe('mouseover', () => {
                     ],
                 },
             ]);
-        } else {
-            // IE driver does not support performActions, fall back to moveTo()
-            await elementToHover.moveTo();
-        }
 
-        const successElement = await component.shadow$('.hovering');
-        const exists = await successElement.isExisting();
-        assert.strictEqual(exists, true);
+            const successElement = await component.shadow$('.hovering');
+            const exists = await successElement.isExisting();
+            assert.strictEqual(exists, true);
+        });
     });
-});
+}


### PR DESCRIPTION
## Details

This test flaps a lot. (E.g. [this run](https://app.circleci.com/pipelines/github/salesforce/lwc/5858/workflows/75b0b5dc-8772-40d5-9279-a085b9f3d206/jobs/43144) and [this run](https://app.circleci.com/pipelines/github/salesforce/lwc/5858/workflows/096029e8-34c5-435f-91ff-e6e16ef0de5a/jobs/43097).)

The original goal of the test was to test `elementsFromPoints()` and how it interacts with ChromeDriver (#2495). So it's kind of pointless to run this test in IE anyway. Let's just disable it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
