### PR TITLE
chore: remove unnecessary containsDynamicChildren

### DIFF
--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -6,14 +6,7 @@
  */
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
-import {
-    BaseElement,
-    ChildNode,
-    LWCDirectiveRenderMode,
-    Node,
-    ParentNode,
-    Root,
-} from '../shared/types';
+import { BaseElement, ChildNode, LWCDirectiveRenderMode, Node, Root } from '../shared/types';
 import {
     isParentNode,
     isSlot,
@@ -23,7 +16,6 @@ import {
     isElement,
     isText,
     isComment,
-    isIfBlock,
     isConditionalParentBlock,
 } from '../shared/ast';
 import { TEMPLATE_FUNCTION_NAME, TEMPLATE_PARAMS } from '../shared/constants';
@@ -60,27 +52,6 @@ export function objectToAST(
     return t.objectExpression(
         Object.keys(obj).map((key) => t.property(t.literal(key), valueMapper(key)))
     );
-}
-
-export function containsDynamicChildren(parent: ParentNode): boolean {
-    const hasDynamicChildren = parent.children.some((child) => {
-        // The child in the children array will only ever contain an IfBlock.
-        // ElseIfBlock and ElseBlock are chained together starting from the IfBlock.
-        if (isForBlock(child) || isIf(child) || isIfBlock(child)) {
-            return containsDynamicChildren(child);
-        }
-
-        return false;
-    });
-
-    // In order to check the if-elseif-else chain fully, if the parent is an IfBlock or ElseIfBlock
-    // the else branch must be checked as well.
-    const elseConditionHasDynamicChildren =
-        isConditionalParentBlock(parent) && parent.else
-            ? containsDynamicChildren(parent.else)
-            : false;
-
-    return hasDynamicChildren || elseConditionHasDynamicChildren;
 }
 
 /**

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -64,7 +64,6 @@ import {
     objectToAST,
     shouldFlatten,
     memorizeHandler,
-    containsDynamicChildren,
     parseClassNames,
     parseStyleText,
     hasIdAttribute,
@@ -164,7 +163,7 @@ function transform(codeGen: CodeGen): t.Expression {
         }
 
         if (shouldFlatten(codeGen, children)) {
-            if (children.length === 1 && !containsDynamicChildren(parent)) {
+            if (children.length === 1) {
                 return res[0];
             } else {
                 return codeGen.genFlatten([t.arrayExpression(res)]);


### PR DESCRIPTION
## Details
Since the main content of `containsDynamicChildren` was removed in https://github.com/salesforce/lwc/commit/17a129e95b21cfd093045e021809053022e98ec5#diff-375bb5567638caba6505ed89abae4d4bc1744f27a71fd1e2a650422f7f6f3b59L67, I don't see how this function will ever return anything other than `false`. If I'm not missing anything, we can save on traversal time and confusion by removing this function.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
