### PR TITLE
fix(engine-dom): make unknown props a warning, not error

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -142,12 +142,11 @@ function setProperty(node: Node, key: string, value: any): void {
     if (process.env.NODE_ENV !== 'production') {
         if (node instanceof Element && !(key in node)) {
             // TODO [#1297]: Move this validation to the compiler
-            assert.fail(
-                `Unknown public property "${key}" of element <${
-                    node.tagName
-                }>. This is likely a typo on the corresponding attribute "${htmlPropertyToAttribute(
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Unknown public property "${key}" of element <${node.tagName.toLowerCase()}>. This is either a typo on the corresponding attribute "${htmlPropertyToAttribute(
                     key
-                )}".`
+                )}", or the attribute does not exist in this browser or DOM implementation.`
             );
         }
     }

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -194,6 +194,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
 
     var customMatchers = {
         toLogErrorDev: consoleDevMatcherFactory('error'),
+        toLogWarningDev: consoleDevMatcherFactory('warn'),
         toThrowErrorDev: function toThrowErrorDev() {
             return {
                 compare: function (actual, expectedErrorCtor, expectedMessage) {

--- a/packages/@lwc/integration-karma/test/component/unknown-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/unknown-properties/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+describe('unknown properties', () => {
+    it('warns when setting unknown properties', () => {
+        const elm = createElement('x-component', { is: Component });
+        expect(() => {
+            document.body.appendChild(elm);
+        }).toLogWarningDev(
+            'Unknown public property "propertyThatDefinitelyDoesNotExist" of element <x-child>. ' +
+                'This is either a typo on the corresponding attribute "property-that-definitely-does-not-exist", or ' +
+                'the attribute does not exist in this browser or DOM implementation.'
+        );
+    });
+});

--- a/packages/@lwc/integration-karma/test/component/unknown-properties/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/component/unknown-properties/x/child/child.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/@lwc/integration-karma/test/component/unknown-properties/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/component/unknown-properties/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/unknown-properties/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/component/unknown-properties/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+  <x-child property-that-definitely-does-not-exist={foo}></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test/component/unknown-properties/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/component/unknown-properties/x/component/component.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    foo = true;
+}


### PR DESCRIPTION
## Details

This partially mitigates #1297.

We have gotten many reports of people's tests failing in Jest or IE11 because of missing properties on `Element` or `HTMLElement`. Rather than make this a dev-only error, let's make it a dev-only warning.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

In dev mode, unknown element properties will now be a warning, not an error.

<!-- If yes, please describe the anticipated observable changes. -->
