### PR TITLE
fix(compiler): escape invalid CSS character # for scope token

### DIFF
--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -66,9 +66,9 @@ export default function templateTransform(
 }
 
 function escapeScopeToken(input: string) {
-    // Minimal escape for strings containing the "@" character, which is disallowed in CSS selectors
+    // Minimal escape for strings containing the "@", "#" characters, which are disallowed in CSS selectors
     // and at the beginning of attribute names
-    return input.replace(/@/g, '___at___');
+    return input.replace(/@/g, '___at___').replace(/#/g, '___hash___');
 }
 
 function serialize(

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -66,8 +66,8 @@ export default function templateTransform(
 }
 
 function escapeScopeToken(input: string) {
-    // Minimal escape for strings containing the "@", "#" characters, which are disallowed in CSS selectors
-    // and at the beginning of attribute names
+    // Minimal escape for strings containing the "@" and "#" characters, which are disallowed
+    // in certain cases in attribute names
     return input.replace(/@/g, '___at___').replace(/#/g, '___hash___');
 }
 

--- a/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/index.spec.js
+++ b/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/index.spec.js
@@ -1,10 +1,25 @@
 import { createElement } from 'lwc';
-import Component from '@x/component';
+import ComponentAtX from '@x/component';
+import ComponentXHashY from 'x#y/component';
 
-describe('invalid character in namespace', () => {
+describe('invalid character @ in namespace', () => {
     let elm;
     beforeEach(() => {
-        elm = createElement('x-component', { is: Component });
+        elm = createElement('x-component', { is: ComponentAtX });
+        document.body.appendChild(elm);
+    });
+
+    it('element renders despite invalid char in namespace', () => {
+        const h1 = elm.shadowRoot.querySelector('h1');
+        expect(h1.textContent).toEqual('Hello world');
+        expect(getComputedStyle(h1).color).toEqual('rgb(0, 128, 0)');
+    });
+});
+
+describe('invalid character # in namespace', () => {
+    let elm;
+    beforeEach(() => {
+        elm = createElement('xy-component', { is: ComponentXHashY });
         document.body.appendChild(elm);
     });
 

--- a/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.css
+++ b/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.css
@@ -1,0 +1,3 @@
+h1 {
+    color: green;
+}

--- a/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.html
+++ b/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>Hello world</h1>
+</template>

--- a/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.js
+++ b/packages/integration-karma/test/shadow-dom/invalid-char-in-namespace/x#y/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details
When using LWR, the module provider expands "&#35;namespace" to the component name to be loaded. &#35; is not a valid character, which causes error as "Uncaught (in promise) DOMException: Failed to execute 'setAttribute' on 'Element': 'color-purple_purple#purple-host' is not a valid attribute name". The fix escapes &#35; with &#95;&#95;&#95;hash___. 

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.
