### PR TITLE
fix(style-compiler): fix whitespace before pseudo-elements

### DIFF
--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/index.spec.js
@@ -1,9 +1,11 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
+import { extractDataIds } from 'test-utils';
 import Basic from 'x/basic';
 import Other from 'x/other';
 import Switchable from 'x/switchable';
 import Unscoped from 'x/unscoped';
 import ShadowWithScoped from 'x/shadowWithScoped';
+import PseudoParent from 'x/pseudoParent';
 
 describe('Light DOM scoped CSS', () => {
     beforeAll(() => {
@@ -81,5 +83,14 @@ describe('Light DOM scoped CSS', () => {
         expect(
             getComputedStyle(elm.shadowRoot.querySelector('x-light-child div')).color
         ).not.toEqual('rgb(255, 0, 0)');
+    });
+
+    it('properly scopes pseudo-elements', () => {
+        const elm = createElement('x-pseudo-parent', { is: PseudoParent });
+        document.body.appendChild(elm);
+        const ids = extractDataIds(elm);
+
+        expect(getComputedStyle(ids.parentDiv, '::after').color).toEqual('rgb(255, 0, 0)');
+        expect(getComputedStyle(ids.childDiv, '::after').color).toEqual('rgb(0, 0, 0)');
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <div data-id="childDiv"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Other extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoChild/pseudoChild.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
-export default class Other extends LightningElement {
+export default class extends LightningElement {
     static renderMode = 'light';
 }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.html
@@ -1,0 +1,4 @@
+<template lwc:render-mode="light">
+    <div data-id="parentDiv"></div>
+    <x-pseudo-child></x-pseudo-child>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Other extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
-export default class Other extends LightningElement {
+export default class extends LightningElement {
     static renderMode = 'light';
 }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.scoped.css
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/x/pseudoParent/pseudoParent.scoped.css
@@ -1,0 +1,3 @@
+.unused-class, ::after {
+    color: red;
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/actual.css
@@ -1,2 +1,17 @@
 ::after {}
 h1::before {}
+
+/* Whitespace before `*::before` */
+*,  *::before {}
+
+/* Whitespace before `::before` */
+*,  ::before {}
+
+/* Whitespace before legacy `:before` */
+*,  :before {}
+
+/* Whitespace before `::before` is a descendant combinator */
+*,  .ancestor ::before {}
+
+/* No whitespace */
+*,::before {}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/pseudo-element/expected.js
@@ -1,7 +1,7 @@
 function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return shadowSelector + "::after {}h1" + shadowSelector + "::before {}";
+  return shadowSelector + "::after {}h1" + shadowSelector + "::before {}*" + shadowSelector + ", *" + shadowSelector + "::before {}*" + shadowSelector + ", " + shadowSelector + "::before {}*" + shadowSelector + ", " + shadowSelector + ":before {}*" + shadowSelector + ", .ancestor" + shadowSelector + " " + shadowSelector + "::before {}*" + shadowSelector + "," + shadowSelector + "::before {}";
   /*LWC compiler vX.X.X*/
 }
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -84,7 +84,16 @@ function scopeSelector(selector: Selector) {
             } else {
                 // Add the scoping token in the first position of the compound selector as a fallback
                 // when there is no node to scope. For example: ::after {}
-                selector.insertBefore(compoundSelector[0], shadowAttribute);
+                const [firstSelector] = compoundSelector;
+                selector.insertBefore(firstSelector, shadowAttribute);
+                // Move any whitespace before the selector (e.g. "  ::after") to before the shadow attribute,
+                // so that the resulting selector is correct (e.g. "  [attr]::after", not "[attr]  ::after")
+                if (firstSelector.spaces.before) {
+                    shadowAttribute.spaces.before = firstSelector.spaces.before;
+                    const clonedFirstSelector = firstSelector.clone({});
+                    clonedFirstSelector.spaces.before = '';
+                    firstSelector.replaceWith(clonedFirstSelector);
+                }
             }
         }
     }


### PR DESCRIPTION
## Details

Fixes #3051

It looks like the problem was just with bare pseudo-elements like `::before` and `::after`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

The behavior before was broken. In the odd case where someone was relying on the broken behavior, the non-broken behavior will be observable. (E.g. with the old behavior, you could use `.unused, ::before {}` as a hack to target any `::before`s in your descendant tree, even if they didn't belong to your component.)

Hopefully this is not a a big deal in practice, and in any case, we need this fix to preserve encapsulation.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11785692
