### PR TITLE
fix: querySelector etc. for root light DOM

### DIFF
--- a/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
@@ -93,4 +93,13 @@ describe('root light element', () => {
             [window, nodes.button, composedPath],
         ]);
     });
+
+    it('querySelector should return slotted elements', () => {
+        setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
+        const nodes = createTestElement('x-root', LightElement);
+        expect(nodes['x-list'].querySelectorAll('button')[0]).toEqual(nodes.button);
+        expect(nodes['x-list'].querySelector('button')).toEqual(nodes.button);
+        expect(nodes['x-list'].getElementsByTagName('button')[0]).toEqual(nodes.button);
+        expect(nodes['x-list'].getElementsByClassName('button')[0]).toEqual(nodes.button);
+    });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
@@ -39,9 +39,6 @@ function dispatchEventWithLog(target, nodes, event) {
 }
 
 describe('root light element', () => {
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', false);
-    });
     if (!process.env.NATIVE_SHADOW) {
         it('should not dispatch events to window from elements slotted into synthetic shadow', () => {
             const nodes = createTestElement('x-root', LightElement);
@@ -60,46 +57,53 @@ describe('root light element', () => {
             ]);
         });
     }
-    it('should throw events properly with flag ENABLE_LIGHT_GET_ROOT_NODE_PATCH', () => {
-        setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
-        const nodes = createTestElement('x-root', LightElement);
+    describe('with flag set', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
+        });
+        afterEach(() => {
+            setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', false);
+        });
 
-        const log = dispatchEventWithLog(
-            nodes.button,
-            nodes,
-            new CustomEvent('test', { bubbles: true, composed: false })
-        );
+        it('should throw events properly with flag ENABLE_LIGHT_GET_ROOT_NODE_PATCH', () => {
+            const nodes = createTestElement('x-root', LightElement);
 
-        const composedPath = [
-            nodes.button,
-            nodes.slot,
-            nodes['x-list'].shadowRoot,
-            nodes['x-list'],
-            nodes['x-root'],
-            document.body,
-            document.documentElement,
-            document,
-            window,
-        ];
-        expect(log).toEqual([
-            [nodes.button, nodes.button, composedPath],
-            [nodes.slot, nodes.button, composedPath],
-            [nodes['x-list'].shadowRoot, nodes.button, composedPath],
-            [nodes['x-list'], nodes.button, composedPath],
-            [nodes['x-root'], nodes.button, composedPath],
-            [document.body, nodes.button, composedPath],
-            [document.documentElement, nodes.button, composedPath],
-            [document, nodes.button, composedPath],
-            [window, nodes.button, composedPath],
-        ]);
-    });
+            const log = dispatchEventWithLog(
+                nodes.button,
+                nodes,
+                new CustomEvent('test', { bubbles: true, composed: false })
+            );
 
-    it('querySelector should return slotted elements', () => {
-        setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
-        const nodes = createTestElement('x-root', LightElement);
-        expect(nodes['x-list'].querySelectorAll('button')[0]).toEqual(nodes.button);
-        expect(nodes['x-list'].querySelector('button')).toEqual(nodes.button);
-        expect(nodes['x-list'].getElementsByTagName('button')[0]).toEqual(nodes.button);
-        expect(nodes['x-list'].getElementsByClassName('button')[0]).toEqual(nodes.button);
+            const composedPath = [
+                nodes.button,
+                nodes.slot,
+                nodes['x-list'].shadowRoot,
+                nodes['x-list'],
+                nodes['x-root'],
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ];
+            expect(log).toEqual([
+                [nodes.button, nodes.button, composedPath],
+                [nodes.slot, nodes.button, composedPath],
+                [nodes['x-list'].shadowRoot, nodes.button, composedPath],
+                [nodes['x-list'], nodes.button, composedPath],
+                [nodes['x-root'], nodes.button, composedPath],
+                [document.body, nodes.button, composedPath],
+                [document.documentElement, nodes.button, composedPath],
+                [document, nodes.button, composedPath],
+                [window, nodes.button, composedPath],
+            ]);
+        });
+
+        it('querySelector should return slotted elements', () => {
+            const nodes = createTestElement('x-root', LightElement);
+            expect(nodes['x-list'].querySelectorAll('button')[0]).toEqual(nodes.button);
+            expect(nodes['x-list'].querySelector('button')).toEqual(nodes.button);
+            expect(nodes['x-list'].getElementsByTagName('button')[0]).toEqual(nodes.button);
+            expect(nodes['x-list'].getElementsByClassName('button')[0]).toEqual(nodes.button);
+        });
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/light-dom/root/x/light/light.html
@@ -1,5 +1,5 @@
 <template lwc:render-mode="light">
     <x-list data-id="x-list">
-        <button data-id="button">Hello</button>
+        <button class="button" data-id="button">Hello</button>
     </x-list>
 </template>

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -254,11 +254,11 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
     if (isSyntheticShadowHost(this)) {
         // element with shadowRoot attached
         const owner = getNodeOwner(this);
-        if (isNull(owner)) {
-            return null;
-        } else if (getNodeKey(this)) {
+        if (getNodeKey(this)) {
             // it is a custom element, and we should then filter by slotted elements
             return getFirstSlottedMatch(this, nodeList);
+        } else if (isNull(owner)) {
+            return null;
         } else {
             // regular element, we should then filter by ownership
             return getFirstMatch(owner, nodeList);
@@ -312,11 +312,11 @@ function getFilteredArrayOfNodes<T extends Node>(
     if (isSyntheticShadowHost(context)) {
         // element with shadowRoot attached
         const owner = getNodeOwner(context);
-        if (isNull(owner)) {
-            filtered = [];
-        } else if (getNodeKey(context)) {
+        if (getNodeKey(context)) {
             // it is a custom element, and we should then filter by slotted elements
             filtered = getAllSlottedMatches(context, unfilteredNodes);
+        } else if (isNull(owner)) {
+            filtered = [];
         } else {
             // regular element, we should then filter by ownership
             filtered = getAllMatches(owner, unfilteredNodes);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -254,7 +254,7 @@ function querySelectorPatched(this: Element /*, selector: string*/): Element | n
     if (isSyntheticShadowHost(this)) {
         // element with shadowRoot attached
         const owner = getNodeOwner(this);
-        if (getNodeKey(this)) {
+        if (!isUndefined(getNodeKey(this))) {
             // it is a custom element, and we should then filter by slotted elements
             return getFirstSlottedMatch(this, nodeList);
         } else if (isNull(owner)) {
@@ -312,7 +312,7 @@ function getFilteredArrayOfNodes<T extends Node>(
     if (isSyntheticShadowHost(context)) {
         // element with shadowRoot attached
         const owner = getNodeOwner(context);
-        if (getNodeKey(context)) {
+        if (!isUndefined(getNodeKey(context))) {
             // it is a custom element, and we should then filter by slotted elements
             filtered = getAllSlottedMatches(context, unfilteredNodes);
         } else if (isNull(owner)) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -137,7 +137,7 @@ export function isSyntheticShadowRoot(node: unknown): node is ShadowRoot {
     return !isUndefined(shadowRootRecord) && node === shadowRootRecord.shadowRoot;
 }
 
-let uid = 1;
+let uid = 0;
 
 export function attachShadow(elm: Element, options: ShadowRootInit): ShadowRoot {
     if (InternalSlot.has(elm)) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -137,7 +137,7 @@ export function isSyntheticShadowRoot(node: unknown): node is ShadowRoot {
     return !isUndefined(shadowRootRecord) && node === shadowRootRecord.shadowRoot;
 }
 
-let uid = 0;
+let uid = 1;
 
 export function attachShadow(elm: Element, options: ShadowRootInit): ShadowRoot {
     if (InternalSlot.has(elm)) {


### PR DESCRIPTION
## Details
Related to #2455 

In the following case
```html
<body>
  <x-light>
     <x-shadow>
        <button></button>
     </x-shadow>
  </x-light>
</body>
```
```
const shadow = document.querySelector('x-shadow');
shadow.querySelector('button'); // returns `null` incorrectly before fix.
```
`button` is within the light DOM of `x-shadow` and should therefore be queryable.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
