### PR TITLE
test(integration-karma): small quality-of-life improvements

### DIFF
--- a/packages/integration-karma/README.md
+++ b/packages/integration-karma/README.md
@@ -8,7 +8,7 @@ Karma integration test for `@lwc/compiler`, `@lwc/engine-dom`, and `@lwc/synthet
 
 Starts the Karma server in `watch` mode and start Google Chrome. Note that you can open different browsers to run the tests in parallel on all the browsers. While the server in running, updating a fixture will trigger the suite to run.
 
-### `yarn start:hydration`
+### `yarn hydration:start`
 
 Starts the Karma server in `watch` mode and start Google Chrome, to run the hydration test suite. Note that you can open different browsers to run the tests in parallel on all the browsers. While the server in running, updating a fixture will trigger the suite to run.
 
@@ -16,7 +16,7 @@ Starts the Karma server in `watch` mode and start Google Chrome, to run the hydr
 
 Run the test suite a single time on Google Chrome.
 
-### `yarn test:hydration`
+### `yarn hydration:test`
 
 Run the hydration test suite a single time on Google Chrome.
 

--- a/packages/integration-karma/package.json
+++ b/packages/integration-karma/package.json
@@ -4,11 +4,11 @@
     "version": "2.13.1",
     "scripts": {
         "start": "karma start ./scripts/karma-configs/test/local.js",
-        "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers Chrome",
+        "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
         "test:compat": "COMPAT=1 yarn test",
         "test:native": "DISABLE_SYNTHETIC=1 yarn test",
         "hydration:start": "karma start ./scripts/karma-configs/hydration/local.js",
-        "hydration:test": "karma start ./scripts/karma-configs/hydration/local.js --single-run --browsers Chrome",
+        "hydration:test": "karma start ./scripts/karma-configs/hydration/local.js --single-run --browsers ChromeHeadless",
         "hydration:sauce": "karma start ./scripts/karma-configs/hydration/sauce.js --single-run",
         "sauce": "karma start ./scripts/karma-configs/test/sauce.js --single-run",
         "coverage": "node ./scripts/merge-coverage.js"

--- a/packages/integration-karma/scripts/karma-configs/hydration/base.js
+++ b/packages/integration-karma/scripts/karma-configs/hydration/base.js
@@ -24,6 +24,12 @@ const TEST_UTILS = require.resolve('../../../helpers/test-utils');
 const TEST_SETUP = require.resolve('../../../helpers/test-setup');
 const TEST_HYDRATE = require.resolve('../../../helpers/test-hydrate');
 
+// Fix Node warning about >10 event listeners ("Possible EventEmitter memory leak detected").
+// This is due to the fact that we are running so many simultaneous rollup commands
+// on so many files. For every `*.spec.js` file, Rollup adds a listener at
+// this line: https://github.com/rollup/rollup/blob/35cbfae/src/utils/hookActions.ts#L37
+process.setMaxListeners(1000);
+
 function getFiles() {
     return [
         createPattern(LWC_ENGINE),

--- a/packages/integration-karma/scripts/karma-configs/test/base.js
+++ b/packages/integration-karma/scripts/karma-configs/test/base.js
@@ -31,6 +31,12 @@ const TEST_UTILS = require.resolve('../../../helpers/test-utils');
 const WIRE_SETUP = require.resolve('../../../helpers/wire-setup');
 const TEST_SETUP = require.resolve('../../../helpers/test-setup');
 
+// Fix Node warning about >10 event listeners ("Possible EventEmitter memory leak detected").
+// This is due to the fact that we are running so many simultaneous rollup commands
+// on so many files. For every `*.spec.js` file, Rollup adds a listener at
+// this line: https://github.com/rollup/rollup/blob/35cbfae/src/utils/hookActions.ts#L37
+process.setMaxListeners(1000);
+
 function getFiles() {
     const frameworkFiles = [];
 

--- a/packages/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/integration-karma/scripts/karma-plugins/lwc.js
@@ -20,12 +20,6 @@ const compatRollupPlugin = require('rollup-plugin-compat');
 const { COMPAT } = require('../shared/options');
 const Watcher = require('./Watcher');
 
-// Fix Node warning about >10 event listeners ("Possible EventEmitter memory leak detected").
-// This is due to the fact that we are running so many simultaneous rollup commands
-// on so many files. For every `*.spec.js` file, Rollup adds a listener at
-// this line: https://github.com/rollup/rollup/blob/35cbfae/src/utils/hookActions.ts#L37
-process.setMaxListeners(1000);
-
 function createPreprocessor(config, emitter, logger) {
     const { basePath } = config;
 


### PR DESCRIPTION
## Details

- Remove Node warning in hydration tests
- Fix README to have proper instructions for hydration tests
- Use Chrome headless when running locally on the CLI (not debug mode)

The reason for Chrome headless is so it doesn't steal your mouse when you run `yarn test` or `yarn test:hydration`. When running `yarn start` or `yarn hydration:start` you will still get headful Chrome.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
