### PR TITLE
chore(nucleus): remove another downstream

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -9,7 +9,6 @@ branches:
       auto-start-from-forks: false
       merge-method: disabled # do not auto-merge; we'll do it ourselves
       required-downstream-deps:
-        - communities/microsite-template-marketing
         - communities/shared-experience-components
         - communities/ui-b2b-components
         - communities/ui-lightning-community


### PR DESCRIPTION
Another Nucleus downstream is [failing](https://nucleus.uipengsys-public.buildndeliver-s.aws-esvc1-useast2.aws.sfdc.cl/workflows/69603#job=207194&step=node-install-patched) for reasons outside of our control.