### PR TITLE
fix: trigger slotchange event on removing slot

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -276,7 +276,7 @@ function mountVNodes(
 }
 
 function unmount(vnode: VNode, parent: ParentNode, doRemove: boolean = false) {
-    const { type, elm } = vnode;
+    const { type, elm, sel } = vnode;
 
     // When unmounting a VNode subtree not all the elements have to removed from the DOM. The
     // subtree root, is the only element worth unmounting from the subtree.
@@ -284,9 +284,10 @@ function unmount(vnode: VNode, parent: ParentNode, doRemove: boolean = false) {
         removeNode(elm!, parent);
     }
 
+    const removeChildren = sel === 'slot'; // slot content is removed to trigger slotchange event when removing slot
     switch (type) {
         case VNodeType.Element:
-            unmountVNodes(vnode.children, elm as ParentNode);
+            unmountVNodes(vnode.children, elm as ParentNode, removeChildren);
             break;
 
         case VNodeType.CustomElement: {

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
@@ -54,6 +54,15 @@ it('should fire slotchange on replace', () => {
     });
 });
 
+it('should fire slotchange when slot is removed', () => {
+    child.setSlotChangeCount(0);
+    child.removeSlot();
+
+    return waitForSlotChange().then(() => {
+        expect(child.getSlotChangeCount()).toBe(1);
+    });
+});
+
 it('should fire slotchange when listener added programmatically', () => {
     let count = 0;
 

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/x/child/child.html
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/x/child/child.html
@@ -1,3 +1,5 @@
 <template>
+  <template if:true={showSlot}>
     <slot onslotchange={handleSlotChange}></slot>
+  </template>
 </template>

--- a/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/x/child/child.js
+++ b/packages/integration-karma/test/shadow-dom/HTMLSlotElement-events/x/child/child.js
@@ -2,6 +2,7 @@ import { LightningElement, api } from 'lwc';
 
 export default class Child extends LightningElement {
     slotChangeCount = 0;
+    showSlot = true;
 
     @api
     getSlotChangeCount() {
@@ -11,6 +12,11 @@ export default class Child extends LightningElement {
     @api
     setSlotChangeCount(value) {
         this.slotChangeCount = value;
+    }
+
+    @api
+    removeSlot() {
+        this.showSlot = false;
     }
 
     handleSlotChange() {


### PR DESCRIPTION
## Details
In native shadow and earlier synethic shadow, `slotchange` event fires when a slot is removed because its children are removed first and then the slot is removed. This PR reintroduces that behavior for synthetic shadow.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* 🚨 Yes, it does introduce a breaking change.
But it's fixing something that broke earlier.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
