### PR TITLE
perf(engine-server): disable reactivity in SSR

### DIFF
--- a/packages/@lwc/engine-core/src/framework/accessor-reactive-observer.ts
+++ b/packages/@lwc/engine-core/src/framework/accessor-reactive-observer.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { isFalse, isTrue } from '@lwc/shared';
+
+import { JobFunction, ReactiveObserver } from '../libs/mutation-tracker';
+import { rerenderVM, VM } from './vm';
+import { addCallbackToNextTick } from './utils';
+
+const DUMMY_ACCESSOR_REACTIVE_OBSERVER = {
+    observe(job: JobFunction) {
+        job();
+    },
+    reset() {},
+    link() {},
+} as unknown as AccessorReactiveObserver;
+
+export class AccessorReactiveObserver extends ReactiveObserver {
+    private value: any;
+    private debouncing: boolean = false;
+    constructor(vm: VM, set: (v: any) => void) {
+        super(() => {
+            if (isFalse(this.debouncing)) {
+                this.debouncing = true;
+                addCallbackToNextTick(() => {
+                    if (isTrue(this.debouncing)) {
+                        const { value } = this;
+                        const { isDirty: dirtyStateBeforeSetterCall, component, idx } = vm;
+                        set.call(component, value);
+                        // de-bouncing after the call to the original setter to prevent
+                        // infinity loop if the setter itself is mutating things that
+                        // were accessed during the previous invocation.
+                        this.debouncing = false;
+                        if (isTrue(vm.isDirty) && isFalse(dirtyStateBeforeSetterCall) && idx > 0) {
+                            // immediate rehydration due to a setter driven mutation, otherwise
+                            // the component will get rendered on the second tick, which it is not
+                            // desirable.
+                            rerenderVM(vm);
+                        }
+                    }
+                });
+            }
+        });
+    }
+    reset(value?: any) {
+        super.reset();
+        this.debouncing = false;
+        if (arguments.length > 0) {
+            this.value = value;
+        }
+    }
+}
+
+export function createAccessorReactiveObserver(
+    vm: VM,
+    set: (v: any) => void
+): AccessorReactiveObserver {
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    return process.env.IS_BROWSER
+        ? new AccessorReactiveObserver(vm, set)
+        : DUMMY_ACCESSOR_REACTIVE_OBSERVER;
+}

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -24,7 +24,7 @@ import {
 } from '@lwc/shared';
 
 import { getAssociatedVM } from './vm';
-import { reactiveMembrane } from './membrane';
+import { getReadOnlyProxy } from './membrane';
 import { HTMLElementConstructor } from './html-element';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { isAttributeLocked } from './attributes';
@@ -54,7 +54,7 @@ function createSetter(key: string) {
         fn = cachedSetterByKey[key] = function (this: HTMLElement, newValue: any): any {
             const vm = getAssociatedVM(this);
             const { setHook } = vm;
-            newValue = reactiveMembrane.getReadOnlyProxy(newValue);
+            newValue = getReadOnlyProxy(newValue);
             setHook(vm.component, key, newValue);
         };
     }

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -42,7 +42,7 @@ import {
 import { unlockAttribute, lockAttribute } from './attributes';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { HTMLElementConstructor } from './base-bridge-element';
-import { setLockerLivePropertyKey } from './membrane';
+import { markLockerLiveObject } from './membrane';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -220,7 +220,7 @@ export const LightningElement: LightningElementConstructor = function (
         vm.getHook = getHook;
     }
 
-    setLockerLivePropertyKey(this);
+    markLockerLiveObject(this);
 
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -42,7 +42,7 @@ import {
 import { unlockAttribute, lockAttribute } from './attributes';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { HTMLElementConstructor } from './base-bridge-element';
-import { lockerLivePropertyKey } from './membrane';
+import { setLockerLivePropertyKey } from './membrane';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -220,8 +220,7 @@ export const LightningElement: LightningElementConstructor = function (
         vm.getHook = getHook;
     }
 
-    // Making the component instance a live value when using Locker to support expandos.
-    (this as any)[lockerLivePropertyKey] = undefined;
+    setLockerLivePropertyKey(this);
 
     // Linking elm, shadow root and component with the VM.
     associateVM(component, vm);

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -6,7 +6,7 @@
  */
 import { assert, isFalse, isFunction, isUndefined } from '@lwc/shared';
 
-import { ReactiveObserver } from '../libs/mutation-tracker';
+import { createReactiveObserver, ReactiveObserver } from './mutation-tracker';
 
 import { invokeComponentRenderMethod, isInvokingRender, invokeEventListener } from './invoker';
 import { VM, scheduleRehydration } from './vm';
@@ -44,7 +44,7 @@ export function getComponentRegisteredTemplate(
 }
 
 export function getTemplateReactiveObserver(vm: VM): ReactiveObserver {
-    return new ReactiveObserver(() => {
+    return createReactiveObserver(() => {
         const { isDirty } = vm;
         if (isFalse(isDirty)) {
             markComponentAsDirty(vm);

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -5,19 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import features from '@lwc/features';
-import { assert, isFalse, isFunction, isTrue, isUndefined, toString } from '@lwc/shared';
+import { assert, isFunction, isUndefined, toString } from '@lwc/shared';
 import { logError } from '../../shared/logger';
 import { isInvokingRender, isBeingConstructed } from '../invoker';
-import {
-    componentValueObserved,
-    componentValueMutated,
-    ReactiveObserver,
-    JobFunction,
-} from '../mutation-tracker';
+import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { LightningElement } from '../base-lightning-element';
-import { getAssociatedVM, rerenderVM, VM } from '../vm';
-import { addCallbackToNextTick } from '../utils';
+import { getAssociatedVM } from '../vm';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
+import { createAccessorReactiveObserver } from '../accessor-reactive-observer';
 
 /**
  * @api decorator to mark public fields and public methods in
@@ -74,57 +69,6 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
         enumerable: true,
         configurable: true,
     };
-}
-
-const DUMMY_ACCESSOR_REACTIVE_OBSERVER = {
-    observe(job: JobFunction) {
-        job();
-    },
-    reset() {},
-    link() {},
-} as unknown as AccessorReactiveObserver;
-
-function createAccessorReactiveObserver(vm: VM, set: (v: any) => void) {
-    // On the server side, we don't need mutation tracking. Skipping it improves performance.
-    return process.env.IS_BROWSER
-        ? new AccessorReactiveObserver(vm, set)
-        : DUMMY_ACCESSOR_REACTIVE_OBSERVER;
-}
-
-export class AccessorReactiveObserver extends ReactiveObserver {
-    private value: any;
-    private debouncing: boolean = false;
-    constructor(vm: VM, set: (v: any) => void) {
-        super(() => {
-            if (isFalse(this.debouncing)) {
-                this.debouncing = true;
-                addCallbackToNextTick(() => {
-                    if (isTrue(this.debouncing)) {
-                        const { value } = this;
-                        const { isDirty: dirtyStateBeforeSetterCall, component, idx } = vm;
-                        set.call(component, value);
-                        // de-bouncing after the call to the original setter to prevent
-                        // infinity loop if the setter itself is mutating things that
-                        // were accessed during the previous invocation.
-                        this.debouncing = false;
-                        if (isTrue(vm.isDirty) && isFalse(dirtyStateBeforeSetterCall) && idx > 0) {
-                            // immediate rehydration due to a setter driven mutation, otherwise
-                            // the component will get rendered on the second tick, which it is not
-                            // desirable.
-                            rerenderVM(vm);
-                        }
-                    }
-                });
-            }
-        });
-    }
-    reset(value?: any) {
-        super.reset();
-        this.debouncing = false;
-        if (arguments.length > 0) {
-            this.value = value;
-        }
-    }
 }
 
 export function createPublicAccessorDescriptor(

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -8,7 +8,7 @@ import { assert, toString } from '@lwc/shared';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
-import { getProxy } from '../membrane';
+import { getReactiveProxy } from '../membrane';
 import { LightningElement } from '../base-lightning-element';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
@@ -24,7 +24,7 @@ export default function track(
 ): any;
 export default function track(target: any): any {
     if (arguments.length === 1) {
-        return getProxy(target);
+        return getReactiveProxy(target);
     }
     if (process.env.NODE_ENV !== 'production') {
         assert.fail(
@@ -58,7 +58,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
                     )}`
                 );
             }
-            const reactiveOrAnyValue = getProxy(newValue);
+            const reactiveOrAnyValue = getReactiveProxy(newValue);
             if (reactiveOrAnyValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = reactiveOrAnyValue;
 

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -8,7 +8,7 @@ import { assert, toString } from '@lwc/shared';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
-import { reactiveMembrane } from '../membrane';
+import { getProxy } from '../membrane';
 import { LightningElement } from '../base-lightning-element';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
@@ -24,7 +24,7 @@ export default function track(
 ): any;
 export default function track(target: any): any {
     if (arguments.length === 1) {
-        return reactiveMembrane.getProxy(target);
+        return getProxy(target);
     }
     if (process.env.NODE_ENV !== 'production') {
         assert.fail(
@@ -58,7 +58,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
                     )}`
                 );
             }
-            const reactiveOrAnyValue = reactiveMembrane.getProxy(newValue);
+            const reactiveOrAnyValue = getProxy(newValue);
             if (reactiveOrAnyValue !== vm.cmpFields[key]) {
                 vm.cmpFields[key] = reactiveOrAnyValue;
 

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -35,6 +35,7 @@ export function getProxy(value: any): any {
     return process.env.IS_BROWSER ? reactiveMembrane.getProxy(value) : value;
 }
 
+// Making the component instance a live value when using Locker to support expandos.
 export function setLockerLivePropertyKey(obj: any): void {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.
     if (process.env.IS_BROWSER) {

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -26,17 +26,18 @@ export function unwrap(value: any): any {
 }
 
 export function getReadOnlyProxy(value: any): any {
-    // On the server side, we don't need mutation tracking. Skipping it improves performance.
-    return process.env.IS_BROWSER ? reactiveMembrane.getReadOnlyProxy(value) : value;
+    // We must return a frozen wrapper around the value, so that child components cannot mutate properties passed to
+    // them from their parents. This applies to both the client and server.
+    return reactiveMembrane.getReadOnlyProxy(value);
 }
 
-export function getProxy(value: any): any {
+export function getReactiveProxy(value: any): any {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.
     return process.env.IS_BROWSER ? reactiveMembrane.getProxy(value) : value;
 }
 
 // Making the component instance a live value when using Locker to support expandos.
-export function setLockerLivePropertyKey(obj: any): void {
+export function markLockerLiveObject(obj: any): void {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.
     if (process.env.IS_BROWSER) {
         obj[lockerLivePropertyKey] = undefined;

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -7,9 +7,9 @@
 import { ObservableMembrane } from 'observable-membrane';
 import { valueObserved, valueMutated } from './mutation-tracker';
 
-export const lockerLivePropertyKey = Symbol.for('@@lockerLiveValue');
+const lockerLivePropertyKey = Symbol.for('@@lockerLiveValue');
 
-export const reactiveMembrane = new ObservableMembrane({
+const reactiveMembrane = new ObservableMembrane({
     valueObserved,
     valueMutated,
     tagPropertyKey: lockerLivePropertyKey,
@@ -21,5 +21,23 @@ export const reactiveMembrane = new ObservableMembrane({
  * change or being removed.
  */
 export function unwrap(value: any): any {
-    return reactiveMembrane.unwrapProxy(value);
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    return process.env.IS_BROWSER ? reactiveMembrane.unwrapProxy(value) : value;
+}
+
+export function getReadOnlyProxy(value: any): any {
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    return process.env.IS_BROWSER ? reactiveMembrane.getReadOnlyProxy(value) : value;
+}
+
+export function getProxy(value: any): any {
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    return process.env.IS_BROWSER ? reactiveMembrane.getProxy(value) : value;
+}
+
+export function setLockerLivePropertyKey(obj: any): void {
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    if (process.env.IS_BROWSER) {
+        obj[lockerLivePropertyKey] = undefined;
+    }
 }

--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -4,15 +4,40 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { valueMutated, valueObserved } from '../libs/mutation-tracker';
+import {
+    JobFunction,
+    CallbackFunction,
+    ReactiveObserver,
+    valueMutated,
+    valueObserved,
+} from '../libs/mutation-tracker';
 import { VM } from './vm';
 
+const DUMMY_REACTIVE_OBSERVER = {
+    observe(job: JobFunction) {
+        job();
+    },
+    reset() {},
+    link() {},
+} as unknown as ReactiveObserver;
+
 export function componentValueMutated(vm: VM, key: PropertyKey) {
-    valueMutated(vm.component, key);
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    if (process.env.IS_BROWSER) {
+        valueMutated(vm.component, key);
+    }
 }
 
 export function componentValueObserved(vm: VM, key: PropertyKey) {
-    valueObserved(vm.component, key);
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    if (process.env.IS_BROWSER) {
+        valueObserved(vm.component, key);
+    }
+}
+
+export function createReactiveObserver(callback: CallbackFunction): ReactiveObserver {
+    // On the server side, we don't need mutation tracking. Skipping it improves performance.
+    return process.env.IS_BROWSER ? new ReactiveObserver(callback) : DUMMY_REACTIVE_OBSERVER;
 }
 
 export * from '../libs/mutation-tracker';

--- a/packages/@lwc/engine-core/src/framework/readonly.ts
+++ b/packages/@lwc/engine-core/src/framework/readonly.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert } from '@lwc/shared';
-import { reactiveMembrane } from './membrane';
+import { getReadOnlyProxy } from './membrane';
 
 /**
  * EXPERIMENTAL: This function allows you to create a reactive readonly
@@ -21,5 +21,5 @@ export function readonly(obj: any): any {
             );
         }
     }
-    return reactiveMembrane.getReadOnlyProxy(obj);
+    return getReadOnlyProxy(obj);
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -39,7 +39,7 @@ import {
 import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
-import { AccessorReactiveObserver } from './decorators/api';
+import { AccessorReactiveObserver } from './accessor-reactive-observer';
 import { removeActiveVM } from './hot-swaps';
 import { VNodes, VCustomElement, VNode, VNodeType } from './vnodes';
 

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -14,7 +14,11 @@ import {
 } from '@lwc/shared';
 import featureFlags from '@lwc/features';
 import { LightningElement } from './base-lightning-element';
-import { componentValueMutated, ReactiveObserver } from './mutation-tracker';
+import {
+    componentValueMutated,
+    createReactiveObserver,
+    ReactiveObserver,
+} from './mutation-tracker';
 import { runWithBoundaryProtection, VMState, VM } from './vm';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
@@ -87,7 +91,7 @@ function createConfigWatcher(
 ): { computeConfigAndUpdate: () => void; ro: ReactiveObserver } {
     let hasPendingConfig: boolean = false;
     // creating the reactive observer for reactive params when needed
-    const ro = new ReactiveObserver(() => {
+    const ro = createReactiveObserver(() => {
         if (hasPendingConfig === false) {
             hasPendingConfig = true;
             // collect new config in the micro-task

--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
@@ -64,8 +64,8 @@ export function valueObserved(target: object, key: PropertyKey) {
     }
 }
 
-type CallbackFunction = (rp: ReactiveObserver) => void;
-type JobFunction = () => void;
+export type CallbackFunction = (rp: ReactiveObserver) => void;
+export type JobFunction = () => void;
 
 export class ReactiveObserver {
     private listeners: ObservedMemberPropertyRecords[] = [];

--- a/packages/@lwc/engine-dom/scripts/rollup.config.js
+++ b/packages/@lwc/engine-dom/scripts/rollup.config.js
@@ -9,6 +9,7 @@
 
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const replace = require('@rollup/plugin-replace');
 const typescript = require('../../../../scripts/rollup/typescript');
 const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
 const lwcFeatures = require('../../../../scripts/rollup/lwcFeatures');
@@ -37,6 +38,12 @@ module.exports = {
         typescript(),
         writeDistAndTypes(),
         lwcFeatures(),
+        replace({
+            values: {
+                'process.env.IS_BROWSER': 'true',
+            },
+            preventAssignment: true,
+        }),
     ],
 
     onwarn({ code, message }) {

--- a/packages/@lwc/engine-server/scripts/rollup.config.js
+++ b/packages/@lwc/engine-server/scripts/rollup.config.js
@@ -42,17 +42,6 @@ module.exports = {
             },
             preventAssignment: true,
         }),
-        {
-            // Check that the output bundle does not include the reactivity / observable-membrane code
-            name: 'check-no-reactivity',
-            renderChunk(code) {
-                if (/\b(ReactiveObserver|ObservableMembrane)\b/.test(code)) {
-                    throw new Error(
-                        '@lwc/engine-server should not include ReactiveObserver or ObservableMembrane.'
-                    );
-                }
-            },
-        },
     ],
 
     onwarn({ code, message }) {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/expected.html
@@ -1,0 +1,15 @@
+<x-parent>
+  <template shadowroot="open">
+    <x-child>
+      <template shadowroot="open">
+        <div>
+          
+array: error hit during mutation
+object: error hit during mutation
+deep: error hit during mutation
+object: error hit during deletion
+        </div>
+      </template>
+    </x-child>
+  </template>
+</x-parent>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-parent';
+export { default } from 'x/parent';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+  <div>{result}</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/child/child.js
@@ -1,0 +1,39 @@
+import { LightningElement, api } from "lwc";
+
+export default class extends LightningElement {
+  @api array
+  @api object
+  @api deep
+
+  result
+
+  connectedCallback() {
+    const results = []
+    
+    try {
+      this.array.push('bar')
+    } catch (err) {
+      results.push('array: error hit during mutation')
+    }
+
+    try {
+      this.object.foo = 'baz'
+    } catch (err) {
+      results.push('object: error hit during mutation')
+    }
+    
+    try {
+      this.deep.foo[0].quux = 'quux'
+    } catch (err) {
+      results.push('deep: error hit during mutation')
+    }
+
+    try {
+      delete this.object.foo
+    } catch (err) {
+      results.push('object: error hit during deletion')
+    }
+
+    this.result = '\n' + results.join('\n')
+  }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/parent/parent.html
@@ -1,0 +1,8 @@
+<template>
+  <x-child
+    array={array}
+    object={object}
+    deep={deep}
+  >
+  </x-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/parent/parent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-prop/modules/x/parent/parent.js
@@ -1,0 +1,7 @@
+import { LightningElement } from "lwc";
+
+export default class extends LightningElement {
+  array = [1, 2, 3]
+  object = { foo: 'bar '}
+  deep = { foo: [{ bar: 'baz' }]}
+}


### PR DESCRIPTION
## Details

Removes reactivity (`observable-membrane`, `ReactiveObserver`) from `@lwc/engine-server`. Reactivity is not needed server-side.

The bundle size for `engine-server.js` drops from 246 kB to 218 kB (**27.8kB / 11.3% reduction**).

Performance in the `engine-server` Tachometer benchmarks improves **13%-18%**:

![Screen Shot 2022-07-28 at 11 09 32 AM](https://user-images.githubusercontent.com/283842/181608341-7e08c9dd-e461-4c0f-99b3-f629c2455d7a.png)
![Screen Shot 2022-07-28 at 11 09 36 AM](https://user-images.githubusercontent.com/283842/181608347-1901588c-967e-4b39-ae15-f21abb154d4a.png)




## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

**Technically** this would be a breaking change if any consumer were directly using `@lwc/engine-core`. They would need to know to transform `process.env.IS_BROWSER`. But I'm certain we don't have any consumers who are doing that.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
