### PR TITLE
feat(compiler): add compiler option to specify custom renderer config

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -6,6 +6,7 @@
  */
 import { CompilerValidationErrors, invariant } from '@lwc/errors';
 import { isUndefined, isBoolean, isObject } from '@lwc/shared';
+import { CustomRendererConfig } from '@lwc/template-compiler';
 
 type RecursiveRequired<T> = {
     [P in keyof T]-?: RecursiveRequired<T[P]>;
@@ -69,13 +70,18 @@ export interface TransformOptions {
     preserveHtmlComments?: boolean;
     scopedStyles?: boolean;
     enableStaticContentOptimization?: boolean;
+    customRendererConfig?: CustomRendererConfig;
 }
 
-type RequiredTransformOptions = Omit<TransformOptions, 'name' | 'namespace' | 'scopedStyles'>;
+type RequiredTransformOptions = Omit<
+    TransformOptions,
+    'name' | 'namespace' | 'scopedStyles' | 'customRendererConfig'
+>;
 export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTransformOptions> {
     name?: string;
     namespace?: string;
     scopedStyles?: boolean;
+    customRendererConfig?: CustomRendererConfig;
 }
 
 export function validateTransformOptions(options: TransformOptions): NormalizedTransformOptions {

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -71,4 +71,42 @@ describe('transformSync', () => {
         expect(warnings).toHaveLength(0);
         expect(code).toMatch('<img');
     });
+
+    it('should provide custom renderer hooks when config specified', () => {
+        const template = `
+            <template>
+                <svg aria-hidden="true" class="slds-icon" title="when needed">
+                    <use xlink:href="/assets/icons/standard-sprite/svg/symbols.svg#case"></use>
+                </svg>
+            </template>
+        `;
+        const { code, warnings } = transformSync(template, 'foo.html', {
+            customRendererConfig: {
+                directives: [],
+                elements: [
+                    {
+                        tagName: 'use',
+                        namespace: 'http://www.w3.org/2000/svg',
+                        attributes: ['href', 'xlink:href'],
+                    },
+                ],
+            },
+            ...TRANSFORMATION_OPTIONS,
+        });
+        expect(warnings).toHaveLength(0);
+        expect(code).toMatch('renderer: renderer');
+    });
+
+    it('should not provide custom renderer hooks when no config specified', () => {
+        const template = `
+            <template>
+                <svg aria-hidden="true" class="slds-icon" title="when needed">
+                    <use xlink:href="/assets/icons/standard-sprite/svg/symbols.svg#case"></use>
+                </svg>
+            </template>
+        `;
+        const { code, warnings } = transformSync(template, 'foo.html', TRANSFORMATION_OPTIONS);
+        expect(warnings).toHaveLength(0);
+        expect(code).not.toMatch('renderer: renderer');
+    });
 });

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -27,8 +27,12 @@ export default function templateTransform(
     filename: string,
     options: NormalizedTransformOptions
 ): TransformResult {
-    const { experimentalDynamicComponent, preserveHtmlComments, enableStaticContentOptimization } =
-        options;
+    const {
+        experimentalDynamicComponent,
+        preserveHtmlComments,
+        enableStaticContentOptimization,
+        customRendererConfig,
+    } = options;
     const experimentalDynamicDirective = Boolean(experimentalDynamicComponent);
 
     let result;
@@ -37,6 +41,7 @@ export default function templateTransform(
             experimentalDynamicDirective,
             preserveHtmlComments,
             enableStaticContentOptimization,
+            customRendererConfig,
         });
     } catch (e) {
         throw normalizeToCompilerError(TransformerErrors.HTML_TRANSFORMER_ERROR, e, { filename });

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -20,6 +20,7 @@ import generate from './codegen';
 import { TemplateCompileResult, TemplateParseResult } from './shared/types';
 
 export * from './shared/types';
+export { CustomRendererConfig, CustomRendererElementConfig } from './shared/renderer-hooks';
 export { Config } from './config';
 
 export function parse(source: string, config: Config = {}): TemplateParseResult {


### PR DESCRIPTION
## Details


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-11254381](https://gus.lightning.force.com/a07EE00000ydqfmYAA)
