### PR TITLE
test: run feature flag test code only in karma

### DIFF
--- a/packages/@lwc/engine-core/src/testFeatureFlag.ts
+++ b/packages/@lwc/engine-core/src/testFeatureFlag.ts
@@ -7,7 +7,9 @@
 
 import features from '@lwc/features';
 
-if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+// Only used in LWC's Karma tests
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     window.addEventListener('test-dummy-flag', () => {
         let hasFlag = false;
         if (features.DUMMY_TEST_FLAG) {

--- a/packages/@lwc/engine-dom/src/testFeatureFlag.ts
+++ b/packages/@lwc/engine-dom/src/testFeatureFlag.ts
@@ -7,7 +7,9 @@
 
 import features from '@lwc/features';
 
-if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+// Only used in LWC's Karma tests
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     window.addEventListener('test-dummy-flag', () => {
         let hasFlag = false;
         if (features.DUMMY_TEST_FLAG) {

--- a/packages/@lwc/synthetic-shadow/src/testFeatureFlag.ts
+++ b/packages/@lwc/synthetic-shadow/src/testFeatureFlag.ts
@@ -7,7 +7,9 @@
 
 import features from '@lwc/features';
 
-if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+// Only used in LWC's Karma tests
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     window.addEventListener('test-dummy-flag', () => {
         let hasFlag = false;
         if (features.DUMMY_TEST_FLAG) {


### PR DESCRIPTION
## Details

After clicking the merge button on #2812, I realized that the new test code can be tweaked to only run in Karma. This will avoid everyday users seeing a weird `test-dummy-flag` event added to the `window`, even in dev mode.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
