### PR TITLE
test(integration-karma): ensure constructable stylesheets are re-used

### DIFF
--- a/packages/integration-karma/test/rendering/stylesheets/index.spec.js
+++ b/packages/integration-karma/test/rendering/stylesheets/index.spec.js
@@ -2,6 +2,8 @@ import { createElement } from 'lwc';
 
 import Component from 'x/component';
 import IdenticalComponent from 'x/identicalComponent';
+import Sharing1 from 'x/sharing1';
+import Sharing2 from 'x/sharing2';
 
 // This test makes no sense for browsers that don't support constructable stylesheets
 // or for synthetic shadow
@@ -32,6 +34,24 @@ if (process.env.NATIVE_SHADOW && document.adoptedStyleSheets) {
             expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
             expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
                 elm2.shadowRoot.adoptedStyleSheets[0]
+            );
+        });
+
+        it('re-uses constructable stylesheets for components with shared style', () => {
+            const elm1 = createElement('x-sharing1', { is: Sharing1 });
+            const elm2 = createElement('x-sharing2', { is: Sharing2 });
+
+            document.body.appendChild(elm1);
+            document.body.appendChild(elm2);
+
+            // imported style is the same, but after the import they're different
+            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(2);
+            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(2);
+            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
+                elm2.shadowRoot.adoptedStyleSheets[0]
+            );
+            expect(elm1.shadowRoot.adoptedStyleSheets[1]).not.toBe(
+                elm2.shadowRoot.adoptedStyleSheets[1]
             );
         });
     });

--- a/packages/integration-karma/test/rendering/stylesheets/index.spec.js
+++ b/packages/integration-karma/test/rendering/stylesheets/index.spec.js
@@ -1,0 +1,38 @@
+import { createElement } from 'lwc';
+
+import Component from 'x/component';
+import IdenticalComponent from 'x/identicalComponent';
+
+// This test makes no sense for browsers that don't support constructable stylesheets
+// or for synthetic shadow
+if (process.env.NATIVE_SHADOW && document.adoptedStyleSheets) {
+    describe('stylesheets', () => {
+        it('re-uses constructable stylesheets for instances of the same component', () => {
+            const elm1 = createElement('x-component', { is: Component });
+            const elm2 = createElement('x-component', { is: Component });
+
+            document.body.appendChild(elm1);
+            document.body.appendChild(elm2);
+
+            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
+                elm2.shadowRoot.adoptedStyleSheets[0]
+            );
+        });
+
+        it('re-uses constructable stylesheets for components with identical styles', () => {
+            const elm1 = createElement('x-component', { is: Component });
+            const elm2 = createElement('x-identical-component', { is: IdenticalComponent });
+
+            document.body.appendChild(elm1);
+            document.body.appendChild(elm2);
+
+            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
+                elm2.shadowRoot.adoptedStyleSheets[0]
+            );
+        });
+    });
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/component/component.css
+++ b/packages/integration-karma/test/rendering/stylesheets/x/component/component.css
@@ -1,0 +1,3 @@
+h1 {
+  color: darkorchid;
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/component/component.html
+++ b/packages/integration-karma/test/rendering/stylesheets/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+  <h1>hello world</h1>
+</template>

--- a/packages/integration-karma/test/rendering/stylesheets/x/component/component.js
+++ b/packages/integration-karma/test/rendering/stylesheets/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.css
+++ b/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.css
@@ -1,0 +1,3 @@
+h1 {
+  color: darkorchid;
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.html
+++ b/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.html
@@ -1,0 +1,3 @@
+<template>
+  <h1>hello world</h1>
+</template>

--- a/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.js
+++ b/packages/integration-karma/test/rendering/stylesheets/x/identicalComponent/identicalComponent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/rendering/stylesheets/x/shared.css
+++ b/packages/integration-karma/test/rendering/stylesheets/x/shared.css
@@ -1,0 +1,3 @@
+h1 {
+  background: blue;
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.css
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.css
@@ -1,0 +1,5 @@
+@import '../shared.css';
+
+h1 {
+  color: red;
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.html
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.html
@@ -1,0 +1,3 @@
+<template>
+  <h1>hello</h1>
+</template>

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.js
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing1/sharing1.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.css
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.css
@@ -1,0 +1,5 @@
+@import '../shared.css';
+
+h1 {
+  color: green;
+}

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.html
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.html
@@ -1,0 +1,3 @@
+<template>
+  <h1>hello</h1>
+</template>

--- a/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.js
+++ b/packages/integration-karma/test/rendering/stylesheets/x/sharing2/sharing2.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

To get the full perf benefit of constructable stylesheets, we should be reusing the same instance of the `CSSStyleSheet` object for identical stylesheets, rather than re-creating them. But this is easy to regress, so I realized we should probably have a test for it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
