### PR TITLE
fix(template-compiler): emit child elements for empty templates

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -589,10 +589,11 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Warning,
         url: '',
     },
-    UNKNOWN_TEMPLATE_ATTRIBUTE: {
+    INVALID_TEMPLATE_ATTRIBUTE: {
         code: 1145,
         message:
-            'Non root templates only support for:each, iterator and if directives. All other attributes will be ignored.',
+            'Invalid attributes detected on template. The following attributes are not supported by templates in LWC: {0}. For more information, ' +
+            'please visit https://lwc.dev/guide/reference#html-template-directives',
         level: DiagnosticLevel.Warning,
         url: '',
     },

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/actual.html
@@ -1,6 +1,6 @@
 <template>
     <section>
-        <template if:true={showItems} for:each={items} for:item="item" onfoo={handleFoo}>
+        <template if:true={showItems} for:each={items} for:item="item" onfoo={handleFoo} class="slds-m-around_medium">
             <p key={item.id}>1{item}</p>
         </template>
     </section>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/metadata.json
@@ -2,13 +2,13 @@
     "warnings": [
         {
             "code": 1145,
-            "message": "LWC1145: Non root templates only support for:each, iterator and if directives. All other attributes will be ignored.",
+            "message": "LWC1145: Invalid attributes detected on template. The following attributes are not supported by templates in LWC: onfoo, class. For more information, please visit https://lwc.dev/guide/reference#html-template-directives",
             "level": 2,
             "location": {
                 "line": 3,
                 "column": 9,
                 "start": 33,
-                "length": 142
+                "length": 171
             }
         }
     ]

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/actual.html
@@ -1,3 +1,5 @@
 <template>
-    <template onfoo={handleFoo}></template>
+    <template class="slds-m-around_medium">
+        Hello
+    </template>
 </template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/expected.js
@@ -1,7 +1,7 @@
 import { registerTemplate } from "lwc";
-const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  return stc0;
+  const { t: api_text } = $api;
+  return [api_text("Hello")];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/single-attribute/metadata.json
@@ -2,13 +2,13 @@
     "warnings": [
         {
             "code": 1145,
-            "message": "LWC1145: Non root templates only support for:each, iterator and if directives. All other attributes will be ignored.",
+            "message": "LWC1145: Invalid attributes detected on template. The following attributes are not supported by templates in LWC: class. For more information, please visit https://lwc.dev/guide/reference#html-template-directives",
             "level": 2,
             "location": {
                 "line": 2,
                 "column": 5,
                 "start": 15,
-                "length": 39
+                "length": 69
             }
         }
     ]


### PR DESCRIPTION
## Details
The template compiler refactor (#2518) introduced a regression where child elements of empty templates are no longer rendered.

After the refactor, the parser ignores [empty templates completely](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/template-compiler/src/parser/index.ts#L181-L185) and does not generate any AST nodes for them.

Empty templates here refer to non-root templates that do not have a valid LWC template directive.

There is an [existing warning message](packages/@lwc/errors/src/compiler/error-info/template-transform.ts) for empty templates that will be converted to an error message in 242.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

Empty templates with children will now have their children rendered to the DOM.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11291795
