### PR TITLE
fix: make ElementSourceLocation.endTag a required field

### DIFF
--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -41,7 +41,7 @@ export interface SourceLocation {
 
 export interface ElementSourceLocation extends SourceLocation {
     startTag: SourceLocation;
-    endTag?: SourceLocation;
+    endTag: SourceLocation;
 }
 
 export interface Literal<Value = string | boolean> {


### PR DESCRIPTION
## Details
While investigating a bug related to location information endTag, it was noticed that this field is always present. Updating TS definition to reflect that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
