### PR TITLE
fix: relax static id validation in iterations

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -107,7 +107,7 @@ export const ParserDiagnostics = {
         code: 1041,
         message:
             'Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.',
-        level: DiagnosticLevel.Error,
+        level: DiagnosticLevel.Warning,
         url: '',
     },
 

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-id/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-id/metadata.json
@@ -36,7 +36,7 @@
         {
             "code": 1041,
             "message": "LWC1041: Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.",
-            "level": 1,
+            "level": 2,
             "location": {
                 "line": 7,
                 "column": 16,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/actual.html
@@ -1,0 +1,21 @@
+<template>
+    <!-- Inline for each -->
+    <div for:each={items} for:item="item" key={item.key}>
+        <span id="a"></span>
+    </div>
+
+    <!-- Template for each -->
+    <template for:each={items} for:item="item">
+        <span key={item.key} id="b"></span>
+    </template>
+
+    <!-- Inline iterator -->
+    <div iterator:item={items} key={item.key}>
+        <span id="c"></span>
+    </div>
+
+    <!-- Template iterator -->
+    <template iterator:item={items}>
+        <span key={item.key} id="d"></span>
+    </template>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
@@ -1,0 +1,81 @@
+import { registerTemplate } from "lwc";
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const {
+    k: api_key,
+    gid: api_scoped_id,
+    h: api_element,
+    i: api_iterator,
+    f: api_flatten,
+  } = $api;
+  return api_flatten([
+    api_iterator($cmp.items, function (item) {
+      return api_element(
+        "div",
+        {
+          key: api_key(0, item.key),
+        },
+        [
+          api_element("span", {
+            attrs: {
+              id: api_scoped_id("a"),
+            },
+            key: 1,
+          }),
+        ]
+      );
+    }),
+    api_iterator($cmp.items, function (item) {
+      return api_element("span", {
+        attrs: {
+          id: api_scoped_id("b"),
+        },
+        key: api_key(2, item.key),
+      });
+    }),
+    api_iterator(
+      $cmp.items,
+      function (itemValue, itemIndex, itemFirst, itemLast) {
+        const item = {
+          value: itemValue,
+          index: itemIndex,
+          first: itemFirst,
+          last: itemLast,
+        };
+        return api_element(
+          "div",
+          {
+            key: api_key(3, item.key),
+          },
+          [
+            api_element("span", {
+              attrs: {
+                id: api_scoped_id("c"),
+              },
+              key: 4,
+            }),
+          ]
+        );
+      }
+    ),
+    api_iterator(
+      $cmp.items,
+      function (itemValue, itemIndex, itemFirst, itemLast) {
+        const item = {
+          value: itemValue,
+          index: itemIndex,
+          first: itemFirst,
+          last: itemLast,
+        };
+        return api_element("span", {
+          attrs: {
+            id: api_scoped_id("d"),
+          },
+          key: api_key(5, item.key),
+        });
+      }
+    ),
+  ]);
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/metadata.json
@@ -1,0 +1,48 @@
+{
+    "warnings": [
+        {
+            "code": 1041,
+            "message": "LWC1041: Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.",
+            "level": 2,
+            "location": {
+                "line": 4,
+                "column": 15,
+                "start": 112,
+                "length": 6
+            }
+        },
+        {
+            "code": 1041,
+            "message": "LWC1041: Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.",
+            "level": 2,
+            "location": {
+                "line": 9,
+                "column": 30,
+                "start": 247,
+                "length": 6
+            }
+        },
+        {
+            "code": 1041,
+            "message": "LWC1041: Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.",
+            "level": 2,
+            "location": {
+                "line": 14,
+                "column": 15,
+                "start": 369,
+                "length": 6
+            }
+        },
+        {
+            "code": 1041,
+            "message": "LWC1041: Static id values are not allowed in iterators. Id values must be unique within a template and must therefore be computed with an expression.",
+            "level": 2,
+            "location": {
+                "line": 19,
+                "column": 30,
+                "start": 493,
+                "length": 6
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Backport of https://github.com/salesforce/lwc/pull/2831