### PR TITLE
chore(nucleus): remove salesforcedevs/developer-website

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -18,7 +18,6 @@ branches:
         - lwc/lwc-platform
         - salesforce/lwr
         - salesforce/utam-docs
-        - salesforcedevs/developer-website
         - uiplatform/nucleus
   release:
     pull-request:


### PR DESCRIPTION
## Details

This downstream has failed several of the recent builds. Doesn't appear to be an intermittent issue – looks like their build has a true failure in Nucleus. Let's remove it.