### PR TITLE
chore(nucleus): refresh downstreams based on flappiness

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -9,12 +9,38 @@ branches:
       auto-start-from-forks: false
       merge-method: disabled # do not auto-merge; we'll do it ourselves
       required-downstream-deps:
+        - Guardrails/analyzer-framework
+        - LightningMobileRuntime/ui-lmr-components
+        - MobilePlatform/lds-debug-app
+        - Trailhead-Platform/ui-trailhead-core-components
+        - automation-platform/ui-interaction-explorer-components
+        - communities/microsite-template-marketing
         - communities/shared-experience-components
+        - communities/talon-template-byo
         - communities/ui-b2b-components
+        - communities/ui-cms-components
+        - communities/ui-commerce-components
+        - communities/ui-dxp-components
+        - communities/ui-feeds-components
         - communities/ui-lightning-community
+        - communities/webruntime
+        - lwc/lwc-platform
+        - nrkruk/lwc-dev-core
+        - omnistudio/ui-omniscript-components
+        - ris-gpta/core_via_components
+        - salesforce/builder-framework
+        - salesforce/lds-lightning-platform
+        - salesforce/locker
+        - salesforce/luvio
         - salesforce/lwr
+        - salesforce/lwr-everywhere
+        - salesforce/lwr-lightning-platform
+        - salesforce/lwr-recipes
+        - salesforce/o11y-sample-app
         - salesforce/utam-docs
-        - uiplatform/nucleus
+        - salesforcedevs/doc-framework-monorepo
+        - swanaselja/experience-container-validate
+        - uiplatform/aura-hotswap-bundle
   release:
     pull-request:
       <<: *branch-definition


### PR DESCRIPTION
## Details

Update Nucleus required downstreams based on an updated [flappiness analysis](https://salesforce.quip.com/RbQhA8P7ImzK).

Some of these may start flapping in the future, but we can remove them if that happens.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11254165
