### PR TITLE
fix: `getRootNode` for elements slotted into synthetic shadow from root light DOM components

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -20,6 +20,7 @@ const features: FeatureFlagMap = {
     ENABLE_NODE_PATCH: null,
     ENABLE_REACTIVE_SETTER: null,
     ENABLE_WIRE_SYNC_EMIT: null,
+    ENABLE_LIGHT_GET_ROOT_NODE_PATCH: null,
 };
 
 if (!globalThis.lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -98,6 +98,13 @@ export interface FeatureFlagMap {
      * of next tick. It only affects wire configurations that depend on component values.
      */
     ENABLE_WIRE_SYNC_EMIT: FeatureFlagValue;
+
+    /**
+     * Flag to fix `getRootNode` on elements slotted from root into Synthetic Shadow.
+     * The following API is affected by this flag:
+     *  - `Node.prototype.getRootNode`
+     */
+    ENABLE_LIGHT_GET_ROOT_NODE_PATCH: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
@@ -1,0 +1,75 @@
+import { createElement } from 'lwc';
+import { extractDataIds } from 'test-utils';
+
+import LightElement from 'x/light';
+
+function createTestElement(tag, component) {
+    const elm = createElement(tag, { is: component });
+    elm.setAttribute('data-id', tag);
+    document.body.appendChild(elm);
+    return extractDataIds(elm);
+}
+
+function dispatchEventWithLog(target, nodes, event) {
+    const log = [];
+
+    const allNodes = [
+        ...Object.values(nodes),
+        document.body,
+        document.documentElement,
+        document,
+        window,
+    ];
+    const listeners = new Map();
+    allNodes.forEach((node) => {
+        const listener = (event) => {
+            log.push([event.currentTarget, event.target, event.composedPath()]);
+        };
+        node.addEventListener(event.type, listener);
+        listeners.set(node, listener);
+    });
+
+    target.dispatchEvent(event);
+
+    allNodes.forEach((node) => {
+        node.removeEventListener(event.type, listeners.get(node));
+        listeners.delete(node);
+    });
+    return log;
+}
+
+describe('root light element', () => {
+    // eslint-disable-next-line jest/no-focused-tests
+    it('should throw events properly', () => {
+        const nodes = createTestElement('x-root', LightElement);
+
+        const log = dispatchEventWithLog(
+            nodes.button,
+            nodes,
+            new CustomEvent('test', { bubbles: true, composed: false })
+        );
+
+        const composedPath = [
+            nodes.button,
+            nodes.slot,
+            nodes['x-list'].shadowRoot,
+            nodes['x-list'],
+            nodes['x-root'],
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ];
+        expect(log).toEqual([
+            [nodes.button, nodes.button, composedPath],
+            [nodes.slot, nodes.button, composedPath],
+            [nodes['x-list'].shadowRoot, nodes.button, composedPath],
+            [nodes['x-list'], nodes.button, composedPath],
+            [nodes['x-root'], nodes.button, composedPath],
+            [document.body, nodes.button, composedPath],
+            [document.documentElement, nodes.button, composedPath],
+            [document, nodes.button, composedPath],
+            [window, nodes.button, composedPath],
+        ]);
+    });
+});

--- a/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
@@ -42,22 +42,24 @@ describe('root light element', () => {
     afterEach(() => {
         setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', false);
     });
-    it('should not dispatch events to window from elements slotted into synthetic shadow', () => {
-        const nodes = createTestElement('x-root', LightElement);
+    if (!process.env.NATIVE_SHADOW) {
+        it('should not dispatch events to window from elements slotted into synthetic shadow', () => {
+            const nodes = createTestElement('x-root', LightElement);
 
-        const log = dispatchEventWithLog(
-            nodes.button,
-            nodes,
-            new CustomEvent('test', { bubbles: true, composed: false })
-        );
+            const log = dispatchEventWithLog(
+                nodes.button,
+                nodes,
+                new CustomEvent('test', { bubbles: true, composed: false })
+            );
 
-        const composedPath = [nodes.button, nodes.slot, nodes['x-list'].shadowRoot];
-        expect(log).toEqual([
-            [nodes.button, nodes.button, composedPath],
-            [nodes.slot, nodes.button, composedPath],
-            [nodes['x-list'].shadowRoot, nodes.button, composedPath],
-        ]);
-    });
+            const composedPath = [nodes.button, nodes.slot, nodes['x-list'].shadowRoot];
+            expect(log).toEqual([
+                [nodes.button, nodes.button, composedPath],
+                [nodes.slot, nodes.button, composedPath],
+                [nodes['x-list'].shadowRoot, nodes.button, composedPath],
+            ]);
+        });
+    }
     it('should throw events properly with flag ENABLE_LIGHT_GET_ROOT_NODE_PATCH', () => {
         setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
         const nodes = createTestElement('x-root', LightElement);

--- a/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <x-list data-id="x-list">
+        <button data-id="button">Hello</button>
+    </x-list>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Light extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/light-dom/root/x/list/list.html
+++ b/packages/@lwc/integration-karma/test/light-dom/root/x/list/list.html
@@ -1,0 +1,3 @@
+<template>
+    <slot data-id="slot"></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/root/x/list/list.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/x/list/list.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class List extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -38,15 +38,8 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             expect(nodes.consumer.parentElement).toEqual(elm);
         });
 
-        // Issue [#2424]: Synthetic shadow returns an incorrect root node because the <p>
-        // doesn't have an owner key. However, synthetic shadow is no longer being changed.
-        // This test verifies that the existing behavior in synthetic shadow does not regress.
         it('getRootNode', () => {
-            const expectedRootNode = process.env.NATIVE_SHADOW
-                ? document // native, correct behavior
-                : nodes['consumer.shadowRoot']; // incorrect, existing behavior
-
-            expect(nodes.p.getRootNode()).toEqual(expectedRootNode);
+            expect(nodes.p.getRootNode()).toEqual(document);
             expect(nodes.consumer.getRootNode()).toEqual(document);
         });
         // TODO [#2425]: Incorrect serialization

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { defineProperty, isNull, isUndefined } from '@lwc/shared';
-import { parentNodeGetter } from '../env/node';
 
 // Used as a back reference to identify the host element
 const HostElementKey = '$$HostElementKey$$';
@@ -47,13 +46,14 @@ export function getNodeOwnerKey(node: Node): number | undefined {
 export function getNodeNearestOwnerKey(node: Node): number | undefined {
     let host: Node | null = node;
     let hostKey: number | undefined;
-    // search for the first element with owner identity (just in case of manually inserted elements)
+    // search for the first element with owner identity
+    // in case of manually inserted elements and elements slotted from Light DOM
     while (!isNull(host)) {
         hostKey = getNodeOwnerKey(host);
         if (!isUndefined(hostKey)) {
             return hostKey;
         }
-        host = parentNodeGetter.call(host) as ShadowedNode | null;
+        host = host.parentNode as ShadowedNode | null;
     }
 }
 

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { defineProperty, isNull, isUndefined } from '@lwc/shared';
+import { parentNodeGetter } from '../env/node';
+import { isSyntheticSlotElement } from '../faux-shadow/traverse';
 
 // Used as a back reference to identify the host element
 const HostElementKey = '$$HostElementKey$$';
@@ -53,7 +55,10 @@ export function getNodeNearestOwnerKey(node: Node): number | undefined {
         if (!isUndefined(hostKey)) {
             return hostKey;
         }
-        host = host.parentNode as ShadowedNode | null;
+        host = parentNodeGetter.call(host) as ShadowedNode | null;
+        if (!isNull(host) && isSyntheticSlotElement(host)) {
+            return undefined;
+        }
     }
 }
 

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { defineProperty, isNull, isUndefined } from '@lwc/shared';
+import featureFlags from '@lwc/features';
+
 import { parentNodeGetter } from '../env/node';
 import { isSyntheticSlotElement } from '../faux-shadow/traverse';
 
@@ -56,8 +58,11 @@ export function getNodeNearestOwnerKey(node: Node): number | undefined {
             return hostKey;
         }
         host = parentNodeGetter.call(host) as ShadowedNode | null;
-        if (!isNull(host) && isSyntheticSlotElement(host)) {
-            return undefined;
+
+        if (featureFlags.ENABLE_LIGHT_GET_ROOT_NODE_PATCH) {
+            if (!isNull(host) && isSyntheticSlotElement(host)) {
+                return undefined;
+            }
         }
     }
 }


### PR DESCRIPTION
## Details
We were using native `parentNode` while navigating up to find the nearest root node.
This made sense when the element was inserted via `lwc:dom="manual"`.

It breaks down when an element is slotted into a Shadow DOM element, because the
native `parentNode` doesn't give us the right parent node (it gives us the slot).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
