### PR TITLE
test(integration-karma): silence lwc rollup plugin warnings

### DIFF
--- a/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -64,10 +64,10 @@ async function getCompiledModule(dirName) {
 
         external: ['lwc', 'test-utils', '@test/loader'], // @todo: add ssr modules for test-utils and @test/loader
 
-        onwarn(warning) {
+        onwarn(warning, warn) {
             // Ignore warnings from our own Rollup plugin
             if (warning.plugin !== 'rollup-plugin-lwc-compiler') {
-                console.warn(warning.message);
+                warn(warning);
             }
         },
     });

--- a/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -63,6 +63,13 @@ async function getCompiledModule(dirName) {
         cache,
 
         external: ['lwc', 'test-utils', '@test/loader'], // @todo: add ssr modules for test-utils and @test/loader
+
+        onwarn(warning) {
+            // Ignore warnings from our own Rollup plugin
+            if (warning.plugin !== 'rollup-plugin-lwc-compiler') {
+                console.warn(warning.message);
+            }
+        },
     });
 
     const { watchFiles } = bundle;

--- a/packages/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/integration-karma/scripts/karma-plugins/lwc.js
@@ -69,6 +69,13 @@ function createPreprocessor(config, emitter, logger) {
                 // Rollup should not attempt to resolve the engine and the test utils, Karma takes care of injecting it
                 // globally in the page before running the tests.
                 external: ['lwc', 'wire-service', 'test-utils', '@test/loader'],
+
+                onwarn(warning) {
+                    // Ignore warnings from our own Rollup plugin
+                    if (warning.plugin !== 'rollup-plugin-lwc-compiler') {
+                        console.warn(warning.message);
+                    }
+                },
             });
 
             watcher.watchSuite(input, bundle.watchFiles);

--- a/packages/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/integration-karma/scripts/karma-plugins/lwc.js
@@ -70,10 +70,10 @@ function createPreprocessor(config, emitter, logger) {
                 // globally in the page before running the tests.
                 external: ['lwc', 'wire-service', 'test-utils', '@test/loader'],
 
-                onwarn(warning) {
+                onwarn(warning, warn) {
                     // Ignore warnings from our own Rollup plugin
                     if (warning.plugin !== 'rollup-plugin-lwc-compiler') {
-                        console.warn(warning.message);
+                        warn(warning);
                     }
                 },
             });


### PR DESCRIPTION
## Details

Since #2833 was merged, we now have annoying warning messages in the console when we run the integration tests. This fixes that. We don't need to be notified of our own warnings.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
