### PR TITLE
feat(engine-dom): add wire debug info and devtool formatters

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -171,6 +171,10 @@ export interface VM<N = HostNode, E = HostElement> {
     /**
      * Renderer API */
     renderer: RendererAPI;
+
+    /**
+     * Debug info bag. Stores useful debug information about the component. */
+    debugInfo?: Record<symbol, any>;
 }
 
 type VMAssociable = HostNode | LightningElement;
@@ -333,6 +337,10 @@ export function createVM<HostNode, HostElement>(
 
         renderer,
     };
+
+    if (process.env.NODE_ENV !== 'production') {
+        vm.debugInfo = create(null);
+    }
 
     vm.shadowMode = computeShadowMode(vm, renderer);
     vm.tro = getTemplateReactiveObserver(vm);

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -174,7 +174,7 @@ export interface VM<N = HostNode, E = HostElement> {
 
     /**
      * Debug info bag. Stores useful debug information about the component. */
-    debugInfo?: Record<symbol, any>;
+    debugInfo?: Record<string, any>;
 }
 
 type VMAssociable = HostNode | LightningElement;

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -6,6 +6,7 @@
  */
 import {
     assert,
+    create,
     isUndefined,
     ArrayPush,
     defineProperty,
@@ -20,12 +21,20 @@ import { updateComponentValue } from './update-component-value';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
+const WIRE_DEBUG_ENTRY = Symbol.for('@wire');
 
 const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
 
 interface WireContextInternalEventPayload {
     setNewContext(newContext: ContextValue): void;
     setDisconnectedCallback(disconnectCallback: () => void): void;
+}
+
+interface WireDebugInfo {
+    data?: any;
+    config?: ConfigValue;
+    context?: ContextValue;
+    isDataProvisionedForConfig: boolean;
 }
 
 export class WireContextRegistrationEvent extends CustomEvent<undefined> {
@@ -157,9 +166,34 @@ function createConnector(
     resetConfigWatcher: () => void;
 } {
     const { method, adapter, configCallback, dynamic } = wireDef;
-    const dataCallback = isUndefined(method)
+    let debugInfo: WireDebugInfo;
+
+    if (process.env.NODE_ENV !== 'production') {
+        const wireSymbol = Symbol(`@wire ${isUndefined(method) ? name : method.name}`);
+
+        debugInfo = create(null) as WireDebugInfo;
+
+        debugInfo.isDataProvisionedForConfig = false;
+        vm.debugInfo![WIRE_DEBUG_ENTRY][wireSymbol] = debugInfo;
+    }
+
+    const fieldOrMethodCallback = isUndefined(method)
         ? createFieldDataCallback(vm, name)
         : createMethodDataCallback(vm, method);
+
+    const dataCallback = (value: any) => {
+        if (process.env.NODE_ENV !== 'production') {
+            debugInfo.data = value;
+
+            // Note: most of the time, the data provided is for the current config, but there may be
+            // some conditions in which it does not, ex:
+            // race conditions in a poor network while the adapter does not cancel a previous request.
+            debugInfo.isDataProvisionedForConfig = true;
+        }
+
+        fieldOrMethodCallback(value);
+    };
+
     let context: ContextValue | undefined;
     let connector: WireAdapter;
 
@@ -190,6 +224,13 @@ function createConnector(
             noop,
             () => {
                 // job
+
+                if (process.env.NODE_ENV !== 'production') {
+                    debugInfo.config = config;
+                    debugInfo.context = context;
+                    debugInfo.isDataProvisionedForConfig = false;
+                }
+
                 connector.update(config, context);
             },
             noop
@@ -316,6 +357,8 @@ export function installWireAdapters(vm: VM) {
         context,
         def: { wire },
     } = vm;
+
+    vm.debugInfo![WIRE_DEBUG_ENTRY] = create(null);
 
     const wiredConnecting = (context.wiredConnecting = []);
     const wiredDisconnecting = (context.wiredDisconnecting = []);

--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -21,7 +21,7 @@ import { updateComponentValue } from './update-component-value';
 
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
-const WIRE_DEBUG_ENTRY = Symbol.for('@wire');
+const WIRE_DEBUG_ENTRY = '@wire';
 
 const WireMetaMap: Map<PropertyDescriptor, WireDef> = new Map();
 
@@ -34,7 +34,7 @@ interface WireDebugInfo {
     data?: any;
     config?: ConfigValue;
     context?: ContextValue;
-    isDataProvisionedForConfig: boolean;
+    wasDataProvisionedForConfig: boolean;
 }
 
 export class WireContextRegistrationEvent extends CustomEvent<undefined> {
@@ -169,12 +169,12 @@ function createConnector(
     let debugInfo: WireDebugInfo;
 
     if (process.env.NODE_ENV !== 'production') {
-        const wireSymbol = Symbol(`@wire ${isUndefined(method) ? name : method.name}`);
+        const wiredPropOrMethod = isUndefined(method) ? name : method.name;
 
         debugInfo = create(null) as WireDebugInfo;
 
-        debugInfo.isDataProvisionedForConfig = false;
-        vm.debugInfo![WIRE_DEBUG_ENTRY][wireSymbol] = debugInfo;
+        debugInfo.wasDataProvisionedForConfig = false;
+        vm.debugInfo![WIRE_DEBUG_ENTRY][wiredPropOrMethod] = debugInfo;
     }
 
     const fieldOrMethodCallback = isUndefined(method)
@@ -188,7 +188,7 @@ function createConnector(
             // Note: most of the time, the data provided is for the current config, but there may be
             // some conditions in which it does not, ex:
             // race conditions in a poor network while the adapter does not cancel a previous request.
-            debugInfo.isDataProvisionedForConfig = true;
+            debugInfo.wasDataProvisionedForConfig = true;
         }
 
         fieldOrMethodCallback(value);
@@ -228,7 +228,7 @@ function createConnector(
                 if (process.env.NODE_ENV !== 'production') {
                     debugInfo.config = config;
                     debugInfo.context = context;
-                    debugInfo.isDataProvisionedForConfig = false;
+                    debugInfo.wasDataProvisionedForConfig = false;
                 }
 
                 connector.update(config, context);

--- a/packages/@lwc/engine-dom/jest.config.js
+++ b/packages/@lwc/engine-dom/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
     ...BASE_CONFIG,
     displayName: 'lwc-engine-dom',
     roots: ['<rootDir>/src'],
+    testEnvironment: 'jsdom',
 };

--- a/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
+++ b/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import {
+    createElement,
+    LightningElement,
+    registerComponent,
+    registerTemplate,
+    registerDecorators,
+} from '@lwc/engine-dom';
+import { globalThis } from '@lwc/shared';
+
+// it needs to be imported from the window, otherwise the checks for associated vms is done against "@lwc/engine-core"
+const LightningElementFormatter = globalThis['devtoolsFormatters'].find((f: any) => {
+    return f.name === 'LightningElementFormatter';
+});
+
+class WireAdapter {
+    dc: any;
+
+    constructor(dc: any) {
+        this.dc = dc;
+    }
+
+    update(c: any) {
+        this.dc(c);
+    }
+    connect() {}
+    disconnect() {}
+}
+
+describe('Lightning Element formatter', () => {
+    const { header } = LightningElementFormatter;
+
+    it('should not contain body', () => {
+        expect(LightningElementFormatter.hasBody()).toBe(false);
+    });
+
+    it('should not format objects without VM', () => {
+        expect(header({})).toBeNull();
+        expect(header(document.createElement('div'))).toBeNull();
+        expect(header(document.createElement('x-foo'))).toBeNull();
+
+        class WordCount extends HTMLParagraphElement {
+            constructor() {
+                super();
+            }
+        }
+        customElements.define('word-count', WordCount, { extends: 'p' });
+        expect(header(document.createElement('word-count'))).toBeNull();
+    });
+
+    it('should format LWC custom elements', () => {
+        let componentInstance: LightningElement;
+        const Foo = registerComponent(
+            class Foo extends LightningElement {
+                constructor() {
+                    super();
+                    componentInstance = this;
+                }
+            },
+            { tmpl: registerTemplate(() => []) }
+        );
+        const elm = createElement('x-foo', { is: Foo });
+        document.body.appendChild(elm);
+
+        const result = header(elm);
+        expect(result).toHaveLength(4);
+        expect(result[0]).toBe('div');
+
+        const obj = result[2];
+        expect(obj[0]).toBe('object');
+        expect(obj[1].object).toBe(elm);
+        expect(obj[1].config.skip).toBe(true);
+
+        const cmp = result[3][3];
+        expect(obj[0]).toBe('object');
+        expect(cmp[1].object).toBe(componentInstance!);
+    });
+
+    it('should not format component instances when there is no debug information', () => {
+        let componentInstance: LightningElement;
+        const Foo = registerComponent(
+            class Foo extends LightningElement {
+                constructor() {
+                    super();
+                    componentInstance = this;
+                }
+            },
+            { tmpl: registerTemplate(() => []) }
+        );
+        const elm = createElement('x-foo', { is: Foo });
+        document.body.appendChild(elm);
+
+        expect(header(componentInstance!)).toBe(null);
+    });
+
+    it('should format component instances when there is debug information', () => {
+        // atm only wire information is exposed
+        let componentInstance: LightningElement;
+
+        const Component = registerComponent(
+            class Foo extends LightningElement {
+                foo: any;
+                constructor() {
+                    super();
+                    this.foo = void 0;
+                    componentInstance = this;
+                }
+            },
+            { tmpl: registerTemplate(() => []) }
+        );
+
+        registerDecorators(Component, {
+            wire: {
+                foo: {
+                    adapter: WireAdapter,
+                    config: function () {
+                        return {};
+                    },
+                },
+            },
+        });
+
+        const elm = createElement('x-foo', { is: Component });
+        document.body.appendChild(elm);
+
+        const result = header(componentInstance!);
+
+        expect(result).toHaveLength(4);
+        const obj = result[2];
+        expect(obj[0]).toBe('object');
+        expect(obj[1].object).toBe(componentInstance!);
+        expect(obj[1].config.skip).toBe(true);
+
+        const debugInfo = result[3][3];
+
+        expect(debugInfo[0]).toBe('object');
+        // expect(debugInfo[1].object).not.toBeNull();
+        expect(debugInfo[1].object).toMatchInlineSnapshot(`
+            {
+              Symbol(@wire): {
+                Symbol(@wire foo): {
+                  "config": {},
+                  "context": undefined,
+                  "data": {},
+                  "isDataProvisionedForConfig": true,
+                },
+              },
+            }
+        `);
+    });
+});

--- a/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
+++ b/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
@@ -142,12 +142,12 @@ describe('Lightning Element formatter', () => {
         // expect(debugInfo[1].object).not.toBeNull();
         expect(debugInfo[1].object).toMatchInlineSnapshot(`
             {
-              Symbol(@wire): {
-                Symbol(@wire foo): {
+              "@wire": {
+                "foo": {
                   "config": {},
                   "context": undefined,
                   "data": {},
-                  "isDataProvisionedForConfig": true,
+                  "wasDataProvisionedForConfig": true,
                 },
               },
             }

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -6,7 +6,7 @@
  */
 
 import { getAssociatedVMIfPresent, LightningElement } from '@lwc/engine-core';
-import { isUndefined, ownKeys } from '@lwc/shared';
+import { isUndefined, keys } from '@lwc/shared';
 
 /**
  * Displays the header for a custom element.
@@ -34,7 +34,7 @@ function getHeaderForComponentInstance(
     componentInstance: LightningElement,
     debugInfo: Record<symbol, any>
 ) {
-    if (ownKeys(debugInfo).length === 0) {
+    if (keys(debugInfo).length === 0) {
         // there is no debug information, no need to customize this component instance
         return null;
     }

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { getAssociatedVMIfPresent, LightningElement } from '@lwc/engine-core';
+import { isUndefined, ownKeys } from '@lwc/shared';
+
+/**
+ * Displays the header for a custom element.
+ *
+ * @param ce the custom element
+ * @param componentInstance component instance associated with the custom element.
+ */
+function getHeaderForCustomElement(ce: HTMLElement, componentInstance: LightningElement) {
+    // [element]
+    // LWC component instance: [vm.component]
+    return [
+        'div',
+        {},
+        ['object', { object: ce, config: { skip: true } }],
+        [
+            'div',
+            {},
+            ['span', { style: 'margin: 0 5px; color: red' }, 'LWC component instance:'],
+            ['object', { object: componentInstance }],
+        ],
+    ];
+}
+
+function getHeaderForComponentInstance(
+    componentInstance: LightningElement,
+    debugInfo: Record<symbol, any>
+) {
+    if (ownKeys(debugInfo).length === 0) {
+        // there is no debug information, no need to customize this component instance
+        return null;
+    }
+
+    // [component]
+    // Debug information: [vm.debugInfo]
+    return [
+        'div',
+        {},
+        ['object', { object: componentInstance, config: { skip: true } }],
+        [
+            'div',
+            {},
+            ['span', { style: 'margin: 0 5px; color: red' }, 'Debug information:'],
+            ['object', { object: debugInfo }],
+        ],
+    ];
+}
+
+export const LightningElementFormatter = {
+    name: 'LightningElementFormatter',
+
+    header(obj: any, config?: Record<string, any>) {
+        const vm = getAssociatedVMIfPresent(obj);
+
+        if (!isUndefined(vm) && (isUndefined(config) || !config.skip)) {
+            if (obj instanceof HTMLElement) {
+                return getHeaderForCustomElement(obj, vm.component);
+            } else {
+                return getHeaderForComponentInstance(obj, vm.debugInfo!);
+            }
+        }
+
+        return null;
+    },
+    hasBody() {
+        return false;
+    },
+};

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -24,7 +24,7 @@ function getHeaderForCustomElement(ce: HTMLElement, componentInstance: Lightning
         [
             'div',
             {},
-            ['span', { style: 'margin: 0 5px; color: red' }, 'LWC component instance:'],
+            ['span', { style: 'margin: 0 5px; color: red' }, 'LWC:'],
             ['object', { object: componentInstance }],
         ],
     ];
@@ -48,7 +48,7 @@ function getHeaderForComponentInstance(
         [
             'div',
             {},
-            ['span', { style: 'margin: 0 5px; color: red' }, 'Debug information:'],
+            ['span', { style: 'margin: 0 5px; color: red' }, 'Debug:'],
             ['object', { object: debugInfo }],
         ],
     ];

--- a/packages/@lwc/engine-dom/src/formatters/index.ts
+++ b/packages/@lwc/engine-dom/src/formatters/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { globalThis, ArrayPush } from '@lwc/shared';
+import { LightningElementFormatter } from './component';
+
+function init() {
+    const devtoolsFormatters = globalThis.devtoolsFormatters || [];
+    ArrayPush.call(devtoolsFormatters, LightningElementFormatter);
+    globalThis.devtoolsFormatters = devtoolsFormatters;
+}
+
+if (process.env.NODE_ENV !== 'production') {
+    init();
+}

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -14,6 +14,9 @@ import './testFeatureFlag.ts';
 // Tests -------------------------------------------------------------------------------------------
 import './testFeatureFlag.ts';
 
+// DevTools Formatters
+import './formatters';
+
 // Engine-core public APIs -------------------------------------------------------------------------
 export {
     createContextProvider,

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -20,8 +20,6 @@ const {
     setPrototypeOf,
 } = Object;
 
-const { ownKeys } = Reflect;
-
 const { isArray } = Array;
 
 const {
@@ -83,7 +81,6 @@ export {
     isArray,
     isFrozen,
     keys,
-    ownKeys,
     seal,
     setPrototypeOf,
     StringCharCodeAt,

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -20,6 +20,8 @@ const {
     setPrototypeOf,
 } = Object;
 
+const { ownKeys } = Reflect;
+
 const { isArray } = Array;
 
 const {
@@ -81,6 +83,7 @@ export {
     isArray,
     isFrozen,
     keys,
+    ownKeys,
     seal,
     setPrototypeOf,
     StringCharCodeAt,


### PR DESCRIPTION
## Details
This PR solves #1902 by adding debug information for wired properties and methods on a component, exposing it via [Custom Object Formatters in Chrome DevTools](https://docs.google.com/document/d/1FTascZXT9cxfetuPRT2eXPQKXui4nWFivUnS_335T3U/preview#).

The information about each wired property/method has the following shape:
- `data`: the last value emitted by the wire adapter.
- `config`: the last config reported to the wire adapter.
- `context`: for context wire adapters use only.
- `isDataProvisionedForConfig`: `bool`: whether or not the data provisioned by the wire adapter correspond to the config. Note: the wire protocol does not know this for certain, it is `true` if the adapter emits data after a config was reported.

This information is exposed via Custom Object Formatters. The only way to access this information it is to enable the custom formatters in Chrome and inspect a component instance (`this`) or inspect a rendered LWC custom element.

Ex (via a custom element):
<img width="728" alt="image" src="https://user-images.githubusercontent.com/534821/194884480-b95c2406-355d-4f73-ab16-e141a07d403b.png">

Ex (component instance):
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/534821/194884682-673a45a6-b1bc-4960-8749-00f15fc0585c.png">

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
