### PR TITLE
fix: implicit hydration with pre-existing elms in DOM

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -135,8 +135,16 @@ function nextSibling(node: Node): Node | null {
 }
 
 function attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
-    if (hydrating) {
-        return element.shadowRoot!;
+    // `hydrating` will be true in two cases:
+    //   1. upon initial load with an SSR-generated DOM, while in Shadow render mode
+    //   2. when a webapp author places <c-app> in their static HTML and mounts their
+    //      root component with customeElement.define('c-app', Ctor)
+    //
+    // The second case can be treated as a failed hydration with nominal impact
+    // to performance. However, because <c-app> won't have a <template shadowroot>
+    // declarative child, `element.shadowRoot` is `null`.
+    if (hydrating && element.shadowRoot) {
+        return element.shadowRoot;
     }
     return element.attachShadow(options);
 }

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -2,6 +2,7 @@ import { LightningElement } from 'lwc';
 
 import ReflectElement from 'x/reflect';
 import LifecycleParent from 'x/lifecycleParent';
+import WithChildElms from 'x/withChildElms';
 
 // We can't register standard custom elements if we run compat because of the transformation applied to the component
 // constructor.
@@ -33,6 +34,37 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
 
         expect(elm.shadowRoot).not.toBe(null);
         expect(elm.shadowRoot.mode).toBe('open');
+    });
+
+    describe('implicit hydration', () => {
+        let consoleSpy;
+        beforeEach(() => {
+            // eslint-disable-next-line no-undef
+            consoleSpy = TestUtils.spyConsole();
+        });
+        afterEach(() => {
+            consoleSpy.reset();
+        });
+
+        it('should occur when element exists before customElements.define', () => {
+            const elm = document.createElement('test-custom-element-preexisting');
+            document.body.appendChild(elm);
+
+            expect(elm.shadowRoot).toBe(null);
+            customElements.define(
+                'test-custom-element-preexisting',
+                WithChildElms.CustomElementConstructor
+            );
+            expect(elm.shadowRoot).not.toBe(null);
+
+            const observedErrors = consoleSpy.calls.error
+                .flat()
+                .map((err) => (err instanceof Error ? err.message : err));
+            expect(observedErrors).toContain(
+                '[LWC error]: Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.\n'
+            );
+            expect(observedErrors).toContain('[LWC error]: Hydration completed with errors.\n');
+        });
     });
 
     describe('lifecycle', () => {

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/withChildElms/withChildElms.html
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/withChildElms/withChildElms.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/withChildElms/withChildElms.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/withChildElms/withChildElms.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {}


### PR DESCRIPTION
## Details

This resolves [W-11233285](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000yKKx8YAG/view).

The issue occurs when a top-level `<x-app>` tag is in the DOM before `customElements.define` is called, using that pre-existing tag as the mount point for the application. That looks something like this:
```html
<!DOCTYPE html>
<html>
  <body>
    <x-app></x-app>
    <script src="dist/main.js"></script>
  </body>
</html>
```
with entry-point JS like this:
```javascript
import App from "x/app";
customElements.define("x-app", App.CustomElementConstructor);
```

The usage here is not incorrect, but diverges from the LWC-recommended pattern of `createElement("x-app", { is: App })`. Issues arise from this in LWC due to the incorrect belief that `element.shadowRoot` would always be non-null in `attachShadow` when `hydrating === true`.

The change in this PR allows this unexpected pattern to function, treating the situation as a rehydration with mismatches (with commensurate dev-mode errors in the console). In parallel, I'll suggest that the user adopt the `createElement` pattern to avoid the errors in the console.

I considered solving this by silencing the hydration mismatches only when this pattern was used. The easiest way to do this was to check for `element.isConnected && !element.shadowRoot` earlier in the hydration process. However, this breaks LightDOM rehydration. As far as I can tell, there isn't an elegant way to determine whether an implicit hydration with `customElements.define` is happening post-SSR or just because someone stuck the tag in the DOM already. Unless we want to drop implicit hydration altogether for `customElements.define`, this seemed like the best way forward.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11233285
