### PR TITLE
fix(template-compiler): Produce proper void and self closing elements

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { rollup } from 'rollup';
 // @ts-ignore
 import lwcRollupPlugin from '@lwc/rollup-plugin';
-import { isVoidElement } from '@lwc/shared';
+import { isVoidElement, HTML_NAMESPACE } from '@lwc/shared';
 import { testFixtureDir } from '@lwc/jest-utils-lwc-internals';
 import type * as lwc from '../index';
 
@@ -77,7 +77,7 @@ function formatHTML(src: string): string {
         if (src.charAt(pos) === '<') {
             const tagNameMatch = src.slice(pos).match(/(\w+)/);
 
-            const isVoid = isVoidElement(tagNameMatch![0]);
+            const isVoid = isVoidElement(tagNameMatch![0], HTML_NAMESPACE);
             const isClosing = src.charAt(pos + 1) === '/';
             const isComment =
                 src.charAt(pos + 1) === '!' &&

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -96,7 +96,8 @@ function formatHTML(src: string): string {
 
             res += getPadding() + src.slice(start, pos) + '\n';
 
-            if (!isClosing && !isVoid && !isComment) {
+            const isSelfClosing = src.charAt(pos - 2) === '/';
+            if (!isClosing && !isSelfClosing && !isVoid && !isComment) {
                 depth++;
             }
         }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
@@ -4,23 +4,23 @@
       <defs>
         <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
           <stop class="static" offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"/>
-            <stop class="static" offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"/>
-            </linearGradient>
-          </defs>
-          <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
-          </svg>
-          <svg class="static" height="150" width="400">
-            <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
-            </svg>
-            <div>
-              <svg xmlns="http://www.w3.org/2000/svg">
-                <path/>
-                  <path/>
-                  </svg>
-                </div>
-                <svg xmlns="http://www.w3.org/2000/svg">
-                  <path/>
-                    <path/>
-                    </svg>
-                  </template>
-                </x-svgs>
+          <stop class="static" offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"/>
+        </linearGradient>
+      </defs>
+      <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
+    </svg>
+    <svg class="static" height="150" width="400">
+      <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
+    </svg>
+    <div>
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <path/>
+        <path/>
+      </svg>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <path/>
+      <path/>
+    </svg>
+  </template>
+</x-svgs>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
@@ -3,32 +3,24 @@
     <svg height="150" width="400">
       <defs>
         <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop class="static" offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1">
-          </stop>
-          <stop class="static" offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1">
-          </stop>
-        </linearGradient>
-      </defs>
-      <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)">
-      </ellipse>
-    </svg>
-    <svg class="static" height="150" width="400">
-      <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)">
-      </ellipse>
-    </svg>
-    <div>
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <path>
-        </path>
-        <path>
-        </path>
-      </svg>
-    </div>
-    <svg xmlns="http://www.w3.org/2000/svg">
-      <path>
-      </path>
-      <path>
-      </path>
-    </svg>
-  </template>
-</x-svgs>
+          <stop class="static" offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"/>
+            <stop class="static" offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"/>
+            </linearGradient>
+          </defs>
+          <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
+          </svg>
+          <svg class="static" height="150" width="400">
+            <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>
+            </svg>
+            <div>
+              <svg xmlns="http://www.w3.org/2000/svg">
+                <path/>
+                  <path/>
+                  </svg>
+                </div>
+                <svg xmlns="http://www.w3.org/2000/svg">
+                  <path/>
+                    <path/>
+                    </svg>
+                  </template>
+                </x-svgs>

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { createVM, connectRootElement, LightningElement } from '@lwc/engine-core';
-import { isString, isFunction, isObject, isNull } from '@lwc/shared';
+import { isString, isFunction, isObject, isNull, HTML_NAMESPACE } from '@lwc/shared';
 
 import { renderer } from '../renderer';
 import { serializeElement } from '../serializer';
@@ -14,6 +14,7 @@ import { HostElement, HostNodeType } from '../types';
 const FakeRootElement: HostElement = {
     type: HostNodeType.Element,
     name: 'fake-root-element',
+    namespace: HTML_NAMESPACE,
     parent: null,
     shadowRoot: null,
     children: [],

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -14,6 +14,7 @@ import {
     StringToLowerCase,
     htmlPropertyToAttribute,
     noop,
+    HTML_NAMESPACE,
 } from '@lwc/shared';
 
 import { HostNode, HostElement, HostAttribute, HostNodeType, HostChildNode } from './types';
@@ -25,10 +26,11 @@ function unsupportedMethod(name: string): () => never {
     };
 }
 
-function createElement(name: string): HostElement {
+function createElement(name: string, namespace?: string): HostElement {
     return {
         type: HostNodeType.Element,
         name,
+        namespace: namespace ?? HTML_NAMESPACE,
         parent: null,
         shadowRoot: null,
         children: [],

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -68,7 +68,7 @@ export function serializeElement(element: HostElement): string {
 
     output += serializeChildNodes(element.children);
 
-    if ((!isForeignElement && !isVoidElement(name)) || hasChildren) {
+    if (!isVoidElement(name, namespace) || hasChildren) {
         output += `</${name}>`;
     }
 

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { htmlEscape, isVoidElement } from '@lwc/shared';
+import { htmlEscape, HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
 
 import { HostElement, HostShadowRoot, HostAttribute, HostChildNode, HostNodeType } from './types';
 
@@ -46,20 +46,29 @@ function serializeShadowRoot(shadowRoot: HostShadowRoot): string {
 
 export function serializeElement(element: HostElement): string {
     let output = '';
-    const { name } = element;
+
+    const { name, namespace } = element;
+    const isForeignElement = namespace !== HTML_NAMESPACE;
+    const hasChildren = element.children.length > 0;
 
     const attrs = element.attributes.length ? ` ${serializeAttributes(element.attributes)}` : '';
-    const children = serializeChildNodes(element.children);
 
-    output += `<${name}${attrs}>`;
+    output += `<${name}${attrs}`;
+
+    if (isForeignElement && !hasChildren) {
+        output += '/>';
+        return output;
+    }
+
+    output += '>';
 
     if (element.shadowRoot) {
         output += serializeShadowRoot(element.shadowRoot);
     }
 
-    output += children;
+    output += serializeChildNodes(element.children);
 
-    if (!isVoidElement(name)) {
+    if ((!isForeignElement && !isVoidElement(name)) || hasChildren) {
         output += `</${name}>`;
     }
 

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -47,6 +47,7 @@ export interface HostShadowRoot {
 export interface HostElement {
     type: HostNodeType.Element;
     name: string;
+    namespace: string;
     parent: HostElement | null;
     shadowRoot: HostShadowRoot | null;
     children: HostChildNode[];

--- a/packages/@lwc/shared/src/void-elements.ts
+++ b/packages/@lwc/shared/src/void-elements.ts
@@ -5,11 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { HTML_NAMESPACE } from './namespaces';
+
 // Void elements are elements that self-close even without an explicit solidus (slash),
 // e.g. `</tagName>` or `<tagName />`. For instance, `<meta>` closes on its own; no need for a slash.
 // These only come from HTML; there are no void elements in the SVG or MathML namespaces.
 // See: https://html.spec.whatwg.org/multipage/syntax.html#syntax-tags
-export const VOID_ELEMENTS = [
+const VOID_ELEMENTS_SET = new Set([
     'area',
     'base',
     'br',
@@ -23,10 +25,8 @@ export const VOID_ELEMENTS = [
     'source',
     'track',
     'wbr',
-];
+]);
 
-const VOID_ELEMENTS_SET = new Set(VOID_ELEMENTS);
-
-export function isVoidElement(name: string): boolean {
-    return VOID_ELEMENTS_SET.has(name.toLowerCase());
+export function isVoidElement(name: string, namespace: string): boolean {
+    return namespace === HTML_NAMESPACE && VOID_ELEMENTS_SET.has(name.toLowerCase());
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><ellipse${3}></ellipse></svg>`;
+const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><ellipse${3}/></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}></path><path${3}></path></svg></div>`;
+const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/><path${3}/></svg></div>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><g${3}><path${3}></path><path${3}></path></g></svg></div>`;
+const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><g${3}><path${3}/><path${3}/></g></svg></div>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}></path><path${3}></path></svg>`;
+const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/><path${3}/></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -1,20 +1,20 @@
 import { parseSVGFragment, registerTemplate } from "lwc";
-const $fragment1 = parseSVGFragment`<feFlood x="25%" y="25%" width="50%" height="50%" flood-color="green" flood-opacity="0.75"${3}></feFlood>`;
-const $fragment2 = parseSVGFragment`<feBlend x="25%" y="25%" width="50%" height="50%" in2="SourceGraphic" mode="multiply"${3}></feBlend>`;
-const $fragment3 = parseSVGFragment`<feMerge x="25%" y="25%" width="50%" height="50%"${3}><feMergeNode in="SourceGraphic"${3}></feMergeNode><feMergeNode in="FillPaint"${3}></feMergeNode></feMerge>`;
-const $fragment4 = parseSVGFragment`<g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}></rect><line x2="200" y2="200"${3}></line><line x1="200" y2="200"${3}></line></g>`;
-const $fragment5 = parseSVGFragment`<circle fill="green" filter="url(#flood)" cx="100" cy="100" r="90"${3}></circle>`;
-const $fragment6 = parseSVGFragment`<g transform="translate(200 0)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}></rect><line x2="200" y2="200"${3}></line><line x1="200" y2="200"${3}></line></g><circle fill="green" filter="url(#blend)" cx="100" cy="100" r="90"${3}></circle></g>`;
-const $fragment7 = parseSVGFragment`<g transform="translate(0 200)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}></rect><line x2="200" y2="200"${3}></line><line x1="200" y2="200"${3}></line></g><circle fill="green" fill-opacity="0.5" filter="url(#merge)" cx="100" cy="100" r="90"${3}></circle></g>`;
-const $fragment8 = parseSVGFragment`<rect fill="none" stroke="blue" x="1" y="1" width="598" height="248"${3}></rect>`;
-const $fragment9 = parseSVGFragment`<g${3}><rect x="50" y="25" width="100" height="200" filter="url(#Default)"${3}></rect><rect x="50" y="25" width="100" height="200" fill="none" stroke="green"${3}></rect><rect x="250" y="25" width="100" height="200" filter="url(#Fitted)"${3}></rect><rect x="250" y="25" width="100" height="200" fill="none" stroke="green"${3}></rect><rect x="450" y="25" width="100" height="200" filter="url(#Shifted)"${3}></rect><rect x="450" y="25" width="100" height="200" fill="none" stroke="green"${3}></rect></g>`;
+const $fragment1 = parseSVGFragment`<feFlood x="25%" y="25%" width="50%" height="50%" flood-color="green" flood-opacity="0.75"${3}/>`;
+const $fragment2 = parseSVGFragment`<feBlend x="25%" y="25%" width="50%" height="50%" in2="SourceGraphic" mode="multiply"${3}/>`;
+const $fragment3 = parseSVGFragment`<feMerge x="25%" y="25%" width="50%" height="50%"${3}><feMergeNode in="SourceGraphic"${3}/><feMergeNode in="FillPaint"${3}/></feMerge>`;
+const $fragment4 = parseSVGFragment`<g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g>`;
+const $fragment5 = parseSVGFragment`<circle fill="green" filter="url(#flood)" cx="100" cy="100" r="90"${3}/>`;
+const $fragment6 = parseSVGFragment`<g transform="translate(200 0)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g><circle fill="green" filter="url(#blend)" cx="100" cy="100" r="90"${3}/></g>`;
+const $fragment7 = parseSVGFragment`<g transform="translate(0 200)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g><circle fill="green" fill-opacity="0.5" filter="url(#merge)" cx="100" cy="100" r="90"${3}/></g>`;
+const $fragment8 = parseSVGFragment`<rect fill="none" stroke="blue" x="1" y="1" width="598" height="248"${3}/>`;
+const $fragment9 = parseSVGFragment`<g${3}><rect x="50" y="25" width="100" height="200" filter="url(#Default)"${3}/><rect x="50" y="25" width="100" height="200" fill="none" stroke="green"${3}/><rect x="250" y="25" width="100" height="200" filter="url(#Fitted)"${3}/><rect x="250" y="25" width="100" height="200" fill="none" stroke="green"${3}/><rect x="450" y="25" width="100" height="200" filter="url(#Shifted)"${3}/><rect x="450" y="25" width="100" height="200" fill="none" stroke="green"${3}/></g>`;
 const $fragment10 = parseSVGFragment`<desc${3}>Produces a 3D lighting effect.</desc>`;
-const $fragment11 = parseSVGFragment`<feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"${3}></feGaussianBlur>`;
-const $fragment12 = parseSVGFragment`<feOffset in="blur" dx="4" dy="4" result="offsetBlur"${3}></feOffset>`;
-const $fragment13 = parseSVGFragment`<feSpecularLighting in="blur" surfaceScale="5" specularConstant=".75" specularExponent="20" lighting-color="#bbbbbb" result="specOut"${3}><fePointLight x="-5000" y="-10000" z="20000"${3}></fePointLight></feSpecularLighting>`;
-const $fragment14 = parseSVGFragment`<feComposite in="specOut" in2="SourceAlpha" operator="in" result="specOut"${3}></feComposite>`;
-const $fragment15 = parseSVGFragment`<feComposite in="SourceGraphic" in2="specOut" operator="arithmetic" k1="0" k2="1" k3="1" k4="0" result="litPaint"${3}></feComposite>`;
-const $fragment16 = parseSVGFragment`<feMerge${3}><feMergeNode in="offsetBlur"${3}></feMergeNode><feMergeNode in="litPaint"${3}></feMergeNode></feMerge>`;
+const $fragment11 = parseSVGFragment`<feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"${3}/>`;
+const $fragment12 = parseSVGFragment`<feOffset in="blur" dx="4" dy="4" result="offsetBlur"${3}/>`;
+const $fragment13 = parseSVGFragment`<feSpecularLighting in="blur" surfaceScale="5" specularConstant=".75" specularExponent="20" lighting-color="#bbbbbb" result="specOut"${3}><fePointLight x="-5000" y="-10000" z="20000"${3}/></feSpecularLighting>`;
+const $fragment14 = parseSVGFragment`<feComposite in="specOut" in2="SourceAlpha" operator="in" result="specOut"${3}/>`;
+const $fragment15 = parseSVGFragment`<feComposite in="SourceGraphic" in2="specOut" operator="arithmetic" k1="0" k2="1" k3="1" k4="0" result="litPaint"${3}/>`;
+const $fragment16 = parseSVGFragment`<feMerge${3}><feMergeNode in="offsetBlur"${3}/><feMergeNode in="litPaint"${3}/></feMerge>`;
 const stc0 = {
   attrs: {
     width: "400",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -1,7 +1,7 @@
 import { parseSVGFragment, registerTemplate } from "lwc";
-const $fragment1 = parseSVGFragment`<stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"${3}></stop>`;
-const $fragment2 = parseSVGFragment`<stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"${3}></stop>`;
-const $fragment3 = parseSVGFragment`<ellipse cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"${3}></ellipse>`;
+const $fragment1 = parseSVGFragment`<stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"${3}/>`;
+const $fragment2 = parseSVGFragment`<stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"${3}/>`;
+const $fragment3 = parseSVGFragment`<ellipse cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"${3}/>`;
 const stc0 = {
   attrs: {
     height: "150",

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"${3}><rect width="100%" height="100%" fill="red"${3}></rect><circle cx="150" cy="100" r="80" fill="green"${3}></circle><text x="150" y="125" font-size="60" text-anchor="middle" fill="white"${3}>SVG</text></svg>`;
+const $fragment1 = parseFragment`<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"${3}><rect width="100%" height="100%" fill="red"${3}/><circle cx="150" cy="100" r="80" fill="green"${3}/><text x="150" y="125" font-size="60" text-anchor="middle" fill="white"${3}>SVG</text></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}></path></svg>`;
+const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg width="200" height="200"${3}><image xlink:href="/foo.png" x="1" y="2" height="200" width="200"${3}></image></svg>`;
+const $fragment1 = parseFragment`<svg width="200" height="200"${3}><image xlink:href="/foo.png" x="1" y="2" height="200" width="200"${3}/></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -1,5 +1,5 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg${3}><a${3}></a><circle${3}></circle><defs${3}></defs><desc${3}></desc><ellipse${3}></ellipse><filter${3}></filter><g${3}></g><line${3}></line><marker${3}></marker><mask${3}></mask><path${3}></path><pattern${3}></pattern><polygon${3}></polygon><polyline${3}></polyline><rect${3}></rect><stop${3}></stop><symbol${3}></symbol><text${3}></text><title${3}></title><tspan${3}></tspan><use${3}></use></svg>`;
+const $fragment1 = parseFragment`<svg${3}><a${3}/><circle${3}/><defs${3}/><desc${3}/><ellipse${3}/><filter${3}/><g${3}/><line${3}/><marker${3}/><mask${3}/><path${3}/><pattern${3}/><polygon${3}/><polyline${3}/><rect${3}/><stop${3}/><symbol${3}/><text${3}/><title${3}/><tspan${3}/><use${3}/></svg>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { st: api_static_fragment } = $api;
   return [api_static_fragment($fragment1(), 1)];

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { htmlEscape, isVoidElement } from '@lwc/shared';
+import { htmlEscape, HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
 import { ChildNode, Element, Literal } from '../shared/types';
 import { isElement, isText, isComment } from '../shared/ast';
 
@@ -99,11 +99,20 @@ function serializeChildren(
 export function serializeStaticElement(element: Element, preserveComments: boolean): string {
     const { name: tagName } = element;
 
-    let html = `<${tagName}${serializeAttrs(element)}>`;
+    const isForeignElement = element.namespace !== HTML_NAMESPACE;
+    const hasChildren = element.children.length > 0;
 
+    let html = `<${tagName}${serializeAttrs(element)}`;
+
+    if (isForeignElement && !hasChildren) {
+        html += '/>';
+        return html;
+    }
+
+    html += '>';
     html += serializeChildren(element.children, tagName, preserveComments);
 
-    if (!isVoidElement(tagName)) {
+    if ((!isForeignElement && !isVoidElement(tagName)) || hasChildren) {
         html += `</${tagName}>`;
     }
 

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -97,9 +97,9 @@ function serializeChildren(
 }
 
 export function serializeStaticElement(element: Element, preserveComments: boolean): string {
-    const { name: tagName } = element;
+    const { name: tagName, namespace } = element;
 
-    const isForeignElement = element.namespace !== HTML_NAMESPACE;
+    const isForeignElement = namespace !== HTML_NAMESPACE;
     const hasChildren = element.children.length > 0;
 
     let html = `<${tagName}${serializeAttrs(element)}`;
@@ -112,7 +112,7 @@ export function serializeStaticElement(element: Element, preserveComments: boole
     html += '>';
     html += serializeChildren(element.children, tagName, preserveComments);
 
-    if ((!isForeignElement && !isVoidElement(tagName)) || hasChildren) {
+    if (!isVoidElement(tagName, namespace) || hasChildren) {
         html += `</${tagName}>`;
     }
 

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -7,7 +7,7 @@
 import { AriaAttrNameToPropNameMap } from '@lwc/shared';
 
 import { HTML_ATTRIBUTE_ELEMENT_MAP } from './utils/html-element-attributes';
-import { HTML_ELEMENTS, HTML_VOID_ELEMENTS } from './utils/html-elements';
+import { HTML_ELEMENTS } from './utils/html-elements';
 import { SVG_ELEMENTS } from './utils/svg-elements';
 
 export const EXPRESSION_RE = /(\{(?:.)+?\})/g;
@@ -136,8 +136,6 @@ export const DISALLOWED_MATHML_TAGS = new Set([
     'meta',
 ]);
 
-export const VOID_ELEMENT_SET = new Set(HTML_VOID_ELEMENTS);
-
 export const ATTRS_PROPS_TRANFORMS: { [name: string]: string } = {
     accesskey: 'accessKey',
     readonly: 'readOnly',
@@ -164,11 +162,7 @@ export const HTML_ATTRIBUTES_REVERSE_LOOKUP: {
     [attr: string]: string[];
 } = HTML_ATTRIBUTE_ELEMENT_MAP;
 
-export const KNOWN_HTML_AND_SVG_ELEMENTS = new Set([
-    ...HTML_ELEMENTS,
-    ...HTML_VOID_ELEMENTS,
-    ...SVG_ELEMENTS,
-]);
+export const KNOWN_HTML_AND_SVG_ELEMENTS = new Set([...HTML_ELEMENTS, ...SVG_ELEMENTS]);
 
 export const HTML_TAG = {
     A: 'a',

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -6,7 +6,7 @@
  */
 import * as parse5 from 'parse5';
 
-import { HTML_NAMESPACE, SVG_NAMESPACE, MATHML_NAMESPACE } from '@lwc/shared';
+import { HTML_NAMESPACE, SVG_NAMESPACE, MATHML_NAMESPACE, isVoidElement } from '@lwc/shared';
 import { ParserDiagnostics, DiagnosticLevel } from '@lwc/errors';
 
 import * as t from '../shared/estree';
@@ -64,7 +64,6 @@ import {
     ROOT_TEMPLATE_DIRECTIVES,
     SUPPORTED_SVG_TAGS,
     VALID_IF_MODIFIER,
-    VOID_ELEMENT_SET,
 } from './constants';
 
 type TemplateElement = parse5.Element & { tagName: 'template' };
@@ -959,9 +958,8 @@ function validateElement(ctx: ParserCtx, element: BaseElement, parse5Elm: parse5
     // Note: Parse5 currently fails to collect end tag location for element with a tag name
     // containing an upper case character (inikulin/parse5#352).
     const hasClosingTag = Boolean(element.location.endTag);
-    const isVoidElement = VOID_ELEMENT_SET.has(tag);
     if (
-        !isVoidElement &&
+        !isVoidElement(tag, namespace) &&
         !hasClosingTag &&
         tag === tag.toLocaleLowerCase() &&
         namespace === HTML_NAMESPACE

--- a/packages/@lwc/template-compiler/src/parser/utils/html-elements.ts
+++ b/packages/@lwc/template-compiler/src/parser/utils/html-elements.ts
@@ -5,8 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-export { VOID_ELEMENTS as HTML_VOID_ELEMENTS } from '@lwc/shared';
-
 /*
  * MIT License
  *

--- a/packages/@lwc/template-compiler/src/shared/ast.ts
+++ b/packages/@lwc/template-compiler/src/shared/ast.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { HTML_NAMESPACE } from '@lwc/shared';
 import * as parse5 from 'parse5';
 
 import {
@@ -72,6 +73,7 @@ export function component(
     return {
         type: 'Component',
         name: parse5Elm.nodeName,
+        namespace: HTML_NAMESPACE,
         location: elementSourceLocation(parse5ElmLocation),
         attributes: [],
         properties: [],
@@ -85,6 +87,7 @@ export function slot(slotName: string, parse5ElmLocation: parse5.ElementLocation
     return {
         type: 'Slot',
         name: 'slot',
+        namespace: HTML_NAMESPACE,
         slotName,
         location: elementSourceLocation(parse5ElmLocation),
         attributes: [],

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -143,7 +143,7 @@ export interface AbstractBaseElement extends BaseParentNode {
     attributes: Attribute[];
     listeners: EventListener[];
     directives: ElementDirective[];
-    namespace?: string;
+    namespace: string;
 }
 
 export interface Element extends AbstractBaseElement {


### PR DESCRIPTION
## Details

This PR contains the changes I think are worth integrating into https://github.com/salesforce/lwc/pull/2898:
- Update `isVoidElement` function signature to accept a namespace. This avoids having to check if the element originates from the correct namespace.
- Update template compiler and engine serialization logic to account for void HTML elements and self-closing foreign elements.
- Remove `HTML_VOID_ELEMENTS` from `KNOWN_HTML_AND_SVG_ELEMENTS` since this set already contains all the void elements.
- Remove now unused `VOID_ELEMENT_SET`. 

> **Note**: The `KNOWN_HTML_AND_SVG_ELEMENTS` should be unnecessary because we already have `SUPPORTED_SVG_TAGS` set. Theoretically, we should revert it back to `KNOWN_HTML_ELEMENTS`, however, after experimenting with it, it might have other impacts on HTML template validation logic (eg. attribute validation).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
