### PR TITLE
fix(engine-core): remove ENABLE_HMR flag

### DIFF
--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -11,7 +11,6 @@ const features: FeatureFlagMap = {
     DUMMY_TEST_FLAG: null,
     ENABLE_ELEMENT_PATCH: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
-    ENABLE_HMR: null,
     ENABLE_HTML_COLLECTIONS_PATCH: null,
     ENABLE_INNER_OUTER_TEXT_PATCH: null,
     ENABLE_MIXED_SHADOW_MODE: null,

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -33,13 +33,6 @@ export interface FeatureFlagMap {
     ENABLE_REACTIVE_SETTER: FeatureFlagValue;
 
     /**
-     * LWC engine flag to enable hot module replacement. It allows to exchange, component
-     * definition, template and stylesheets at runtime without having to reload the entire
-     * application.
-     */
-    ENABLE_HMR: FeatureFlagValue;
-
-    /**
      * Synthetic shadow DOM flag to enable strict `HTMLElement.prototype.innerText` and
      * `HTMLElement.prototype.outerText` shadow dom semantic.
      */

--- a/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest, swapComponent } from 'lwc';
+import { createElement, swapComponent } from 'lwc';
 
 import Container from 'base/container';
 import A from 'base/a';
@@ -8,7 +8,6 @@ import D from 'base/d';
 import E from 'base/e';
 
 describe('component swapping', () => {
-    setFeatureFlagForTest('ENABLE_HMR', true);
     it('should work before and after instantiation', () => {
         expect(swapComponent(A, B)).toBe(true);
         const elm = createElement('x-container', { is: Container });


### PR DESCRIPTION
## Details

This flag is no longer necessary. LWR is already using it, and on platform, we already block access to these APIs and tree-shake them out. (If you don't use these APIs, they are tree-shaken.)

This is the only flag LWR is using, so we can simplify their usage of LWC by just enabling HMR by default.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

Not detectable on platform.

<!-- If yes, please describe the anticipated observable changes. -->
