### PR TITLE
fix: use Fragment VNodes for if-elseif-else children

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -43,6 +43,7 @@ import {
     VNodeType,
     VStatic,
     Key,
+    VFragment,
 } from './vnodes';
 
 const SymbolIterator: typeof Symbol.iterator = Symbol.iterator;
@@ -59,6 +60,18 @@ function st(fragment: Element, key: Key): VStatic {
         key,
         elm: undefined,
         fragment,
+        owner: getVMBeingRendered()!,
+    };
+}
+
+// [fr]agment node
+function fr(key: Key, children: VNodes): VFragment {
+    return {
+        type: VNodeType.Fragment,
+        sel: undefined,
+        key,
+        elm: undefined,
+        children: [t(''), ...children, t('')],
         owner: getVMBeingRendered()!,
     };
 }
@@ -541,6 +554,7 @@ const api = ObjectFreeze({
     k,
     co,
     dc,
+    fr,
     ti,
     st,
     gid,

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -71,7 +71,7 @@ function fr(key: Key, children: VNodes): VFragment {
         sel: undefined,
         key,
         elm: undefined,
-        children: [t(''), ...children, t('')],
+        children: [t('', key + 's'), ...children, t('', key + 'e')],
         owner: getVMBeingRendered()!,
     };
 }
@@ -359,8 +359,8 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string): VText {
-    let sel, key, elm;
+function t(text: string, key?: Key): VText {
+    let sel, elm;
     return {
         type: VNodeType.Text,
         sel,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -30,6 +30,7 @@ import {
     VElement,
     VCustomElement,
     VStatic,
+    VFragment,
 } from './vnodes';
 
 import { patchProps } from './modules/props';
@@ -86,6 +87,11 @@ function hydrateNode(node: Node, vnode: VNode, renderer: RendererAPI): Node | nu
         case VNodeType.Static:
             // VStatic are cacheable and cannot have custom renderer associated to them
             hydratedNode = hydrateStaticElement(node, vnode, renderer);
+            break;
+
+        case VNodeType.Fragment:
+            // @todo: what's vnode.data.renderer? do we need to update the fragment vnode?
+            hydratedNode = hydrateFragment(node, vnode, renderer);
             break;
 
         case VNodeType.Element:
@@ -152,6 +158,12 @@ function hydrateStaticElement(elm: Node, vnode: VStatic, renderer: RendererAPI):
     vnode.elm = elm;
 
     return elm;
+}
+
+function hydrateFragment(elm: Node, vnode: VFragment, renderer: RendererAPI): Node | null {
+    hydrateChildren(elm, vnode.children, renderer.getProperty(elm, 'parentNode'), vnode.owner);
+
+    return vnode.children[vnode.children.length - 1]!.elm as Node;
 }
 
 function hydrateElement(elm: Node, vnode: VElement, renderer: RendererAPI): Node | null {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -51,7 +51,7 @@ export interface VText extends BaseVNode {
     type: VNodeType.Text;
     sel: undefined;
     text: string;
-    key: undefined;
+    key: Key | undefined;
 }
 
 export interface VComment extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -16,11 +16,16 @@ export const enum VNodeType {
     Element,
     CustomElement,
     Static,
+    Fragment,
 }
 
-export type VNode = VText | VComment | VElement | VCustomElement | VStatic;
-export type VParentElement = VElement | VCustomElement;
+export type VNode = VText | VComment | VElement | VCustomElement | VStatic | VFragment;
+export type VParentElement = VElement | VCustomElement | VFragment;
 export type VNodes = Readonly<Array<VNode | null>>;
+
+export interface BaseVParent {
+    children: VNodes;
+}
 
 export interface BaseVNode {
     type: VNodeType;
@@ -37,6 +42,11 @@ export interface VStatic extends BaseVNode {
     fragment: Element;
 }
 
+export interface VFragment extends BaseVNode, BaseVParent {
+    sel: undefined;
+    type: VNodeType.Fragment;
+}
+
 export interface VText extends BaseVNode {
     type: VNodeType.Text;
     sel: undefined;
@@ -51,10 +61,9 @@ export interface VComment extends BaseVNode {
     key: undefined;
 }
 
-export interface VBaseElement extends BaseVNode {
+export interface VBaseElement extends BaseVNode, BaseVParent {
     sel: string;
     data: VElementData;
-    children: VNodes;
     elm: Element | undefined;
     key: Key;
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/comments-foreach/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/comments-foreach/expected.html
@@ -1,6 +1,7 @@
 <x-comments-foreach>
   <template shadowroot="open">
     <ul>
+      ‍
       <!-- color -->
       <li>
         red
@@ -13,6 +14,7 @@
       <li>
         yellow
       </li>
+      ‍
     </ul>
   </template>
 </x-comments-foreach>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-block/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-block/expected.html
@@ -1,6 +1,7 @@
 <x-for-each-block>
   <template shadowroot="open">
     <ul>
+      ‍
       <li>
         0 - paris
       </li>
@@ -10,6 +11,7 @@
       <li>
         2 - tokyo
       </li>
+      ‍
     </ul>
   </template>
 </x-for-each-block>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-child-nested/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-child-nested/expected.html
@@ -1,10 +1,12 @@
 <x-for-each-child-nested>
   <template shadowroot="open">
     <ol>
+      ‍
       <li>
         europe
         <x-child>
           <template shadowroot="open">
+            ‍
             <li>
               0 - paris
             </li>
@@ -14,6 +16,7 @@
             <li>
               2 - rome
             </li>
+            ‍
           </template>
         </x-child>
       </li>
@@ -21,6 +24,7 @@
         asia
         <x-child>
           <template shadowroot="open">
+            ‍
             <li>
               0 - tokyo
             </li>
@@ -30,9 +34,11 @@
             <li>
               2 - singapore
             </li>
+            ‍
           </template>
         </x-child>
       </li>
+      ‍
     </ol>
   </template>
 </x-for-each-child-nested>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-nested/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-each-nested/expected.html
@@ -1,9 +1,11 @@
 <x-for-each-nested>
   <template shadowroot="open">
     <ol>
+      ‍
       <li>
         europe
         <ul>
+          ‍
           <li>
             paris
           </li>
@@ -13,11 +15,13 @@
           <li>
             rome
           </li>
+          ‍
         </ul>
       </li>
       <li>
         asia
         <ul>
+          ‍
           <li>
             tokyo
           </li>
@@ -27,8 +31,10 @@
           <li>
             singapore
           </li>
+          ‍
         </ul>
       </li>
+      ‍
     </ol>
   </template>
 </x-for-each-nested>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-is-connected/expected.html
@@ -1,6 +1,7 @@
 <x-getter-is-connected>
   <template shadowroot="open">
     <ul>
+      ‍
       <li>
         constructor: false
       </li>
@@ -10,6 +11,7 @@
       <li>
         render: true
       </li>
+      ‍
     </ul>
   </template>
 </x-getter-is-connected>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/iterator-block/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/iterator-block/expected.html
@@ -1,6 +1,7 @@
 <x-iterator-block>
   <template shadowroot="open">
     <ul>
+      ‍
       <li>
         <div class="list-first">
         </div>
@@ -14,6 +15,7 @@
         <div class="list-last">
         </div>
       </li>
+      ‍
     </ul>
   </template>
 </x-iterator-block>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
@@ -1,6 +1,7 @@
 <x-lifecycle-hooks>
   <template shadowroot="open">
     <ul>
+      ‍
       <li>
         constructor
       </li>
@@ -10,6 +11,7 @@
       <li>
         render
       </li>
+      ‍
     </ul>
   </template>
 </x-lifecycle-hooks>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/foreach/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/foreach/index.spec.js
@@ -15,10 +15,12 @@ export default {
 
         expect(hydratedSnapshot.text).not.toBe(snapshots.text);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
+        expect(consoleCalls.error).toHaveSize(3);
+        // extra li does not matches with the fragmentEnd text node delimiter
+        expect(consoleCalls.error[0][0].message).toContain('incorrect node type received');
+        expect(consoleCalls.error[1][0].message).toContain(
             'Server rendered more nodes than the client.'
         );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        expect(consoleCalls.error[2][0].message).toContain('Hydration completed with errors.');
     },
 };

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -15,6 +15,10 @@ function createTestElement(tag, component) {
     return extractDataIds(elm);
 }
 
+function filterEmptyTextNodes(node) {
+    return !(node.nodeType === Node.TEXT_NODE && node.nodeValue === '');
+}
+
 describe('Slotting', () => {
     it('should render properly', () => {
         const nodes = createTestElement('x-default-slot', BasicSlot);
@@ -28,7 +32,9 @@ describe('Slotting', () => {
 
     it('should render dynamic children', async () => {
         const nodes = createTestElement('x-dynamic-children', DynamicChildren);
-        expect(Array.from(nodes['x-light-container'].childNodes)).toEqual([
+        expect(
+            Array.from(nodes['x-light-container'].childNodes).filter(filterEmptyTextNodes)
+        ).toEqual([
             nodes['container-upper-slot-default'],
             nodes['1'],
             nodes['2'],
@@ -41,7 +47,9 @@ describe('Slotting', () => {
         nodes.button.click();
         await Promise.resolve();
 
-        expect(Array.from(nodes['x-light-container'].childNodes)).toEqual([
+        expect(
+            Array.from(nodes['x-light-container'].childNodes).filter(filterEmptyTextNodes)
+        ).toEqual([
             nodes['container-upper-slot-default'],
             nodes['5'],
             nodes['4'],

--- a/packages/@lwc/integration-karma/test/template/empty-template/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/empty-template/index.spec.js
@@ -88,6 +88,9 @@ describe('non-root templates without lwc directives', () => {
             { nodeType: Node.ELEMENT_NODE, tagName: 'LI', textContent: 'two' },
             { nodeType: Node.ELEMENT_NODE, tagName: 'LI', textContent: 'three' },
         ];
-        testTemplateRendering(expected, elm.shadowRoot.childNodes);
+        testTemplateRendering(
+            expected,
+            Array.from(elm.shadowRoot.childNodes).filter((node) => node.textContent !== '')
+        );
     });
 });

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -10,9 +10,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     h: api_element,
     k: api_key,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
   } = $api;
-  return api_flatten([
+  return [
     api_custom_element("x-subject", _xSubject, {
       props: {
         htmlFor: api_scoped_id("foo"),
@@ -54,27 +54,30 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       key: 5,
     }),
-    api_iterator($cmp.things, function (thing) {
-      return [
-        api_element(
-          "p",
-          {
-            attrs: {
-              id: api_scoped_id(thing.id),
+    api_fragment(
+      "it-fr8",
+      api_iterator($cmp.things, function (thing) {
+        return [
+          api_element(
+            "p",
+            {
+              attrs: {
+                id: api_scoped_id(thing.id),
+              },
+              key: api_key(6, thing.key),
             },
-            key: api_key(6, thing.key),
-          },
-          [api_text("description text")]
-        ),
-        api_element("input", {
-          attrs: {
-            "aria-describedby": api_scoped_id(thing.id),
-          },
-          key: api_key(7, thing.key),
-        }),
-      ];
-    }),
-  ]);
+            [api_text("description text")]
+          ),
+          api_element("input", {
+            attrs: {
+              "aria-describedby": api_scoped_id(thing.id),
+            },
+            key: api_key(7, thing.key),
+          }),
+        ];
+      })
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
@@ -4,24 +4,30 @@ const stc0 = {
   svg: true,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, h: api_element, i: api_iterator } = $api;
+  const {
+    k: api_key,
+    h: api_element,
+    i: api_iterator,
+    fr: api_fragment,
+  } = $api;
   return [
-    api_element(
-      "svg",
-      stc0,
-      api_iterator($cmp.lines, function (line) {
-        return api_element("line", {
-          attrs: {
-            x1: line.x1,
-            y1: line.y1,
-            x2: line.x2,
-            y2: line.y2,
-          },
-          key: api_key(1, line.key),
-          svg: true,
-        });
-      })
-    ),
+    api_element("svg", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.lines, function (line) {
+          return api_element("line", {
+            attrs: {
+              x1: line.x1,
+              y1: line.y1,
+              x2: line.x2,
+              y2: line.y2,
+            },
+            key: api_key(1, line.key),
+            svg: true,
+          });
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -10,24 +10,26 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.colors, function (color) {
-        return [
-          api_comment(" color "),
-          api_element(
-            "li",
-            {
-              key: api_key(1, color),
-            },
-            [api_text(api_dynamic_text(color))]
-          ),
-        ];
-      })
-    ),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.colors, function (color) {
+          return [
+            api_comment(" color "),
+            api_element(
+              "li",
+              {
+                key: api_key(1, color),
+              },
+              [api_text(api_dynamic_text(color))]
+            ),
+          ];
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -12,76 +12,72 @@ const stc1 = {
   classMap: {
     s2: true,
   },
-  key: 3,
+  key: 4,
 };
-const stc2 = [];
-const stc3 = {
+const stc2 = {
   classMap: {
     s3: true,
   },
-  key: 6,
+  key: 8,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     t: api_text,
     i: api_iterator,
+    fr: api_fragment,
     st: api_static_fragment,
-    f: api_flatten,
     h: api_element,
     k: api_key,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_flatten([
-        api_text("Other Child"),
+    api_element("section", stc0, [
+      api_text("Other Child"),
+      api_fragment(
+        "it-fr1",
         api_iterator($cmp.items, function (item) {
           return api_text("X");
-        }),
-        api_static_fragment($fragment1(), 2),
-      ])
-    ),
-    api_element(
-      "section",
-      stc1,
-      api_flatten([
-        api_text("Other Child"),
-        $cmp.isTrue
-          ? api_iterator($cmp.items, function (item) {
+        })
+      ),
+      api_static_fragment($fragment1(), 3),
+    ]),
+    api_element("section", stc1, [
+      api_text("Other Child"),
+      $cmp.isTrue
+        ? api_fragment(
+            "it-fr7",
+            api_iterator($cmp.items, function (item) {
               return [
                 api_element(
                   "p",
                   {
-                    key: api_key(4, item.id),
+                    key: api_key(5, item.id),
                   },
                   [api_text("X1")]
                 ),
                 api_element(
                   "p",
                   {
-                    key: api_key(5, item.id),
+                    key: api_key(6, item.id),
                   },
                   [api_text("X2")]
                 ),
               ];
             })
-          : stc2,
-      ])
-    ),
-    api_element(
-      "section",
-      stc3,
-      api_flatten([
-        api_static_fragment($fragment2(), 8),
+          )
+        : null,
+    ]),
+    api_element("section", stc2, [
+      api_static_fragment($fragment2(), 10),
+      api_fragment(
+        "it-fr12",
         api_iterator($cmp.items, function (item) {
           return api_element("div", {
-            key: api_key(9, item.id),
+            key: api_key(11, item.id),
           });
-        }),
-      ])
-    ),
-    api_static_fragment($fragment3(), 11),
+        })
+      ),
+    ]),
+    api_static_fragment($fragment3(), 14),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
@@ -9,23 +9,25 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return $cmp.showItems
-          ? api_element(
-              "p",
-              {
-                key: api_key(1, item.id),
-              },
-              [api_text("1" + api_dynamic_text(item))]
-            )
-          : null;
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return $cmp.showItems
+            ? api_element(
+                "p",
+                {
+                  key: api_key(1, item.id),
+                },
+                [api_text("1" + api_dynamic_text(item))]
+              )
+            : null;
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
@@ -9,21 +9,23 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.items, function (item, index) {
-        return api_element(
-          "li",
-          {
-            key: api_key(1, item.id),
-          },
-          [api_text(api_dynamic_text(index) + " - " + api_dynamic_text(item))]
-        );
-      })
-    ),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item, index) {
+          return api_element(
+            "li",
+            {
+              key: api_key(1, item.id),
+            },
+            [api_text(api_dynamic_text(index) + " - " + api_dynamic_text(item))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
@@ -15,22 +15,24 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "div",
-          {
-            classMap: stc1,
-            key: api_key(1, item.id),
-          },
-          [api_element("p", stc2, [api_text(api_dynamic_text(item))])]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "div",
+            {
+              classMap: stc1,
+              key: api_key(1, item.id),
+            },
+            [api_element("p", stc2, [api_text(api_dynamic_text(item))])]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
@@ -18,25 +18,27 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "div",
-          {
-            classMap: stc1,
-            key: api_key(1, item.id),
-          },
-          [
-            api_element("p", stc2, [api_text(api_dynamic_text(item))]),
-            api_element("p", stc3, [api_text(api_dynamic_text($cmp.item2))]),
-          ]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr4",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "div",
+            {
+              classMap: stc1,
+              key: api_key(1, item.id),
+            },
+            [
+              api_element("p", stc2, [api_text(api_dynamic_text(item))]),
+              api_element("p", stc3, [api_text(api_dynamic_text($cmp.item2))]),
+            ]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
@@ -9,22 +9,24 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "li",
-          {
-            className: item.x,
-            key: api_key(1, item.id),
-          },
-          [api_text(api_dynamic_text(item))]
-        );
-      })
-    ),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "li",
+            {
+              className: item.x,
+              key: api_key(1, item.id),
+            },
+            [api_text(api_dynamic_text(item))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -10,14 +10,13 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
     st: api_static_fragment,
-    f: api_flatten,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_flatten([
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
         api_iterator($cmp.items, function (item) {
           return api_element(
             "li",
@@ -27,10 +26,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             },
             [api_text(api_dynamic_text(item))]
           );
-        }),
-        api_static_fragment($fragment1(), 3),
-      ])
-    ),
+        })
+      ),
+      api_static_fragment($fragment1(), 4),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -12,22 +12,24 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     st: api_static_fragment,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "div",
-          {
-            classMap: stc1,
-            key: api_key(1, item.id),
-          },
-          [api_static_fragment($fragment1(), 3)]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr4",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "div",
+            {
+              classMap: stc1,
+              key: api_key(1, item.id),
+            },
+            [api_static_fragment($fragment1(), 3)]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
@@ -9,30 +9,32 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return [
-          api_element(
-            "p",
-            {
-              key: api_key(1, item.keyOne),
-            },
-            [api_text("1" + api_dynamic_text(item))]
-          ),
-          api_element(
-            "p",
-            {
-              key: api_key(2, item.keyTwo),
-            },
-            [api_text("2" + api_dynamic_text(item))]
-          ),
-        ];
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
+        api_iterator($cmp.items, function (item) {
+          return [
+            api_element(
+              "p",
+              {
+                key: api_key(1, item.keyOne),
+              },
+              [api_text("1" + api_dynamic_text(item))]
+            ),
+            api_element(
+              "p",
+              {
+                key: api_key(2, item.keyTwo),
+              },
+              [api_text("2" + api_dynamic_text(item))]
+            ),
+          ];
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
@@ -9,44 +9,46 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return [
-          api_element(
-            "p",
-            {
-              key: api_key(1, item.keyOne),
-            },
-            [api_text("1" + api_dynamic_text(item))]
-          ),
-          api_element(
-            "p",
-            {
-              key: api_key(2, item.keyTwo),
-            },
-            [api_text("2" + api_dynamic_text(item.foo))]
-          ),
-          api_element(
-            "p",
-            {
-              key: api_key(3, item.keyThree),
-            },
-            [api_text("3" + api_dynamic_text($cmp.other))]
-          ),
-          api_element(
-            "p",
-            {
-              key: api_key(4, item.keyFour),
-            },
-            [api_text("4" + api_dynamic_text($cmp.other.foo))]
-          ),
-        ];
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr5",
+        api_iterator($cmp.items, function (item) {
+          return [
+            api_element(
+              "p",
+              {
+                key: api_key(1, item.keyOne),
+              },
+              [api_text("1" + api_dynamic_text(item))]
+            ),
+            api_element(
+              "p",
+              {
+                key: api_key(2, item.keyTwo),
+              },
+              [api_text("2" + api_dynamic_text(item.foo))]
+            ),
+            api_element(
+              "p",
+              {
+                key: api_key(3, item.keyThree),
+              },
+              [api_text("3" + api_dynamic_text($cmp.other))]
+            ),
+            api_element(
+              "p",
+              {
+                key: api_key(4, item.keyFour),
+              },
+              [api_text("4" + api_dynamic_text($cmp.other.foo))]
+            ),
+          ];
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
@@ -3,7 +3,7 @@ const stc0 = {
   key: 0,
 };
 const stc1 = {
-  key: 3,
+  key: 4,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
@@ -12,13 +12,12 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_flatten([
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
         api_iterator($cmp.items, function (item) {
           return [
             api_element(
@@ -36,10 +35,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               [api_text("2" + api_dynamic_text(item))]
             ),
           ];
-        }),
-        api_element("p", stc1, [api_text("3" + api_dynamic_text($cmp.item))]),
-      ])
-    ),
+        })
+      ),
+      api_element("p", stc1, [api_text("3" + api_dynamic_text($cmp.item))]),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
@@ -9,21 +9,23 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "p",
-          {
-            key: api_key(1, item.id),
-          },
-          [api_text("1" + api_dynamic_text(item))]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "p",
+            {
+              key: api_key(1, item.id),
+            },
+            [api_text("1" + api_dynamic_text(item))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
@@ -17,29 +17,27 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     h: api_element,
     k: api_key,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
     c: api_custom_element,
   } = $api;
   return [
-    api_custom_element(
-      "a-b",
-      _aB,
-      stc0,
-      api_flatten([
-        $cmp.isTrue
-          ? api_element("div", {
-              props: {
-                innerHTML:
-                  $ctx._rawHtml$0 !== ($ctx._rawHtml$0 = $cmp.ifRawHtml)
-                    ? ($ctx._sanitizedHtml$0 = api_sanitize_html_content(
-                        $cmp.ifRawHtml
-                      ))
-                    : $ctx._sanitizedHtml$0,
-              },
-              context: stc1,
-              key: 1,
-            })
-          : null,
+    api_custom_element("a-b", _aB, stc0, [
+      $cmp.isTrue
+        ? api_element("div", {
+            props: {
+              innerHTML:
+                $ctx._rawHtml$0 !== ($ctx._rawHtml$0 = $cmp.ifRawHtml)
+                  ? ($ctx._sanitizedHtml$0 = api_sanitize_html_content(
+                      $cmp.ifRawHtml
+                    ))
+                  : $ctx._sanitizedHtml$0,
+            },
+            context: stc1,
+            key: 1,
+          })
+        : null,
+      api_fragment(
+        "it-fr3",
         api_iterator($cmp.items, function (item) {
           return api_element("div", {
             props: {
@@ -53,9 +51,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             context: stc1,
             key: api_key(2, item.id),
           });
-        }),
-      ])
-    ),
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
@@ -12,36 +12,38 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return api_element(
-          "div",
-          {
-            attrs: {
-              "data-islast": x.last,
-              "data-isfirst": x.first,
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return api_element(
+            "div",
+            {
+              attrs: {
+                "data-islast": x.last,
+                "data-isfirst": x.first,
+              },
+              key: api_key(1, x.value.id),
             },
-            key: api_key(1, x.value.id),
-          },
-          [
-            api_element("span", stc1, [
-              api_text("Row: " + api_dynamic_text(x.index)),
-            ]),
-            api_text(". Value: " + api_dynamic_text(x.value)),
-          ]
-        );
-      })
-    ),
+            [
+              api_element("span", stc1, [
+                api_text("Row: " + api_dynamic_text(x.index)),
+              ]),
+              api_text(". Value: " + api_dynamic_text(x.value)),
+            ]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
@@ -12,36 +12,38 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return api_element(
-          "div",
-          {
-            attrs: {
-              "data-islast": x.last,
-              "data-isfirst": x.first,
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return api_element(
+            "div",
+            {
+              attrs: {
+                "data-islast": x.last,
+                "data-isfirst": x.first,
+              },
+              key: api_key(1, x.value.id),
             },
-            key: api_key(1, x.value.id),
-          },
-          [
-            api_element("span", stc1, [
-              api_text("Row: " + api_dynamic_text(x.index)),
-            ]),
-            api_text(". Value: " + api_dynamic_text(x.value)),
-          ]
-        );
-      })
-    ),
+            [
+              api_element("span", stc1, [
+                api_text("Row: " + api_dynamic_text(x.index)),
+              ]),
+              api_text(". Value: " + api_dynamic_text(x.value)),
+            ]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
@@ -10,23 +10,25 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     c: api_custom_element,
     i: api_iterator,
+    fr: api_fragment,
     h: api_element,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_custom_element(
-          "ns-item",
-          _nsItem,
-          {
-            key: api_key(1, item.key),
-          },
-          [api_text(api_dynamic_text(item.value))]
-        );
-      })
-    ),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return api_custom_element(
+            "ns-item",
+            _nsItem,
+            {
+              key: api_key(1, item.key),
+            },
+            [api_text(api_dynamic_text(item.value))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
@@ -9,21 +9,23 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "li",
-          {
-            key: api_key(1, item.key),
-          },
-          [api_text(api_dynamic_text(item.value))]
-        );
-      })
-    ),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "li",
+            {
+              key: api_key(1, item.key),
+            },
+            [api_text(api_dynamic_text(item.value))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
@@ -15,22 +15,24 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return api_element(
-          "div",
-          {
-            classMap: stc1,
-            key: api_key(1, item.id),
-          },
-          [api_element("p", stc2, [api_text(api_dynamic_text(item))])]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr3",
+        api_iterator($cmp.items, function (item) {
+          return api_element(
+            "div",
+            {
+              classMap: stc1,
+              key: api_key(1, item.id),
+            },
+            [api_element("p", stc2, [api_text(api_dynamic_text(item))])]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
@@ -9,27 +9,29 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return api_element(
-          "p",
-          {
-            key: api_key(1, $cmp.foo),
-          },
-          [api_text(api_dynamic_text(x.value))]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return api_element(
+            "p",
+            {
+              key: api_key(1, $cmp.foo),
+            },
+            [api_text(api_dynamic_text(x.value))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
@@ -9,27 +9,29 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return api_element(
-          "p",
-          {
-            key: api_key(1, $cmp.foo.index),
-          },
-          [api_text(api_dynamic_text(x.value))]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return api_element(
+            "p",
+            {
+              key: api_key(1, $cmp.foo.index),
+            },
+            [api_text(api_dynamic_text(x.value))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
@@ -6,33 +6,42 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
-  return api_iterator($cmp.features, function (feature) {
-    return api_iterator(
-      feature.innerFeatures,
-      function (featureValue, featureIndex, featureFirst, featureLast) {
-        const feature = {
-          value: featureValue,
-          index: featureIndex,
-          first: featureFirst,
-          last: featureLast,
-        };
-        return api_element(
-          "p",
-          {
-            key: api_key(0, feature.value.label),
-          },
-          [
-            api_text(
-              api_dynamic_text(feature.value.label) +
-                " " +
-                api_dynamic_text(feature.label)
-            ),
-          ]
+  return [
+    api_fragment(
+      "it-fr2",
+      api_iterator($cmp.features, function (feature) {
+        return api_fragment(
+          "it-fr1",
+          api_iterator(
+            feature.innerFeatures,
+            function (featureValue, featureIndex, featureFirst, featureLast) {
+              const feature = {
+                value: featureValue,
+                index: featureIndex,
+                first: featureFirst,
+                last: featureLast,
+              };
+              return api_element(
+                "p",
+                {
+                  key: api_key(0, feature.value.label),
+                },
+                [
+                  api_text(
+                    api_dynamic_text(feature.value.label) +
+                      " " +
+                      api_dynamic_text(feature.label)
+                  ),
+                ]
+              );
+            }
+          )
         );
-      }
-    );
-  });
+      })
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
@@ -9,27 +9,29 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return api_element(
-          "p",
-          {
-            key: api_key(1, x.value),
-          },
-          [api_text(api_dynamic_text(x.value))]
-        );
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return api_element(
+            "p",
+            {
+              key: api_key(1, x.value),
+            },
+            [api_text(api_dynamic_text(x.value))]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -12,47 +12,49 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
-        const x = {
-          value: xValue,
-          index: xIndex,
-          first: xFirst,
-          last: xLast,
-        };
-        return [
-          api_element(
-            "div",
-            {
-              attrs: {
-                "data-islast": x.last,
-                "data-isfirst": x.first,
-              },
-              key: api_key(1, x.value.id),
-            },
-            [
-              api_element("span", stc1, [
-                api_text("Row: " + api_dynamic_text(x.index)),
-              ]),
-              api_text(". Value: " + api_dynamic_text(x.value)),
-            ]
-          ),
-          $cmp.isTrue
-            ? api_element(
-                "div",
-                {
-                  key: api_key(3, x.value.key),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr4",
+        api_iterator($cmp.items, function (xValue, xIndex, xFirst, xLast) {
+          const x = {
+            value: xValue,
+            index: xIndex,
+            first: xFirst,
+            last: xLast,
+          };
+          return [
+            api_element(
+              "div",
+              {
+                attrs: {
+                  "data-islast": x.last,
+                  "data-isfirst": x.first,
                 },
-                [api_text("Text")]
-              )
-            : null,
-        ];
-      })
-    ),
+                key: api_key(1, x.value.id),
+              },
+              [
+                api_element("span", stc1, [
+                  api_text("Row: " + api_dynamic_text(x.index)),
+                ]),
+                api_text(". Value: " + api_dynamic_text(x.value)),
+              ]
+            ),
+            $cmp.isTrue
+              ? api_element(
+                  "div",
+                  {
+                    key: api_key(3, x.value.key),
+                  },
+                  [api_text("Text")]
+                )
+              : null,
+          ];
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-else/expected.js
@@ -1,13 +1,21 @@
 import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<h1${3}>if condition</h1>`;
 const stc0 = {
-  key: 2,
+  key: 3,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, dc: api_dynamic_component } = $api;
-  return $cmp.visible.if
-    ? [api_static_fragment($fragment1(), 1)]
-    : [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)];
+  const {
+    st: api_static_fragment,
+    dc: api_dynamic_component,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.visible.if
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else-nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else-nested/expected.js
@@ -6,23 +6,53 @@ const $fragment4 = parseFragment`<h1${3}>inner elseif</h1>`;
 const $fragment5 = parseFragment`<h1${3}>inner else</h1>`;
 const $fragment6 = parseFragment`<h1${3}>outer else</h1>`;
 const stc0 = {
-  key: 8,
+  key: 10,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, dc: api_dynamic_component } = $api;
-  return $cmp.outer.if
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.outer.elseif1
-    ? [api_static_fragment($fragment2(), 3)]
-    : $cmp.outer.elseif2
-    ? $cmp.inner.if
-      ? [api_static_fragment($fragment3(), 5)]
-      : $cmp.inner.elseif
-      ? [api_static_fragment($fragment4(), 7)]
-      : $cmp.inner.elseif2
-      ? [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)]
-      : [api_static_fragment($fragment5(), 10)]
-    : [api_static_fragment($fragment6(), 12)];
+  const {
+    st: api_static_fragment,
+    dc: api_dynamic_component,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.outer.if
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.outer.elseif1
+            ? api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)])
+            : api_fragment("if-fr0", [
+                $cmp.outer.elseif2
+                  ? api_fragment("if-fr0", [
+                      $cmp.inner.if
+                        ? api_fragment("if-fr5", [
+                            api_static_fragment($fragment3(), 7),
+                          ])
+                        : api_fragment("if-fr5", [
+                            $cmp.inner.elseif
+                              ? api_fragment("if-fr5", [
+                                  api_static_fragment($fragment4(), 9),
+                                ])
+                              : api_fragment("if-fr5", [
+                                  $cmp.inner.elseif2
+                                    ? api_fragment("if-fr5", [
+                                        api_dynamic_component(
+                                          "x-foo",
+                                          $cmp.trackedProp.foo,
+                                          stc0
+                                        ),
+                                      ])
+                                    : api_fragment("if-fr5", [
+                                        api_static_fragment($fragment5(), 12),
+                                      ]),
+                                ]),
+                          ]),
+                    ])
+                  : api_fragment("if-fr0", [
+                      api_static_fragment($fragment6(), 14),
+                    ]),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else/expected.js
@@ -2,15 +2,25 @@ import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<h1${3}>if condition</h1>`;
 const $fragment2 = parseFragment`<h1${3}>elseif condition</h1>`;
 const stc0 = {
-  key: 4,
+  key: 5,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, dc: api_dynamic_component } = $api;
-  return $cmp.visible.if
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.visible.elseif
-    ? [api_static_fragment($fragment2(), 3)]
-    : [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)];
+  const {
+    st: api_static_fragment,
+    dc: api_dynamic_component,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.visible.if
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.visible.elseif
+            ? api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)])
+            : api_fragment("if-fr0", [
+                api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-multiple/expected.js
@@ -3,17 +3,35 @@ const $fragment1 = parseFragment`<h1${3}>if condition</h1>`;
 const $fragment2 = parseFragment`<h1${3}>elseif condition</h1>`;
 const $fragment3 = parseFragment`<h1${3}>else condition</h1>`;
 const stc0 = {
-  key: 4,
+  key: 5,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, dc: api_dynamic_component } = $api;
-  return $cmp.visible.if
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.visible.elseif
-    ? [api_static_fragment($fragment2(), 3)]
-    : $cmp.visible.elseif2
-    ? [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)]
-    : [api_static_fragment($fragment3(), 6)];
+  const {
+    st: api_static_fragment,
+    dc: api_dynamic_component,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.visible.if
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.visible.elseif
+            ? api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)])
+            : api_fragment("if-fr0", [
+                $cmp.visible.elseif2
+                  ? api_fragment("if-fr0", [
+                      api_dynamic_component(
+                        "x-foo",
+                        $cmp.trackedProp.foo,
+                        stc0
+                      ),
+                    ])
+                  : api_fragment("if-fr0", [
+                      api_static_fragment($fragment3(), 7),
+                    ]),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif/expected.js
@@ -1,16 +1,26 @@
 import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<h1${3}>if condition</h1>`;
 const stc0 = {
-  key: 2,
+  key: 3,
 };
 const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, dc: api_dynamic_component } = $api;
-  return $cmp.visible.if
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.visible.elseif
-    ? [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)]
-    : stc1;
+  const {
+    st: api_static_fragment,
+    dc: api_dynamic_component,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.visible.if
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.visible.elseif
+            ? api_fragment("if-fr0", [
+                api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+              ])
+            : api_fragment("if-fr0", stc1),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if/expected.js
@@ -1,13 +1,17 @@
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
+  key: 1,
 };
 const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { dc: api_dynamic_component } = $api;
-  return $cmp.visible.if
-    ? [api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0)]
-    : stc1;
+  const { dc: api_dynamic_component, fr: api_fragment } = $api;
+  return [
+    $cmp.visible.if
+      ? api_fragment("if-fr0", [
+          api_dynamic_component("x-foo", $cmp.trackedProp.foo, stc0),
+        ])
+      : api_fragment("if-fr0", stc1),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/flattening/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/flattening/expected.js
@@ -5,17 +5,20 @@ const $fragment3 = parseFragment`<h1${3}>things</h1>`;
 const $fragment4 = parseFragment`<h1${3}>hello</h1>`;
 const $fragment5 = parseFragment`<h1${3}>world!</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, st: api_static_fragment, f: api_flatten } = $api;
-  return api_flatten([
+  const { t: api_text, st: api_static_fragment, fr: api_fragment } = $api;
+  return [
     $cmp.visible
-      ? [api_text("Conditional Text"), api_static_fragment($fragment1(), 1)]
-      : [
-          api_static_fragment($fragment2(), 3),
-          api_static_fragment($fragment3(), 5),
-        ],
-    api_static_fragment($fragment4(), 7),
-    api_static_fragment($fragment5(), 9),
-  ]);
+      ? api_fragment("if-fr0", [
+          api_text("Conditional Text"),
+          api_static_fragment($fragment1(), 2),
+        ])
+      : api_fragment("if-fr0", [
+          api_static_fragment($fragment2(), 4),
+          api_static_fragment($fragment3(), 6),
+        ]),
+    api_static_fragment($fragment4(), 8),
+    api_static_fragment($fragment5(), 10),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/components/expected.js
@@ -2,16 +2,20 @@ import _cCustom from "c/custom";
 import _cCustomAlt from "c/customAlt";
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   key: 1,
 };
+const stc1 = {
+  key: 2,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
-  return $cmp.visible
-    ? [api_custom_element("c-custom", _cCustom, stc0)]
-    : [api_custom_element("c-custom-alt", _cCustomAlt, stc1)];
+  const { c: api_custom_element, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_custom_element("c-custom", _cCustom, stc0)])
+      : api_fragment("if-fr0", [
+          api_custom_element("c-custom-alt", _cCustomAlt, stc1),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/html-elements/expected.js
@@ -2,10 +2,12 @@ import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<h1${3}>Visible Header</h1>`;
 const $fragment2 = parseFragment`<h1${3}>Alternative Header</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return $cmp.visible
-    ? [api_static_fragment($fragment1(), 1)]
-    : [api_static_fragment($fragment2(), 3)];
+  const { st: api_static_fragment, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/template/expected.js
@@ -1,7 +1,11 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
-  return $cmp.visible ? [api_text("Conditional Text")] : [api_text("Else!")];
+  const { t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [api_text("Else!")]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/components/expected.js
@@ -3,21 +3,29 @@ import _cCustomElseif from "c/customElseif";
 import _cCustomElse from "c/customElse";
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   key: 1,
 };
-const stc2 = {
+const stc1 = {
   key: 2,
 };
+const stc2 = {
+  key: 3,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
-  return $cmp.visible
-    ? [api_custom_element("c-custom", _cCustom, stc0)]
-    : $cmp.elseif
-    ? [api_custom_element("c-custom-elseif", _cCustomElseif, stc1)]
-    : [api_custom_element("c-custom-else", _cCustomElse, stc2)];
+  const { c: api_custom_element, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_custom_element("c-custom", _cCustom, stc0)])
+      : api_fragment("if-fr0", [
+          $cmp.elseif
+            ? api_fragment("if-fr0", [
+                api_custom_element("c-custom-elseif", _cCustomElseif, stc1),
+              ])
+            : api_fragment("if-fr0", [
+                api_custom_element("c-custom-else", _cCustomElse, stc2),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/html-elements/expected.js
@@ -3,12 +3,16 @@ const $fragment1 = parseFragment`<h1${3}>Visible Header</h1>`;
 const $fragment2 = parseFragment`<h1${3}>First Alternative Header</h1>`;
 const $fragment3 = parseFragment`<h1${3}>Alternative Header</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return $cmp.visible
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.elseifCondition
-    ? [api_static_fragment($fragment2(), 3)]
-    : [api_static_fragment($fragment3(), 5)];
+  const { st: api_static_fragment, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.elseifCondition
+            ? api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)])
+            : api_fragment("if-fr0", [api_static_fragment($fragment3(), 6)]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/template/expected.js
@@ -1,11 +1,15 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
-  return $cmp.visible
-    ? [api_text("Conditional Text")]
-    : $cmp.elseifCondition
-    ? [api_text("Elseif!")]
-    : [api_text("Else!")];
+  const { t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [
+          $cmp.elseifCondition
+            ? api_fragment("if-fr0", [api_text("Elseif!")])
+            : api_fragment("if-fr0", [api_text("Else!")]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/components/expected.js
@@ -1,27 +1,31 @@
 import _cCustom from "c/custom";
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
+  key: 1,
 };
 const stc1 = {
-  key: 1,
+  key: 2,
 };
 const stc2 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, c: api_custom_element } = $api;
-  return $cmp.visible
-    ? [
-        api_custom_element("c-custom", _cCustom, stc0, [
-          api_text("Visible Header"),
+  const { t: api_text, c: api_custom_element, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [
+          api_custom_element("c-custom", _cCustom, stc0, [
+            api_text("Visible Header"),
+          ]),
+        ])
+      : api_fragment("if-fr0", [
+          $cmp.elseifCondition
+            ? api_fragment("if-fr0", [
+                api_custom_element("c-custom", _cCustom, stc1, [
+                  api_text("First Alternative Header"),
+                ]),
+              ])
+            : api_fragment("if-fr0", stc2),
         ]),
-      ]
-    : $cmp.elseifCondition
-    ? [
-        api_custom_element("c-custom", _cCustom, stc1, [
-          api_text("First Alternative Header"),
-        ]),
-      ]
-    : stc2;
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/html-elements/expected.js
@@ -3,12 +3,16 @@ const $fragment1 = parseFragment`<h1${3}>Visible Header</h1>`;
 const $fragment2 = parseFragment`<h1${3}>First Alternative Header</h1>`;
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return $cmp.visible
-    ? [api_static_fragment($fragment1(), 1)]
-    : $cmp.elseifCondition
-    ? [api_static_fragment($fragment2(), 3)]
-    : stc0;
+  const { st: api_static_fragment, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", [
+          $cmp.elseifCondition
+            ? api_fragment("if-fr0", [api_static_fragment($fragment2(), 4)])
+            : api_fragment("if-fr0", stc0),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/template/expected.js
@@ -1,12 +1,16 @@
 import { registerTemplate } from "lwc";
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
-  return $cmp.visible
-    ? [api_text("Conditional Text")]
-    : $cmp.displayAlt
-    ? [api_text("Elseif!")]
-    : stc0;
+  const { t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [
+          $cmp.displayAlt
+            ? api_fragment("if-fr0", [api_text("Elseif!")])
+            : api_fragment("if-fr0", stc0),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/components/expected.js
@@ -1,12 +1,16 @@
 import _cCustom from "c/custom";
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
+  key: 1,
 };
 const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element } = $api;
-  return $cmp.visible ? [api_custom_element("c-custom", _cCustom, stc0)] : stc1;
+  const { c: api_custom_element, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_custom_element("c-custom", _cCustom, stc0)])
+      : api_fragment("if-fr0", stc1),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/html-elements/expected.js
@@ -2,8 +2,12 @@ import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<h1${3}></h1>`;
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return $cmp.visible ? [api_static_fragment($fragment1(), 1)] : stc0;
+  const { st: api_static_fragment, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+      : api_fragment("if-fr0", stc0),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/template/expected.js
@@ -1,8 +1,12 @@
 import { registerTemplate } from "lwc";
 const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text } = $api;
-  return $cmp.visible ? [api_text("Conditional Text")] : stc0;
+  const { t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", stc0),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/interop/foreach-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/interop/foreach-if/expected.js
@@ -1,13 +1,25 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, i: api_iterator } = $api;
-  return $cmp.visible
-    ? api_iterator($cmp.items, function (item) {
-        return api_text("Conditional Iteration");
-      })
-    : api_iterator($cmp.altItems, function (item) {
-        return api_text("Else Iteration");
-      });
+  const { t: api_text, i: api_iterator, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [
+          api_fragment(
+            "it-fr1",
+            api_iterator($cmp.items, function (item) {
+              return api_text("Conditional Iteration");
+            })
+          ),
+        ])
+      : api_fragment("if-fr0", [
+          api_fragment(
+            "it-fr2",
+            api_iterator($cmp.altItems, function (item) {
+              return api_text("Else Iteration");
+            })
+          ),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/mixed-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/mixed-elements/expected.js
@@ -2,15 +2,28 @@ import _cDefault from "c/default";
 import { parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<div${3}>Elseif!</div>`;
 const stc0 = {
-  key: 2,
+  key: 3,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, st: api_static_fragment, c: api_custom_element } = $api;
-  return $cmp.visible
-    ? [api_text("Conditional Text")]
-    : $cmp.elseifCondition
-    ? [api_static_fragment($fragment1(), 1)]
-    : [api_custom_element("c-default", _cDefault, stc0, [api_text("Else!")])];
+  const {
+    t: api_text,
+    st: api_static_fragment,
+    c: api_custom_element,
+    fr: api_fragment,
+  } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [
+          $cmp.elseifCondition
+            ? api_fragment("if-fr0", [api_static_fragment($fragment1(), 2)])
+            : api_fragment("if-fr0", [
+                api_custom_element("c-default", _cDefault, stc0, [
+                  api_text("Else!"),
+                ]),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/nested/expected.js
@@ -8,71 +8,83 @@ import _cCustomElseif from "c/customElseif";
 import _cCustomElse from "c/customElse";
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
-};
-const stc1 = {
   key: 1,
 };
-const stc2 = {
+const stc1 = {
   key: 2,
 };
-const stc3 = {
-  key: 3,
-};
-const stc4 = {
+const stc2 = {
   key: 4,
 };
-const stc5 = {
-  key: 5,
-};
-const stc6 = {
+const stc3 = {
   key: 6,
 };
-const stc7 = {
+const stc4 = {
   key: 7,
 };
+const stc5 = {
+  key: 8,
+};
+const stc6 = {
+  key: 9,
+};
+const stc7 = {
+  key: 10,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { c: api_custom_element, t: api_text, f: api_flatten } = $api;
-  return $cmp.visible
-    ? [api_custom_element("c-custom", _cCustom, stc0)]
-    : $cmp.elseif
-    ? [
-        api_custom_element(
-          "c-custom-elseif",
-          _cCustomElseif,
-          stc1,
-          api_flatten([
-            api_text("If Text"),
-            $cmp.showNestedIf
-              ? [
-                  api_custom_element(
-                    "c-nested",
-                    _cNested,
-                    stc2,
-                    $cmp.doubleNestedIf
-                      ? [
-                          api_custom_element(
-                            "c-double-nested",
-                            _cDoubleNested,
-                            stc3
-                          ),
-                        ]
-                      : [
-                          api_custom_element(
-                            "c-double-nested-else",
-                            _cDoubleNestedElse,
-                            stc4
-                          ),
-                        ]
-                  ),
-                ]
-              : $cmp.elseifNested
-              ? [api_custom_element("c-nested-elseif", _cNestedElseif, stc5)]
-              : [api_custom_element("c-nested-else", _cNestedElse, stc6)],
-          ])
-        ),
-      ]
-    : [api_custom_element("c-custom-else", _cCustomElse, stc7)];
+  const { c: api_custom_element, t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_custom_element("c-custom", _cCustom, stc0)])
+      : api_fragment("if-fr0", [
+          $cmp.elseif
+            ? api_fragment("if-fr0", [
+                api_custom_element("c-custom-elseif", _cCustomElseif, stc1, [
+                  api_text("If Text"),
+                  $cmp.showNestedIf
+                    ? api_fragment("if-fr3", [
+                        api_custom_element("c-nested", _cNested, stc2, [
+                          $cmp.doubleNestedIf
+                            ? api_fragment("if-fr5", [
+                                api_custom_element(
+                                  "c-double-nested",
+                                  _cDoubleNested,
+                                  stc3
+                                ),
+                              ])
+                            : api_fragment("if-fr5", [
+                                api_custom_element(
+                                  "c-double-nested-else",
+                                  _cDoubleNestedElse,
+                                  stc4
+                                ),
+                              ]),
+                        ]),
+                      ])
+                    : api_fragment("if-fr3", [
+                        $cmp.elseifNested
+                          ? api_fragment("if-fr3", [
+                              api_custom_element(
+                                "c-nested-elseif",
+                                _cNestedElseif,
+                                stc5
+                              ),
+                            ])
+                          : api_fragment("if-fr3", [
+                              api_custom_element(
+                                "c-nested-else",
+                                _cNestedElse,
+                                stc6
+                              ),
+                            ]),
+                      ]),
+                ]),
+              ])
+            : api_fragment("if-fr0", [
+                api_custom_element("c-custom-else", _cCustomElse, stc7),
+              ]),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/preserve-comments/preserve-comments-disabled/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/preserve-comments/preserve-comments-disabled/expected.js
@@ -1,9 +1,11 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, f: api_flatten } = $api;
-  return api_flatten([
-    $cmp.visible ? [api_text("Conditional Text")] : [api_text("Else!")],
-  ]);
+  const { t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.visible
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [api_text("Else!")]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/not-in-same-condition-tree/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/not-in-same-condition-tree/expected.js
@@ -1,51 +1,57 @@
 import { registerTemplate } from "lwc";
 const stc0 = {
-  key: 0,
+  key: 1,
 };
 const stc1 = {
   attrs: {
     name: "outside-slot",
   },
-  key: 1,
+  key: 2,
 };
 const stc2 = [];
 const stc3 = {
   attrs: {
     name: "outside-slot",
   },
-  key: 2,
+  key: 3,
 };
 const stc4 = {
-  key: 3,
+  key: 5,
 };
 const stc5 = {
   attrs: {
     name: "outside-slot",
   },
-  key: 4,
+  key: 6,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { t: api_text, s: api_slot, h: api_element, f: api_flatten } = $api;
-  return api_flatten([
+  const { t: api_text, s: api_slot, h: api_element, fr: api_fragment } = $api;
+  return [
     $cmp.condition
-      ? [api_text("Conditional Text")]
-      : $cmp.altCondition
-      ? [
-          api_element("div", stc0, [
-            api_slot("outside-slot", stc1, stc2, $slotset),
-          ]),
-        ]
-      : [api_slot("outside-slot", stc3, stc2, $slotset)],
+      ? api_fragment("if-fr0", [api_text("Conditional Text")])
+      : api_fragment("if-fr0", [
+          $cmp.altCondition
+            ? api_fragment("if-fr0", [
+                api_element("div", stc0, [
+                  api_slot("outside-slot", stc1, stc2, $slotset),
+                ]),
+              ])
+            : api_fragment("if-fr0", [
+                api_slot("outside-slot", stc3, stc2, $slotset),
+              ]),
+        ]),
     $cmp.anotherCondition
-      ? [api_text("Another Conditional Text")]
-      : $cmp.anotherAltCondition
-      ? [
-          api_element("div", stc4, [
-            api_slot("outside-slot", stc5, stc2, $slotset),
-          ]),
-        ]
-      : stc2,
-  ]);
+      ? api_fragment("if-fr4", [api_text("Another Conditional Text")])
+      : api_fragment("if-fr4", [
+          $cmp.anotherAltCondition
+            ? api_fragment("if-fr4", [
+                api_element("div", stc4, [
+                  api_slot("outside-slot", stc5, stc2, $slotset),
+                ]),
+              ])
+            : api_fragment("if-fr4", stc2),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/same-branch-condition-tree/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/same-branch-condition-tree/expected.js
@@ -3,28 +3,30 @@ const stc0 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 0,
+  key: 1,
 };
 const stc1 = [];
 const stc2 = {
-  key: 1,
+  key: 2,
 };
 const stc3 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 2,
+  key: 3,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot, h: api_element, t: api_text } = $api;
-  return $cmp.condition
-    ? [
-        api_slot("nested-slot", stc0, stc1, $slotset),
-        api_element("div", stc2, [
-          api_slot("nested-slot", stc3, stc1, $slotset),
-        ]),
-      ]
-    : [api_text("Alternative Text")];
+  const { s: api_slot, h: api_element, t: api_text, fr: api_fragment } = $api;
+  return [
+    $cmp.condition
+      ? api_fragment("if-fr0", [
+          api_slot("nested-slot", stc0, stc1, $slotset),
+          api_element("div", stc2, [
+            api_slot("nested-slot", stc3, stc1, $slotset),
+          ]),
+        ])
+      : api_fragment("if-fr0", [api_text("Alternative Text")]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/complex/expected.js
@@ -10,76 +10,90 @@ const stc2 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 1,
+  key: 3,
 };
 const stc3 = {
-  key: 2,
+  key: 6,
 };
 const stc4 = {
-  key: 3,
+  key: 7,
 };
 const stc5 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 4,
+  key: 8,
 };
 const stc6 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 5,
+  key: 9,
 };
 const stc7 = {
   attrs: {
     name: "conditional-slot",
   },
-  key: 6,
+  key: 10,
 };
 const stc8 = {
   attrs: {
     name: "conditional-slot",
   },
-  key: 7,
+  key: 11,
 };
 const stc9 = {
   attrs: {
     name: "nested-slot",
   },
-  key: 8,
+  key: 12,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot, t: api_text, h: api_element, f: api_flatten } = $api;
-  return api_flatten([
+  const { s: api_slot, t: api_text, h: api_element, fr: api_fragment } = $api;
+  return [
     api_slot("outer-slot", stc0, stc1, $slotset),
     $cmp.condition
-      ? api_flatten([
+      ? api_fragment("if-fr1", [
           $cmp.nested
-            ? [
+            ? api_fragment("if-fr2", [
                 api_text("Conditional Nested Text"),
                 api_slot("nested-slot", stc2, stc1, $slotset),
-              ]
-            : $cmp.doubleNested
-            ? [api_text("Double Nested")]
-            : $cmp.doubleNestedAlt
-            ? $cmp.tripleNested
-              ? [
-                  api_element("div", stc3, [
-                    api_element("div", stc4, [
-                      api_text("Triple Nested Text"),
-                      api_slot("nested-slot", stc5, stc1, $slotset),
+              ])
+            : api_fragment("if-fr2", [
+                $cmp.doubleNested
+                  ? api_fragment("if-fr4", [api_text("Double Nested")])
+                  : api_fragment("if-fr4", [
+                      $cmp.doubleNestedAlt
+                        ? api_fragment("if-fr4", [
+                            $cmp.tripleNested
+                              ? api_fragment("if-fr5", [
+                                  api_element("div", stc3, [
+                                    api_element("div", stc4, [
+                                      api_text("Triple Nested Text"),
+                                      api_slot(
+                                        "nested-slot",
+                                        stc5,
+                                        stc1,
+                                        $slotset
+                                      ),
+                                    ]),
+                                  ]),
+                                ])
+                              : api_fragment("if-fr5", stc1),
+                          ])
+                        : api_fragment("if-fr4", [
+                            api_text("Else"),
+                            api_slot("nested-slot", stc6, stc1, $slotset),
+                          ]),
                     ]),
-                  ]),
-                ]
-              : stc1
-            : [api_text("Else"), api_slot("nested-slot", stc6, stc1, $slotset)],
+              ]),
           api_slot("conditional-slot", stc7, stc1, $slotset),
         ])
-      : [
+      : api_fragment("if-fr1", [
           api_slot("conditional-slot", stc8, stc1, $slotset),
           api_slot("nested-slot", stc9, stc1, $slotset),
-        ],
-  ]);
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/simple/expected.js
@@ -3,20 +3,26 @@ const stc0 = {
   attrs: {
     name: "conditional-slot",
   },
-  key: 0,
+  key: 1,
 };
 const stc1 = [];
 const stc2 = {
   attrs: {
     name: "conditional-slot",
   },
-  key: 1,
+  key: 2,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { s: api_slot } = $api;
-  return $cmp.condition
-    ? [api_slot("conditional-slot", stc0, stc1, $slotset)]
-    : [api_slot("conditional-slot", stc2, stc1, $slotset)];
+  const { s: api_slot, fr: api_fragment } = $api;
+  return [
+    $cmp.condition
+      ? api_fragment("if-fr0", [
+          api_slot("conditional-slot", stc0, stc1, $slotset),
+        ])
+      : api_fragment("if-fr0", [
+          api_slot("conditional-slot", stc2, stc1, $slotset),
+        ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
@@ -4,9 +4,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     d: api_dynamic_text,
     t: api_text,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
   } = $api;
-  return api_flatten([
+  return [
     api_text(
       api_dynamic_text($cmp.val) +
         " " +
@@ -14,14 +14,17 @@ function tmpl($api, $cmp, $slotset, $ctx) {
         " " +
         api_dynamic_text($cmp.val[$cmp.state.foo][$cmp.state.bar])
     ),
-    api_iterator($cmp.arr, function (item, index) {
-      return api_text(
-        api_dynamic_text($cmp.arr[index]) +
-          " " +
-          api_dynamic_text($cmp.arr[$cmp.state.val])
-      );
-    }),
-  ]);
+    api_fragment(
+      "it-fr0",
+      api_iterator($cmp.arr, function (item, index) {
+        return api_text(
+          api_dynamic_text($cmp.arr[index]) +
+            " " +
+            api_dynamic_text($cmp.arr[$cmp.state.val])
+        );
+      })
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes-mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes-mixed/expected.js
@@ -9,23 +9,25 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return $cmp.showItems
-          ? api_element(
-              "p",
-              {
-                key: api_key(1, item.id),
-              },
-              [api_text("1" + api_dynamic_text(item))]
-            )
-          : null;
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return $cmp.showItems
+            ? api_element(
+                "p",
+                {
+                  key: api_key(1, item.id),
+                },
+                [api_text("1" + api_dynamic_text(item))]
+              )
+            : null;
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/multiple-attributes/expected.js
@@ -9,23 +9,25 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
-    api_element(
-      "section",
-      stc0,
-      api_iterator($cmp.items, function (item) {
-        return $cmp.showItems
-          ? api_element(
-              "p",
-              {
-                key: api_key(1, item.id),
-              },
-              [api_text("1" + api_dynamic_text(item))]
-            )
-          : null;
-      })
-    ),
+    api_element("section", stc0, [
+      api_fragment(
+        "it-fr2",
+        api_iterator($cmp.items, function (item) {
+          return $cmp.showItems
+            ? api_element(
+                "p",
+                {
+                  key: api_key(1, item.id),
+                },
+                [api_text("1" + api_dynamic_text(item))]
+              )
+            : null;
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
@@ -7,16 +7,27 @@ const stc0 = {
 };
 const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = $api;
-  return api_iterator($cmp.items, function (item) {
-    return api_element(
-      "div",
-      {
-        key: api_key(0, item),
-      },
-      [api_slot("james", stc0, stc1, $slotset)]
-    );
-  });
+  const {
+    k: api_key,
+    s: api_slot,
+    h: api_element,
+    i: api_iterator,
+    fr: api_fragment,
+  } = $api;
+  return [
+    api_fragment(
+      "it-fr2",
+      api_iterator($cmp.items, function (item) {
+        return api_element(
+          "div",
+          {
+            key: api_key(0, item),
+          },
+          [api_slot("james", stc0, stc1, $slotset)]
+        );
+      })
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
@@ -4,16 +4,27 @@ const stc0 = {
 };
 const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { k: api_key, s: api_slot, h: api_element, i: api_iterator } = $api;
-  return api_iterator($cmp.items, function (item) {
-    return api_element(
-      "div",
-      {
-        key: api_key(0, item),
-      },
-      [api_slot("", stc0, stc1, $slotset)]
-    );
-  });
+  const {
+    k: api_key,
+    s: api_slot,
+    h: api_element,
+    i: api_iterator,
+    fr: api_fragment,
+  } = $api;
+  return [
+    api_fragment(
+      "it-fr2",
+      api_iterator($cmp.items, function (item) {
+        return api_element(
+          "div",
+          {
+            key: api_key(0, item),
+          },
+          [api_slot("", stc0, stc1, $slotset)]
+        );
+      })
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -10,6 +10,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     k: api_key,
     d: api_dynamic_text,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   const { _m0 } = $ctx;
   return [
@@ -23,31 +24,32 @@ function tmpl($api, $cmp, $slotset, $ctx) {
       },
       [api_text("New")]
     ),
-    api_element(
-      "ul",
-      stc0,
-      api_iterator($cmp.list, function (task) {
-        return api_element(
-          "li",
-          {
-            key: api_key(2, task.id),
-          },
-          [
-            api_text(api_dynamic_text(task.title)),
-            api_element(
-              "button",
-              {
-                key: 3,
-                on: {
-                  click: api_bind(task.delete),
+    api_element("ul", stc0, [
+      api_fragment(
+        "it-fr4",
+        api_iterator($cmp.list, function (task) {
+          return api_element(
+            "li",
+            {
+              key: api_key(2, task.id),
+            },
+            [
+              api_text(api_dynamic_text(task.title)),
+              api_element(
+                "button",
+                {
+                  key: 3,
+                  on: {
+                    click: api_bind(task.delete),
+                  },
                 },
-              },
-              [api_text("[X]")]
-            ),
-          ]
-        );
-      })
-    ),
+                [api_text("[X]")]
+              ),
+            ]
+          );
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -1,27 +1,29 @@
 import { registerTemplate } from "lwc";
-const stc0 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     t: api_text,
     k: api_key,
     h: api_element,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
   } = $api;
-  return $cmp.isTrue
-    ? api_flatten([
-        api_text("Outer"),
-        api_iterator($cmp.items, function (item) {
-          return api_element(
-            "p",
-            {
-              key: api_key(0, item.id),
-            },
-            [api_text("Inner")]
-          );
-        }),
-      ])
-    : stc0;
+  return [
+    $cmp.isTrue ? api_text("Outer") : null,
+    $cmp.isTrue
+      ? api_fragment(
+          "it-fr1",
+          api_iterator($cmp.items, function (item) {
+            return api_element(
+              "p",
+              {
+                key: api_key(0, item.id),
+              },
+              [api_text("Inner")]
+            );
+          })
+        )
+      : null,
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
@@ -5,76 +5,88 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     gid: api_scoped_id,
     h: api_element,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
   } = $api;
-  return api_flatten([
-    api_iterator($cmp.items, function (item) {
-      return api_element(
-        "div",
-        {
-          key: api_key(0, item.key),
-        },
-        [
-          api_element("span", {
-            attrs: {
-              id: api_scoped_id("a"),
-            },
-            key: 1,
-          }),
-        ]
-      );
-    }),
-    api_iterator($cmp.items, function (item) {
-      return api_element("span", {
-        attrs: {
-          id: api_scoped_id("b"),
-        },
-        key: api_key(2, item.key),
-      });
-    }),
-    api_iterator(
-      $cmp.items,
-      function (itemValue, itemIndex, itemFirst, itemLast) {
-        const item = {
-          value: itemValue,
-          index: itemIndex,
-          first: itemFirst,
-          last: itemLast,
-        };
+  return [
+    api_fragment(
+      "it-fr2",
+      api_iterator($cmp.items, function (item) {
         return api_element(
           "div",
           {
-            key: api_key(3, item.key),
+            key: api_key(0, item.key),
           },
           [
             api_element("span", {
               attrs: {
-                id: api_scoped_id("c"),
+                id: api_scoped_id("a"),
               },
-              key: 4,
+              key: 1,
             }),
           ]
         );
-      }
+      })
     ),
-    api_iterator(
-      $cmp.items,
-      function (itemValue, itemIndex, itemFirst, itemLast) {
-        const item = {
-          value: itemValue,
-          index: itemIndex,
-          first: itemFirst,
-          last: itemLast,
-        };
+    api_fragment(
+      "it-fr4",
+      api_iterator($cmp.items, function (item) {
         return api_element("span", {
           attrs: {
-            id: api_scoped_id("d"),
+            id: api_scoped_id("b"),
           },
-          key: api_key(5, item.key),
+          key: api_key(3, item.key),
         });
-      }
+      })
     ),
-  ]);
+    api_fragment(
+      "it-fr7",
+      api_iterator(
+        $cmp.items,
+        function (itemValue, itemIndex, itemFirst, itemLast) {
+          const item = {
+            value: itemValue,
+            index: itemIndex,
+            first: itemFirst,
+            last: itemLast,
+          };
+          return api_element(
+            "div",
+            {
+              key: api_key(5, item.key),
+            },
+            [
+              api_element("span", {
+                attrs: {
+                  id: api_scoped_id("c"),
+                },
+                key: 6,
+              }),
+            ]
+          );
+        }
+      )
+    ),
+    api_fragment(
+      "it-fr9",
+      api_iterator(
+        $cmp.items,
+        function (itemValue, itemIndex, itemFirst, itemLast) {
+          const item = {
+            value: itemValue,
+            index: itemIndex,
+            first: itemFirst,
+            last: itemLast,
+          };
+          return api_element("span", {
+            attrs: {
+              id: api_scoped_id("d"),
+            },
+            key: api_key(8, item.key),
+          });
+        }
+      )
+    ),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/usage-if-for-each/expected.js
@@ -16,25 +16,23 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     h: api_element,
     k: api_key,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
     c: api_custom_element,
   } = $api;
   return [
-    api_custom_element(
-      "a-b",
-      _aB,
-      stc0,
-      api_flatten([
-        $cmp.isTrue
-          ? api_element("div", {
-              props: {
-                innerHTML: $cmp.ifRawHtml,
-              },
-              context: stc1,
-              key: 1,
-              renderer: renderer,
-            })
-          : null,
+    api_custom_element("a-b", _aB, stc0, [
+      $cmp.isTrue
+        ? api_element("div", {
+            props: {
+              innerHTML: $cmp.ifRawHtml,
+            },
+            context: stc1,
+            key: 1,
+            renderer: renderer,
+          })
+        : null,
+      api_fragment(
+        "it-fr3",
         api_iterator($cmp.items, function (item) {
           return api_element("div", {
             props: {
@@ -44,9 +42,9 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: api_key(2, item.id),
             renderer: renderer,
           });
-        }),
-      ])
-    ),
+        })
+      ),
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -7,31 +7,28 @@ const stc0 = {
 const stc1 = {
   key: 1,
 };
-const stc2 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     st: api_static_fragment,
     t: api_text,
     i: api_iterator,
-    f: api_flatten,
+    fr: api_fragment,
     c: api_custom_element,
     h: api_element,
   } = $api;
   return [
     api_element("div", stc0, [
-      api_custom_element(
-        "x-b",
-        _xB,
-        stc1,
-        api_flatten([
-          $cmp.isLoading ? api_static_fragment($fragment1(), 3) : null,
-          $cmp.haveLoadedItems
-            ? api_iterator($cmp.menuItems, function (item) {
+      api_custom_element("x-b", _xB, stc1, [
+        $cmp.isLoading ? api_static_fragment($fragment1(), 3) : null,
+        $cmp.haveLoadedItems
+          ? api_fragment(
+              "it-fr4",
+              api_iterator($cmp.menuItems, function (item) {
                 return api_text("x");
               })
-            : stc2,
-        ])
-      ),
+            )
+          : null,
+      ]),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -6,32 +6,32 @@ const stc0 = {
   },
   key: 0,
 };
-const stc1 = [];
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     k: api_key,
     t: api_text,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
     c: api_custom_element,
   } = $api;
   return [
-    api_custom_element(
-      "a-b",
-      _aB,
-      stc0,
+    api_custom_element("a-b", _aB, stc0, [
       $cmp.isTrue
-        ? api_iterator($cmp.items, function (item) {
-            return api_element(
-              "p",
-              {
-                key: api_key(1, item.id),
-              },
-              [api_text("X")]
-            );
-          })
-        : stc1
-    ),
+        ? api_fragment(
+            "it-fr2",
+            api_iterator($cmp.items, function (item) {
+              return api_element(
+                "p",
+                {
+                  key: api_key(1, item.id),
+                },
+                [api_text("X")]
+              );
+            })
+          )
+        : null,
+    ]),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-th-or-td/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-th-or-td/expected.js
@@ -8,7 +8,7 @@ const stc1 = {
   key: 1,
 };
 const stc2 = {
-  key: 5,
+  key: 6,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
@@ -16,35 +16,38 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     st: api_static_fragment,
     h: api_element,
     i: api_iterator,
+    fr: api_fragment,
   } = $api;
   return [
     api_element("table", stc0, [
-      api_element(
-        "thead",
-        stc1,
-        api_iterator($cmp.rows, function (row) {
-          return api_element(
-            "tr",
-            {
-              key: api_key(2, row.id),
-            },
-            [api_static_fragment($fragment1(), 4)]
-          );
-        })
-      ),
-      api_element(
-        "tbody",
-        stc2,
-        api_iterator($cmp.rows, function (row) {
-          return api_element(
-            "tr",
-            {
-              key: api_key(6, row.id),
-            },
-            [api_static_fragment($fragment2(), 8)]
-          );
-        })
-      ),
+      api_element("thead", stc1, [
+        api_fragment(
+          "it-fr5",
+          api_iterator($cmp.rows, function (row) {
+            return api_element(
+              "tr",
+              {
+                key: api_key(2, row.id),
+              },
+              [api_static_fragment($fragment1(), 4)]
+            );
+          })
+        ),
+      ]),
+      api_element("tbody", stc2, [
+        api_fragment(
+          "it-fr10",
+          api_iterator($cmp.rows, function (row) {
+            return api_element(
+              "tr",
+              {
+                key: api_key(7, row.id),
+              },
+              [api_static_fragment($fragment2(), 9)]
+            );
+          })
+        ),
+      ]),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -92,8 +92,6 @@ export function containsDynamicChildren(parent: ParentNode): boolean {
 export function shouldFlatten(codeGen: CodeGen, children: ChildNode[]): boolean {
     return children.some((child) => {
         return (
-            // ForBlock will generate a list of iterable vnodes
-            isForBlock(child) ||
             // IfBlock, ElseIfBlock, and Else children will always be an array
             isIfBlock(child) ||
             // light DOM slots

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -92,8 +92,6 @@ export function containsDynamicChildren(parent: ParentNode): boolean {
 export function shouldFlatten(codeGen: CodeGen, children: ChildNode[]): boolean {
     return children.some((child) => {
         return (
-            // IfBlock, ElseIfBlock, and Else children will always be an array
-            isIfBlock(child) ||
             // light DOM slots
             (isSlot(child) && codeGen.renderMode === LWCDirectiveRenderMode.light) ||
             // If node is only a control flow node and does not map to a stand alone element.

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -263,14 +263,9 @@ function transform(codeGen: CodeGen): t.Expression {
             expression = expression.elements[0] as t.Expression;
         }
 
-        let res: t.Expression;
-        if (isForEach(forBlock)) {
-            res = applyInlineFor(forBlock, expression);
-        } else {
-            res = applyInlineForOf(forBlock, expression);
-        }
-
-        return res;
+        return isForEach(forBlock)
+            ? applyInlineFor(forBlock, expression)
+            : applyInlineForOf(forBlock, expression);
     }
 
     function transformForChildren(forBlock: ForBlock): t.Expression {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -205,24 +205,29 @@ function transform(codeGen: CodeGen): t.Expression {
      * Transforms an IfBlock or ElseifBlock along with both its direct descendants and its 'else' descendants.
      *
      * @param conditionalParentBlock The IfBlock or ElseifBlock to transform into a conditional expression
+     * @param key The key to use for this chain of IfBlock/ElseifBlock branches, if applicable
      * @returns A conditional expression representing the full conditional tree with conditionalParentBlock as the root node
      */
     function transformConditionalParentBlock(
-        conditionalParentBlock: IfBlock | ElseifBlock
+        conditionalParentBlock: IfBlock | ElseifBlock,
+        key?: string | number
     ): t.Expression {
+        const ifBlockKey = key || codeGen.generateKey('if-fr');
         const childrenExpression = transformChildren(conditionalParentBlock);
         let elseExpression: t.Expression = t.arrayExpression([]);
 
         if (conditionalParentBlock.else) {
             elseExpression = isElseifBlock(conditionalParentBlock.else)
-                ? transformConditionalParentBlock(conditionalParentBlock.else)
+                ? t.arrayExpression([
+                      transformConditionalParentBlock(conditionalParentBlock.else, ifBlockKey),
+                  ])
                 : transformChildren(conditionalParentBlock.else);
         }
 
         return t.conditionalExpression(
             codeGen.bindExpression(conditionalParentBlock.condition),
-            childrenExpression,
-            elseExpression
+            codeGen.genFragment(t.literal(ifBlockKey), childrenExpression),
+            codeGen.genFragment(t.literal(ifBlockKey), elseExpression)
         );
     }
 


### PR DESCRIPTION
## Details
Builds on top of https://github.com/salesforce/lwc/pull/3034 to resolve issue with diffing algo. if-elseif-else children are now properly marked as fragments so that the diffing algo can update the nodes properly.

Has dependencies on both https://github.com/salesforce/lwc/pull/3034 and https://github.com/salesforce/lwc/pull/3030 and should only be merged into a branch that contains both those changes.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
