### PR TITLE
add: event support to @lwc/engine-server

### DIFF
--- a/ephemeral-notes.md
+++ b/ephemeral-notes.md
@@ -1,0 +1,9 @@
+# Ephemeral Notes
+
+**NOTE: This doc will be deleted before merging and only serves as a temporary location for feedback.**
+
+- **Why not use the `EventTarget` implementation in Node v14+?** The Node implementation leaves out support for event propagation through a hierarchy of `EventTarget`s. This is the exact behavior that is required to support LWR use cases; much of the rest of the `EventTarget` interface is superfluous.
+- **Why redefine types in `engine-server` that are implicit DOM types (see `lib.dom.d.ts`)?** Unfortunately, it is not permitted to import specific types explicity. Typescript assumes that if you want one DOM type, you are in a browser and will want _all_ DOM types to be implicityly available globally. That may lead to confusion in the future when browser-only types are available in Node-only code. The best alternative is to copy the types we need into `engine-server`.
+- **Which DOM event phases will be supported?** At present, there does not appear to be a use case for supporting the `capture` or `target` phases. As such, server-side DOM-like events will only support the `bubble` phase of event propagation.
+- **Is `Event#preventDefault` handled in any way?** No. Firstly, we're not providing an actual `Event` type - that's up to consumers. Secondly, there is no default behavior to prevent, so this isn't a considering in the SSR context.
+

--- a/ephemeral-notes.md
+++ b/ephemeral-notes.md
@@ -3,6 +3,7 @@
 **NOTE: This doc will be deleted before merging and only serves as a temporary location for feedback.**
 
 - **Why not use the `EventTarget` implementation in Node v14+?** The Node implementation leaves out support for event propagation through a hierarchy of `EventTarget`s. This is the exact behavior that is required to support LWR use cases; much of the rest of the `EventTarget` interface is superfluous.
+- **What version of Node is required?** Node >= 16
 - **Why redefine types in `engine-server` that are implicit DOM types (see `lib.dom.d.ts`)?** Unfortunately, it is not permitted to import specific types explicity. Typescript assumes that if you want one DOM type, you are in a browser and will want _all_ DOM types to be implicityly available globally. That may lead to confusion in the future when browser-only types are available in Node-only code. The best alternative is to copy the types we need into `engine-server`.
 - **Which DOM event phases will be supported?** At present, there does not appear to be a use case for supporting the `capture` or `target` phases. As such, server-side DOM-like events will only support the `bubble` phase of event propagation.
 - **Is `Event#preventDefault` handled in any way?** No. Firstly, we're not providing an actual `Event` type - that's up to consumers. Secondly, there is no default behavior to prevent, so this isn't a considering in the SSR context.

--- a/ephemeral-notes.md
+++ b/ephemeral-notes.md
@@ -6,5 +6,5 @@
 - **What version of Node is required?** Node >= 16
 - **Why redefine types in `engine-server` that are implicit DOM types (see `lib.dom.d.ts`)?** Unfortunately, it is not permitted to import specific types explicity. Typescript assumes that if you want one DOM type, you are in a browser and will want _all_ DOM types to be implicityly available globally. That may lead to confusion in the future when browser-only types are available in Node-only code. The best alternative is to copy the types we need into `engine-server`.
 - **Which DOM event phases will be supported?** At present, there does not appear to be a use case for supporting the `capture` or `target` phases. As such, server-side DOM-like events will only support the `bubble` phase of event propagation.
-- **Is `Event#preventDefault` handled in any way?** No. Firstly, we're not providing an actual `Event` type - that's up to consumers. Secondly, there is no default behavior to prevent, so this isn't a considering in the SSR context.
+- **Is `Event#preventDefault` handled in any way?** No. Firstly, we're not providing an actual `Event` type - that's up to consumers. Secondly, there is no default behavior to prevent, so this isn't a consideration in the SSR context.
 

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-server",
-    "version": "2.20.0",
+    "version": "2.20.0-canary-ssr.1",
     "description": "Renders LWC components in a server environment.",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -428,7 +428,7 @@ function dispatchEvent(target: HostNode, event: Event): boolean {
             if (callbacks) {
                 for (const callback of callbacks) {
                     if (!stopImmediately) {
-                        callback(eventProxy);
+                        callback.call(target, eventProxy);
                     }
                 }
             }

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -17,7 +17,14 @@ import {
     HTML_NAMESPACE,
 } from '@lwc/shared';
 
-import { HostNode, HostElement, HostAttribute, HostNodeType, HostChildNode, HostShadowRoot } from './types';
+import {
+    HostNode,
+    HostElement,
+    HostAttribute,
+    HostNodeType,
+    HostChildNode,
+    HostShadowRoot,
+} from './types';
 import { classNameToTokenList, tokenListToClassName } from './utils/classes';
 
 function unsupportedMethod(name: string): () => never {
@@ -430,6 +437,8 @@ function dispatchEvent(target: HostNode, event: Event): boolean {
     } while (
         !stop &&
         currentNode &&
+        // Events do not propagate through shadow boundaries unless composed
+        // is set to true.
         (currentNode.type !== HostNodeType.ShadowRoot || event.composed === true)
     );
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -17,7 +17,7 @@ import {
     HTML_NAMESPACE,
 } from '@lwc/shared';
 
-import { HostNode, HostElement, HostAttribute, HostNodeType, HostChildNode } from './types';
+import { HostNode, HostElement, HostAttribute, HostNodeType, HostChildNode, HostShadowRoot } from './types';
 import { classNameToTokenList, tokenListToClassName } from './utils/classes';
 
 function unsupportedMethod(name: string): () => never {
@@ -391,7 +391,7 @@ function dispatchEvent(target: HostNode, event: Event): boolean {
         return true;
     }
 
-    let currentNode: HostElement | null = target;
+    let currentNode: HostElement | HostShadowRoot | null = target;
     let stop = false;
     let stopImmediately = false;
 
@@ -423,7 +423,7 @@ function dispatchEvent(target: HostNode, event: Event): boolean {
             }
         }
         currentNode = currentNode.parent;
-    } while (!stop && currentNode);
+    } while (!stop && currentNode && currentNode.type !== HostNodeType.ShadowRoot);
 
     // `preventDefault` is not supported, so the return value will never be false.
     return true;

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -400,7 +400,7 @@ function dispatchEvent(target: HostNode, event: Event): boolean {
     }
 
     let currentNode: HostElement | HostShadowRoot | null = target;
-    let stop = false;
+    let stop = !event.bubbles;
     let stopImmediately = false;
 
     const stopPropagation = () => {

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -42,6 +42,7 @@ export interface HostShadowRoot {
     children: HostChildNode[];
     mode: 'open' | 'closed';
     delegatesFocus: boolean;
+    parent: HostElement;
 }
 
 export interface HostElement {

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -48,7 +48,7 @@ export interface HostElement {
     type: HostNodeType.Element;
     name: string;
     namespace: string;
-    parent: HostElement | null;
+    parent: HostElement | HostShadowRoot | null;
     shadowRoot: HostShadowRoot | null;
     children: HostChildNode[];
     attributes: HostAttribute[];

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -52,7 +52,7 @@ export interface HostElement {
     shadowRoot: HostShadowRoot | null;
     children: HostChildNode[];
     attributes: HostAttribute[];
-    eventListeners: Record<string, Function[]>;
+    eventListeners: Record<string, Set<EventListener>>;
 }
 
 export type HostNode = HostText | HostElement | HostComment;


### PR DESCRIPTION
## Details

This adds support for dispatching events during SSR. Everything is synchronous, and only the `bubble` phase of event propagation is supported.

This implementation seems to be working as expected in the LWR PoC, so I'd like to start working on tests. However, before doing that, I'd like feedback on the implementation in case folks want to see changes.

Before this PR can be merged, the following tasks need to be completed:

- [ ] add full test coverage
- [ ] drop the `canary-ssr` version bump commits
- [ ] delete `ephemeral-notes.md`

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
