### PR TITLE
fix(babel-plugin-component): default/star imports should not throw

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/export-engine-star/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/export-engine-star/actual.js
@@ -1,0 +1,1 @@
+export * as lwc from 'lwc'

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/export-engine-star/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/export-engine-star/expected.js
@@ -1,0 +1,1 @@
+export * as lwc from 'lwc';

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
@@ -1,0 +1,6 @@
+import lwc, {LightningElement} from 'lwc'
+
+// eslint-disable-next-line no-console
+console.log(lwc)
+
+export default class extends LightningElement {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
@@ -1,0 +1,9 @@
+import _tmpl from "./test.html";
+import lwc, { registerComponent as _registerComponent, LightningElement } from "lwc";
+// eslint-disable-next-line no-console
+console.log(lwc);
+export default _registerComponent(class extends LightningElement {
+  /*LWC compiler vX.X.X*/
+}, {
+  tmpl: _tmpl
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
@@ -1,0 +1,4 @@
+import lwc from 'lwc'
+
+// eslint-disable-next-line no-console
+console.log(lwc)

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
@@ -1,0 +1,3 @@
+import lwc from 'lwc'; // eslint-disable-next-line no-console
+
+console.log(lwc);

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-star/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-star/actual.js
@@ -1,0 +1,3 @@
+import * as lwc from 'lwc'
+
+export default class extends lwc.LightningElement {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-star/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-star/expected.js
@@ -1,0 +1,8 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent } from "lwc";
+import * as lwc from 'lwc';
+export default _registerComponent(class extends lwc.LightningElement {
+  /*LWC compiler vX.X.X*/
+}, {
+  tmpl: _tmpl
+});

--- a/packages/@lwc/babel-plugin-component/src/utils.js
+++ b/packages/@lwc/babel-plugin-component/src/utils.js
@@ -55,6 +55,8 @@ function getEngineImportSpecifiers(path) {
         imports
             // Flat-map the specifier list for each import statement
             .flatMap((importStatement) => importStatement.get('specifiers'))
+            // Skip ImportDefaultSpecifier and ImportNamespaceSpecifier
+            .filter((specifier) => specifier.type === 'ImportSpecifier')
             // Get the list of specifiers with their name
             .map((specifier) => {
                 const imported = specifier.get('imported').node.name;


### PR DESCRIPTION
## Details

Currently the Babel plugin will throw an error at this line if the code it's processing tries to import the default or `*` from the `"lwc"` package:

https://github.com/salesforce/lwc/blob/03491dcf775021f3ba42cc49431238947f6504a7/packages/%40lwc/babel-plugin-component/src/utils.js#L60

The reason is that `specifier.get('imported').node` is undefined.

This PR fixes that. It doesn't attempt to surface any errors for `import lwc from 'lwc'` or `import * as lwc from 'lwc'` since that's already handled by `eslint-plugin-lwc`. The goal is just to avoid an unhandled exception.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
