### PR TITLE
chore: update geckodriver version for firefox

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -26,7 +26,7 @@ const SAUCE_BROWSERS = [
         browserName: 'firefox',
         version: 'latest',
         'sauce:options': {
-            geckodriverVersion: '0.30.0',
+            geckodriverVersion: '0.31.0',
         },
     },
     {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -18,21 +18,25 @@ const SAUCE_BROWSERS = [
     {
         label: 'sl_chrome_latest',
         browserName: 'chrome',
-        version: 'latest',
+        browserVersion: 'latest',
     },
-    // TODO [#3083]: re-enable Firefox tests
+    // TODO [#3083]: Update to latest firefox and geckodriver.
+    // Pin firefox version to 105 and geckodriver to 0.30.0 for now because of
+    // issues running the latest version of firefox with geckodriver > 0.30.0
+    // in saucelabs.
     {
         label: 'sl_firefox_latest',
         browserName: 'firefox',
-        version: 'latest',
-        'sauce:options': {
-            geckodriverVersion: '0.31.0',
+        browserVersion: '105',
+        sauceOptions: {
+            geckodriverVersion: '0.30.0',
         },
     },
     {
         label: 'sl_safari_latest',
         browserName: 'safari',
-        version: 'latest',
+        browserVersion: 'latest',
+        platformName: 'macOS 12',
     },
 ];
 

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -25,7 +25,7 @@ const SAUCE_BROWSERS = [
         label: 'sl_firefox_latest',
         browserName: 'firefox',
         version: 'latest',
-        'source:options': {
+        'sauce:options': {
             geckodriverVersion: '0.31.0',
         },
     },

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -24,6 +24,7 @@ const SAUCE_BROWSERS = [
     // Pin firefox version to 105 and geckodriver to 0.30.0 for now because of
     // issues running the latest version of firefox with geckodriver > 0.30.0
     // in saucelabs.
+    // https://saucelabs.com/blog/update-firefox-tests-before-oct-4-2022
     {
         label: 'sl_firefox_latest',
         browserName: 'firefox',

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -26,7 +26,7 @@ const SAUCE_BROWSERS = [
         browserName: 'firefox',
         version: 'latest',
         'sauce:options': {
-            geckodriverVersion: '0.31.0',
+            geckodriverVersion: '0.30.0',
         },
     },
     {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -21,11 +21,14 @@ const SAUCE_BROWSERS = [
         version: 'latest',
     },
     // TODO [#3083]: re-enable Firefox tests
-    // {
-    //     label: 'sl_firefox_latest',
-    //     browserName: 'firefox',
-    //     version: '103',
-    // },
+    {
+        label: 'sl_firefox_latest',
+        browserName: 'firefox',
+        version: 'latest',
+        'source:options': {
+            geckodriverVersion: '0.31.0',
+        },
+    },
     {
         label: 'sl_safari_latest',
         browserName: 'safari',

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/sauce.js
@@ -37,7 +37,7 @@ const SAUCE_BROWSERS = [
         label: 'sl_safari_latest',
         browserName: 'safari',
         browserVersion: 'latest',
-        platformName: 'macOS 12',
+        platformName: 'macOS 12', // Note: this must be updated when macOS releases new updates
     },
 ];
 

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -32,7 +32,7 @@ const SAUCE_BROWSERS = [
         nativeShadowCompatible: true,
         test_hydration: true,
         'sauce:options': {
-            geckodriverVersion: '0.30.0',
+            geckodriverVersion: '0.31.0',
         },
     },
     {
@@ -67,7 +67,7 @@ const SAUCE_BROWSERS = [
         compat: true,
         nativeShadowCompatible: false,
         'sauce:options': {
-            geckodriverVersion: '0.30.0',
+            geckodriverVersion: '0.31.0',
         },
     },
     {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -31,7 +31,7 @@ const SAUCE_BROWSERS = [
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,
-        'source:options': {
+        'sauce:options': {
             geckodriverVersion: '0.31.0',
         },
     },

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -60,13 +60,16 @@ const SAUCE_BROWSERS = [
         nativeShadowCompatible: false,
     },
     // TODO [#3083]: re-enable Firefox tests
-    // {
-    //     label: 'sl_firefox_compat',
-    //     browserName: 'firefox',
-    //     version: '54',
-    //     compat: true,
-    //     nativeShadowCompatible: false,
-    // },
+    {
+        label: 'sl_firefox_compat',
+        browserName: 'firefox',
+        version: '54',
+        compat: true,
+        nativeShadowCompatible: false,
+        'sauce:options': {
+            geckodriverVersion: '0.30.0',
+        },
+    },
     {
         label: 'sl_safari_compat',
         browserName: 'safari',

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -27,6 +27,7 @@ const SAUCE_BROWSERS = [
     // Pin firefox version to 105 and geckodriver to 0.30.0 for now because of
     // issues running the latest version of firefox with geckodriver > 0.30.0
     // in saucelabs.
+    // https://saucelabs.com/blog/update-firefox-tests-before-oct-4-2022
     {
         label: 'sl_firefox_latest',
         browserName: 'firefox',
@@ -52,35 +53,22 @@ const SAUCE_BROWSERS = [
     {
         label: 'sl_ie11',
         browserName: 'internet explorer',
-        browserVersion: '11',
+        version: '11',
         compat: true,
         nativeShadowCompatible: false,
     },
     {
         label: 'sl_chrome_compat',
         browserName: 'chrome',
-        browserVersion: '59',
+        version: '59',
         compat: true,
         nativeShadowCompatible: false,
-    },
-    // TODO [#3083]: Update to latest geckodriver.
-    // Pin geckodriver to 0.30.0 for now because of issues running
-    // the latest version of firefox with geckodriver > 0.30.0 in saucelabs.
-    {
-        label: 'sl_firefox_compat',
-        browserName: 'firefox',
-        browserVersion: '54',
-        compat: true,
-        nativeShadowCompatible: false,
-        sauceOptions: {
-            geckodriverVersion: '0.30.0',
-        },
     },
     {
         label: 'sl_safari_compat',
         browserName: 'safari',
-        browserVersion: '10',
-        platformName: 'OS X 10.11',
+        version: '10',
+        platform: 'OS X 10.11',
         compat: true,
         nativeShadowCompatible: false,
     },

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -24,14 +24,17 @@ const SAUCE_BROWSERS = [
         test_hydration: true,
     },
     // TODO [#3083]: re-enable Firefox tests
-    // {
-    //     label: 'sl_firefox_latest',
-    //     browserName: 'firefox',
-    //     version: '103',
-    //     compat: false,
-    //     nativeShadowCompatible: true,
-    //     test_hydration: true,
-    // },
+    {
+        label: 'sl_firefox_latest',
+        browserName: 'firefox',
+        version: '103',
+        compat: false,
+        nativeShadowCompatible: true,
+        test_hydration: true,
+        'source:options': {
+            geckodriverVersion: '0.31.0',
+        },
+    },
     {
         label: 'sl_safari_latest',
         browserName: 'safari',

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -18,63 +18,69 @@ const SAUCE_BROWSERS = [
     {
         label: 'sl_chrome_latest',
         browserName: 'chrome',
-        version: 'latest',
+        browserVersion: 'latest',
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,
     },
-    // TODO [#3083]: re-enable Firefox tests
+    // TODO [#3083]: Update to latest firefox and geckodriver.
+    // Pin firefox version to 105 and geckodriver to 0.30.0 for now because of
+    // issues running the latest version of firefox with geckodriver > 0.30.0
+    // in saucelabs.
     {
         label: 'sl_firefox_latest',
         browserName: 'firefox',
-        version: 'latest',
+        browserVersion: '105',
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,
-        'sauce:options': {
-            geckodriverVersion: '0.31.0',
+        sauceOptions: {
+            geckodriverVersion: '0.30.0',
         },
     },
     {
         label: 'sl_safari_latest',
         browserName: 'safari',
-        version: 'latest',
+        browserVersion: 'latest',
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,
+        platformName: 'macOS 12',
     },
 
     // Compat browsers
     {
         label: 'sl_ie11',
         browserName: 'internet explorer',
-        version: '11',
+        browserVersion: '11',
         compat: true,
         nativeShadowCompatible: false,
     },
     {
         label: 'sl_chrome_compat',
         browserName: 'chrome',
-        version: '59',
+        browserVersion: '59',
         compat: true,
         nativeShadowCompatible: false,
     },
-    // TODO [#3083]: re-enable Firefox tests
+    // TODO [#3083]: Update to latest geckodriver.
+    // Pin geckodriver to 0.30.0 for now because of issues running
+    // the latest version of firefox with geckodriver > 0.30.0 in saucelabs.
     {
         label: 'sl_firefox_compat',
         browserName: 'firefox',
-        version: '54',
+        browserVersion: '54',
         compat: true,
         nativeShadowCompatible: false,
-        'sauce:options': {
-            geckodriverVersion: '0.31.0',
+        sauceOptions: {
+            geckodriverVersion: '0.30.0',
         },
     },
     {
         label: 'sl_safari_compat',
         browserName: 'safari',
-        version: '10',
-        platform: 'OS X 10.11',
+        browserVersion: '10',
+        platformName: 'OS X 10.11',
         compat: true,
         nativeShadowCompatible: false,
     },

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -27,7 +27,7 @@ const SAUCE_BROWSERS = [
     {
         label: 'sl_firefox_latest',
         browserName: 'firefox',
-        version: '103',
+        version: 'latest',
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -32,7 +32,7 @@ const SAUCE_BROWSERS = [
         nativeShadowCompatible: true,
         test_hydration: true,
         'sauce:options': {
-            geckodriverVersion: '0.31.0',
+            geckodriverVersion: '0.30.0',
         },
     },
     {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/sauce.js
@@ -46,7 +46,7 @@ const SAUCE_BROWSERS = [
         compat: false,
         nativeShadowCompatible: true,
         test_hydration: true,
-        platformName: 'macOS 12',
+        platformName: 'macOS 12', // Note: this must be updated when macOS releases new updates
     },
 
     // Compat browsers

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -73,7 +73,13 @@ function getSauceConfig(config, { suiteName, tags, customData, browsers }) {
 
         browsers: browsers.map((browser) => browser.label),
         customLaunchers: browsers.reduce((acc, browser) => {
-            const { label, browserName, platform, version } = browser;
+            const {
+                label,
+                browserName,
+                platform,
+                version,
+                'sauce:options': sauce_options,
+            } = browser;
             return {
                 ...acc,
                 [label]: {
@@ -81,6 +87,7 @@ function getSauceConfig(config, { suiteName, tags, customData, browsers }) {
                     browserName,
                     platform,
                     version,
+                    'sauce:options': sauce_options,
                 },
             };
         }, {}),

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -73,14 +73,34 @@ function getSauceConfig(config, { suiteName, tags, customData, browsers }) {
 
         browsers: browsers.map((browser) => browser.label),
         customLaunchers: browsers.reduce((acc, browser) => {
-            const { label, browserName, platformName, browserVersion, sauceOptions } = browser;
+            // Karma-sauce-launcher uses the browserVersion key to determine if the format is W3C or JWP (deprecated).
+            // https://github.com/karma-runner/karma-sauce-launcher/blob/59b0c5c877448e064ad56449cd906743721c6b62/src/utils.ts#L15-L18
+            // Standard karma tests need to be in W3C in order to pass the sauce:options.
+            // Compat tests need to be in JWP format to utilize older browser versions.
+            // Details about W3C and JWP formats: https://saucelabs.com/platform/platform-configurator
+            const {
+                label,
+                browserName,
+                // platformName is only applicable for W3C
+                platformName,
+                // platform is only applicable for JWP
+                platform,
+                // browserVersion is only applicable for W3C
+                browserVersion,
+                // version is only applicable for JWP
+                version,
+                // sauce:options is only applicable for W3C
+                sauceOptions,
+            } = browser;
             return {
                 ...acc,
                 [label]: {
                     base: 'SauceLabs',
                     browserName,
                     platformName,
+                    platform,
                     browserVersion,
+                    version,
                     'sauce:options': sauceOptions,
                 },
             };

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -73,21 +73,15 @@ function getSauceConfig(config, { suiteName, tags, customData, browsers }) {
 
         browsers: browsers.map((browser) => browser.label),
         customLaunchers: browsers.reduce((acc, browser) => {
-            const {
-                label,
-                browserName,
-                platform,
-                version,
-                'sauce:options': sauce_options,
-            } = browser;
+            const { label, browserName, platformName, browserVersion, sauceOptions } = browser;
             return {
                 ...acc,
                 [label]: {
                     base: 'SauceLabs',
                     browserName,
-                    platform,
-                    version,
-                    'sauce:options': sauce_options,
+                    platformName,
+                    browserVersion,
+                    'sauce:options': sauceOptions,
                 },
             };
         }, {}),


### PR DESCRIPTION
## Details
Addresses #3083 switching to W3C format for saucelab capabilities config, pin firefox version to 105 and `geckodriverVersion` to 0.30.0.

See the Saucelabs article for [details](https://saucelabs.com/blog/update-firefox-tests-before-oct-4-2022).

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

