### PR TITLE
fix: only remove slot children in synthetic shadow

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -284,7 +284,9 @@ function unmount(vnode: VNode, parent: ParentNode, doRemove: boolean = false) {
         removeNode(elm!, parent);
     }
 
-    const removeChildren = sel === 'slot'; // slot content is removed to trigger slotchange event when removing slot
+    // Slot content is removed to trigger slotchange event when removing slot.
+    // Only required for synthetic shadow.
+    const removeChildren = sel === 'slot' && vnode.owner.shadowMode === ShadowMode.Synthetic;
     switch (type) {
         case VNodeType.Element:
             unmountVNodes(vnode.children, elm as ParentNode, removeChildren);

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -284,13 +284,15 @@ function unmount(vnode: VNode, parent: ParentNode, doRemove: boolean = false) {
         removeNode(elm!, parent);
     }
 
-    // Slot content is removed to trigger slotchange event when removing slot.
-    // Only required for synthetic shadow.
-    const removeChildren = sel === 'slot' && vnode.owner.shadowMode === ShadowMode.Synthetic;
     switch (type) {
-        case VNodeType.Element:
+        case VNodeType.Element: {
+            // Slot content is removed to trigger slotchange event when removing slot.
+            // Only required for synthetic shadow.
+            const removeChildren =
+                sel === 'slot' && vnode.owner.shadowMode === ShadowMode.Synthetic;
             unmountVNodes(vnode.children, elm as ParentNode, removeChildren);
             break;
+        }
 
         case VNodeType.CustomElement: {
             const { vm } = vnode;


### PR DESCRIPTION
## Details

Follow-up to #2840.

I'm not sure if this change is really worth making, but it seems nice to call out here that `removeChildren` is only necessary for synthetic shadow. Maybe this will make it easier to remove in the future when synthetic shadow is gone? Or if we do an "LWC lite" build?

If not, I'd also be happy just to add a code comment that this is only needed for synthetic.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->