### PR TITLE
fix(template-compiler): static content template string escaping

### DIFF
--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -1,5 +1,6 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
 import Container from 'x/container';
+import Escape from 'x/escape';
 import MultipleStyles from 'x/multipleStyles';
 import SvgNs from 'x/svgNs';
 import Table from 'x/table';
@@ -106,5 +107,21 @@ describe('tables and static content', () => {
             expect(elm.shadowRoot.querySelectorAll('td').length).toEqual(1);
             expect(elm.shadowRoot.querySelector('td').textContent).toEqual('');
         });
+    });
+});
+
+describe('template literal escaping', () => {
+    it('should properly render escaped content', () => {
+        const elm = createElement('x-escape', { is: Escape });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.querySelector('.backtick-text').textContent).toBe('Escape `me`');
+        expect(elm.shadowRoot.querySelector('.backtick-attr').getAttribute('data-message')).toBe(
+            'Escape `me`'
+        );
+
+        expect(elm.shadowRoot.querySelector('.dollar-attr').getAttribute('data-message')).toBe(
+            'Escape ${me}'
+        );
     });
 });

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -115,13 +115,33 @@ describe('template literal escaping', () => {
         const elm = createElement('x-escape', { is: Escape });
         document.body.appendChild(elm);
 
-        expect(elm.shadowRoot.querySelector('.backtick-text').textContent).toBe('Escape `me`');
-        expect(elm.shadowRoot.querySelector('.backtick-attr').getAttribute('data-message')).toBe(
-            'Escape `me`'
-        );
+        // "`"
+        [
+            () => elm.shadowRoot.querySelector('.backtick-text').textContent,
+            () => elm.shadowRoot.querySelector('.backtick-comment').firstChild.textContent,
+            () => elm.shadowRoot.querySelector('.backtick-attr').getAttribute('data-message'),
+        ].forEach((selector) => {
+            expect(selector()).toBe('Escape `me`');
+        });
 
+        // "\`"
+        [
+            () => elm.shadowRoot.querySelector('.backtick-escape-text').textContent,
+            () => elm.shadowRoot.querySelector('.backtick-escape-comment').firstChild.textContent,
+            () =>
+                elm.shadowRoot.querySelector('.backtick-escape-attr').getAttribute('data-message'),
+        ].forEach((selector) => {
+            expect(selector()).toBe('Escape \\`me`');
+        });
+
+        // "${"
         expect(elm.shadowRoot.querySelector('.dollar-attr').getAttribute('data-message')).toBe(
             'Escape ${me}'
         );
+
+        // "\${"
+        expect(
+            elm.shadowRoot.querySelector('.dollar-escape-attr').getAttribute('data-message')
+        ).toBe('Escape \\${me}');
     });
 });

--- a/packages/@lwc/integration-karma/test/static-content/x/escape/escape.html
+++ b/packages/@lwc/integration-karma/test/static-content/x/escape/escape.html
@@ -1,0 +1,6 @@
+<template>
+    <div class="backtick-text">Escape `me`</div>
+    <div class="backtick-attr" data-message="Escape `me`"></div>
+
+    <div class="dollar-attr" data-message="Escape ${me}"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/static-content/x/escape/escape.html
+++ b/packages/@lwc/integration-karma/test/static-content/x/escape/escape.html
@@ -1,6 +1,13 @@
-<template>
+<template lwc:preserve-comments>
     <div class="backtick-text">Escape `me`</div>
+    <div class="backtick-escape-text">Escape \`me`</div>
+    
+    <div class="backtick-comment"><!--Escape `me`--></div>
+    <div class="backtick-escape-comment"><!--Escape \`me`--></div>
+
     <div class="backtick-attr" data-message="Escape `me`"></div>
+    <div class="backtick-escape-attr" data-message="Escape \`me`"></div>
 
     <div class="dollar-attr" data-message="Escape ${me}"></div>
+    <div class="dollar-escape-attr" data-message="Escape \${me}"></div>
 </template>

--- a/packages/@lwc/integration-karma/test/static-content/x/escape/escape.js
+++ b/packages/@lwc/integration-karma/test/static-content/x/escape/escape.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Escape extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-escaping/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<h1 data-foo="&quot;>\x3Cscript>alert('pwned')\x3C/script>\x3Ch1 foo=&quot;"${3}></h1>`;
+const $fragment1 = parseFragment`<h1 data-foo="&quot;>\\x3Cscript>alert('pwned')\\x3C/script>\\x3Ch1 foo=&quot;"${3}></h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/class-attr-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/class-attr-escaping/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<h1 class="&quot;>\x3Cscript>alert('pwned')\x3C/script>\x3Ch1 foo=&quot;${0}"${2}></h1>`;
+const $fragment1 = parseFragment`<h1 class="&quot;>\\x3Cscript>alert('pwned')\\x3C/script>\\x3Ch1 foo=&quot;${0}"${2}></h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/actual.html
@@ -1,0 +1,11 @@
+<template lwc:preserve-comments>
+    <div>Escape `me`</div>
+    <div data-message="Escape `me`"></div>
+    <div><!-- Escape `me` --></div>
+    <xmp>Escape `me`</xmp>
+
+    <div>Escape ${me}</div>
+    <div data-message="Escape ${me}"></div>
+    <div><!-- Escape ${me} --></div>
+    <xmp>Escape ${me}</xmp>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/actual.html
@@ -4,6 +4,11 @@
     <div><!-- Escape `me` --></div>
     <xmp>Escape `me`</xmp>
 
+    <div>Escape \`me`</div>
+    <div data-message="Escape \`me`"></div>
+    <div><!-- Escape \`me` --></div>
+    <xmp>Escape \`me`</xmp>
+
     <div>Escape ${me}</div>
     <div data-message="Escape ${me}"></div>
     <div><!-- Escape ${me} --></div>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
@@ -1,0 +1,38 @@
+import { parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<div${3}>Escape \`me\`</div>`;
+const $fragment2 = parseFragment`<div data-message="Escape \`me\`"${3}></div>`;
+const $fragment3 = parseFragment`<div${3}><!-- Escape \`me\` --></div>`;
+const $fragment4 = parseFragment`<xmp${3}>Escape \`me\`</xmp>`;
+const $fragment5 = parseFragment`<div data-message="Escape \${me}"${3}></div>`;
+const $fragment6 = parseFragment`<div${3}><!-- Escape \${me} --></div>`;
+const stc0 = {
+  key: 8,
+};
+const stc1 = {
+  key: 13,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const {
+    st: api_static_fragment,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+  } = $api;
+  return [
+    api_static_fragment($fragment1(), 1),
+    api_static_fragment($fragment2(), 3),
+    api_static_fragment($fragment3(), 5),
+    api_static_fragment($fragment4(), 7),
+    api_element("div", stc0, [
+      api_text("Escape $" + api_dynamic_text($cmp.me)),
+    ]),
+    api_static_fragment($fragment5(), 10),
+    api_static_fragment($fragment6(), 12),
+    api_element("xmp", stc1, [
+      api_text("Escape $" + api_dynamic_text($cmp.me)),
+    ]),
+  ];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
@@ -3,13 +3,17 @@ const $fragment1 = parseFragment`<div${3}>Escape \`me\`</div>`;
 const $fragment2 = parseFragment`<div data-message="Escape \`me\`"${3}></div>`;
 const $fragment3 = parseFragment`<div${3}><!-- Escape \`me\` --></div>`;
 const $fragment4 = parseFragment`<xmp${3}>Escape \`me\`</xmp>`;
-const $fragment5 = parseFragment`<div data-message="Escape \${me}"${3}></div>`;
-const $fragment6 = parseFragment`<div${3}><!-- Escape \${me} --></div>`;
+const $fragment5 = parseFragment`<div${3}>Escape \\\`me\`</div>`;
+const $fragment6 = parseFragment`<div data-message="Escape \\\`me\`"${3}></div>`;
+const $fragment7 = parseFragment`<div${3}><!-- Escape \\\`me\` --></div>`;
+const $fragment8 = parseFragment`<xmp${3}>Escape \\\`me\`</xmp>`;
+const $fragment9 = parseFragment`<div data-message="Escape \${me}"${3}></div>`;
+const $fragment10 = parseFragment`<div${3}><!-- Escape \${me} --></div>`;
 const stc0 = {
-  key: 8,
+  key: 16,
 };
 const stc1 = {
-  key: 13,
+  key: 21,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
@@ -23,11 +27,15 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_static_fragment($fragment2(), 3),
     api_static_fragment($fragment3(), 5),
     api_static_fragment($fragment4(), 7),
+    api_static_fragment($fragment5(), 9),
+    api_static_fragment($fragment6(), 11),
+    api_static_fragment($fragment7(), 13),
+    api_static_fragment($fragment8(), 15),
     api_element("div", stc0, [
       api_text("Escape $" + api_dynamic_text($cmp.me)),
     ]),
-    api_static_fragment($fragment5(), 10),
-    api_static_fragment($fragment6(), 12),
+    api_static_fragment($fragment9(), 18),
+    api_static_fragment($fragment10(), 20),
     api_element("xmp", stc1, [
       api_text("Escape $" + api_dynamic_text($cmp.me)),
     ]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/metadata.json
@@ -1,0 +1,26 @@
+{
+    "warnings": [
+        {
+            "code": 1123,
+            "message": "LWC1123: Unknown html tag '<xmp>'. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element and https://developer.mozilla.org/en-US/docs/Web/SVG/Element",
+            "level": 2,
+            "location": {
+                "line": 5,
+                "column": 5,
+                "start": 143,
+                "length": 22
+            }
+        },
+        {
+            "code": 1123,
+            "message": "LWC1123: Unknown html tag '<xmp>'. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element and https://developer.mozilla.org/en-US/docs/Web/SVG/Element",
+            "level": 2,
+            "location": {
+                "line": 10,
+                "column": 5,
+                "start": 280,
+                "length": 23
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/metadata.json
@@ -21,6 +21,17 @@
                 "start": 280,
                 "length": 23
             }
+        },
+        {
+            "code": 1123,
+            "message": "LWC1123: Unknown html tag '<xmp>'. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element and https://developer.mozilla.org/en-US/docs/Web/SVG/Element",
+            "level": 2,
+            "location": {
+                "line": 15,
+                "column": 5,
+                "start": 418,
+                "length": 23
+            }
         }
     ]
 }

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -23,10 +23,10 @@ const rawContentElements = new Set([
 
 /**
  * Escape all the characters that could break a JavaScript template string literal: "`" (backtick),
- * "${" (dollar + open curly).
+ * "${" (dollar + open curly) and "\" (backslash).
  */
 function templateStringEscape(str: string): string {
-    return str.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+    return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 }
 
 function serializeAttrs(element: Element): string {

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { htmlEscape, isVoidElement } from '@lwc/shared';
-import { ChildNode, Element, Literal } from '../shared/types';
+import { ChildNode, Comment, Element, Literal, Text } from '../shared/types';
 import { isElement, isText, isComment } from '../shared/ast';
 
 // Implementation based on the parse5 serializer: https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/serializer/index.ts
@@ -21,6 +21,14 @@ const rawContentElements = new Set([
     'PLAINTEXT',
 ]);
 
+/**
+ * Escape all the characters that could break a JavaScript template string literal: "`" (backtick),
+ * "${" (dollar + open curly).
+ */
+function templateStringEscape(str: string): string {
+    return str.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
 function serializeAttrs(element: Element): string {
     /**
      * 0: styleToken in existing class attr
@@ -31,7 +39,7 @@ function serializeAttrs(element: Element): string {
     let hasClassAttr = false;
 
     const collector = ({ name, value }: { name: string; value: string | boolean }) => {
-        let v = value;
+        let v = typeof value === 'string' ? templateStringEscape(value) : value;
 
         if (name === 'class') {
             hasClassAttr = true;
@@ -79,13 +87,9 @@ function serializeChildren(
         if (isElement(child)) {
             html += serializeStaticElement(child, preserveComments);
         } else if (isText(child)) {
-            if (rawContentElements.has(parentTagName.toUpperCase())) {
-                html += child.raw;
-            } else {
-                html += htmlEscape((child.value as Literal<string>).value);
-            }
+            html += serializeTextNode(child, rawContentElements.has(parentTagName.toUpperCase()));
         } else if (isComment(child)) {
-            html += preserveComments ? `<!--${htmlEscape(child.value)}-->` : '';
+            html += serializeCommentNode(child, preserveComments);
         } else {
             throw new TypeError(
                 'Unknown node found while serializing static content. Allowed nodes types are: Element, Text and Comment.'
@@ -94,6 +98,21 @@ function serializeChildren(
     });
 
     return html;
+}
+
+function serializeCommentNode(comment: Comment, preserveComment: boolean): string {
+    return preserveComment ? `<!--${htmlEscape(templateStringEscape(comment.value))}-->` : '';
+}
+
+function serializeTextNode(text: Text, useRawContent: boolean): string {
+    let content;
+    if (useRawContent) {
+        content = text.raw;
+    } else {
+        content = htmlEscape((text.value as Literal<string>).value);
+    }
+
+    return templateStringEscape(content);
 }
 
 export function serializeStaticElement(element: Element, preserveComments: boolean): string {


### PR DESCRIPTION
## Details

This PR addresses the string escaping issue when some static content uses the backtick "`" or dollar + open curly "${".

----

**Side note:** The current `serializeStaticElement` implementation is incorrect. This function returns the template string literal content as a string. This template string literal content is composed of a mix of template elements and JavaScript expressions. This string content is [then passed](https://github.com/salesforce/lwc/blob/34c08b0cd4be072cc54a10560f9d1c365cec074a/packages/@lwc/template-compiler/src/codegen/codegen.ts#L448-L460) to the `t.templateLiteral` factory function to create an AST node. This part is incorrect.

The `serializeStaticElement` should generate independent AST nodes for each part of the template literal. This happens to work today because AString (the codegen library used in the template compiler) favors performance over spec compliance. It's fine for now, but it's something we might want to correct later.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

## GUS work item
W-11336199
