### PR TITLE
refactor(engine): removing isHydrating global flag used across packages

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -81,7 +81,6 @@ export {
     setHTMLElement,
     setInsert,
     setIsConnected,
-    setIsHydrating,
     setIsNativeShadowDefined,
     setIsSyntheticShadowDefined,
     setNextSibling,

--- a/packages/@lwc/engine-core/src/renderer.ts
+++ b/packages/@lwc/engine-core/src/renderer.ts
@@ -40,12 +40,6 @@ export function setHTMLElement(HTMLElementImpl: HTMLElementType) {
 // Functions
 //
 
-type isHydratingFunc = () => boolean;
-export let isHydrating: isHydratingFunc;
-export function setIsHydrating(isHydratingImpl: isHydratingFunc) {
-    isHydrating = isHydratingImpl;
-}
-
 type insertFunc = (node: N, parent: E, anchor: N | null) => void;
 export let insert: insertFunc;
 export function setInsert(insertImpl: insertFunc) {

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -13,7 +13,6 @@ import {
     getAssociatedVMIfPresent,
 } from '@lwc/engine-core';
 import { isFunction, isNull, isObject } from '@lwc/shared';
-import { setIsHydrating } from '../renderer';
 
 function resetShadowRootAndLightDom(element: Element, Ctor: typeof LightningElement) {
     if (element.shadowRoot) {
@@ -76,16 +75,9 @@ export function hydrateComponent(
     }
 
     try {
-        // Let the renderer know we are hydrating, so it does not replace the existing shadowRoot
-        // and uses the same algo to create the stylesheets as in SSR.
-        setIsHydrating(true);
-
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);
-
-        // set it back since now we finished hydration.
-        setIsHydrating(false);
     } catch (e) {
         // Fallback: In case there's an error while hydrating, let's log the error, and replace the element content
         //           with the client generated DOM.
@@ -98,11 +90,7 @@ export function hydrateComponent(
 
         // we need to recreate the vm with the hydration flag on, so it re-uses the existing shadowRoot.
         createVMWithProps(element, Ctor, props);
-        setIsHydrating(false);
 
         connectRootElement(element);
-    } finally {
-        // in case there's an error during recovery
-        setIsHydrating(false);
     }
 }

--- a/packages/@lwc/engine-dom/src/initializeRenderer.ts
+++ b/packages/@lwc/engine-dom/src/initializeRenderer.ts
@@ -29,7 +29,6 @@ import {
     setHTMLElement,
     setInsert,
     setIsConnected,
-    setIsHydrating,
     setIsNativeShadowDefined,
     setIsSyntheticShadowDefined,
     setNextSibling,
@@ -71,7 +70,6 @@ import {
     HTMLElement,
     insert,
     isConnected,
-    isHydrating,
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     nextSibling,
@@ -112,7 +110,6 @@ setGetProperty(getProperty);
 setHTMLElement(HTMLElement);
 setInsert(insert);
 setIsConnected(isConnected);
-setIsHydrating(isHydrating);
 setIsNativeShadowDefined(isNativeShadowDefined);
 setIsSyntheticShadowDefined(isSyntheticShadowDefined);
 setNextSibling(nextSibling);

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -117,7 +117,13 @@ export function nextSibling(node: Node): Node | null {
 }
 
 export function attachShadow(element: HTMLElement, options: ShadowRootInit): ShadowRoot {
-    const internals = element.attachInternals?.();
+    let internals: ElementInternals | undefined;
+    try {
+        internals = element.attachInternals?.();
+    } catch {
+        // unregistered elements will throw, in which case we go with plan B
+        // to inspect the open shadowRoot on the element.
+    }
     return internals?.shadowRoot || element.shadowRoot || element.attachShadow(options);
 }
 

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -82,17 +82,7 @@ if (isCustomElementRegistryAvailable()) {
     HTMLElementConstructor.prototype = HTMLElement.prototype;
 }
 
-let hydrating = false;
-
-export function setIsHydrating(value: boolean) {
-    hydrating = value;
-}
-
 export const ssr: boolean = false;
-
-export function isHydrating(): boolean {
-    return hydrating;
-}
 
 export const isNativeShadowDefined: boolean = globalThis[KEY__IS_NATIVE_SHADOW_ROOT_DEFINED];
 export const isSyntheticShadowDefined: boolean = hasOwnProperty.call(
@@ -127,10 +117,8 @@ export function nextSibling(node: Node): Node | null {
 }
 
 export function attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
-    if (hydrating) {
-        return element.shadowRoot!;
-    }
-    return element.attachShadow(options);
+    const internals = (element as any).attachInternals?.();
+    return internals?.shadowRoot || element.shadowRoot || element.attachShadow(options);
 }
 
 export function setText(node: Node, content: string): void {

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -116,8 +116,8 @@ export function nextSibling(node: Node): Node | null {
     return node.nextSibling;
 }
 
-export function attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
-    const internals = (element as any).attachInternals?.();
+export function attachShadow(element: HTMLElement, options: ShadowRootInit): ShadowRoot {
+    const internals = element.attachInternals?.();
     return internals?.shadowRoot || element.shadowRoot || element.attachShadow(options);
 }
 

--- a/packages/@lwc/engine-server/src/initializeRenderer.ts
+++ b/packages/@lwc/engine-server/src/initializeRenderer.ts
@@ -29,7 +29,6 @@ import {
     setHTMLElement,
     setInsert,
     setIsConnected,
-    setIsHydrating,
     setIsNativeShadowDefined,
     setIsSyntheticShadowDefined,
     setNextSibling,
@@ -71,7 +70,6 @@ import {
     HTMLElement,
     insert,
     isConnected,
-    isHydrating,
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     nextSibling,
@@ -112,7 +110,6 @@ setGetProperty(getProperty);
 setHTMLElement(HTMLElement);
 setInsert(insert);
 setIsConnected(isConnected);
-setIsHydrating(isHydrating);
 setIsNativeShadowDefined(isNativeShadowDefined);
 setIsSyntheticShadowDefined(isSyntheticShadowDefined);
 setNextSibling(nextSibling);

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -61,14 +61,6 @@ class HTMLElementImpl {
 
 export const ssr: boolean = true;
 
-export function setIsHydrating(_value: boolean) {
-    /* No-op in SSR */
-}
-
-export function isHydrating(): boolean {
-    return false;
-}
-
 export const isNativeShadowDefined: boolean = false;
 export const isSyntheticShadowDefined: boolean = false;
 


### PR DESCRIPTION
## Details

If seems that `isHydrating` was used for two main things:

1. to know whether or not to call `attachShadow`
2. to treat style nodes differently

For 1, we can solve that using element internals, since IE11 doesn't support SSR, we can rely on internals or attach a new shadow, and not having to observe anything about rehydration.

For 2, I don't know what the deal is.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
