### PR TITLE
fix: mismatch with scoped CSS classname when hydrating

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/scope-token-class.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/scope-token-class.ts
@@ -1,0 +1,6 @@
+import { VM } from '../vm';
+
+export function getScopeTokenClass(owner: VM): string | null {
+    const { cmpTemplate, context } = owner;
+    return (context.hasScopedStyles && cmpTemplate?.stylesheetToken) || null;
+}

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -57,6 +57,7 @@ import { patchProps } from './modules/props';
 import { patchClassAttribute } from './modules/computed-class-attr';
 import { patchStyleAttribute } from './modules/computed-style-attr';
 import { applyEventListeners } from './modules/events';
+import { getScopeTokenClass } from './modules/scope-token-class';
 import { applyStaticClassAttribute } from './modules/static-class-attr';
 import { applyStaticStyleAttribute } from './modules/static-style-attr';
 
@@ -401,10 +402,10 @@ function setElementShadowToken(elm: Element, token: string) {
 
 // Set the scope token class for *.scoped.css styles
 function setScopeTokenClassIfNecessary(elm: Element, owner: VM, renderer: RendererAPI) {
-    const { cmpTemplate, context } = owner;
-    const { getClassList } = renderer;
-    const token = cmpTemplate?.stylesheetToken;
-    if (!isUndefined(token) && context.hasScopedStyles) {
+    const token = getScopeTokenClass(owner);
+
+    if (token) {
+        const { getClassList } = renderer;
         // TODO [#2762]: this dot notation with add is probably problematic
         // probably we should have a renderer api for just the add operation
         getClassList(elm).add(token);

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/expected.html
@@ -1,0 +1,10 @@
+<x-attribute-dynamic-with-scoped-css class="x-attribute-dynamic-with-scoped-css_attribute-dynamic-with-scoped-css-host">
+  <template shadowroot="open">
+    <style class="x-attribute-dynamic-with-scoped-css_attribute-dynamic-with-scoped-css" type="text/css">
+      div.x-attribute-dynamic-with-scoped-css_attribute-dynamic-with-scoped-css {color: black;}div.kree.x-attribute-dynamic-with-scoped-css_attribute-dynamic-with-scoped-css {color: blue;}
+    </style>
+    <div class="x-attribute-dynamic-with-scoped-css_attribute-dynamic-with-scoped-css kree">
+      In the middle of my backswing?!
+    </div>
+  </template>
+</x-attribute-dynamic-with-scoped-css>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-attribute-dynamic-with-scoped-css';
+export { default } from 'x/attribute-dynamic-with-scoped-css';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.html
@@ -1,0 +1,3 @@
+<template>
+    <div class={dynamicClass}>In the middle of my backswing?!</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class AttributeDynamicWithScopedCss extends LightningElement {
+  dynamicClass = 'kree'
+};

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.scoped.css
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.scoped.css
@@ -1,0 +1,7 @@
+div {
+  color: black;
+}
+
+div.kree {
+  color:  blue;
+}

--- a/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/index.spec.js
@@ -1,0 +1,6 @@
+export default {
+    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
+        hydrateComponent(target, Component, {});
+        expect(consoleSpy.calls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.html
@@ -1,0 +1,4 @@
+<template>
+  <h1 class={dynamic}>howdydude</h1>
+  <!-- why does the output of SSR put the scoping tokay on the <h1> tag? -->
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    // howdydude
+    dynamic = 'foo';
+}

--- a/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.scoped.css
+++ b/packages/@lwc/integration-karma/test-hydration/stylesheet/scoped-styles-with-dynamic-class/x/main/main.scoped.css
@@ -1,0 +1,4 @@
+h1 {
+  color: green;
+}
+/* howdydude */


### PR DESCRIPTION
## Details

Closes #2926.

This is what's going on:

- A component uses scoped CSS.
- SSR:
    1. VDOM is generated for that component.
    2. Later, a component-specific classname is added to VDOM descendant nodes of that component.
    3. During serialization, the classname is serialized in the `class` attr alongside any other classes specified for each of the descendants.
- Browser:
    1. The serialized HTML becomes DOM.
    2. When `hydrateComponent` is called, VDOM is generated for that component _(corresponding to step SSR.i)_
    3. VDOM is validated against the DOM.
        + The descendant DOM elements contain scoped CSS classnames.
        + Corresponding VDOM nodes do not contain scoped CSS classnames.
        + Hydration mismatch occurs.
    4. Because a hydration mismatch occurs, the mismatching element is replaced:
        + New DOM is generated from the VDOM.
        + This new DOM element is mounted to its parent. During mounting, the scoped CSS classname is appended to the DOM node. _(corresponding to step SSR.ii)_
        + The old DOM element is removed from the DOM.

TLDR: Validation occurs 1) against the VDOM (which never contains this classname) and 2) before the classname is added to the DOM (making the timing of validation an issue for this bug).

Two solutions came to mind:

1. Update the validation logic such that it accounts for the possible presence of scoped CSS classnames.
2. Change how scoped CSS classnames are applied - instead of adding these classes to DOM while mounting, modify the VDOM earlier in the process, making VDOM the source of truth.

This PR implements solution #1. #2 seems cleaner, but requires a more significant refactor. I'm happy to go in that direction, if folks are in favor.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

This is a bug fix and shouldn't break any existing functionality.

## GUS work item

W-11403024