### PR TITLE
fix(engine-core): add shim for old stylesheetTokens internal API

### DIFF
--- a/packages/@lwc/engine-core/src/framework/secure-template.ts
+++ b/packages/@lwc/engine-core/src/framework/secure-template.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { defineProperty, isUndefined } from '@lwc/shared';
 import { Template } from './template';
 import { checkVersionMismatch } from './check-version-mismatch';
 
@@ -27,6 +28,33 @@ export function registerTemplate(tpl: Template): Template {
         checkVersionMismatch(tpl, 'template');
     }
     signedTemplateSet.add(tpl);
+
+    // FIXME[@W-10950976]: the template object should be frozen, and it should not be possible to set
+    // the stylesheets or stylesheetToken(s). For backwards compat, though, we shim stylesheetTokens
+    // on top of stylesheetToken for anyone who is accessing the old internal API.
+    // Details: https://salesforce.quip.com/v1rmAFu2cKAr
+    defineProperty(tpl, 'stylesheetTokens', {
+        get() {
+            const { stylesheetToken } = this;
+            if (isUndefined(stylesheetToken)) {
+                return stylesheetToken;
+            }
+            // Shim for the old `stylesheetTokens` property
+            // See https://github.com/salesforce/lwc/pull/2332/files#diff-7901555acef29969adaa6583185b3e9bce475cdc6f23e799a54e0018cb18abaa
+            return {
+                hostAttribute: `${stylesheetToken}-host`,
+                shadowAttribute: stylesheetToken,
+            };
+        },
+
+        set(value) {
+            // If the value is null or some other exotic object, you would be broken anyway in the past
+            // because the engine would try to access hostAttribute/shadowAttribute, which would throw an error.
+            // However it may be undefined in newer versions of LWC, so we need to guard against that case.
+            this.stylesheetToken = isUndefined(value) ? undefined : (value as any).shadowAttribute;
+        },
+    });
+
     // chaining this method as a way to wrap existing
     // assignment of templates easily, without too much transformation
     return tpl;

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/index.spec.js
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/index.spec.js
@@ -1,0 +1,38 @@
+import { createElement } from 'lwc';
+import PatchesStylesheet from 'x/patchesStylesheet';
+import InspectStylesheets from 'x/inspectStylesheets';
+
+describe('legacy undocumented stylesheetTokens API', () => {
+    it('can patch a template with stylesheets onto a template without stylesheets', () => {
+        const elm = createElement('x-patches-stylesheet', { is: PatchesStylesheet });
+        document.body.appendChild(elm);
+        const div = elm.shadowRoot.querySelector('div');
+        expect(div.textContent).toEqual('without stylesheet');
+        expect(getComputedStyle(div).color).toEqual('rgb(0, 0, 255)');
+    });
+
+    it('reflects old stylesheetTokens API to/from new stylesheetToken API', () => {
+        const elm = createElement('x-inspect-stylesheets', { is: InspectStylesheets });
+        document.body.appendChild(elm);
+
+        const { withStylesheet, withoutStylesheet } = elm;
+
+        expect(typeof withStylesheet.stylesheetToken).toEqual('string');
+        expect(typeof withStylesheet.stylesheetTokens).toEqual('object');
+        expect(Object.keys(withStylesheet.stylesheetTokens).sort()).toEqual([
+            'hostAttribute',
+            'shadowAttribute',
+        ]);
+        expect(typeof withStylesheet.stylesheetTokens.hostAttribute).toEqual('string');
+        expect(typeof withStylesheet.stylesheetTokens.shadowAttribute).toEqual('string');
+        expect(typeof withoutStylesheet.stylesheetToken).toEqual('undefined');
+        expect(typeof withoutStylesheet.stylesheetTokens).toEqual('undefined');
+
+        // patch the one with a stylesheet onto the one without
+        withoutStylesheet.stylesheetTokens = withStylesheet.stylesheetTokens;
+
+        // stylesheetTokens should reflect stylesheetToken
+        expect(withoutStylesheet.stylesheetTokens).toEqual(withStylesheet.stylesheetTokens);
+        expect(withoutStylesheet.stylesheetToken).toEqual(withStylesheet.stylesheetToken);
+    });
+});

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/inspectStylesheets.js
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/inspectStylesheets.js
@@ -1,0 +1,13 @@
+import { api, LightningElement } from 'lwc';
+import withStylesheet from './withStylesheet.html';
+import withoutStylesheet from './withoutStylesheet.html';
+
+export default class extends LightningElement {
+    @api get withStylesheet() {
+        return withStylesheet;
+    }
+
+    @api get withoutStylesheet() {
+        return withoutStylesheet;
+    }
+}

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withStylesheet.css
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withStylesheet.css
@@ -1,0 +1,3 @@
+div {
+  color: blue;
+}

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withStylesheet.html
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withStylesheet.html
@@ -1,0 +1,3 @@
+<template>
+  <div>with stylesheet</div>
+</template>

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withoutStylesheet.html
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/inspectStylesheets/withoutStylesheet.html
@@ -1,0 +1,3 @@
+<template>
+  <div>without stylesheet</div>
+</template>

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/patchesStylesheet.js
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/patchesStylesheet.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc';
+import withStylesheet from './withStylesheet.html';
+import withoutStylesheet from './withoutStylesheet.html';
+
+export default class extends LightningElement {
+    render() {
+        // patch stylesheets onto the template with no stylesheets
+        withoutStylesheet.stylesheets = withStylesheet.stylesheets;
+        withoutStylesheet.stylesheetToken = withStylesheet.stylesheetToken;
+        return withoutStylesheet;
+    }
+}

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withStylesheet.css
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withStylesheet.css
@@ -1,0 +1,3 @@
+div {
+  color: blue;
+}

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withStylesheet.html
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withStylesheet.html
@@ -1,0 +1,3 @@
+<template>
+  <div>with stylesheet</div>
+</template>

--- a/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withoutStylesheet.html
+++ b/packages/integration-karma/test/rendering/legacy-stylesheet-api/x/patchesStylesheet/withoutStylesheet.html
@@ -1,0 +1,3 @@
+<template>
+  <div>without stylesheet</div>
+</template>


### PR DESCRIPTION
## Details

Adds a shim for the old `stylesheetTokens` internal API on top of the new `stylesheetToken` API. Neither one should be used by component authors (since they are internal and undocumented), but they are used in the wild, so this unbreaks anyone who is using the old API.

Related:

- https://github.com/salesforce/lwc/pull/2332
- https://github.com/salesforce/lwc/pull/2670

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

If you were setting the `stylesheetTokens` on a template by copying it from one template to the other, it broke due to https://github.com/salesforce/lwc/pull/2332 and https://github.com/salesforce/lwc/pull/2670. With this PR, it works like before.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11093934
