### PR TITLE
feat(errors): add new lwc diagnostic errors

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/compiler.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/compiler.ts
@@ -215,3 +215,9 @@ export const TransformerErrors = {
         url: '',
     },
 };
+
+export const COMPILER_PLUGIN_ERROR = {
+    code: 1153,
+    message: `An error occurred with plugin "{0}" at hook "{1}": {2}`,
+    level: DiagnosticLevel.Error,
+};

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1153
+ * Next error code: 1154
  */
 
 export * from './compiler';


### PR DESCRIPTION
## Details
This PR adds a new error diagnostic for compiler errors, this is to be mainly used on `lwc-platform` to indicate when there is a rollup plugin error.

See # 838 in lwc-platform.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## GUS work item
W-11128179