### PR TITLE
fix: text + expression concatenation in style-compiler with custom resolver

### DIFF
--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/actual.css
@@ -1,0 +1,6 @@
+div {
+  --slds-c-button-neutral-shadow-focus: var(
+    --slds-c-buttonstateful-shadow-focus,
+    var(--sds-g-color-brand-base-50, #0176d3) black
+  );
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/config.json
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/config.json
@@ -1,0 +1,5 @@
+{
+  "customProperties": {
+    "resolverModule": "custom-properties-resolver"
+  }
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver-and-color-name/expected.js
@@ -1,0 +1,8 @@
+import varResolver from "custom-properties-resolver";
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
+  var shadowSelector = token ? ("[" + token + "]") : "";
+  var hostSelector = token ? ("[" + token + "-host]") : "";
+  return "div" + shadowSelector + " {--slds-c-button-neutral-shadow-focus: " + (varResolver("--slds-c-buttonstateful-shadow-focus",varResolver("--sds-g-color-brand-base-50","#0176d3") + " black")) + ";}";
+  /*LWC compiler vX.X.X*/
+}
+export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/actual.css
@@ -1,0 +1,6 @@
+div {
+  --slds-c-button-neutral-shadow-focus: var(
+    --slds-c-buttonstateful-shadow-focus,
+    var(--sds-g-color-brand-base-50, #0176d3) 0 0 3px
+  );
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/config.json
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/config.json
@@ -1,0 +1,5 @@
+{
+  "customProperties": {
+    "resolverModule": "custom-properties-resolver"
+  }
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/var-nested-with-resolver/expected.js
@@ -1,0 +1,8 @@
+import varResolver from "custom-properties-resolver";
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
+  var shadowSelector = token ? ("[" + token + "]") : "";
+  var hostSelector = token ? ("[" + token + "-host]") : "";
+  return "div" + shadowSelector + " {--slds-c-button-neutral-shadow-focus: " + (varResolver("--slds-c-buttonstateful-shadow-focus",varResolver("--sds-g-color-brand-base-50","#0176d3") + " 0 0 3px")) + ";}";
+  /*LWC compiler vX.X.X*/
+}
+export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -352,7 +352,7 @@ function recursiveValueParse(node: any, inVarExpression = false): Token[] {
                 // If we have a token sequence of text + expression or expression + text,
                 // we need to add the concatenation operator. Examples:
                 //   Input:  var(--x, 0 0 2px var(--y, #fff))
-                //   Output: varResolver("--x", "0 0 2px " + varResolver("--y", "#fff")
+                //   Output: varResolver("--x", "0 0 2px " + varResolver("--y", "#fff"))
                 //
                 //   Input:  var(--x, var(--y, #fff) 0 0 2px)
                 //   Output: varResolver("--x", varResolver("--y", "#fff") + " 0 0 2px")

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -355,7 +355,7 @@ function recursiveValueParse(node: any, inVarExpression = false): Token[] {
                 //   Output: varResolver("--x", "0 0 2px " + varResolver("--y", "#fff"))
                 //
                 //   Input:  var(--x, var(--y, #fff) 0 0 2px)
-                //   Output: varResolver("--x", varResolver("--y", "#fff") + " 0 0 2px")
+                //   Output: varResolver("--x", varResolver("--y", "#fff") + " 0 0 2px"))
                 const shouldAddConcatenator =
                     token.type !== TokenType.divider &&
                     nextToken &&

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -351,8 +351,11 @@ function recursiveValueParse(node: any, inVarExpression = false): Token[] {
 
                 // If we have a token sequence of text + expression or expression + text,
                 // we need to add the concatenation operator. Examples:
-                //   var(--x, 0 0 2px var(--y, #fff))
-                //   var(--x, var(--y, #fff) 0 0 2px)
+                //   Input:  var(--x, 0 0 2px var(--y, #fff))
+                //   Output: varResolver("--x", "0 0 2px " + varResolver("--y", "#fff")
+                //
+                //   Input:  var(--x, var(--y, #fff) 0 0 2px)
+                //   Output: varResolver("--x", varResolver("--y", "#fff") + " 0 0 2px")
                 const shouldAddConcatenator =
                     token.type !== TokenType.divider &&
                     nextToken &&

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -289,6 +289,10 @@ function tokenizeCss(data: string): Token[] {
     return tokens;
 }
 
+function isTextOrExpression(token: Token): boolean {
+    return token.type === TokenType.text || token.type == TokenType.expression;
+}
+
 /*
  * This method takes a tokenized CSS property value `1px solid var(--foo , bar)`
  * and transforms its custom variables in function calls
@@ -367,9 +371,7 @@ function recursiveValueParse(node: any, inVarExpression = false): Token[] {
                 // tokens (see above comment), a concatenator will never be required if
                 // `token` or `nextToken` is an identifier.
                 const shouldAddConcatenator =
-                    (token.type === TokenType.text || token.type == TokenType.expression) &&
-                    nextToken &&
-                    (nextToken.type === TokenType.text || nextToken.type === TokenType.expression);
+                    isTextOrExpression(token) && nextToken && isTextOrExpression(nextToken);
                 const concatOperator = shouldAddConcatenator ? ' + ' : '';
 
                 return buffer + normalizedToken + concatOperator;

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -353,11 +353,11 @@ function recursiveValueParse(node: any, inVarExpression = false): Token[] {
                 // we need to add the concatenation operator. Examples:
                 //   var(--x, 0 0 2px var(--y, #fff))
                 //   var(--x, var(--y, #fff) 0 0 2px)
-                const shouldAddConcatinator =
+                const shouldAddConcatenator =
                     token.type !== TokenType.divider &&
                     nextToken &&
                     nextToken.type !== TokenType.divider;
-                const concatOperator = shouldAddConcatinator ? ' + ' : '';
+                const concatOperator = shouldAddConcatenator ? ' + ' : '';
 
                 return buffer + normalizedToken + concatOperator;
             }, '');


### PR DESCRIPTION
## Details

Previously, when using a custom `var` resolver, `var(foo, bar) 0 0 3px` would be compiled incorrectly by omitting a `+` between the resolved value of `var(foo, bar)` and the `0 0 3px` that followed. A complete example can be found in the test fixture that's added in the PR.

Fixes W-11159171.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.
* 🚨 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
