### PR TITLE
chore(perf-benchmarks): bust NX cache based on env vars

### DIFF
--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -28,6 +28,24 @@
             "build": {
                 "outputs": [
                     "./dist"
+                ],
+                "//": "The build output depends on these env variables. See: https://nx.dev/concepts/how-caching-works#runtime-hash-inputs",
+                "inputs": [
+                    {
+                        "env": "BENCHMARK_REPO"
+                    },
+                    {
+                        "env": "BENCHMARK_REF"
+                    },
+                    {
+                        "env": "BENCHMARK_AUTO_SAMPLE_CONDITIONS"
+                    },
+                    {
+                        "env": "BENCHMARK_SAMPLE_SIZE"
+                    },
+                    {
+                        "env": "BENCHMARK_TIMEOUT"
+                    }
                 ]
             }
         }


### PR DESCRIPTION
## Details

When running `yarn:performance`, there are certain environmental variables that affect the output. NX [needs to be told about these](https://nx.dev/concepts/how-caching-works#runtime-hash-inputs), or else it won't bust the cache properly.

I tested manually and the NX cache appears to be working correctly. It also still considers source files to be part of the cache key.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

