### PR TITLE
fix(template-compiler): support exportparts attribute

### DIFF
--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/index.spec.js
@@ -1,0 +1,20 @@
+import { createElement } from 'lwc';
+import { extractDataIds } from 'test-utils';
+import Grandparent from 'x/grandparent';
+
+if (process.env.NATIVE_SHADOW) {
+    describe('part and exportparts', () => {
+        it('supports part and exportparts', () => {
+            const elm = createElement('x-grandparent', { is: Grandparent });
+            document.body.appendChild(elm);
+
+            const ids = extractDataIds(elm);
+
+            return Promise.resolve().then(() => {
+                expect(getComputedStyle(ids.overlay).color).toEqual('rgb(255, 0, 0)');
+                expect(getComputedStyle(ids.text).color).toEqual('rgb(0, 0, 255)');
+                expect(getComputedStyle(ids.badge).color).toEqual('rgb(0, 128, 0)');
+            });
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/anotherChild/anotherChild.html
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/anotherChild/anotherChild.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/anotherChild/anotherChild.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/anotherChild/anotherChild.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <div data-id="overlay" part="overlay">overlay</div>
+</template>

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.css
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.css
@@ -1,0 +1,11 @@
+x-parent::part(text) {
+    color: blue;
+}
+
+x-parent::part(overlay) {
+    color: red;
+}
+
+x-parent::part(badge) {
+    color: green;
+}

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.html
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.html
@@ -1,0 +1,3 @@
+<template>
+    <x-parent></x-parent>
+</template>

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/grandparent/grandparent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <x-child exportparts="overlay"></x-child>
+    <x-another-child data-id="text" part="text"></x-another-child>
+    <div data-id="badge" part="badge">badge</div>
+</template>

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -200,6 +200,9 @@ export function isAttribute(element: BaseElement, attrName: string): boolean {
             attrName === 'class' ||
             attrName === 'key' ||
             attrName === 'slot' ||
+            // `exportparts` is only valid on a shadow host, and only available as an attribute, not a property
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts
+            attrName === 'exportparts' ||
             !!attrName.match(DATA_RE)
         );
     }


### PR DESCRIPTION
## Details

Fixes #3005

Adds support for the [`exportparts`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts) attribute.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

You can use `exportparts` now without it throwing an error.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-11605544
