### PR TITLE
perf(engine-core): render separate style tags

### DIFF
--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayJoin, ArrayPush, isArray, isNull, isUndefined, KEY__SCOPED_CSS } from '@lwc/shared';
+import { ArrayMap, ArrayPush, isArray, isNull, isUndefined, KEY__SCOPED_CSS } from '@lwc/shared';
 
 import api from './api';
 import { RenderMode, ShadowMode, VM } from './vm';
@@ -199,7 +199,7 @@ function getNearestNativeShadowComponent(vm: VM): VM | null {
     return owner;
 }
 
-export function createStylesheet(vm: VM, stylesheets: string[]): VNode | null {
+export function createStylesheet(vm: VM, stylesheets: string[]): VNode[] | null {
     const {
         renderMode,
         shadowMode,
@@ -215,8 +215,7 @@ export function createStylesheet(vm: VM, stylesheets: string[]): VNode | null {
         //       the first time the VM renders.
 
         // native shadow or light DOM, SSR
-        const combinedStylesheetContent = ArrayJoin.call(stylesheets, '\n');
-        return createInlineStyleVNode(combinedStylesheetContent);
+        return ArrayMap.call(stylesheets, createInlineStyleVNode) as VNode[];
     } else {
         // native shadow or light DOM, DOM renderer
         const root = getNearestNativeShadowComponent(vm);

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -6,7 +6,7 @@
  */
 import {
     ArrayIndexOf,
-    ArraySplice,
+    ArrayUnshift,
     assert,
     create,
     isArray,
@@ -202,7 +202,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache);
                 const { styleVNodes } = context;
                 if (!isNull(styleVNodes)) {
-                    ArraySplice.call(vnodes, 0, 0, ...styleVNodes);
+                    ArrayUnshift.apply(vnodes, styleVNodes);
                 }
             });
         },

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -6,7 +6,7 @@
  */
 import {
     ArrayIndexOf,
-    ArrayUnshift,
+    ArraySplice,
     assert,
     create,
     isArray,
@@ -180,7 +180,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                     // Evaluate, create stylesheet and cache the produced VNode for future
                     // re-rendering.
                     const stylesheetsContent = getStylesheetsContent(vm, html);
-                    context.styleVNode =
+                    context.styleVNodes =
                         stylesheetsContent.length === 0
                             ? null
                             : createStylesheet(vm, stylesheetsContent);
@@ -200,9 +200,9 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 isUpdatingTemplate = true;
 
                 vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache);
-                const { styleVNode } = context;
-                if (!isNull(styleVNode)) {
-                    ArrayUnshift.call(vnodes, styleVNode);
+                const { styleVNodes } = context;
+                if (!isNull(styleVNodes)) {
+                    ArraySplice.call(vnodes, 0, 0, ...styleVNodes);
                 }
             });
         },

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -87,8 +87,8 @@ export interface Context {
     hasTokenInAttribute: boolean | undefined;
     /** Whether or not light DOM scoped styles are present in the stylesheets. */
     hasScopedStyles: boolean | undefined;
-    /** The VNode injected in all the shadow trees to apply the associated component stylesheets. */
-    styleVNode: VNode | null;
+    /** The VNodes injected in all the shadow trees to apply the associated component stylesheets. */
+    styleVNodes: VNode[] | null;
     /** Object used by the template function to store information that can be reused between
      *  different render cycle of the same template. */
     tplCache: TemplateCache;
@@ -304,7 +304,7 @@ export function createVM<HostNode, HostElement>(
             hasTokenInClass: undefined,
             hasTokenInAttribute: undefined,
             hasScopedStyles: undefined,
-            styleVNode: null,
+            styleVNodes: null,
             tplCache: EmptyObject,
             wiredConnecting: EmptyArray,
             wiredDisconnecting: EmptyArray,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-multiple/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-multiple/expected.html
@@ -1,7 +1,9 @@
 <x-parent>
   <style type="text/css">
     p {background-color: blue;}
-p {color: red;}
+  </style>
+  <style type="text/css">
+    p {color: red;}
   </style>
   <p>
     Hello

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-scoped-styles/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-scoped-styles/expected.html
@@ -1,7 +1,9 @@
 <x-basic class="x-basic_basic-host">
   <style class="x-basic_basic" type="text/css">
     p {color: red;}
-p.x-basic_basic {background-color: blue;}.x-basic_basic-host {display: block;border: 1px solid black;}
+  </style>
+  <style class="x-basic_basic" type="text/css">
+    p.x-basic_basic {background-color: blue;}.x-basic_basic-host {display: block;border: 1px solid black;}
   </style>
   <p class="x-basic_basic">
     Hello

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/expected.html
@@ -1,0 +1,26 @@
+<x-parent>
+  <template shadowroot="open">
+    <style type="text/css">
+      div {border: 1px solid turquoise;}
+    </style>
+    <style type="text/css">
+      div {background: blue;}
+    </style>
+    <x-child>
+      <template shadowroot="open">
+        <style type="text/css">
+          div {border: 1px solid turquoise;}
+        </style>
+        <style type="text/css">
+          div {color: red;}
+        </style>
+        <div>
+          Hello child
+        </div>
+      </template>
+    </x-child>
+    <div>
+      Hello parent
+    </div>
+  </template>
+</x-parent>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-parent';
+export { default } from 'x/parent';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.css
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.css
@@ -1,0 +1,5 @@
+@import '../shared.css';
+
+div {
+    color: red;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <div>Hello child</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.css
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.css
@@ -1,0 +1,5 @@
+@import '../shared.css';
+
+div {
+    background: blue;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.html
@@ -1,0 +1,4 @@
+<template>
+    <x-child></x-child>
+    <div>Hello parent</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/shared.css
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-shared/modules/x/shared.css
@@ -1,0 +1,3 @@
+div {
+  border: 1px solid turquoise;
+}


### PR DESCRIPTION
## Details

This is a stop-gap solution to #2851.

When we render components with shared stylesheets, the browser can optimize those stylesheets under the hood if the `<style>`s are byte-for-byte identical. (I don't have a benchmark handy, but just trust me that browsers do this. 🙂)

```css
/* component.css */
@import './shared.css';

h1 { color: red }
```

Right now we concatenate a component's styles into a single `<style>`, including any shared stylesheets. So the browser cannot optimize, because the duplicated styles are embedded inside of separate `<style>`s that are not byte-for-byte identical.

This PR optimizes the engine so that it emits separate `<style>`s instead. The ordering is maintained, so that effectively you end up with the same styles being applied.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

A component may have more than one `<style>` node now. If component authors are trying to detect this (e.g. by using `this.template.firstChild` to get the `<style>`, or doing `[...this.template.children].slice(1)` to get everything but the first `<style>` element), then this PR will break them.

In practice though, developers already have to worry about the case of browsers that support constructable stylesheets versus those that don't. And on-platform, native shadow has not reached widespread adoption yet. So ideally this will not break anyone.

If developers really need to separate `<style>` from non-`<style>` tags, their best bet is:

```js
this.template.querySelectorAll('style') // style tags
this.template.querySelectorAll(':not(style)') // non-style tags
```
<!-- If yes, please describe the anticipated observable changes. -->

## Gus WI

W-11256353