### PR TITLE
feat: Add playground in LWC repo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ coverage/
 fixtures/
 public/
 __benchmarks_results__/
+playground/

--- a/.eslintrc
+++ b/.eslintrc
@@ -156,6 +156,15 @@
             "rules": {
                 "no-console": "off"
             }
+        },
+        {
+            "files": [
+                "playground/**/*"
+            ],
+
+            "env": {
+                "browser": true
+            }
         }
     ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -156,15 +156,6 @@
             "rules": {
                 "no-console": "off"
             }
-        },
-        {
-            "files": [
-                "playground/**/*"
-            ],
-
-            "env": {
-                "browser": true
-            }
         }
     ]
 }

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -12,7 +12,7 @@ about: Create an issue to help us improve
 <!--
 If LWC specific issue, update link with your example
 -->
-https://webcomponents.dev/create/lwc
+https://playground.lwc.dev
 
 <!--
 if specific code snippet, paste the example here

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 .project/
 
 lib/
+playground/dist/
 packages/**/dist/
 benchmarking/dist/
 __benchmarks_results__/

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
   },
   "workspaces": [
     "packages/@lwc/*",
-    "packages/lwc"
+    "packages/lwc",
+    "playground"
   ],
   "engines": {
     "node": ">=10"

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/playground/.vscode/settings.json
+++ b/playground/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    /**
+     * Format a file on save.
+     * Disable to prevent Stackblitz to format LWC components template files.
+     */
+    "editor.formatOnSave": false
+}

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,8 @@
+# LWC playground
+
+The simplest LWC setup for simple experiments and bug reproductions.
+
+```sh
+$ npm run dev       # Get app server running
+$ npm run build     # Build app in production mode
+```

--- a/playground/README.md
+++ b/playground/README.md
@@ -5,4 +5,5 @@ The simplest LWC setup for simple experiments and bug reproductions.
 ```sh
 $ npm run dev       # Get app server running
 $ npm run build     # Build app in production mode
+$ npx serve         # Serve the app (after running `npm run build`).
 ```

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>LWC playground</title>
+</head>
+<body>
+    <script src="dist/main.js"></script>
+</body>
+</html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -5,6 +5,6 @@
     <title>LWC playground</title>
 </head>
 <body>
-    <script src="dist/main.js"></script>
+    <script src="dist/main.js" type="module"></script>
 </body>
 </html>

--- a/playground/lwc.config.json
+++ b/playground/lwc.config.json
@@ -1,0 +1,7 @@
+{
+    "modules": [
+        {
+            "dir": "src/modules"
+        }
+    ]
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "name": "lwc-playground",
+  "version": "2.20.0",
+  "description": "Playground project to experiment with LWC.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/salesforce/lwc.git",
+    "directory": "playground"
+  },
+  "scripts": {
+    "dev": "rollup -c --watch",
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "@lwc/rollup-plugin": "^2.20.3",
+    "@rollup/plugin-replace": "^4.0.0",
+    "lwc": "^2.20.3",
+    "rollup": "^2.75.7",
+    "rollup-plugin-serve": "^2.0.0"
+  }
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,11 +3,6 @@
   "name": "lwc-playground",
   "version": "2.20.0",
   "description": "Playground project to experiment with LWC.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/salesforce/lwc.git",
-    "directory": "playground"
-  },
   "scripts": {
     "dev": "rollup -c --watch",
     "build": "rollup -c"

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,7 +5,7 @@
   "description": "Playground project to experiment with LWC.",
   "scripts": {
     "dev": "rollup -c --watch",
-    "build": "rollup -c"
+    "build": "NODE_ENV=production rollup -c"
   },
   "devDependencies": {
     "@lwc/rollup-plugin": "^2.20.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "lwc-playground",
-  "version": "2.20.0",
+  "version": "2.20.2",
   "description": "Playground project to experiment with LWC.",
   "scripts": {
     "dev": "rollup -c --watch",
@@ -12,6 +12,7 @@
     "@rollup/plugin-replace": "^4.0.0",
     "lwc": "^2.20.3",
     "rollup": "^2.75.7",
-    "rollup-plugin-serve": "^2.0.0"
+    "rollup-plugin-serve": "^2.0.0",
+    "rollup-plugin-livereload": "^2.0.5"
   }
 }

--- a/playground/rollup.config.js
+++ b/playground/rollup.config.js
@@ -1,0 +1,31 @@
+/* eslint-env node */
+
+import lwc from '@lwc/rollup-plugin';
+import replace from '@rollup/plugin-replace';
+import serve from 'rollup-plugin-serve';
+
+const __ENV__ = process.env.NODE_ENV ?? 'development';
+
+export default (args) => {
+  return {
+    input: 'src/main.js',
+
+    output: {
+      file: 'dist/main.js',
+      format: 'esm',
+    },
+
+    plugins: [
+      replace({
+        'process.env.NODE_ENV': JSON.stringify(__ENV__),
+        preventAssignment: true,
+      }),
+      lwc(),
+      args.watch &&
+        serve({
+          open: false,
+          port: 3000,
+        }),
+    ],
+  };
+};

--- a/playground/rollup.config.js
+++ b/playground/rollup.config.js
@@ -1,29 +1,31 @@
 import lwc from '@lwc/rollup-plugin';
 import replace from '@rollup/plugin-replace';
 import serve from 'rollup-plugin-serve';
+import livereload from 'rollup-plugin-livereload';
 
 const __ENV__ = process.env.NODE_ENV ?? 'development';
 
 export default (args) => {
-  return {
-    input: 'src/main.js',
+    return {
+        input: 'src/main.js',
 
-    output: {
-      file: 'dist/main.js',
-      format: 'esm',
-    },
+        output: {
+            file: 'dist/main.js',
+            format: 'esm',
+        },
 
-    plugins: [
-      replace({
-        'process.env.NODE_ENV': JSON.stringify(__ENV__),
-        preventAssignment: true,
-      }),
-      lwc(),
-      args.watch &&
-        serve({
-          open: false,
-          port: 3000,
-        }),
-    ],
-  };
+        plugins: [
+            replace({
+                'process.env.NODE_ENV': JSON.stringify(__ENV__),
+                preventAssignment: true,
+            }),
+            lwc(),
+            args.watch &&
+                serve({
+                    open: false,
+                    port: 3000,
+                }),
+            args.watch && livereload(),
+        ],
+    };
 };

--- a/playground/rollup.config.js
+++ b/playground/rollup.config.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 import lwc from '@lwc/rollup-plugin';
 import replace from '@rollup/plugin-replace';
 import serve from 'rollup-plugin-serve';

--- a/playground/src/main.js
+++ b/playground/src/main.js
@@ -1,0 +1,5 @@
+import { createElement } from "lwc";
+import App from "x/app";
+
+const elm = createElement("x-app", { is: App });
+document.body.appendChild(elm);

--- a/playground/src/modules/x/app/app.html
+++ b/playground/src/modules/x/app/app.html
@@ -1,0 +1,4 @@
+<template>
+    <h1>Hello world!</h1>
+    <x-counter></x-counter>
+</template>

--- a/playground/src/modules/x/app/app.js
+++ b/playground/src/modules/x/app/app.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class App extends LightningElement {}

--- a/playground/src/modules/x/counter/counter.html
+++ b/playground/src/modules/x/counter/counter.html
@@ -1,0 +1,5 @@
+<template>
+    Counter: {counter}
+    <button onclick={decrement}>-</button>
+    <button onclick={increment}>+</button>
+</template>

--- a/playground/src/modules/x/counter/counter.js
+++ b/playground/src/modules/x/counter/counter.js
@@ -1,0 +1,12 @@
+import { LightningElement } from "lwc";
+
+export default class extends LightningElement {
+    counter = 0;
+
+    increment() {
+        this.counter++;
+    }
+    decrement() {
+        this.counter--;
+    }
+}

--- a/playground/src/modules/x/counter/counter.js
+++ b/playground/src/modules/x/counter/counter.js
@@ -1,4 +1,4 @@
-import { LightningElement } from "lwc";
+import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
     counter = 0;

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -105,6 +105,7 @@ const GENERIC_IGNORED_PATTERNS = [
 const CUSTOM_IGNORED_PATTERNS = [
     // add anything repo specific here
     'babel.config.js',
+    'playground/',
     '/fixtures/',
     '/@lwc/integration-tests/src/(.(?!.*.spec.js$))*$',
     '/@lwc/integration-karma/test/.*$',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5179,7 +5179,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@3.5.3, chokidar@^3.0.0, chokidar@^3.5.1, chokidar@^3.5.3:
+chokidar@3.5.3, chokidar@^3.0.0, chokidar@^3.5.0, chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -9303,6 +9303,21 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
+livereload-js@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-3.4.0.tgz#2083158125f16fb5207141bbadb9bdc26cfdb1ef"
+  integrity sha512-F/pz9ZZP+R+arY94cECTZco7PXgBXyL+KVWUPZq8AQE9TOu14GV6fYeKOviv02JCvFa4Oi3Rs1hYEpfeajc+ow==
+
+livereload@^0.9.1:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/livereload/-/livereload-0.9.3.tgz#a714816375ed52471408bede8b49b2ee6a0c55b1"
+  integrity sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==
+  dependencies:
+    chokidar "^3.5.0"
+    livereload-js "^3.3.1"
+    opts ">= 1.2.0"
+    ws "^7.4.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -10438,6 +10453,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+"opts@>= 1.2.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opts/-/opts-2.0.2.tgz#a17e189fbbfee171da559edd8a42423bc5993ce1"
+  integrity sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==
 
 ora@^5.4.1:
   version "5.4.1"
@@ -11599,6 +11619,13 @@ rollup-plugin-compat@^0.22.4:
     "@rollup/pluginutils" "~4.1.1"
     es5-proxy-compat "0.22.4"
     magic-string "~0.25.1"
+
+rollup-plugin-livereload@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-livereload/-/rollup-plugin-livereload-2.0.5.tgz#4747fa292a2cceb0c972c573d71b3d66b4252b37"
+  integrity sha512-vqQZ/UQowTW7VoiKEM5ouNW90wE5/GZLfdWuR0ELxyKOJUIaj+uismPZZaICU4DnWPVjnpCDDxEqwU7pcKY/PA==
+  dependencies:
+    livereload "^0.9.1"
 
 rollup-plugin-serve@^2.0.0:
   version "2.0.0"
@@ -13377,6 +13404,11 @@ ws@^7.2.3:
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
   integrity sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==
+
+ws@^7.4.3:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@~8.2.3:
   version "8.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9770,6 +9770,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@>=2.4.6:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mime@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
@@ -10404,6 +10409,11 @@ only@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==
+
+opener@1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -11589,6 +11599,21 @@ rollup-plugin-compat@^0.22.4:
     "@rollup/pluginutils" "~4.1.1"
     es5-proxy-compat "0.22.4"
     magic-string "~0.25.1"
+
+rollup-plugin-serve@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-serve/-/rollup-plugin-serve-2.0.0.tgz#f5ac0d9740f8c30e8be353a780303838fa1dac0e"
+  integrity sha512-adII2hdsHyNftFhg4bx55B6ogZWmySEGtdqcqxwZQi3BryAnfzQ+xRb1/BLe3DR1lX9QxnpwtHbBCSULyXbMwA==
+  dependencies:
+    mime ">=2.4.6"
+    opener "1"
+
+rollup@^2.75.7:
+  version "2.75.7"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.7.tgz#221ff11887ae271e37dcc649ba32ce1590aaa0b9"
+  integrity sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rollup@^2.77.0:
   version "2.77.0"


### PR DESCRIPTION
## Details

Add a new `playground` project to this repo. The playground project contains a minimal LWC setup to experiment and reproduce bugs. Keeping this project within the monorepo ensures that the LWC version is always in sync with the latest version available.

This project can be previewed using Stackblitz: https://playground.lwc.dev

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

