### PR TITLE
fix(engine): comment node patched with text node

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -360,13 +360,13 @@ function t(text: string): VText {
 
 // [co]mment node
 function co(text: string): VComment {
-    let sel, key, elm;
+    let sel, elm;
     return {
         type: VNodeType.Comment,
         sel,
         text,
         elm,
-        key,
+        key: 'c',
         owner: getVMBeingRendered()!,
     };
 }

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -48,7 +48,7 @@ export interface VComment extends BaseVNode {
     type: VNodeType.Comment;
     sel: undefined;
     text: string;
-    key: undefined;
+    key: 'c';
 }
 
 export interface VBaseElement extends BaseVNode {

--- a/packages/@lwc/integration-karma/test/template/html-comments/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/html-comments/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 
 import Test from 'x/test';
+import ConfusedWithText from 'x/confusedWithText';
 
 const COMMENT_NODE = 8;
 
@@ -60,6 +61,21 @@ describe('html comments', () => {
         return Promise.resolve().then(() => {
             comments = getChildrenComments(child);
             expect(comments).not.toContain('slotted:odd comment');
+        });
+    });
+
+    it('should not confuse comments with text nodes', () => {
+        const elm = createElement('x-confused-with-text', { is: ConfusedWithText });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.textContent).toBe('helloworld');
+
+        elm.comments = ['comment'];
+
+        return Promise.resolve().then(() => {
+            const comments = getChildrenComments(elm.shadowRoot);
+            expect(comments).toContain('Comment inside for:each');
+            expect(elm.shadowRoot.textContent).toBe('hellocommentworld');
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/template/html-comments/x/confusedWithText/confusedWithText.html
+++ b/packages/@lwc/integration-karma/test/template/html-comments/x/confusedWithText/confusedWithText.html
@@ -1,0 +1,8 @@
+<template lwc:preserve-comments>
+    hello
+    <template for:each={comments} for:item="comment">
+        <!--Comment inside for:each-->
+        <span key={comment}>{comment}</span>
+    </template>
+    world
+</template>

--- a/packages/@lwc/integration-karma/test/template/html-comments/x/confusedWithText/confusedWithText.js
+++ b/packages/@lwc/integration-karma/test/template/html-comments/x/confusedWithText/confusedWithText.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ConfusedWithText extends LightningElement {
+    @api comments = [];
+}


### PR DESCRIPTION
## Details

Fixes #3046 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
