### PR TITLE
chore: fix @lwc/shared version in new package

### DIFF
--- a/packages/@lwc/aria-reflection-polyfill/package.json
+++ b/packages/@lwc/aria-reflection-polyfill/package.json
@@ -35,6 +35,6 @@
         "access": "public"
     },
     "dependencies": {
-        "@lwc/shared": "2.22.0"
+        "@lwc/shared": "2.23.0"
     }
 }


### PR DESCRIPTION
## Details
@lwc/shared version in @lwc/aria-reflection-polyfill is 2.22.0 because when it was created lwc version was 2.22.0. But by the time the PR was merged, lwc version had moved to 2.23.0.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
