### PR TITLE
perf(engine-dom): refactor style cache to reduce lookups

### DIFF
--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -30,7 +30,7 @@ const isIE11 = !isUndefined((document as any).documentMode);
 // Style sheet cache
 //
 
-type CacheData = {
+interface CacheData {
     // Global cache of style elements is used for fast cloning.
     // Global cache of CSSStyleSheets is used because these need to be unique based on content, so the browser
     // can optimize repeated usages across multiple shadow roots.

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -32,15 +32,15 @@ const isIE11 = !isUndefined((document as any).documentMode);
 
 type CacheData = {
     // Global cache of style elements is used for fast cloning.
-    // Global cache of CSSStyleSheets is used because these need to be unique based on content so the browser
-    // can optimize repeated usages across multiple shadow roots
+    // Global cache of CSSStyleSheets is used because these need to be unique based on content, so the browser
+    // can optimize repeated usages across multiple shadow roots.
     stylesheet: CSSStyleSheet | HTMLStyleElement;
-    // Bookkeeping of targets to CSS that has already been injected into them, so we don't duplicate
-    // Note this will never be used by IE11 (because it only uses global styles), so WeakSet support is not important
+    // Bookkeeping of shadow roots that have already had this CSS injected into them, so we don't duplicate stylesheets.
+    // Note this will never be used by IE11 (because it only uses global styles), so WeakSet support is not important.
     roots: WeakSet<ShadowRoot> | undefined;
-    // Same as above, but for the global document to avoid an extra WeakMap lookup for this common case
+    // Same as above, but for the global document to avoid an extra WeakMap lookup for this common case.
     global: boolean;
-    // Keep track of whether the style element has been used already so we know if we need to clone it
+    // Keep track of whether the style element has been used already, so we know if we need to clone it.
     used: boolean;
 };
 

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -75,18 +75,18 @@ function createFreshStyleElement(content: string) {
 }
 
 function createStyleElement(content: string, cacheData: StyleElementCacheData) {
+    if (isIE11) {
+        // For a mysterious reason, IE11 doesn't like the way we clone <style> nodes
+        // and will render the incorrect styles if we do things that way. It's just
+        // a perf optimization, so we can skip it for IE11.
+        return createFreshStyleElement(content);
+    }
     let { stylesheet } = cacheData;
     if (isUndefined(stylesheet)) {
         // Create the style element on-demand
         cacheData.stylesheet = stylesheet = createFreshStyleElement(content);
         // We don't clone every time, because that would be a perf tax on the first time
         return stylesheet;
-    }
-    if (isIE11) {
-        // For a mysterious reason, IE11 doesn't like the way we clone <style> nodes
-        // and will render the incorrect styles if we do things that way. It's just
-        // a perf optimization, so we can skip it for IE11.
-        return createFreshStyleElement(content);
     }
     // This `<style>` may be repeated multiple times in the DOM, so cache it. It's a bit
     // faster to call `cloneNode()` on an existing node than to recreate it every time.

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -45,7 +45,7 @@ interface CacheData {
     used: boolean;
 }
 
-interface ConstrutableStylesheetCacheData extends CacheData {
+interface ConstructableStylesheetCacheData extends CacheData {
     stylesheet: CSSStyleSheet;
 }
 
@@ -106,7 +106,7 @@ function createConstructableStylesheet(content: string) {
 function insertConstructableStylesheet(
     content: string,
     target: ShadowRoot | Document,
-    cacheData: ConstrutableStylesheetCacheData
+    cacheData: ConstructableStylesheetCacheData
 ) {
     const { adoptedStyleSheets } = target;
     const { stylesheet } = cacheData;
@@ -137,7 +137,7 @@ function doInsertStylesheet(content: string, target: ShadowRoot | Document, cach
         insertConstructableStylesheet(
             content,
             target,
-            cacheData as ConstrutableStylesheetCacheData
+            cacheData as ConstructableStylesheetCacheData
         );
     } else {
         // Fall back to <style> element

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -104,11 +104,11 @@ function insertConstructableStylesheet(
     target: ShadowRoot | Document,
     cacheData: ConstrutableStylesheetCacheData
 ) {
-    const { adoptedStyleSheets } = target;
     let { stylesheet } = cacheData;
     if (isUndefined(stylesheet)) {
         cacheData.stylesheet = stylesheet = createConstructableStylesheet(content);
     }
+    const { adoptedStyleSheets } = target;
     // Mutable adopted stylesheets are only supported in certain browsers.
     // The reason we use it is for perf: https://github.com/salesforce/lwc/pull/2683
     if (supportsMutableAdoptedStyleSheets) {

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -42,7 +42,7 @@ interface CacheData {
     global: boolean;
     // Keep track of whether the style element has been used already, so we know if we need to clone it.
     used: boolean;
-};
+}
 
 interface ConstrutableStylesheetCacheData extends CacheData {
     stylesheet: CSSStyleSheet;

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -30,15 +30,29 @@ const isIE11 = !isUndefined((document as any).documentMode);
 // Style sheet cache
 //
 
-// Global cache of style elements used for fast cloning
-let styleElements: Map<string, HTMLStyleElement> = new Map();
-// Global cache of CSSStyleSheets because these need to be unique based on content so the browser
-// can optimize repeated usages across multiple shadow roots
-let stylesheets: Map<string, CSSStyleSheet> = new Map();
-// Bookkeeping of targets to CSS that has already been injected into them, so we don't duplicate
-let shadowRootsToInsertedStylesheets: WeakMap<ShadowRoot, Set<string>> = new WeakMap();
-// Same as above, but for the global document to avoid an extra WeakMap lookup for this common case
-let globalInsertedStylesheets: Set<string> = new Set();
+type CacheData = {
+    // Global cache of style elements is used for fast cloning.
+    // Global cache of CSSStyleSheets is used because these need to be unique based on content so the browser
+    // can optimize repeated usages across multiple shadow roots
+    stylesheet: CSSStyleSheet | HTMLStyleElement;
+    // Bookkeeping of targets to CSS that has already been injected into them, so we don't duplicate
+    // Note this will never be used by IE11 (because it only uses global styles), so WeakSet support is not important
+    roots: WeakSet<ShadowRoot> | undefined;
+    // Same as above, but for the global document to avoid an extra WeakMap lookup for this common case
+    global: boolean;
+    // Keep track of whether the style element has been used already so we know if we need to clone it
+    used: boolean;
+};
+
+interface ConstrutableStylesheetCacheData extends CacheData {
+    stylesheet: CSSStyleSheet;
+}
+
+interface StyleElementCacheData extends CacheData {
+    stylesheet: HTMLStyleElement;
+}
+
+const stylesheetCache: Map<String, CacheData> = new Map();
 
 //
 // Test utilities
@@ -47,10 +61,7 @@ let globalInsertedStylesheets: Set<string> = new Set();
 if (process.env.NODE_ENV === 'development') {
     // @ts-ignore
     window.__lwcResetGlobalStylesheets = () => {
-        styleElements = new Map();
-        stylesheets = new Map();
-        shadowRootsToInsertedStylesheets = new WeakMap();
-        globalInsertedStylesheets = new Set();
+        stylesheetCache.clear();
     };
 }
 
@@ -65,42 +76,37 @@ function createFreshStyleElement(content: string) {
     return elm;
 }
 
-function createStyleElement(content: string) {
-    // For a mysterious reason, IE11 doesn't like the way we clone <style> nodes
-    // and will render the incorrect styles if we do things that way. It's just
-    // a perf optimization, so we can skip it for IE11.
-    if (isIE11) {
-        return createFreshStyleElement(content);
-    }
-
-    let elm = styleElements.get(content);
-    if (isUndefined(elm)) {
-        // We don't clone every time, because that would be a perf tax on the first time
-        elm = createFreshStyleElement(content);
-        styleElements.set(content, elm);
-    } else {
+function createStyleElement(content: string, cacheData: StyleElementCacheData) {
+    const { stylesheet, used } = cacheData;
+    if (used) {
+        // For a mysterious reason, IE11 doesn't like the way we clone <style> nodes
+        // and will render the incorrect styles if we do things that way. It's just
+        // a perf optimization, so we can skip it for IE11.
+        if (isIE11) {
+            return createFreshStyleElement(content);
+        }
         // This `<style>` may be repeated multiple times in the DOM, so cache it. It's a bit
         // faster to call `cloneNode()` on an existing node than to recreate it every time.
-        elm = elm.cloneNode(true) as HTMLStyleElement;
+        return stylesheet.cloneNode(true) as HTMLStyleElement;
     }
-    return elm;
-}
-
-function createOrGetConstructableStylesheet(content: string) {
-    // It's important for CSSStyleSheets to be unique based on their content, so
-    // that adoptedStyleSheets.indexOf(sheet) works
-    let stylesheet = stylesheets.get(content);
-    if (isUndefined(stylesheet)) {
-        stylesheet = new CSSStyleSheet();
-        stylesheet.replaceSync(content);
-        stylesheets.set(content, stylesheet);
-    }
+    // We don't clone every time, because that would be a perf tax on the first time
+    cacheData.used = true;
     return stylesheet;
 }
 
-function insertConstructableStylesheet(content: string, target: ShadowRoot | Document) {
-    const stylesheet = createOrGetConstructableStylesheet(content);
+function createConstructableStylesheet(content: string) {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(content);
+    return stylesheet;
+}
+
+function insertConstructableStylesheet(
+    content: string,
+    target: ShadowRoot | Document,
+    cacheData: ConstrutableStylesheetCacheData
+) {
     const { adoptedStyleSheets } = target;
+    const { stylesheet } = cacheData;
     // Mutable adopted stylesheets are only supported in certain browsers.
     // The reason we use it is for perf: https://github.com/salesforce/lwc/pull/2683
     if (supportsMutableAdoptedStyleSheets) {
@@ -110,43 +116,77 @@ function insertConstructableStylesheet(content: string, target: ShadowRoot | Doc
     }
 }
 
-function insertStyleElement(content: string, target: ShadowRoot | Document) {
-    const elm = createStyleElement(content);
+function insertStyleElement(
+    content: string,
+    target: ShadowRoot | Document,
+    cacheData: StyleElementCacheData
+) {
+    const elm = createStyleElement(content, cacheData);
     const targetAnchorPoint = isDocument(target) ? target.head : target;
     targetAnchorPoint.appendChild(elm);
 }
 
-function doInsertStylesheet(content: string, target: ShadowRoot | Document) {
+function doInsertStylesheet(content: string, target: ShadowRoot | Document, cacheData: CacheData) {
     // Constructable stylesheets are only supported in certain browsers:
     // https://caniuse.com/mdn-api_document_adoptedstylesheets
     // The reason we use it is for perf: https://github.com/salesforce/lwc/pull/2460
     if (supportsConstructableStylesheets) {
-        insertConstructableStylesheet(content, target);
+        insertConstructableStylesheet(
+            content,
+            target,
+            cacheData as ConstrutableStylesheetCacheData
+        );
     } else {
         // Fall back to <style> element
-        insertStyleElement(content, target);
+        insertStyleElement(content, target, cacheData as StyleElementCacheData);
     }
 }
 
-function getInsertedStylesheetsForShadowRoot(target: ShadowRoot) {
-    let insertedStylesheets = shadowRootsToInsertedStylesheets.get(target);
-    if (isUndefined(insertedStylesheets)) {
-        insertedStylesheets = new Set();
-        shadowRootsToInsertedStylesheets.set(target, insertedStylesheets);
+function getCacheData(content: string) {
+    let cacheData = stylesheetCache.get(content);
+    if (isUndefined(cacheData)) {
+        cacheData = {
+            stylesheet: supportsConstructableStylesheets
+                ? createConstructableStylesheet(content)
+                : createFreshStyleElement(content),
+            roots: undefined,
+            global: false,
+            used: false,
+        };
+        stylesheetCache.set(content, cacheData);
     }
-    return insertedStylesheets;
+    return cacheData;
 }
 
-export function insertStylesheet(content: string, target?: ShadowRoot) {
-    const isGlobal = isUndefined(target);
-    const insertedStylesheets = isGlobal
-        ? globalInsertedStylesheets
-        : getInsertedStylesheetsForShadowRoot(target);
-    if (insertedStylesheets.has(content)) {
+function insertGlobalStylesheet(content: string) {
+    const cacheData = getCacheData(content);
+    if (cacheData.global) {
         // already inserted
         return;
     }
-    insertedStylesheets.add(content);
-    const documentOrShadowRoot = isGlobal ? document : target;
-    doInsertStylesheet(content, documentOrShadowRoot);
+    cacheData.global = true; // mark inserted
+    doInsertStylesheet(content, document, cacheData);
+}
+
+function insertLocalStylesheet(content: string, target: ShadowRoot) {
+    const cacheData = getCacheData(content);
+    let { roots } = cacheData;
+    if (isUndefined(roots)) {
+        roots = cacheData.roots = new WeakSet(); // lazily initialize (not needed for global styles)
+    } else if (roots.has(target)) {
+        // already inserted
+        return;
+    }
+    roots.add(target); // mark inserted
+    doInsertStylesheet(content, target, cacheData);
+}
+
+export function insertStylesheet(content: string, target?: ShadowRoot) {
+    if (isUndefined(target)) {
+        // global
+        insertGlobalStylesheet(content);
+    } else {
+        // local
+        insertLocalStylesheet(content, target);
+    }
 }


### PR DESCRIPTION
## Details

I couldn't resist fixing some of the perf regressions introduced in #2827. This refactors the stylesheet cache to avoid making a lot of lookups, which provides some perf wins:

![Screen Shot 2022-05-12 at 9 05 06 AM](https://user-images.githubusercontent.com/283842/168119567-c6d03db4-6397-4cdd-bef3-4a588d969933.png)
 
## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
