### PR TITLE
feat: refactor parser context to support new behavior for slot name tracking

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -638,33 +638,39 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Error,
         url: '',
     },
-    INVALID_IF_BLOCK_DIRECTIVE_WITH_CONDITIONAL: {
+    ELSE_BLOCK_DIRECTIVE_CANNOT_HAVE_VALUE: {
         code: 1155,
+        message: 'lwc:else directive cannot have a value',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+    INVALID_IF_BLOCK_DIRECTIVE_WITH_CONDITIONAL: {
+        code: 1156,
         message: "Invalid usage of 'lwc:if' and '{0}' directives on the same element.",
         level: DiagnosticLevel.Error,
         url: '',
     },
     INVALID_ELSEIF_BLOCK_DIRECTIVE_WITH_CONDITIONAL: {
-        code: 1156,
+        code: 1157,
         message: "Invalid usage of 'lwc:elseif' and '{0}' directives on the same element.",
         level: DiagnosticLevel.Error,
         url: '',
     },
     INVALID_ELSE_BLOCK_DIRECTIVE_WITH_CONDITIONAL: {
-        code: 1157,
+        code: 1158,
         message: "Invalid usage of 'lwc:else' and '{0}' directives on the same element.",
         level: DiagnosticLevel.Error,
         url: '',
     },
     LWC_IF_SCOPE_NOT_FOUND: {
-        code: 1158,
+        code: 1159,
         message:
             "'{0}' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.",
         level: DiagnosticLevel.Error,
         url: '',
     },
     LWC_IF_CANNOT_BE_USED_WITH_IF_DIRECTIVE: {
-        code: 1159,
+        code: 1160,
         message:
             "'{0}' directive cannot be used with 'lwc:if', 'lwc:elseif', or 'lwc:else directives on the same element.",
         level: DiagnosticLevel.Error,

--- a/packages/@lwc/template-compiler/src/__tests__/elseif.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/elseif.spec.ts
@@ -22,7 +22,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -38,7 +38,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -54,7 +54,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -70,13 +70,35 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
     });
 
     describe('invalid uses', () => {
+        it('should throw an error when lwc:else has an expression value', () => {
+            const { warnings } = parseTemplate(
+                `<template>
+                    <template lwc:if={visible}>Conditional Text</template>
+                    <template lwc:else={invalidCondition}>Invalid Text</template>
+                </template>`
+            );
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({});
+        });
+        it('should throw an error when lwc:else has a string value', () => {
+            const { warnings } = parseTemplate(
+                `<template>
+                    <template lwc:if={visible}>Conditional Text</template>
+                    <template lwc:else="invalid">Invalid Text</template>
+                </template>`
+            );
+
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toMatchObject({});
+        });
         it('multiple directives on single element - if and elseif', () => {
             const { warnings } = parseTemplate(
                 `<template><template lwc:if={visible} lwc:elseif={elseif}>Conditional Text</template></template>`
@@ -85,7 +107,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1155: Invalid usage of 'lwc:if' and 'lwc:elseif' directives on the same element.`,
+                message: `LWC1156: Invalid usage of 'lwc:if' and 'lwc:elseif' directives on the same element.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -97,30 +119,10 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1155: Invalid usage of 'lwc:if' and 'lwc:else' directives on the same element.`,
+                message: `LWC1156: Invalid usage of 'lwc:if' and 'lwc:else' directives on the same element.`,
                 location: EXPECTED_LOCATION,
             });
         });
-        /**
-         * Parser should throw the error for multiple directives on an element rather than
-         * the error for not having a preceding lwc:if. This would require a more extensive
-         * refactor of the parsing logic here.
-         */
-        it.skip('multiple directives on single element - elseif and else', () => {
-            const { warnings } = parseTemplate(
-                `<template>
-                    <template lwc:else lwc:elseif={visible}>Conditional Text</template>
-                </template>`
-            );
-
-            expect(warnings.length).toBe(1);
-            expect(warnings[0]).toMatchObject({
-                level: DiagnosticLevel.Error,
-                message: `LWC1155: Invalid usage of 'lwc:elseif' and 'lwc:else' directives on the same element.`,
-                location: EXPECTED_LOCATION,
-            });
-        });
-        // Currently doesn't have a way to identify when we've previously visited an elseif vs if
         it('multiple directives on single element - elseif and else', () => {
             const { warnings } = parseTemplate(
                 `<template>
@@ -132,7 +134,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1156: Invalid usage of 'lwc:elseif' and 'lwc:else' directives on the same element.`,
+                message: `LWC1157: Invalid usage of 'lwc:elseif' and 'lwc:else' directives on the same element.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -199,7 +201,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:elseif' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -215,7 +217,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -231,7 +233,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1159: 'if:true' directive cannot be used with 'lwc:if', 'lwc:elseif', or 'lwc:else directives on the same element.`,
+                message: `LWC1160: 'if:true' directive cannot be used with 'lwc:if', 'lwc:elseif', or 'lwc:else directives on the same element.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -247,7 +249,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1159: 'if:true' directive cannot be used with 'lwc:if', 'lwc:elseif', or 'lwc:else directives on the same element.`,
+                message: `LWC1160: 'if:true' directive cannot be used with 'lwc:if', 'lwc:elseif', or 'lwc:else directives on the same element.`,
                 location: EXPECTED_LOCATION,
             });
         });
@@ -480,7 +482,7 @@ describe('lwc if/elseif/else directives', () => {
                 `<template>
                     <h1 lwc:if={visible}>Visible Header</h1>
                     <h1 lwc:elseif={elseifCondition}>First Alternative Header</h1>
-                    <h1 lwc:else={elseCondition}>Alternative Header</h1>
+                    <h1 lwc:else>Alternative Header</h1>
                 </template>`
             );
 
@@ -923,7 +925,7 @@ describe('lwc if/elseif/else directives', () => {
             expect(warnings.length).toBe(1);
             expect(warnings[0]).toMatchObject({
                 level: DiagnosticLevel.Error,
-                message: `LWC1158: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
+                message: `LWC1159: 'lwc:else' directive must be used immediately after an element with 'lwc:if' or 'lwc:elseif'. No such element found.`,
                 location: EXPECTED_LOCATION,
             });
         });

--- a/packages/@lwc/template-compiler/src/__tests__/elseif.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/elseif.spec.ts
@@ -742,6 +742,52 @@ describe('lwc if/elseif/else directives', () => {
         });
     });
 
+    describe('mixed', () => {
+        it('if-elseif-else', () => {
+            const { root } = parseTemplate(
+                `<template>
+                    <template lwc:if={visible}>Conditional Text</template>
+                    <div lwc:elseif={elseifCondition}>Elseif!</div>
+                    <c-default lwc:else>Else!</c-default>
+                </template>`
+            );
+
+            expect(root.children[0]).toMatchObject({
+                type: 'IfBlock',
+                condition: {
+                    type: 'Identifier',
+                },
+                children: [
+                    {
+                        type: 'Text',
+                        raw: 'Conditional Text',
+                    },
+                ],
+                else: {
+                    type: 'ElseifBlock',
+                    condition: {
+                        type: 'Identifier',
+                    },
+                    children: [
+                        {
+                            type: 'Element',
+                            name: 'div',
+                        },
+                    ],
+                    else: {
+                        type: 'ElseBlock',
+                        children: [
+                            {
+                                type: 'Component',
+                                name: 'c-default',
+                            },
+                        ],
+                    },
+                },
+            });
+        });
+    });
+
     describe('slots', () => {
         it('should warn about duplicate slots when the slots are not rendered in a conditional tree', () => {
             const { warnings } = parseTemplate(

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -600,6 +600,7 @@ function parseElseBlock(
         return;
     }
 
+    // Cannot be used with lwc:if on the same element
     const hasIfBlock = ctx.findInCurrentElementScope(ast.isIfBlock);
     if (hasIfBlock) {
         ctx.throwAtLocation(
@@ -609,6 +610,7 @@ function parseElseBlock(
         );
     }
 
+    // Cannot be used with lwc:elseif on the same element
     const hasElseifBlock = ctx.findInCurrentElementScope(ast.isElseifBlock);
     if (hasElseifBlock) {
         ctx.throwAtLocation(
@@ -618,12 +620,24 @@ function parseElseBlock(
         );
     }
 
+    // Must be used immediately after an lwc:if or lwc:elseif
     const conditionalParent = ctx.getSiblingIfNode();
     if (!conditionalParent || !ast.isConditionalParentBlock(conditionalParent)) {
         ctx.throwAtLocation(
             ParserDiagnostics.LWC_IF_SCOPE_NOT_FOUND,
             ast.sourceLocation(parse5ElmLocation),
             [elseBlockAttribute.name]
+        );
+    }
+
+    // Must not have a value
+    if (
+        ast.isExpression(elseBlockAttribute.value) ||
+        ast.isStringLiteral(elseBlockAttribute.value)
+    ) {
+        ctx.throwAtLocation(
+            ParserDiagnostics.ELSE_BLOCK_DIRECTIVE_CANNOT_HAVE_VALUE,
+            ast.sourceLocation(parse5ElmLocation)
         );
     }
 

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -297,7 +297,7 @@ function parseBaseElement(
     }
 
     if (element) {
-        ctx.addNodeCurrentScope(element);
+        ctx.addNodeCurrentElementScope(element);
         parent.children.push(element);
     }
 
@@ -316,15 +316,24 @@ function parseChildren(
     for (const child of children) {
         ctx.withErrorRecovery(() => {
             if (parse5Utils.isElementNode(child)) {
-                ctx.beginScope();
+                ctx.beginElementScope();
                 parseElement(ctx, child, parent, parse5ParentLocation);
-                ctx.endScope();
+
+                const node = ctx.endElementScope();
+                if (
+                    node &&
+                    ctx.isParsingIfBlock() &&
+                    !ast.isIfBlock(node) &&
+                    !ast.isElseifBlock(node)
+                ) {
+                    ctx.endIfContext();
+                }
             } else if (parse5Utils.isTextNode(child)) {
                 const textNodes = parseText(ctx, child);
                 parent.children.push(...textNodes);
                 // Non whitespace text nodes interrupt any context we may be carrying
-                if (textNodes.length > 0) {
-                    ctx.clearSiblingScope();
+                if (ctx.isParsingIfBlock() && textNodes.length > 0) {
+                    ctx.endIfContext();
                 }
             } else if (parse5Utils.isCommentNode(child)) {
                 const commentNode = parseComment(child);
@@ -332,8 +341,8 @@ function parseChildren(
                 // Comment behavior depends on whether preserveComments is enabled.
                 // If it is enabled, comments become syntactically meaningful and
                 // interrupt any context we may be carrying
-                if (ctx.preserveComments) {
-                    ctx.clearSiblingScope();
+                if (ctx.isParsingIfBlock() && ctx.preserveComments) {
+                    ctx.endIfContext();
                 }
             }
         });
@@ -467,7 +476,7 @@ function parseIf(
     }
 
     // if:true cannot be used with lwc:if, lwc:elseif, lwc:else
-    const incompatibleDirective = ctx.findInCurrentScope(ast.isConditionalBlock);
+    const incompatibleDirective = ctx.findInCurrentElementScope(ast.isConditionalBlock);
     if (incompatibleDirective) {
         ctx.throwAtLocation(
             ParserDiagnostics.LWC_IF_CANNOT_BE_USED_WITH_IF_DIRECTIVE,
@@ -492,7 +501,7 @@ function parseIf(
         ifAttribute.location
     );
 
-    ctx.addNodeCurrentScope(node);
+    ctx.addNodeCurrentElementScope(node);
     parent.children.push(node);
 
     return node;
@@ -522,7 +531,7 @@ function parseIfBlock(
         ifBlockAttribute.location
     );
 
-    ctx.addNodeCurrentScope(ifNode);
+    ctx.addNodeCurrentElementScope(ifNode);
     ctx.beginIfContext(ifNode);
     parent.children.push(ifNode);
 
@@ -540,7 +549,7 @@ function parseElseifBlock(
         return;
     }
 
-    const hasIfBlock = ctx.findInCurrentScope(ast.isIfBlock);
+    const hasIfBlock = ctx.findInCurrentElementScope(ast.isIfBlock);
     if (hasIfBlock) {
         ctx.throwAtLocation(
             ParserDiagnostics.INVALID_IF_BLOCK_DIRECTIVE_WITH_CONDITIONAL,
@@ -556,8 +565,8 @@ function parseElseifBlock(
         );
     }
 
-    const parentIfBlock = ctx.getPrevSiblingIfNode();
-    if (!parentIfBlock) {
+    const conditionalParent = ctx.getSiblingIfNode();
+    if (!conditionalParent || !ast.isConditionalParentBlock(conditionalParent)) {
         ctx.throwAtLocation(
             ParserDiagnostics.LWC_IF_SCOPE_NOT_FOUND,
             ast.sourceLocation(parse5ElmLocation),
@@ -572,8 +581,9 @@ function parseElseifBlock(
     );
 
     // Attach the node as a child of the preceding IfBlock
-    ctx.addNodeCurrentScope(elseifNode);
-    parentIfBlock.else = elseifNode;
+    ctx.addNodeCurrentElementScope(elseifNode);
+    ctx.updateIfContext(elseifNode);
+    conditionalParent.else = elseifNode;
 
     return elseifNode;
 }
@@ -589,7 +599,7 @@ function parseElseBlock(
         return;
     }
 
-    const hasIfBlock = ctx.findInCurrentScope(ast.isIfBlock);
+    const hasIfBlock = ctx.findInCurrentElementScope(ast.isIfBlock);
     if (hasIfBlock) {
         ctx.throwAtLocation(
             ParserDiagnostics.INVALID_IF_BLOCK_DIRECTIVE_WITH_CONDITIONAL,
@@ -598,8 +608,17 @@ function parseElseBlock(
         );
     }
 
-    const parentIfBlock = ctx.getPrevSiblingIfNode();
-    if (!parentIfBlock) {
+    const hasElseifBlock = ctx.findInCurrentElementScope(ast.isElseifBlock);
+    if (hasElseifBlock) {
+        ctx.throwAtLocation(
+            ParserDiagnostics.INVALID_ELSEIF_BLOCK_DIRECTIVE_WITH_CONDITIONAL,
+            ast.sourceLocation(parse5ElmLocation),
+            [elseBlockAttribute.name]
+        );
+    }
+
+    const conditionalParent = ctx.getSiblingIfNode();
+    if (!conditionalParent || !ast.isConditionalParentBlock(conditionalParent)) {
         ctx.throwAtLocation(
             ParserDiagnostics.LWC_IF_SCOPE_NOT_FOUND,
             ast.sourceLocation(parse5ElmLocation),
@@ -613,8 +632,9 @@ function parseElseBlock(
     );
 
     // Attach the node as a child of the preceding IfBlock
-    ctx.addNodeCurrentScope(elseNode);
-    parentIfBlock.else = elseNode;
+    ctx.addNodeCurrentElementScope(elseNode);
+    ctx.updateIfContext(elseNode);
+    conditionalParent.else = elseNode;
 
     return elseNode;
 }
@@ -861,7 +881,7 @@ function parseForEach(
             index
         );
 
-        ctx.addNodeCurrentScope(node);
+        ctx.addNodeCurrentElementScope(node);
         parent.children.push(node);
 
         return node;
@@ -884,7 +904,7 @@ function parseForOf(
         return;
     }
 
-    const hasForEach = ctx.findInCurrentScope(ast.isForEach);
+    const hasForEach = ctx.findInCurrentElementScope(ast.isForEach);
     if (hasForEach) {
         ctx.throwAtLocation(
             ParserDiagnostics.INVALID_FOR_EACH_WITH_ITERATOR,
@@ -911,7 +931,7 @@ function parseForOf(
         iteratorExpression.location
     );
 
-    ctx.addNodeCurrentScope(node);
+    ctx.addNodeCurrentElementScope(node);
     parent.children.push(node);
 
     return node;
@@ -966,7 +986,7 @@ function parseSlot(
     const location = ast.sourceLocation(parse5ElmLocation);
 
     const hasDirectives =
-        ctx.findInCurrentScope(ast.isForBlock) || ctx.findInCurrentScope(ast.isIf);
+        ctx.findInCurrentElementScope(ast.isForBlock) || ctx.findInCurrentElementScope(ast.isIf);
     if (hasDirectives) {
         ctx.throwAtLocation(ParserDiagnostics.SLOT_TAG_CANNOT_HAVE_DIRECTIVES, location);
     }
@@ -1007,8 +1027,8 @@ function parseSlot(
         }
     }
 
-    const alreadySeen = ctx.seenSlots.has(name);
-    ctx.seenSlots.add(name);
+    const alreadySeen = ctx.hasSeenSlot(name);
+    ctx.addSeenSlot(name);
 
     if (alreadySeen) {
         ctx.warnAtLocation(ParserDiagnostics.NO_DUPLICATE_SLOTS, location, [

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -185,7 +185,7 @@ export default class ParserCtx {
     }
 
     hasSeenSlot(name: string): boolean {
-        return this.hasSeenSlotInParentIfTree(name);
+        return this.hasSeenSlotInAncestorIfTree(name);
     }
 
     addSeenSlot(name: string): void {
@@ -254,10 +254,10 @@ export default class ParserCtx {
         }
 
         // Merge seen slot names from the current if chain into the parent scope.
-        const seenSlotsInParentIfTree = this.seenSlotsFromAncestorIfTree();
+        const seenSlotsInAncestorIfTree = this.seenSlotsFromAncestorIfTree();
         for (const seenSlots of currentIfContext.seenSlots) {
             for (const name of seenSlots) {
-                seenSlotsInParentIfTree.add(name);
+                seenSlotsInAncestorIfTree.add(name);
             }
         }
 
@@ -275,7 +275,7 @@ export default class ParserCtx {
         return !!this.currentIfContext() || !!this.ancestorIfContext();
     }
 
-    private hasSeenSlotInParentIfTree(name: string): boolean {
+    private hasSeenSlotInAncestorIfTree(name: string): boolean {
         const seenSlots = this.seenSlotsFromAncestorIfTree();
         return !!seenSlots && seenSlots.has(name);
     }

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -14,12 +14,7 @@ import {
     normalizeToDiagnostic,
 } from '@lwc/errors';
 import { NormalizedConfig } from '../config';
-import {
-    isElseifBlock,
-    isIfBlock,
-    isPreserveCommentsDirective,
-    isRenderModeDirective,
-} from '../shared/ast';
+import { isPreserveCommentsDirective, isRenderModeDirective } from '../shared/ast';
 
 import {
     Root,
@@ -29,6 +24,7 @@ import {
     LWCDirectiveRenderMode,
     IfBlock,
     ElseifBlock,
+    ElseBlock,
 } from '../shared/types';
 
 function normalizeLocation(location?: SourceLocation): Location {
@@ -53,13 +49,13 @@ interface ParentWrapper {
 }
 
 interface IfContext {
-    ifBlockParent: IfBlock;
-    seenSlots: Set<string>;
+    currentNode: IfBlock | ElseifBlock | ElseBlock;
+    seenSlots: Set<string>[];
 }
 
-interface SiblingContext {
-    nodes: ParentNode[];
+interface SiblingScope {
     ifContext?: IfContext;
+    parentIfContext?: IfContext;
 }
 
 export default class ParserCtx {
@@ -72,20 +68,23 @@ export default class ParserCtx {
     readonly seenSlots: Set<string> = new Set();
 
     /**
-     * Scopes keep track of context from sibling nodes and the hierarchy of ParentNodes as the parser
-     * traverses the parse5 AST. Each scope object contains the following:
-     * - an array where each node in the array corresponds to either a ForEach, ForOf, If, Element, Component, or Slot.
-     * - an array holding a cache of the immediately preceding sibling's scope, if relevant.
-     *      - currently, that's IFF the parser is in the process of parsing a series of sibling if|elseif|else directives.
+     * 'elementScopes' keeps track of the hierarchy of ParentNodes as the parser
+     * traverses the parse5 AST. Each 'elementScope' is an array where each node in
+     * the array corresponds to either an IfBlock, ElseifBlock, ElseBlock, ForEach, ForOf, If, Element, Component, or Slot.
      *
-     * Currently, each scope has a hierarchy of ForBlock > IfBlock > Element | Component | Slot.
-     * Note: Not all scopes will have all three, but when they do, they will appear in this order.
+     * Currently, each elementScope has a hierarchy of IfBlock > ForBlock > IfBlock > Element | Component | Slot.
+     * Note: Not all scopes will have all, but when they do, they will appear in this order.
      * We do not keep track of template nodes.
      *
      * Each scope corresponds to the original parse5.Element node.
      */
     private readonly elementScopes: ParentNode[][] = [];
-    private readonly siblingContexts: SiblingContext[] = [];
+
+    /**
+     * 'siblingScopes' keeps track of the context from one sibling node to another.
+     * This is currently used to hold the info needed to properly parse lwc:if, lwc:elseif, and lwc:else directives.
+     */
+    private readonly siblingScopes: SiblingScope[] = [];
 
     renderMode: LWCDirectiveRenderMode;
     preserveComments: boolean;
@@ -154,104 +153,142 @@ export default class ParserCtx {
      * @param {function} predicate - This callback is called once for each sibling in the current scope
      * until it finds one where predicate returns true.
      */
-    findInCurrentScope<A extends ParentNode>(predicate: (node: ParentNode) => node is A): A | null {
-        const currentScope = this.currentScope() || [];
-        const sibling = currentScope.find(predicate);
-        return sibling || null;
+    findInCurrentElementScope<A extends ParentNode>(
+        predicate: (node: ParentNode) => node is A
+    ): A | null {
+        const currentScope = this.currentElementScope() || [];
+        return currentScope.find(predicate) || null;
     }
 
-    beginScope(): void {
+    beginElementScope(): void {
         this.elementScopes.push([]);
     }
 
-    endScope(): void {
+    endElementScope(): ParentNode | undefined {
         const scope = this.elementScopes.pop();
-        if (scope) {
-            this.setSiblingNodes(scope);
+        return scope ? scope[0] : undefined;
+    }
+
+    addNodeCurrentElementScope(node: ParentNode): void {
+        const currentScope = this.currentElementScope();
+
+        if (!currentScope) {
+            throw new Error("Can't invoke addNodeCurrentElementScope if there is no current scope");
+        }
+
+        currentScope.push(node);
+    }
+
+    hasSeenSlot(name: string): boolean {
+        return this.hasSeenSlotInParentIfTree(name);
+    }
+
+    addSeenSlot(name: string): void {
+        const currentSeenSlots = this.seenSlotsFromParentIfTree();
+        if (currentSeenSlots) {
+            currentSeenSlots.add(name);
+        } else {
+            this.seenSlots.add(name);
         }
     }
 
-    addNodeCurrentScope(node: ParentNode): void {
-        const currentScopeNodes = this.currentScope();
-
-        if (!currentScopeNodes) {
-            throw new Error("Can't invoke addNodeCurrentScope if there is no current scope");
-        }
-
-        currentScopeNodes.push(node);
+    private currentElementScope(): ParentNode[] | undefined {
+        return this.elementScopes[this.elementScopes.length - 1];
     }
 
     beginSiblingScope() {
-        this.siblingContexts.push({
-            nodes: [],
+        this.siblingScopes.push({
+            parentIfContext: this.currentIfContext() || this.parentIfContext(),
         });
     }
 
     endSiblingScope() {
-        this.siblingContexts.pop();
+        this.siblingScopes.pop();
     }
 
-    clearSiblingScope() {
-        this.setSiblingNodes([]);
-        this.setCurrentIfContext(undefined);
-    }
-
-    getPrevSiblingIfNode(): IfBlock | ElseifBlock | undefined {
-        const currentSiblingContext = this.currentSiblingContext();
-        if (!currentSiblingContext) {
-            throw new Error("Can't invoke getPrevSiblingIfNode if there is no current scope");
-        }
-
-        const nodes = currentSiblingContext.nodes;
-        if (nodes[0] && (isIfBlock(nodes[0]) || isElseifBlock(nodes[0]))) {
-            return nodes[0];
-        }
-        return undefined;
-    }
-
-    private currentScope(): ParentNode[] | undefined {
-        return this.elementScopes[this.elementScopes.length - 1];
-    }
-
-    private currentSiblingContext(): SiblingContext | undefined {
-        return this.siblingContexts[this.siblingContexts.length - 1];
-    }
-
-    private setSiblingNodes(nodes: ParentNode[]) {
-        this.siblingContexts[this.siblingContexts.length - 1].nodes = nodes;
-    }
-
-    /**
-     * IF CONTEXT STUFF
-     */
     beginIfContext(node: IfBlock) {
         const currentSiblingContext = this.currentSiblingContext();
         if (!currentSiblingContext) {
             throw new Error();
         }
 
+        this.endIfContext();
+
+        const previouslySeenSlots = this.seenSlotsFromParentIfTree();
         currentSiblingContext.ifContext = {
-            ifBlockParent: node,
-            seenSlots: new Set<string>(),
+            currentNode: node,
+            seenSlots: [
+                previouslySeenSlots ? new Set<string>(previouslySeenSlots) : new Set<string>(),
+            ],
         };
     }
 
+    updateIfContext(node: ElseifBlock | ElseBlock) {
+        const currentIfContext = this.currentIfContext();
+        if (!currentIfContext) {
+            throw new Error();
+        }
+
+        currentIfContext.currentNode = node;
+
+        const previouslySeenSlots = this.seenSlotsFromParentIfTree();
+        currentIfContext.seenSlots.push(
+            previouslySeenSlots ? new Set<string>(previouslySeenSlots) : new Set<string>()
+        );
+    }
+
     endIfContext() {
-        this.setCurrentIfContext(undefined);
-    }
+        const currentIfContext = this.currentIfContext();
+        if (!currentIfContext) {
+            return;
+        }
 
-    private getCurrentIfContext(): IfContext | undefined {
+        // Merge seen slot names from the current if-block
+        // into the parent scope.
+        const seenSlotsInParentIfTree = this.seenSlotsFromParentIfTree();
+        for (const seenSlots of currentIfContext.seenSlots) {
+            for (const name of seenSlots) {
+                seenSlotsInParentIfTree.add(name);
+            }
+        }
+
         const currentSiblingContext = this.currentSiblingContext();
         if (currentSiblingContext) {
-            return currentSiblingContext.ifContext;
+            currentSiblingContext.ifContext = undefined;
         }
     }
 
-    private setCurrentIfContext(context: IfContext | undefined): void {
-        const currentSiblingContext = this.currentSiblingContext();
-        if (currentSiblingContext) {
-            currentSiblingContext.ifContext = context;
+    getSiblingIfNode(): ParentNode | undefined {
+        return this.currentIfContext()?.currentNode;
+    }
+
+    isParsingIfBlock(): boolean {
+        return !!this.currentIfContext() || !!this.parentIfContext();
+    }
+
+    private hasSeenSlotInParentIfTree(name: string): boolean {
+        const seenSlots = this.seenSlotsFromParentIfTree();
+        return !!seenSlots && seenSlots.has(name);
+    }
+
+    private currentSiblingContext(): SiblingScope | undefined {
+        return this.siblingScopes[this.siblingScopes.length - 1];
+    }
+
+    private currentIfContext(): IfContext | undefined {
+        return this.currentSiblingContext()?.ifContext;
+    }
+
+    private parentIfContext(): IfContext | undefined {
+        return this.currentSiblingContext()?.parentIfContext;
+    }
+
+    private seenSlotsFromParentIfTree(): Set<string> {
+        const parentIfContext = this.parentIfContext();
+        if (parentIfContext) {
+            return parentIfContext.seenSlots[parentIfContext.seenSlots.length - 1];
         }
+        return this.seenSlots;
     }
 
     /**

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -60,7 +60,7 @@ interface IfContext {
 
 interface SiblingScope {
     ifContext?: IfContext;
-    parentIfContext?: IfContext;
+    ancestorIfContext?: IfContext;
 }
 
 export default class ParserCtx {
@@ -189,7 +189,7 @@ export default class ParserCtx {
     }
 
     addSeenSlot(name: string): void {
-        const currentSeenSlots = this.seenSlotsFromParentIfTree();
+        const currentSeenSlots = this.seenSlotsFromAncestorIfTree();
         if (currentSeenSlots) {
             currentSeenSlots.add(name);
         } else {
@@ -203,7 +203,7 @@ export default class ParserCtx {
 
     beginSiblingScope() {
         this.siblingScopes.push({
-            parentIfContext: this.currentIfContext() || this.parentIfContext(),
+            ancestorIfContext: this.currentIfContext() || this.ancestorIfContext(),
         });
     }
 
@@ -224,7 +224,7 @@ export default class ParserCtx {
             this.endIfChain();
         }
 
-        const previouslySeenSlots = this.seenSlotsFromParentIfTree();
+        const previouslySeenSlots = this.seenSlotsFromAncestorIfTree();
         currentSiblingContext.ifContext = {
             currentNode: node,
             seenSlots: [
@@ -241,7 +241,7 @@ export default class ParserCtx {
 
         currentIfContext.currentNode = node;
 
-        const previouslySeenSlots = this.seenSlotsFromParentIfTree();
+        const previouslySeenSlots = this.seenSlotsFromAncestorIfTree();
         currentIfContext.seenSlots.push(
             previouslySeenSlots ? new Set<string>(previouslySeenSlots) : new Set<string>()
         );
@@ -254,7 +254,7 @@ export default class ParserCtx {
         }
 
         // Merge seen slot names from the current if chain into the parent scope.
-        const seenSlotsInParentIfTree = this.seenSlotsFromParentIfTree();
+        const seenSlotsInParentIfTree = this.seenSlotsFromAncestorIfTree();
         for (const seenSlots of currentIfContext.seenSlots) {
             for (const name of seenSlots) {
                 seenSlotsInParentIfTree.add(name);
@@ -272,11 +272,11 @@ export default class ParserCtx {
     }
 
     isParsingIfBlock(): boolean {
-        return !!this.currentIfContext() || !!this.parentIfContext();
+        return !!this.currentIfContext() || !!this.ancestorIfContext();
     }
 
     private hasSeenSlotInParentIfTree(name: string): boolean {
-        const seenSlots = this.seenSlotsFromParentIfTree();
+        const seenSlots = this.seenSlotsFromAncestorIfTree();
         return !!seenSlots && seenSlots.has(name);
     }
 
@@ -288,14 +288,14 @@ export default class ParserCtx {
         return this.currentSiblingContext()?.ifContext;
     }
 
-    private parentIfContext(): IfContext | undefined {
-        return this.currentSiblingContext()?.parentIfContext;
+    private ancestorIfContext(): IfContext | undefined {
+        return this.currentSiblingContext()?.ancestorIfContext;
     }
 
-    private seenSlotsFromParentIfTree(): Set<string> {
-        const parentIfContext = this.parentIfContext();
-        if (parentIfContext) {
-            return parentIfContext.seenSlots[parentIfContext.seenSlots.length - 1];
+    private seenSlotsFromAncestorIfTree(): Set<string> {
+        const ancestorIfContext = this.ancestorIfContext();
+        if (ancestorIfContext) {
+            return ancestorIfContext.seenSlots[ancestorIfContext.seenSlots.length - 1];
         }
         return this.seenSlots;
     }

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -50,6 +50,11 @@ interface ParentWrapper {
 
 interface IfContext {
     currentNode: IfBlock | ElseifBlock | ElseBlock;
+
+    // Within a specific if-context, each set of seen slot names must be tracked separately
+    // because duplicate names in separate branches of the same if-block are allowed (the branching
+    // logic provides a compile-time guarantee that the slots will not be rendered multiple times).
+    // seenSlots keeps track of each set holding the slots seen in each branch of the if-block.
     seenSlots: Set<string>[];
 }
 
@@ -206,6 +211,8 @@ export default class ParserCtx {
         this.siblingScopes.pop();
     }
 
+    // Next goal is to try and move some of the "business logic" from here out into the parser's index.ts itself
+    // so that ParserCtx can be more of an utility than handling specific logic for how to handle the nodes.
     beginIfContext(node: IfBlock) {
         const currentSiblingContext = this.currentSiblingContext();
         if (!currentSiblingContext) {

--- a/packages/@lwc/template-compiler/src/shared/ast.ts
+++ b/packages/@lwc/template-compiler/src/shared/ast.ts
@@ -420,7 +420,11 @@ export function isElseBlock(node: BaseNode): node is ElseBlock {
     return node.type === 'ElseBlock';
 }
 
-export function isConditionalBlock(node: BaseNode): node is IfBlock | ElseBlock {
+export function isConditionalParentBlock(node: BaseNode): node is IfBlock | ElseifBlock {
+    return isIfBlock(node) || isElseifBlock(node);
+}
+
+export function isConditionalBlock(node: BaseNode): node is IfBlock | ElseifBlock | ElseBlock {
     return isIfBlock(node) || isElseifBlock(node) || isElseBlock(node);
 }
 


### PR DESCRIPTION
## Details
This PR enhances the template compiler's parser to track slot names from various if-block contexts.

**From the RFC:**
A developer may want to use if/else-if/else chains to render a `<slot>`:

```html
<template>
    <template lwc:if={foo}>
        <slot></slot>
    </template>
    <template lwc:else>
        <slot></slot>
    </template>
</template>
```

In this case, the template compiler should _not_ warn about duplicate slots with the same name. This is a perfectly valid use case, and the template compiler knows for certain that the `<slot>` will not be rendered twice.

What this means is that for each new set of if/elseif/else chains, we need to keep track of and avoid using the names found in the other branches of the same chain when checking for duplicate slot names.

This PR accomplishes this by doing the following:
- Tracks the visited slot names inherited at each sibling level from any ancestor if chain. If no if/elseif/else chain is being parsed, this is automatically the global store of seen slots.
- Separately tracks the slot names found in each new branch encountered as part of an if/elseif/else chain. These names are not made available to the parent context while the chain is being parsed.
- If a slot is parsed while parsing the chain, only check the slot name against the names from the parent context + the names visited in the current if/elseif/else branch.
- Once the chain is fully parsed, all names found in the chain are made available to the parent context.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
