### PR TITLE
test(integration-karma): more shadow transitivity tests

### DIFF
--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
@@ -6,6 +6,14 @@ import ParentResetChildAny from 'x/parentResetChildAny';
 import ParentResetChildReset from 'x/parentResetChildReset';
 import ParentLightChildAny from 'x/parentLightChildAny';
 import ParentLightChildReset from 'x/parentLightChildReset';
+import GrandparentAnyParentAnyChildAny from 'x/grandparentAnyParentAnyChildAny';
+import GrandparentAnyParentAnyChildReset from 'x/grandparentAnyParentAnyChildReset';
+import GrandparentAnyParentResetChildAny from 'x/grandparentAnyParentResetChildAny';
+import GrandparentAnyParentResetChildReset from 'x/grandparentAnyParentResetChildReset';
+import GrandparentResetParentAnyChildAny from 'x/grandparentResetParentAnyChildAny';
+import GrandparentResetParentAnyChildReset from 'x/grandparentResetParentAnyChildReset';
+import GrandparentResetParentResetChildAny from 'x/grandparentResetParentResetChildAny';
+import GrandparentResetParentResetChildReset from 'x/grandparentResetParentResetChildReset';
 
 // In compat mode, native components and synthetic components will both render
 // in synthetic style; there's no difference.
@@ -47,6 +55,46 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
             {
                 Component: ParentLightChildReset,
                 tagName: 'x-parent-light-child-reset',
+                nativeLeaf: false,
+            },
+            {
+                Component: GrandparentAnyParentAnyChildAny,
+                tagName: 'x-grandparent-any-parent-any-child-any',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentAnyParentAnyChildReset,
+                tagName: 'x-grandparent-any-parent-any-child-reset',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentAnyParentResetChildAny,
+                tagName: 'x-grandparent-any-parent-reset-child-any',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentAnyParentResetChildReset,
+                tagName: 'x-grandparent-any-parent-reset-child-reset',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentResetParentAnyChildAny,
+                tagName: 'x-grandparent-reset-parent-any-child-any',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentResetParentAnyChildReset,
+                tagName: 'x-grandparent-reset-parent-any-child-reset',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentResetParentResetChildAny,
+                tagName: 'x-grandparent-reset-parent-reset-child-any',
+                nativeLeaf: true,
+            },
+            {
+                Component: GrandparentResetParentResetChildReset,
+                tagName: 'x-grandparent-reset-parent-reset-child-reset',
                 nativeLeaf: false,
             },
         ];

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-any-child-any></x-parent-any-child-any>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-any-child-reset></x-parent-any-child-reset>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-reset-child-any></x-parent-reset-child-any>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-reset-child-reset></x-parent-reset-child-reset>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildAny/grandparentResetParentAnyChildAny.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildAny/grandparentResetParentAnyChildAny.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-any-child-any></x-parent-any-child-any>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildAny/grandparentResetParentAnyChildAny.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildAny/grandparentResetParentAnyChildAny.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildReset/grandparentResetParentAnyChildReset.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildReset/grandparentResetParentAnyChildReset.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-any-child-reset></x-parent-any-child-reset>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildReset/grandparentResetParentAnyChildReset.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentAnyChildReset/grandparentResetParentAnyChildReset.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildAny/grandparentResetParentResetChildAny.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildAny/grandparentResetParentResetChildAny.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-reset-child-any></x-parent-reset-child-any>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildAny/grandparentResetParentResetChildAny.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildAny/grandparentResetParentResetChildAny.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildReset/grandparentResetParentResetChildReset.html
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildReset/grandparentResetParentResetChildReset.html
@@ -1,0 +1,3 @@
+<template>
+  <x-parent-reset-child-reset></x-parent-reset-child-reset>
+</template>

--- a/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildReset/grandparentResetParentResetChildReset.js
+++ b/packages/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentResetParentResetChildReset/grandparentResetParentResetChildReset.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Follow-up to #2859. This adds more tests to ensure that transitive `shadowMode` calculation is working correctly.

I generated these tests using a small script; I did not write these by hand. 🙂 

I had previously considered adding some slot tests too, but that seemed a bit overkill, especially since the slot doesn't affect ownership; whoever is doing the slotting is the owner for the purposes of transitivity calculation.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->