### PR TITLE
refactor(engine): optimize computation of transitive shadow mode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -116,7 +116,7 @@ export interface VM<N = HostNode, E = HostElement> {
     shadowMode: ShadowMode;
     /** Transitive support for native Shadow DOM. A component in native mode
      * transitively opts all of its descendants into native. */
-    readonly nearestSRMode: ShadowMode | null;
+    readonly nearestShadowMode: ShadowMode | null;
     /** The component creation index. */
     idx: number;
     /** Component state, analogous to Element.isConnected */
@@ -289,7 +289,7 @@ export function createVM<HostNode, HostElement>(
 
         renderMode: def.renderMode,
         shadowMode: computeShadowMode(def, owner),
-        nearestSRMode: owner?.shadowRoot ? owner.shadowMode : owner?.nearestSRMode ?? null,
+        nearestShadowMode: owner?.shadowRoot ? owner.shadowMode : owner?.nearestShadowMode ?? null,
 
         context: {
             stylesheetToken: undefined,
@@ -355,7 +355,7 @@ function computeShadowMode(def: ComponentDef, owner: VM | null) {
                     // transitively opts all of its descendants into native.
                     // Synthetic if neither this component nor any of its ancestors are configured
                     // to be native.
-                    shadowMode = owner?.nearestSRMode ?? ShadowMode.Synthetic;
+                    shadowMode = owner?.nearestShadowMode ?? ShadowMode.Synthetic;
                 }
             } else {
                 shadowMode = ShadowMode.Synthetic;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -289,7 +289,7 @@ export function createVM<HostNode, HostElement>(
 
         renderMode: def.renderMode,
         shadowMode: computeShadowMode(def, owner),
-        nearestSRMode: owner?.shadowRoot ? owner.shadowMode : (owner?.nearestSRMode ?? null),
+        nearestSRMode: owner?.shadowRoot ? owner.shadowMode : owner?.nearestSRMode ?? null,
 
         context: {
             stylesheetToken: undefined,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -289,7 +289,7 @@ export function createVM<HostNode, HostElement>(
 
         renderMode: def.renderMode,
         shadowMode: computeShadowMode(def, owner),
-        nearestSRMode: owner?.shadowRoot ? owner.shadowMode : owner?.nearestSRMode || null,
+        nearestSRMode: owner?.shadowRoot ? owner.shadowMode : (owner?.nearestSRMode ?? null),
 
         context: {
             stylesheetToken: undefined,
@@ -355,7 +355,7 @@ function computeShadowMode(def: ComponentDef, owner: VM | null) {
                     // transitively opts all of its descendants into native.
                     // Synthetic if neither this component nor any of its ancestors are configured
                     // to be native.
-                    shadowMode = owner?.nearestSRMode || ShadowMode.Synthetic;
+                    shadowMode = owner?.nearestSRMode ?? ShadowMode.Synthetic;
                 }
             } else {
                 shadowMode = ShadowMode.Synthetic;


### PR DESCRIPTION
## Details

to avoid mixing native and synthetic shadows, a recursion was used to find the nearest owner with a shadow attached. This PR simplifies that process by doing some extra bookkeeping on the value of shadow mode, so no recursion is needed.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
