### PR TITLE
test: add test to confirm observedAttributes behavior

### DIFF
--- a/packages/@lwc/integration-karma/test/component/observed-attributes/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-attributes/index.spec.js
@@ -1,0 +1,37 @@
+import { createElement } from 'lwc';
+import Observes from 'x/observes';
+
+const SUPPORTS_CUSTOM_ELEMENTS = !process.env.COMPAT && 'customElements' in window;
+
+if (SUPPORTS_CUSTOM_ELEMENTS) {
+    describe('observed attributes', () => {
+        const constructorMethods = {
+            CustomElementConstructor: () => {
+                customElements.define(
+                    'x-observes-as-custom-element',
+                    Observes.CustomElementConstructor
+                );
+                const elm = document.createElement('x-observes-as-custom-element');
+                document.body.appendChild(elm);
+                return elm;
+            },
+            createElement: () => {
+                const elm = createElement('x-observes', { is: Observes });
+                document.body.appendChild(elm);
+                return elm;
+            },
+        };
+
+        Object.entries(constructorMethods).forEach(([name, makeElement]) => {
+            // TODO [#2972]: LWC components do not respect observedAttributes/attributeChangedCallback
+            it(`${name} - should not observe attributes`, () => {
+                const elm = makeElement();
+
+                elm.setAttribute('foo', 'bar');
+                elm.removeAttribute('foo');
+
+                expect(elm.changes).toEqual([]);
+            });
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/component/observed-attributes/x/observes/observes.js
+++ b/packages/@lwc/integration-karma/test/component/observed-attributes/x/observes/observes.js
@@ -1,0 +1,11 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static observedAttributes = ['foo'];
+
+    @api changes = [];
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        this.changes.push({ name, oldValue, newValue });
+    }
+}


### PR DESCRIPTION
## Details

Adds a karma test to confirm the behavior described in https://github.com/salesforce/lwc/issues/2972.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

