### PR TITLE
refactor(engine-core): add updateComponentValue util function

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -32,7 +32,7 @@ import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getWrappedComponentsListener } from './component';
 import { vmBeingConstructed, isBeingConstructed, isInvokingRender } from './invoker';
 import { associateVM, getAssociatedVM, RenderMode, ShadowMode, ShadowSupportMode, VM } from './vm';
-import { componentValueMutated, componentValueObserved } from './mutation-tracker';
+import { componentValueObserved } from './mutation-tracker';
 import {
     patchComponentWithRestrictions,
     patchShadowRootWithRestrictions,
@@ -43,6 +43,7 @@ import { unlockAttribute, lockAttribute } from './attributes';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { HTMLElementConstructor } from './base-bridge-element';
 import { lockerLivePropertyKey } from './membrane';
+import { updateComponentValue } from './update-component-value';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -112,11 +113,7 @@ function createBridgeToElementDescriptor(
                 );
             }
 
-            if (newValue !== vm.cmpProps[propName]) {
-                vm.cmpProps[propName] = newValue;
-
-                componentValueMutated(vm, propName);
-            }
+            updateComponentValue(vm, propName, newValue);
             return set.call(vm.elm, newValue);
         },
     };

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -5,12 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, toString } from '@lwc/shared';
-import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
+import { componentValueObserved } from '../mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
 import { reactiveMembrane } from '../membrane';
 import { LightningElement } from '../base-lightning-element';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
+import { updateComponentValue } from '../update-component-value';
 
 /**
  * @track decorator function to mark field value as reactive in
@@ -59,11 +60,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
                 );
             }
             const reactiveOrAnyValue = reactiveMembrane.getProxy(newValue);
-            if (reactiveOrAnyValue !== vm.cmpFields[key]) {
-                vm.cmpFields[key] = reactiveOrAnyValue;
-
-                componentValueMutated(vm, key);
-            }
+            updateComponentValue(vm, key, reactiveOrAnyValue);
         },
         enumerable: true,
         configurable: true,

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -6,9 +6,10 @@
  */
 import { assert } from '@lwc/shared';
 import { LightningElement } from '../base-lightning-element';
-import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
+import { componentValueObserved } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
 import { WireAdapterConstructor } from '../wiring';
+import { updateComponentValue } from '../update-component-value';
 
 /**
  * @wire decorator to wire fields and methods to a wire adapter in
@@ -40,11 +41,7 @@ export function internalWireFieldDecorator(key: string): PropertyDescriptor {
              * letting the author to do the wrong thing, but it will keep our
              * system to be backward compatible.
              */
-            if (value !== vm.cmpFields[key]) {
-                vm.cmpFields[key] = value;
-
-                componentValueMutated(vm, key);
-            }
+            updateComponentValue(vm, key, value);
         },
         enumerable: true,
         configurable: true,

--- a/packages/@lwc/engine-core/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine-core/src/framework/observed-fields.ts
@@ -6,7 +6,8 @@
  */
 import { LightningElement } from './base-lightning-element';
 import { getAssociatedVM } from './vm';
-import { componentValueMutated, componentValueObserved } from './mutation-tracker';
+import { componentValueObserved } from './mutation-tracker';
+import { updateComponentValue } from './update-component-value';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {
@@ -18,11 +19,7 @@ export function createObservedFieldPropertyDescriptor(key: string): PropertyDesc
         set(this: LightningElement, newValue: any) {
             const vm = getAssociatedVM(this);
 
-            if (newValue !== vm.cmpFields[key]) {
-                vm.cmpFields[key] = newValue;
-
-                componentValueMutated(vm, key);
-            }
+            updateComponentValue(vm, key, newValue);
         },
         enumerable: true,
         configurable: true,

--- a/packages/@lwc/engine-core/src/framework/update-component-value.ts
+++ b/packages/@lwc/engine-core/src/framework/update-component-value.ts
@@ -1,0 +1,11 @@
+import { VM } from './vm';
+import { componentValueMutated } from './mutation-tracker';
+
+export function updateComponentValue(vm: VM, key: string, newValue: any) {
+    const { cmpFields } = vm;
+    if (newValue !== cmpFields[key]) {
+        cmpFields[key] = newValue;
+
+        componentValueMutated(vm, key);
+    }
+}

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -14,8 +14,9 @@ import {
 } from '@lwc/shared';
 import featureFlags from '@lwc/features';
 import { LightningElement } from './base-lightning-element';
-import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
+import { ReactiveObserver } from './mutation-tracker';
 import { runWithBoundaryProtection, VMState, VM } from './vm';
+import { updateComponentValue } from './update-component-value';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
@@ -53,14 +54,8 @@ export class WireContextRegistrationEvent extends CustomEvent<undefined> {
 }
 
 function createFieldDataCallback(vm: VM, name: string) {
-    const { cmpFields } = vm;
     return (value: any) => {
-        if (value !== vm.cmpFields[name]) {
-            // storing the value in the underlying storage
-            cmpFields[name] = value;
-
-            componentValueMutated(vm, name);
-        }
+        updateComponentValue(vm, name, value);
     };
 }
 


### PR DESCRIPTION
## Details

Adds a util function to centralize some code repeated across 5 different places. Reduces the size of `engine-dom.min.js` from 54346 bytes to 54199 bytes (-147 bytes).

I don't see this as a big perf improvement; just making the code a bit DRYer.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
