### PR TITLE
chore(perf-benchmarks): fix build script

### DIFF
--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -32,7 +32,7 @@ const toInt = (num) => (typeof num === 'number' ? num : parseInt(num, 10));
 BENCHMARK_SAMPLE_SIZE = toInt(BENCHMARK_SAMPLE_SIZE);
 BENCHMARK_TIMEOUT = toInt(BENCHMARK_TIMEOUT);
 
-const benchmarkComponentsDir = path.join(__dirname, '../../@lwc/perf-benchmarks-components');
+const benchmarkComponentsDir = path.join(__dirname, '../../../@lwc/perf-benchmarks-components');
 
 // lwc packages that need to be swapped in when comparing the current code to the latest tip-of-tree code.
 const swappablePackages = [


### PR DESCRIPTION
## Details

Unfortunately in https://github.com/salesforce/lwc/pull/2896 I missed this path change, so the `yarn build:performance` script broke. This unbreaks it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
