### PR TITLE
chore(playground): remove decorator warning

### DIFF
--- a/playground/jsconfig.json
+++ b/playground/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+      "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
## Details

Fixes this issue:

![Screen Shot 2022-07-29 at 9 24 23 AM](https://user-images.githubusercontent.com/283842/181815306-37d7289f-9ade-44e3-addd-d8a21ebfb9a9.png)

I tried `tsconfig` and workspace settings based on [this SO question](https://stackoverflow.com/questions/38271273/experimental-decorators-warning-in-typescript-compilation), but `jsconfig.json` was the only thing I found that worked.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
