### PR TITLE
feat: accept `config` in `lwc:dynamic`

### DIFF
--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/import-config.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/import-config.spec.js
@@ -1,0 +1,61 @@
+import { createElement } from 'lwc';
+
+import PropContainer from 'x/props';
+
+const macroTask = () => new Promise(setTimeout);
+
+it('should pass props passed as config', async () => {
+    const elm = createElement('x-dynamic', { is: PropContainer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    const child = elm.shadowRoot.querySelector('x-ctor');
+    expect(child).toBeNull();
+    // first rendered with ctor set to undefined (nothing)
+
+    elm.enableOne();
+    await macroTask();
+
+    // second rendered with ctor set to x-configone
+    const oneElm = elm.shadowRoot.querySelector('x-ctor');
+    expect(oneElm).not.toBeNull();
+    const prop1 = oneElm.shadowRoot.querySelector('span');
+    expect(prop1).not.toBeNull();
+    expect(prop1.textContent).toBe('prop1 value');
+
+    elm.enableTwo();
+    await macroTask();
+
+    // third rendered with ctor set to x-configtwo
+    const twoElm = elm.shadowRoot.querySelector('x-ctor');
+    expect(twoElm).not.toBeNull();
+    const span = twoElm.shadowRoot.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('prop2 value');
+});
+
+it("should render the same custom element when constructor doesn't change", async () => {
+    const elm = createElement('x-dynamic', { is: PropContainer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    const child = elm.shadowRoot.querySelector('x-ctor');
+    expect(child).toBeNull();
+    // first rendered with ctor set to undefined (nothing)
+
+    elm.enableOne();
+    await macroTask();
+    const oneElm = elm.shadowRoot.querySelector('x-ctor');
+    elm.enableOneAlternateProps();
+    await macroTask();
+
+    // second rendered with ctor set to x-configone
+    const oneElmAlternate = elm.shadowRoot.querySelector('x-ctor');
+    expect(oneElmAlternate).not.toBeNull();
+    const prop1 = oneElmAlternate.shadowRoot.querySelector('span');
+    expect(prop1).not.toBeNull();
+    expect(prop1.textContent).toBe('prop1 alternate value');
+    expect(oneElm).toBe(oneElmAlternate);
+});

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configone/configone.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configone/configone.html
@@ -1,0 +1,3 @@
+<template>
+    <span>{prop1}</span>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configone/configone.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configone/configone.js
@@ -1,0 +1,5 @@
+import { api, LightningElement } from 'lwc';
+
+export default class ConfigOne extends LightningElement {
+    @api prop1;
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.html
@@ -1,0 +1,3 @@
+<template>
+    <span>{prop2}</span>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/configtwo/configtwo.js
@@ -1,0 +1,5 @@
+import { api, LightningElement } from 'lwc';
+
+export default class Configtwo extends LightningElement {
+    @api prop2;
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/props/props.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/props/props.html
@@ -1,0 +1,3 @@
+<template>
+    <x-ctor lwc:dynamic={config}></x-ctor>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/props/props.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/props/props.js
@@ -1,0 +1,24 @@
+import { track, api, LightningElement } from 'lwc';
+import ConfigOne from 'x/configone';
+import ConfigTwo from 'x/configtwo';
+
+export default class Props extends LightningElement {
+    @track
+    config = undefined;
+
+    @api enableOne() {
+        this.config = { ctor: ConfigOne, props: { prop1: 'prop1 value' } };
+    }
+
+    @api enableTwo() {
+        this.config = { ctor: ConfigTwo, props: { prop2: 'prop2 value' } };
+    }
+
+    @api enableOneAlternateProps() {
+        this.config.props.prop1 = 'prop1 alternate value';
+    }
+
+    @api disableAll() {
+        this.config = null;
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/flatten-child/expected.js
@@ -11,9 +11,12 @@ function tmpl($api, $cmp, $slotset, $ctx) {
   } = $api;
   return api_flatten([
     api_static_fragment($fragment1(), 1),
-    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0, dereference),
   ]);
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
+function dereference(obj, key) {
+  return obj[key];
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
@@ -5,9 +5,12 @@ const stc0 = {
 function tmpl($api, $cmp, $slotset, $ctx) {
   const { dc: api_dynamic_component, f: api_flatten } = $api;
   return api_flatten([
-    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+    api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0, dereference),
   ]);
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
+function dereference(obj, key) {
+  return obj[key];
+}

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -180,7 +180,7 @@ export default class CodeGen {
         data: t.ObjectExpression,
         children: t.Expression
     ) {
-        const args: t.Expression[] = [t.literal(tagName), ctor, data];
+        const args: t.Expression[] = [t.literal(tagName), ctor, data, t.identifier('dereference')];
         if (!isArrayExpression(children) || children.elements.length > 0) {
             args.push(children); // only generate children if non-empty
         }

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -121,6 +121,8 @@ export default class CodeGen {
     memorizedIds: t.Identifier[] = [];
     referencedComponents: Set<string> = new Set();
 
+    hasDynamicComponents: boolean = false;
+
     constructor({
         root,
         state,

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -172,17 +172,21 @@ export function generateTemplateMetadata(codeGen: CodeGen): t.Statement[] {
         metadataExpressions.push(t.expressionStatement(renderModeMetadata));
     }
 
-    metadataExpressions.push(
-        t.functionDeclaration(
-            t.identifier('dereference'),
-            [t.identifier('obj'), t.identifier('key')],
-            t.blockStatement([
-                t.returnStatement(
-                    t.memberExpression(t.identifier('obj'), t.identifier('key'), { computed: true })
-                ),
-            ])
-        )
-    );
+    if (codeGen.hasDynamicComponents) {
+        metadataExpressions.push(
+            t.functionDeclaration(
+                t.identifier('dereference'),
+                [t.identifier('obj'), t.identifier('key')],
+                t.blockStatement([
+                    t.returnStatement(
+                        t.memberExpression(t.identifier('obj'), t.identifier('key'), {
+                            computed: true,
+                        })
+                    ),
+                ])
+            )
+        );
+    }
 
     return metadataExpressions;
 }

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -172,6 +172,18 @@ export function generateTemplateMetadata(codeGen: CodeGen): t.Statement[] {
         metadataExpressions.push(t.expressionStatement(renderModeMetadata));
     }
 
+    metadataExpressions.push(
+        t.functionDeclaration(
+            t.identifier('dereference'),
+            [t.identifier('obj'), t.identifier('key')],
+            t.blockStatement([
+                t.returnStatement(
+                    t.memberExpression(t.identifier('obj'), t.identifier('key'), { computed: true })
+                ),
+            ])
+        )
+    );
+
     return metadataExpressions;
 }
 

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -85,6 +85,7 @@ function transform(codeGen: CodeGen): t.Expression {
         if (dynamic) {
             const expression = codeGen.bindExpression(dynamic.value);
             res = codeGen.genDynamicElement(name, expression, databag, children);
+            codeGen.hasDynamicComponents = true;
         } else if (isComponent(element)) {
             res = codeGen.genCustomElement(
                 name,


### PR DESCRIPTION
## Details
Supersedes #2604 

`lwc:dynamic` after this change accepts an object `{props: Record<string, any>, constructor: LightningElementConstructor}`. We're doing only props for now, since the ask is only for props. We'll enable attrs, event listeners if required.

RFC: https://github.com/salesforce/lwc-rfcs/pull/57

The primary difference is to make it work in compat mode as well. We define a function `dereference` that we pass from template to runtime that does just dereferencing. But since the template is compiled in compat mode, proxies work properly.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
