### PR TITLE
fix: only add version mismatch test code in karma

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -14,7 +14,8 @@ import { LightningElementConstructor } from './base-lightning-element';
 
 let warned = false;
 
-if (process.env.NODE_ENV === 'development') {
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     // @ts-ignore
     window.__lwcResetWarnedOnVersionMismatch = () => {
         warned = false;


### PR DESCRIPTION
## Details

Similar to https://github.com/salesforce/lwc/commit/7e9c5d21a70867fd9a0583759259e4d9fb6ede76, if we're going to be adding globals to the `window` object for our Karma tests, we should check if we're actually in a Karma environment first.

I realized this was broken because it actually breaks `@lwc/engine-server` if you run it with `NODE_ENV=development`. 🤦  (Node doesn't have a `window` object.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

The thing that was broken is no longer broken.

<!-- If yes, please describe the anticipated observable changes. -->
