### PR TITLE
test: add test for named slots and lwc:if directive

### DIFF
--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -2,6 +2,7 @@ import { createElement } from 'lwc';
 import XComplex from 'x/complex';
 import XTest from 'x/test';
 import XForEach from 'x/forEach';
+import XparentWithNamedSlot from 'x/parentWithNamedSlot';
 
 describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     it('should render if branch if the value for lwc:if is truthy', () => {
@@ -144,5 +145,25 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
             .then(() => {
                 expect(element.shadowRoot.querySelector('.if').textContent).toBe('024');
             });
+    });
+
+    describe('slots', () => {
+        it.skip('should render content from named slot', () => {
+            const element = createElement('x-parent', { is: XparentWithNamedSlot });
+            document.body.appendChild(element);
+
+            const child = element.shadowRoot.querySelector('x-child-with-named-slots');
+
+            // When if condition is false, no slot content is provided by parent
+            const assignedNodes = child.shadowRoot.querySelector('slot').assignedNodes();
+            expect(assignedNodes).toHaveSize(0);
+
+            element.condition = true;
+            return Promise.resolve().then(() => {
+                const assignedNodes = child.shadowRoot.querySelector('slot').assignedNodes();
+                expect(assignedNodes).toHaveSize(3); // VFragment has empty text nodes as delimiters
+                expect(assignedNodes[1].innerHTML).toBe('Named slot content from parent');
+            });
+        });
     });
 });

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import XComplex from 'x/complex';
 import XTest from 'x/test';
 import XForEach from 'x/forEach';
-import XparentWithNamedSlot from 'x/parentWithNamedSlot';
+import XParentWithNamedSlot from 'x/parentWithNamedSlot';
 
 describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     it('should render if branch if the value for lwc:if is truthy', () => {
@@ -150,7 +150,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     describe('slots', () => {
         // TODO [#3107]: named slot content wrapped in conditional directives don't work as expected.
         xit('should render content from named slot', () => {
-            const element = createElement('x-parent', { is: XparentWithNamedSlot });
+            const element = createElement('x-parent', { is: XParentWithNamedSlot });
             document.body.appendChild(element);
 
             const child = element.shadowRoot.querySelector('x-child-with-named-slots');

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -148,8 +148,8 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     });
 
     describe('slots', () => {
-        // Issue [#3107]
-        it.skip('should render content from named slot', () => {
+        // TODO [#3107]: named slot content wrapped in conditional directives don't work as expected.
+        xit('should render content from named slot', () => {
             const element = createElement('x-parent', { is: XparentWithNamedSlot });
             document.body.appendChild(element);
 

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -148,6 +148,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     });
 
     describe('slots', () => {
+        // Issue [#3107]
         it.skip('should render content from named slot', () => {
             const element = createElement('x-parent', { is: XparentWithNamedSlot });
             document.body.appendChild(element);

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/childWithNamedSlots/childWithNamedSlots.html
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/childWithNamedSlots/childWithNamedSlots.html
@@ -1,0 +1,3 @@
+<template>
+    <slot name="slotname1"><div>Default slot content</div></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/childWithNamedSlots/childWithNamedSlots.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/childWithNamedSlots/childWithNamedSlots.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/parentWithNamedSlot/parentWithNamedSlot.html
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/parentWithNamedSlot/parentWithNamedSlot.html
@@ -1,0 +1,7 @@
+<template>
+    <x-child-with-named-slots>
+        <template lwc:if={condition}>
+            <div slot="slotname1">Named slot content from parent</div>
+        </template>
+    </x-child-with-named-slots>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/parentWithNamedSlot/parentWithNamedSlot.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/x/parentWithNamedSlot/parentWithNamedSlot.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api condition = false;
+}


### PR DESCRIPTION
## Details
Adds a test case for named slots and slot content wrapped in a lwc:if directive

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11838547