### PR TITLE
fix: append global stylesheets to document.head

### DIFF
--- a/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/index.spec.js
@@ -1,0 +1,16 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+if (!process.env.NATIVE_SHADOW) {
+    describe('global styles', () => {
+        it('injects global styles in document.head in synthetic shadow', () => {
+            const numStyleSheetsBefore = document.styleSheets.length;
+            const elm = createElement('x-component', { is: Component });
+            document.body.appendChild(elm);
+            return Promise.resolve().then(() => {
+                const numStyleSheetsAfter = document.styleSheets.length;
+                expect(numStyleSheetsBefore + 1).toEqual(numStyleSheetsAfter);
+            });
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.css
@@ -1,0 +1,4 @@
+h1 {
+  color: burlywood;
+  background: darkslategray;
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>Hello world</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

In #2827 we started using `document.adoptedStyleSheets` instead of injecting `<style>`s into the `document.head` (in supported browsers). Unfortunately this breaks existing code that expects that it can crawl the CSS for all elements on the page by iterating through `document.styleSheets`. (As it turns out, `document.adoptedStyleSheets` does not affect `document.styleSheets` – they are separate collections.)

I opened #2922 to track removing this once it's safe to go back to using `document.adoptedStyleSheets`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## Gus WI

W-11393601
