### PR TITLE
fix(rollup-plugin): emit warnings during compilation

### DIFF
--- a/packages/@lwc/compiler/README.md
+++ b/packages/@lwc/compiler/README.md
@@ -42,6 +42,7 @@ const { code } = await transform(source, filename, options);
 
 -   `code` (string) - the compiled source code.
 -   `map` (object) - the generated source map.
+-   `warnings` (array, optional) - the array of diagnostic warnings, if any.
 
 ### `version`
 

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -45,6 +45,8 @@ export default function templateTransform(
         throw CompilerError.from(fatalError, { filename });
     }
 
+    // The "Error" diagnostic level makes no sense to include here, because it would already have been
+    // thrown above. As for "Log" and "Fatal", they are currently unused.
     const warnings = result.warnings.filter((_) => _.level === DiagnosticLevel.Warning);
 
     // Rollup only cares about the mappings property on the map. Since producing a source map for

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -45,11 +45,14 @@ export default function templateTransform(
         throw CompilerError.from(fatalError, { filename });
     }
 
+    const warnings = result.warnings.filter((_) => _.level === DiagnosticLevel.Warning);
+
     // Rollup only cares about the mappings property on the map. Since producing a source map for
     // the template doesn't make sense, the transform returns an empty mappings.
     return {
         code: serialize(result.code, filename, options),
         map: { mappings: '' },
+        warnings,
     };
 }
 

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -7,7 +7,12 @@
 import * as path from 'path';
 
 import { isString } from '@lwc/shared';
-import { TransformerErrors, generateCompilerError, invariant } from '@lwc/errors';
+import {
+    TransformerErrors,
+    generateCompilerError,
+    invariant,
+    CompilerDiagnostic,
+} from '@lwc/errors';
 
 import { NormalizedTransformOptions, TransformOptions, validateTransformOptions } from '../options';
 import styleTransform from './style';
@@ -17,6 +22,7 @@ import scriptTransformer from './javascript';
 export interface TransformResult {
     code: string;
     map: unknown;
+    warnings?: CompilerDiagnostic[];
 }
 
 /**

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -24,7 +24,8 @@
     ],
     "devDependencies": {
         "@lwc/compiler": "2.13.3",
-        "@lwc/engine-dom": "2.13.3"
+        "@lwc/engine-dom": "2.13.3",
+        "@lwc/errors": "2.13.3"
     },
     "dependencies": {
         "@lwc/module-resolver": "2.13.3",

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/fixtures/test/test.html
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/fixtures/test/test.html
@@ -1,0 +1,4 @@
+<template>
+    <h1>Hello world</h1>
+</template>
+</template>

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/fixtures/test/test.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/fixtures/test/test.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {}

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import path from 'path';
+import { rollup, RollupWarning } from 'rollup';
+
+import lwc from '../../index';
+
+function normalizeWarning(warning: RollupWarning) {
+    return {
+        code: warning.code,
+        frame: warning.frame,
+        hook: warning.hook,
+        id: warning.id && path.relative(__dirname, warning.id),
+        message: warning.message,
+        plugin: warning.plugin,
+        pluginCode: warning.pluginCode,
+        loc: warning.loc && {
+            column: warning.loc.column,
+            line: warning.loc.line,
+            file: warning.loc.file && path.relative(__dirname, warning.loc.file),
+        },
+    };
+}
+
+describe('warnings', () => {
+    it('should emit a warning for double </template> tags', async () => {
+        const warnings: RollupWarning[] = [];
+        const bundle = await rollup({
+            input: path.resolve(__dirname, 'fixtures/test/test.js'),
+            plugins: [lwc()],
+            onwarn(warning) {
+                warnings.push(warning);
+            },
+        });
+
+        const { output } = await bundle.generate({
+            format: 'esm',
+        });
+
+        // Compilation should be successful
+        expect(output.length).toEqual(1);
+        expect(typeof output[0].code).toEqual('string');
+        expect(warnings.map(normalizeWarning)).toEqual([
+            {
+                code: 'PLUGIN_WARNING',
+                frame: '</template>',
+                hook: 'transform',
+                id: 'fixtures/test/test.html',
+                message:
+                    '@lwc/rollup-plugin: LWC1148: Invalid HTML syntax: end-tag-without-matching-open-element. ' +
+                    'This will not be supported in future versions of LWC. For more information, please visit ' +
+                    'https://html.spec.whatwg.org/multipage/parsing.html#parse-error-end-tag-without-matching-open-element',
+                plugin: 'rollup-plugin-lwc-compiler',
+                pluginCode: 'LWC1148',
+                loc: {
+                    column: 1,
+                    line: 4,
+                    file: 'fixtures/test/test.html',
+                },
+            },
+        ]);
+    });
+});

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -8,10 +8,11 @@ import fs from 'fs';
 import path from 'path';
 import { URLSearchParams } from 'url';
 
-import { Plugin, SourceMapInput } from 'rollup';
+import { Plugin, SourceMapInput, RollupWarning } from 'rollup';
 import pluginUtils, { FilterPattern } from '@rollup/pluginutils';
 import { transformSync, StylesheetConfig, DynamicComponentConfig } from '@lwc/compiler';
 import { resolveModule, ModuleRecord } from '@lwc/module-resolver';
+import type { CompilerDiagnostic } from '@lwc/errors';
 
 export interface RollupLwcOptions {
     /** A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should transform on. By default all files are targeted. */
@@ -31,6 +32,8 @@ export interface RollupLwcOptions {
     /** The configuration to pass to `@lwc/compiler`. */
     experimentalDynamicComponent?: DynamicComponentConfig;
 }
+
+const PLUGIN_NAME = 'rollup-plugin-lwc-compiler';
 
 const DEFAULT_MODULES = [
     { npm: '@lwc/engine-dom' },
@@ -65,6 +68,43 @@ function parseQueryParamsForScopedOption(id: string): scopedOption {
     };
 }
 
+function transformWarningToRollupWarning(
+    warning: CompilerDiagnostic,
+    src: string,
+    id: string
+): RollupWarning {
+    // For reference on RollupWarnings, a good example is:
+    // https://github.com/rollup/plugins/blob/53776ee/packages/typescript/src/diagnostics/toWarning.ts
+    const pluginCode = `LWC${warning.code}`; // modeled after TypeScript, e.g. TS5055
+    const result: RollupWarning = {
+        // Replace any newlines in case they exist, just so the Rollup output looks a bit cleaner
+        message: `@lwc/rollup-plugin: ${warning.message?.replace(/\n/g, ' ')}`,
+        plugin: PLUGIN_NAME,
+        pluginCode,
+    };
+    const { location } = warning;
+    if (location) {
+        result.loc = {
+            // The CompilerDiagnostic from @lwc/template-compiler reports an undefined filename, because it loses the
+            // filename context here:
+            // https://github.com/salesforce/lwc/blob/e2bc36f/packages/%40lwc/compiler/src/transformers/template.ts#L35-L38
+            file: id,
+            // For LWC, the column is 0-based and the line is 1-based. Rollup just reports this for informational
+            // purposes, though; it doesn't seem to matter what we put here.
+            column: location.column,
+            line: location.line,
+        };
+        // To get a fancier output like @rollup/plugin-typescript's, we would need to basically do our
+        // own color coding on the entire line, adding the wavy lines to indicate an error, etc. You can see how
+        // TypeScript does it here: https://github.com/microsoft/TypeScript/blob/1a4643b/src/compiler/program.ts#L453-L485
+        // Outputting just the string that caused the error is good enough for now though.
+        if (typeof location.start === 'number' && typeof location.length === 'number') {
+            result.frame = src.substring(location.start, location.start + location.length);
+        }
+    }
+    return result;
+}
+
 export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
     const filter = pluginUtils.createFilter(pluginOptions.include, pluginOptions.exclude);
 
@@ -77,7 +117,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
     } = pluginOptions;
 
     return {
-        name: 'rollup-plugin-lwc-compiler',
+        name: PLUGIN_NAME,
 
         buildStart({ input }) {
             if (rootDir === undefined) {
@@ -168,7 +208,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             // Extract module name and namespace from file path
             const [namespace, name] = path.dirname(id).split(path.sep).slice(-2);
 
-            const { code, map } = transformSync(src, id, {
+            const { code, map, warnings } = transformSync(src, id, {
                 name,
                 namespace,
                 outputConfig: { sourcemap },
@@ -177,6 +217,12 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 preserveHtmlComments,
                 scopedStyles: scoped,
             });
+
+            if (warnings) {
+                for (const warning of warnings) {
+                    this.warn(transformWarningToRollupWarning(warning, src, id));
+                }
+            }
 
             const rollupMap = map as SourceMapInput;
             return { code, map: rollupMap };


### PR DESCRIPTION
## Details
Fixes #2771

Propagates template compiler warnings from `@lwc/compiler` to `@lwc/rollup-plugin`, where it is logged using the [standard Rollup `this.warn()` method](https://rollupjs.org/guide/en/#thiswarn) as a [RollupWarning](https://github.com/rollup/rollup/blob/619563871dd73d64b3670c01c410ba9f882b723c/src/rollup/types.d.ts#L9-L22).

Here is what a warning looks like when running `rollup` in the console ([source](https://github.com/nolanlawson/lwc-barebone/commit/b2b7007fe5c89d28449ff61ed73554dee67bf9a3):

```
(!) Plugin rollup-plugin-lwc-compiler: @lwc/rollup-plugin: LWC1148: Invalid HTML syntax: end-tag-without-matching-open-element. This will not be supported in future versions of LWC. For more information, please visit https://html.spec.whatwg.org/multipage/parsing.html#parse-error-end-tag-without-matching-open-element
src/modules/x/app/app.html: (4:1)
</template>
```

Screenshot:

![Screen Shot 2022-05-12 at 2 07 57 PM](https://user-images.githubusercontent.com/283842/168168406-81a3346b-971f-42f1-a236-903d4fa064da.png)


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

If you're using the Rollup plugin directly (e.g. off-core), and if you were using `onwarn` to capture warnings, it previously would never be called. Now it will be called with a `RollupWarning`.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-10930894
