### PR TITLE
refactor(engine): remove ssr global flag

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -11,7 +11,6 @@ type N = HostNode;
 type E = HostElement;
 
 export interface RendererAPI {
-    ssr: boolean;
     isNativeShadowDefined: boolean;
     isSyntheticShadowDefined: boolean;
     HTMLElementExported: typeof HTMLElement;

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -213,13 +213,13 @@ export function createStylesheet(vm: VM, stylesheets: string[]): VNode[] | null 
     const {
         renderMode,
         shadowMode,
-        renderer: { ssr, insertStylesheet },
+        renderer: { insertStylesheet },
     } = vm;
     if (renderMode === RenderMode.Shadow && shadowMode === ShadowMode.Synthetic) {
         for (let i = 0; i < stylesheets.length; i++) {
             insertStylesheet(stylesheets[i]);
         }
-    } else if (ssr || vm.hydrated) {
+    } else if (!process.env.IS_BROWSER || vm.hydrated) {
         // Note: We need to ensure that during hydration, the stylesheets method is the same as those in ssr.
         //       This works in the client, because the stylesheets are created, and cached in the VM
         //       the first time the VM renders.

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -475,10 +475,9 @@ function patchShadowRoot(vm: VM, newCh: VNodes) {
 export function runRenderedCallback(vm: VM) {
     const {
         def: { renderedCallback },
-        renderer: { ssr },
     } = vm;
 
-    if (isTrue(ssr)) {
+    if (!process.env.IS_BROWSER) {
         return;
     }
 
@@ -674,10 +673,7 @@ export function resetComponentRoot(vm: VM) {
 }
 
 export function scheduleRehydration(vm: VM) {
-    const {
-        renderer: { ssr },
-    } = vm;
-    if (isTrue(ssr) || isTrue(vm.isScheduled)) {
+    if (!process.env.IS_BROWSER || isTrue(vm.isScheduled)) {
         return;
     }
 

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -88,8 +88,6 @@ export function setIsHydrating(value: boolean) {
     hydrating = value;
 }
 
-const ssr: boolean = false;
-
 function isHydrating(): boolean {
     return hydrating;
 }
@@ -291,7 +289,6 @@ function assertInstanceOfHTMLElement(elm: any, msg: string) {
 const HTMLElementExported = HTMLElementConstructor as typeof HTMLElement;
 
 export const renderer = {
-    ssr,
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     HTMLElementExported,

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -75,8 +75,6 @@ class HTMLElementImpl {
     }
 }
 
-const ssr: boolean = true;
-
 function isHydrating(): boolean {
     return false;
 }
@@ -412,7 +410,6 @@ const HTMLElementExported = HTMLElementImpl as typeof HTMLElement;
 const assertInstanceOfHTMLElement = noop as (elm: any, msg: string) => void;
 
 export const renderer = {
-    ssr,
     isNativeShadowDefined,
     isSyntheticShadowDefined,
     HTMLElementExported,


### PR DESCRIPTION
## Details

Now that we have `process.env.IS_BROWSER` (via #2961), we can use that instead of `renderer.ssr`. It's strictly better, because it will cause SSR-only/browser-only code to get tree-shaken when building `engine-dom`/`engine-server`. Also Locker does not need to intercept `renderer.ssr`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->