### PR TITLE
chore(nucleus): remove locker

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -30,7 +30,6 @@ branches:
         - ris-gpta/core_via_components
         - salesforce/builder-framework
         - salesforce/lds-lightning-platform
-        - salesforce/locker
         - salesforce/luvio
         - salesforce/lwr
         - salesforce/lwr-everywhere


### PR DESCRIPTION
## Details

See [this thread](https://salesforce-internal.slack.com/archives/G0213GSKXA6/p1659120221912479) for context. We hit a flapper, also it doesn't make much sense for this downstream to be there.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
