### PR TITLE
refactor(features): rename runtimeFlags to lwcRuntimeFlags

### DIFF
--- a/packages/@lwc/features/src/__tests__/flags-prod.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags-prod.spec.ts
@@ -38,38 +38,38 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                     console.log('features.ENABLE_FEATURE_NULL');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                     console.log('!features.ENABLE_FEATURE_NULL');
                 }
             `,
         },
         'should not transform null runtime flags': {
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_NULL');
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_NULL');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('!runtimeFlags.ENABLE_FEATURE_NULL');
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('!lwcRuntimeFlags.ENABLE_FEATURE_NULL');
                 }
             `,
             output: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_NULL');
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_NULL');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('!runtimeFlags.ENABLE_FEATURE_NULL');
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('!lwcRuntimeFlags.ENABLE_FEATURE_NULL');
                 }
             `,
         },
@@ -86,7 +86,7 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
                 {
                     console.log('features.ENABLE_FEATURE_TRUE');
                 }
@@ -94,20 +94,20 @@ pluginTester({
         },
         'should transform boolean-true runtime flags': {
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_TRUE) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_TRUE');
+                if (lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_TRUE');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_TRUE) {
-                    console.log('!runtimeFlags.ENABLE_FEATURE_TRUE');
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
+                    console.log('!lwcRuntimeFlags.ENABLE_FEATURE_TRUE');
                 }
             `,
             output: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
                 {
-                    console.log('runtimeFlags.ENABLE_FEATURE_TRUE');
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_TRUE');
                 }
             `,
         },
@@ -124,7 +124,7 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
                 {
                     console.log('!features.ENABLE_FEATURE_FALSE');
                 }
@@ -132,20 +132,20 @@ pluginTester({
         },
         'should transform boolean-false runtime flags': {
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_FALSE) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_FALSE');
+                if (lwcRuntimeFlags.ENABLE_FEATURE_FALSE) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_FALSE');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_FALSE) {
-                    console.log('!runtimeFlags.ENABLE_FEATURE_FALSE');
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_FALSE) {
+                    console.log('!lwcRuntimeFlags.ENABLE_FEATURE_FALSE');
                 }
             `,
             output: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
                 {
-                    console.log('!runtimeFlags.ENABLE_FEATURE_FALSE');
+                    console.log('!lwcRuntimeFlags.ENABLE_FEATURE_FALSE');
                 }
             `,
         },
@@ -158,7 +158,7 @@ pluginTester({
                 }
             `,
             output: `
-                import FEATURES, { runtimeFlags } from '@lwc/features';
+                import FEATURES, { lwcRuntimeFlags } from '@lwc/features';
 
                 if (isTrue(FEATURES.ENABLE_FEATURE_TRUE)) {
                     console.log('isTrue(ENABLE_FEATURE_TRUE)');
@@ -167,17 +167,17 @@ pluginTester({
         },
         'should not transform if-tests that are not member expressions (runtime)': {
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (isTrue(runtimeFlags.ENABLE_FEATURE_TRUE)) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_TRUE');
+                if (isTrue(lwcRuntimeFlags.ENABLE_FEATURE_TRUE)) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_TRUE');
                 }
             `,
             output: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (isTrue(runtimeFlags.ENABLE_FEATURE_TRUE)) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_TRUE');
+                if (isTrue(lwcRuntimeFlags.ENABLE_FEATURE_TRUE)) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_TRUE');
                 }
             `,
         },
@@ -187,7 +187,7 @@ pluginTester({
                 console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
             `,
             output: `
-                import feats, { runtimeFlags } from '@lwc/features';
+                import feats, { lwcRuntimeFlags } from '@lwc/features';
                 console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
             `,
         },
@@ -228,16 +228,16 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                     {
                         console.log('nested feature flags sounds like a vary bad idea');
                     }
                 }
 
                 {
-                    if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                    if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                         console.log('nested feature flags sounds like a vary bad idea');
                     }
                 }
@@ -258,7 +258,7 @@ pluginTester({
                 }
             `,
             output: `
-                import featureFlag, { runtimeFlags } from '@lwc/features';
+                import featureFlag, { lwcRuntimeFlags } from '@lwc/features';
 
                 function awesome() {
                     const featureFlag = {
@@ -277,14 +277,14 @@ pluginTester({
         },
         'should not transform member expressions that are not runtime flag lookups': {
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
                 if (churroteria.ENABLE_FEATURE_TRUE) {
                     console.log('churroteria.ENABLE_FEATURE_TRUE');
                 }
             `,
             output: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
                 if (churroteria.ENABLE_FEATURE_TRUE) {
                     console.log('churroteria.ENABLE_FEATURE_TRUE');

--- a/packages/@lwc/features/src/__tests__/flags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/flags.spec.ts
@@ -38,13 +38,13 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                     console.log('features.ENABLE_FEATURE_NULL');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                     console.log('!features.ENABLE_FEATURE_NULL');
                 }
             `,
@@ -62,13 +62,13 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_TRUE) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
                     console.log('features.ENABLE_FEATURE_TRUE');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_TRUE) {
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
                     console.log('!features.ENABLE_FEATURE_TRUE');
                 }
             `,
@@ -86,13 +86,13 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_FALSE) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_FALSE) {
                     console.log('features.ENABLE_FEATURE_FALSE');
                 }
 
-                if (!runtimeFlags.ENABLE_FEATURE_FALSE) {
+                if (!lwcRuntimeFlags.ENABLE_FEATURE_FALSE) {
                     console.log('!features.ENABLE_FEATURE_FALSE');
                 }
             `,
@@ -106,7 +106,7 @@ pluginTester({
                 }
             `,
             output: `
-                import FEATURES, { runtimeFlags } from '@lwc/features';
+                import FEATURES, { lwcRuntimeFlags } from '@lwc/features';
 
                 if (isTrue(FEATURES.ENABLE_FEATURE_TRUE)) {
                     console.log('isTrue(ENABLE_FEATURE_TRUE)');
@@ -119,17 +119,17 @@ pluginTester({
                 console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
             `,
             output: `
-                import feats, { runtimeFlags } from '@lwc/features';
+                import feats, { lwcRuntimeFlags } from '@lwc/features';
                 console.log(feats.ENABLE_FEATURE_NULL ? 'foo' : 'bar');
             `,
         },
-        'should throw an error if runtimeFlags are imported': {
-            error: 'Invalid import of "runtimeFlags" from "@lwc/features". Use the default export from "@lwc/features" instead of the "runtimeFlags" export when implementing your feature behind a flag.',
+        'should throw an error if lwcRuntimeFlags are imported': {
+            error: 'Invalid import of "lwcRuntimeFlags" from "@lwc/features". Use the default export from "@lwc/features" instead of the "lwcRuntimeFlags" export when implementing your feature behind a flag.',
             code: `
-                import { runtimeFlags } from '@lwc/features';
+                import { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                    console.log('runtimeFlags.ENABLE_FEATURE_NULL');
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    console.log('lwcRuntimeFlags.ENABLE_FEATURE_NULL');
                 }
             `,
         },
@@ -170,16 +170,16 @@ pluginTester({
                 }
             `,
             output: `
-                import features, { runtimeFlags } from '@lwc/features';
+                import features, { lwcRuntimeFlags } from '@lwc/features';
 
-                if (runtimeFlags.ENABLE_FEATURE_NULL) {
-                    if (runtimeFlags.ENABLE_FEATURE_TRUE) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
+                    if (lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
                         console.log('nested feature flags sounds like a vary bad idea');
                     }
                 }
 
-                if (runtimeFlags.ENABLE_FEATURE_TRUE) {
-                    if (runtimeFlags.ENABLE_FEATURE_NULL) {
+                if (lwcRuntimeFlags.ENABLE_FEATURE_TRUE) {
+                    if (lwcRuntimeFlags.ENABLE_FEATURE_NULL) {
                         console.log('nested feature flags sounds like a vary bad idea');
                     }
                 }
@@ -204,7 +204,7 @@ pluginTester({
                 }
             `,
             output: `
-                import featureFlag, { runtimeFlags } from '@lwc/features';
+                import featureFlag, { lwcRuntimeFlags } from '@lwc/features';
 
                 function awesome() {
                     const featureFlag = {
@@ -230,7 +230,7 @@ pluginTester({
                 }
             `,
             output: `
-                import featureFlags, { runtimeFlags } from '@lwc/features';
+                import featureFlags, { lwcRuntimeFlags } from '@lwc/features';
 
                 if (churroteria.ENABLE_FEATURE_TRUE) {
                     console.log('churroteria.ENABLE_FEATURE_TRUE');
@@ -246,7 +246,7 @@ pluginTester({
                 }
             `,
             output: `
-                import featureFlags, { runtimeFlags } from '@lwc/features';
+                import featureFlags, { lwcRuntimeFlags } from '@lwc/features';
 
                 if (featureFlags['ENABLE_FEATURE_TRUE']) {
                     console.log("featureFlags['ENABLE_FEATURE_TRUE']");

--- a/packages/@lwc/features/src/babel-plugin/index.js
+++ b/packages/@lwc/features/src/babel-plugin/index.js
@@ -6,7 +6,7 @@
  */
 const defaultFeatureFlags = require('../../').default;
 
-const RUNTIME_FLAGS_IDENTIFIER = 'runtimeFlags';
+const RUNTIME_FLAGS_IDENTIFIER = 'lwcRuntimeFlags';
 const FEATURES_PACKAGE_NAME = '@lwc/features';
 
 function validate(name, value) {

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -25,7 +25,7 @@ if (!globalThis.lwcRuntimeFlags) {
     Object.defineProperty(globalThis, 'lwcRuntimeFlags', { value: create(null) });
 }
 
-export const runtimeFlags: Partial<FeatureFlagMap> = globalThis.lwcRuntimeFlags;
+export const lwcRuntimeFlags: Partial<FeatureFlagMap> = globalThis.lwcRuntimeFlags;
 
 /**
  * Set the value at runtime of a given feature flag. This method only be invoked once per feature
@@ -54,10 +54,10 @@ export function setFeatureFlag(name: FeatureFlagName, value: FeatureFlagValue): 
     }
     if (process.env.NODE_ENV !== 'production') {
         // Allow the same flag to be set more than once outside of production to enable testing
-        runtimeFlags[name] = value;
+        lwcRuntimeFlags[name] = value;
     } else {
         // Disallow the same flag to be set more than once in production
-        const runtimeValue = runtimeFlags[name];
+        const runtimeValue = lwcRuntimeFlags[name];
         if (!isUndefined(runtimeValue)) {
             // eslint-disable-next-line no-console
             console.error(
@@ -65,7 +65,7 @@ export function setFeatureFlag(name: FeatureFlagName, value: FeatureFlagValue): 
             );
             return;
         }
-        defineProperty(runtimeFlags, name, { value });
+        defineProperty(lwcRuntimeFlags, name, { value });
     }
 }
 
@@ -78,5 +78,7 @@ export function setFeatureFlagForTest(name: FeatureFlagName, value: FeatureFlagV
         setFeatureFlag(name, value);
     }
 }
+
+export const runtimeFlags = lwcRuntimeFlags; // backwards compatibility for before this was renamed
 
 export default features;


### PR DESCRIPTION
## Details

In our build artifacts for `engine-dom` and `engine-server`, I would like to be able to replace runtime flags with `true` and `false` for tree-shaking purposes. (I.e. a consumer can tree-shake out any runtime features they are not using.)

This is possible today with e.g. `@rollup/plugin-replace`, but currently our build artifacts contain things like:

```js
if (runtimeFlags.ENABLE_REACTIVE_SETTER) {
```

... which would require:

```js
replace({
  'runtimeFlags.ENABLE_REACTIVE_SETTER': 'false',
  preventAssignment: true
})
```

I propose renaming `runtimeFlags` to the more explicit `lwcRuntimeFlags`, because:

1. It makes it more obvious that you're replacing an LWC runtime flag.
2. It matches the name of the global anyway.
3. It completely eliminates the possibility of collision with some other library/framework using a variable called `runtimeFlags`.

So we would have:

```js
if (lwcRuntimeFlags.ENABLE_REACTIVE_SETTER) {
```

and:

```js
replace({
  'lwcRuntimeFlags.ENABLE_REACTIVE_SETTER': 'false',
  preventAssignment: true
})
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
