### PR TITLE
[DO NOT MERGE] Testing Nucleus with native custom element lifecycle callbacks

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -25,6 +25,7 @@ const features: FeatureFlagMap = {
 if (!globalThis.lwcRuntimeFlags) {
     Object.defineProperty(globalThis, 'lwcRuntimeFlags', { value: create(null) });
 }
+globalThis.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE = true;
 
 export const runtimeFlags: Partial<FeatureFlagMap> = globalThis.lwcRuntimeFlags;
 


### PR DESCRIPTION
I'm just curious if enabling #2987 causes downstream Nucleus failures.