### PR TITLE
test(integration-karma): improve test coverage

### DIFF
--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/index.spec.js
@@ -1,0 +1,28 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).not.toBe(snapshots.p);
+        expect(p.className).not.toBe(snapshots.classes);
+        expect(p.className).toBe('c1 c2 c3');
+
+        expect(consoleCalls.error).toHaveSize(2);
+        expect(consoleCalls.error[0][0].message).toContain(
+            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c1 c3"'
+        );
+        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c1 c3" onclick={onClick}>txt</p>
+    </template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c1 c2 c3" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/index.spec.js
@@ -1,0 +1,28 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).not.toBe(snapshots.p);
+        expect(p.className).not.toBe(snapshots.classes);
+        expect(p.className).toBe('c1 c3');
+
+        expect(consoleCalls.error).toHaveSize(2);
+        expect(consoleCalls.error[0][0].message).toContain(
+            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c3" but found "c1 c2 c3"'
+        );
+        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c1 c2 c3" onclick={onClick}>txt</p>
+    </template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c1 c3" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/index.spec.js
@@ -1,0 +1,23 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).toBe(snapshots.p);
+        expect(p.className).toBe(snapshots.classes);
+
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c3 c2 c1" onclick={onClick}>txt</p>
+    </template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p class="c1 c2 c3" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-same-different-order/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/index.spec.js
@@ -1,0 +1,30 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).not.toBe(snapshots.p);
+        expect(p.getAttribute('style')).not.toBe(snapshots.style);
+        expect(p.getAttribute('style')).toBe(
+            'background-color: red; border-color: red !important;'
+        );
+
+        expect(consoleCalls.error).toHaveSize(2);
+        expect(consoleCalls.error[0][0].message).toContain(
+            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red important!" but found "background-color: red; border-color: red"'
+        );
+        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red !important;" onclick={onClick}>txt</p>
+    </template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red;" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-different-priority/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/index.spec.js
@@ -1,0 +1,30 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).not.toBe(snapshots.p);
+        expect(p.getAttribute('style')).not.toBe(snapshots.style);
+        expect(p.getAttribute('style')).toBe(
+            'background-color: red; border-color: red; margin: 1px;'
+        );
+
+        expect(consoleCalls.error).toHaveSize(2);
+        expect(consoleCalls.error[0][0].message).toContain(
+            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red"'
+        );
+        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red;" onclick={onClick}>txt</p>
+    </template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red; margin: 1px;" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-client/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/index.spec.js
@@ -1,0 +1,28 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).not.toBe(snapshots.p);
+        expect(p.getAttribute('style')).not.toBe(snapshots.style);
+        expect(p.getAttribute('style')).toBe('background-color: red; border-color: red;');
+
+        expect(consoleCalls.error).toHaveSize(2);
+        expect(consoleCalls.error[0][0].message).toContain(
+            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px"'
+        );
+        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red;" onclick={onClick}>txt</p>
+    </template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red; margin: 1px;" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-extra-from-server/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/index.spec.js
@@ -1,0 +1,23 @@
+export default {
+    props: {
+        ssr: true,
+    },
+    clientProps: {
+        ssr: false,
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).toBe(snapshots.p);
+        expect(p.getAttribute('style')).toBe(snapshots.style);
+
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/x/main/main.html
@@ -1,0 +1,10 @@
+<template>
+    <template if:true={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="background-color: red; border-color: red; margin: 1px;" onclick={onClick}>txt</p>
+    </template>
+    <template if:false={ssr}>
+        <!-- onclick disables static content optimization -->
+        <p style="margin: 1px; border-color: red; background-color: red;" onclick={onClick}>txt</p>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-different-order/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api ssr;
+
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/index.spec.js
@@ -1,0 +1,15 @@
+export default {
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).toBe(snapshots.p);
+        expect(p.getAttribute('style')).toBe(snapshots.style);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/x/main/main.html
@@ -1,0 +1,5 @@
+<template>
+    <!-- Note: extra spaces matters -->
+    <!-- onclick disables static content optimization -->
+    <p style="background-color: red; border-color:     red !important   ;    " onclick={onClick}>txt</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same-priority/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    onClick() {}
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/index.spec.js
@@ -1,0 +1,17 @@
+export default {
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            style: p.getAttribute('style'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+
+        expect(p).toBe(snapshots.p);
+        expect(p.getAttribute('style')).toBe(snapshots.style);
+
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/x/main/main.html
@@ -1,0 +1,4 @@
+<template>
+    <!-- onclick disables static content optimization -->
+    <p style="background-color: red; border-color: red; margin: 1px;" onclick={onClick}>txt</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static-unoptimized-same/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    onClick() {}
+}


### PR DESCRIPTION
## Details

Partially addresses #2817. Improves test coverage from 84.88% to 85.49% (lines).

This PR just adds some more tests for class/style hydration mismatches, modifying existing tests to _not_ use the static content optimization.

I also found #2962 in the process, but I did not attempt to fix it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
