### PR TITLE
refactor(engine): remove isHydrating global flag

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -15,7 +15,6 @@ export interface RendererAPI {
     isNativeShadowDefined: boolean;
     isSyntheticShadowDefined: boolean;
     HTMLElementExported: typeof HTMLElement;
-    isHydrating: () => boolean;
     insert: (node: N, parent: E, anchor: N | null) => void;
     remove: (node: N, parent: E) => void;
     cloneNode: (node: N, deep: boolean) => N;

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -14,7 +14,6 @@ import {
 } from '@lwc/engine-core';
 import { isFunction, isNull, isObject } from '@lwc/shared';
 import { renderer } from '../renderer';
-import { setIsHydrating } from '../renderer';
 
 function resetShadowRootAndLightDom(element: Element, Ctor: typeof LightningElement) {
     if (element.shadowRoot) {
@@ -77,16 +76,9 @@ export function hydrateComponent(
     }
 
     try {
-        // Let the renderer know we are hydrating, so it does not replace the existing shadowRoot
-        // and uses the same algo to create the stylesheets as in SSR.
-        setIsHydrating(true);
-
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);
-
-        // set it back since now we finished hydration.
-        setIsHydrating(false);
     } catch (e) {
         // Fallback: In case there's an error while hydrating, let's log the error, and replace the element content
         //           with the client generated DOM.
@@ -99,11 +91,7 @@ export function hydrateComponent(
 
         // we need to recreate the vm with the hydration flag on, so it re-uses the existing shadowRoot.
         createVMWithProps(element, Ctor, props);
-        setIsHydrating(false);
 
         connectRootElement(element);
-    } finally {
-        // in case there's an error during recovery
-        setIsHydrating(false);
     }
 }

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -16,6 +16,7 @@ import {
     KEY__SHADOW_TOKEN,
     setPrototypeOf,
     StringToLowerCase,
+    isNull,
 } from '@lwc/shared';
 import { insertStylesheet } from './styles';
 import { createFragment } from './createFragment';
@@ -82,17 +83,7 @@ if (isCustomElementRegistryAvailable()) {
     HTMLElementConstructor.prototype = HTMLElement.prototype;
 }
 
-let hydrating = false;
-
-export function setIsHydrating(value: boolean) {
-    hydrating = value;
-}
-
 const ssr: boolean = false;
-
-function isHydrating(): boolean {
-    return hydrating;
-}
 
 const isNativeShadowDefined: boolean = globalThis[KEY__IS_NATIVE_SHADOW_ROOT_DEFINED];
 export const isSyntheticShadowDefined: boolean = hasOwnProperty.call(
@@ -131,15 +122,11 @@ function nextSibling(node: Node): Node | null {
 }
 
 function attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
-    // `hydrating` will be true in two cases:
+    // `shadowRoot` will be non-null in two cases:
     //   1. upon initial load with an SSR-generated DOM, while in Shadow render mode
     //   2. when a webapp author places <c-app> in their static HTML and mounts their
-    //      root component with customeElement.define('c-app', Ctor)
-    //
-    // The second case can be treated as a failed hydration with nominal impact
-    // to performance. However, because <c-app> won't have a <template shadowroot>
-    // declarative child, `element.shadowRoot` is `null`.
-    if (hydrating && element.shadowRoot) {
+    //      root component with customElement.define('c-app', Ctor)
+    if (!isNull(element.shadowRoot)) {
         return element.shadowRoot;
     }
     return element.attachShadow(options);
@@ -295,7 +282,6 @@ export const renderer = {
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     HTMLElementExported,
-    isHydrating,
     insert,
     remove,
     cloneNode,

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -77,10 +77,6 @@ class HTMLElementImpl {
 
 const ssr: boolean = true;
 
-function isHydrating(): boolean {
-    return false;
-}
-
 const isNativeShadowDefined: boolean = false;
 const isSyntheticShadowDefined: boolean = false;
 
@@ -416,7 +412,6 @@ export const renderer = {
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     HTMLElementExported,
-    isHydrating,
     insert,
     remove,
     cloneNode,


### PR DESCRIPTION
## Details

Rebased and slightly-tweaked version of #2806. I only wrote it because I forgot that that PR existed.

Based on what I've seen with pivots (#2724), we don't need `isHydrating` anymore, and in fact it breaks some tests in that PR if I don't remove it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->