### PR TITLE
feat: extract pivots into @lwc/scoped-registry package

### DIFF
--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
@@ -6,7 +6,7 @@
  */
 import { isUndefined } from '@lwc/shared';
 import features from '@lwc/features';
-import { createScopedRegistry, CreateScopedConstructor } from './create-scoped-registry';
+import { createScopedRegistry, CreateScopedConstructor } from '@lwc/scoped-registry';
 import { hasCustomElements } from './has-custom-elements';
 import type { LifecycleCallback } from '@lwc/engine-core';
 

--- a/packages/@lwc/scoped-registry/README.md
+++ b/packages/@lwc/scoped-registry/README.md
@@ -1,0 +1,136 @@
+# @lwc/scoped-registry
+
+Allows [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) to share the same tag name in the same DOM without conflicts. In a sense, it is a (partial) polyfill for [Scoped Custom Element Registries](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md).
+
+## Installation
+
+```sh
+npm install @lwc/scoped-registry
+```
+
+## Usage
+
+Import the library:
+
+```js
+import { createScopedRegistry } from '@lwc/scoped-registry';
+```
+
+Create a scoped registry:
+
+```js
+const createScopedConstructor = createScopedRegistry();
+```
+
+Next, create two separate "userland" constructors:
+
+```js
+class UserCtor1 extends HTMLElement {
+    connectedCallback() {
+        console.log('I am x-foo!');
+    }
+}
+
+class UserCtor2 extends HTMLElement {
+    connectedCallback() {
+        console.log('I am also x-foo!');
+    }
+}
+```
+
+Then, create a "scoped constructor" (passing in any user constructor, which is used as an optimization hint):
+
+```js
+const ScopedCtor = createScopedConstructor('x-foo', UserCtor1);
+```
+
+Now you can create two elements with the same tag name, but different behavior!
+
+```js
+const elm1 = new ScopedCtor(UserCtor1);
+const elm2 = new ScopedCtor(UserCtor2);
+
+document.body.appendChild(elm1);
+document.body.appendChild(elm2);
+```
+
+These two elements can coexistent in the same DOM, but with different functionality (constructor, `connectedCallback`, `observedAttributes`, etc.).
+
+## How it works
+
+The core concept behind this library is ["pivots"](https://github.com/caridy/redefine-custom-elements), based on [an implementation in Polymer's web components polyfills](https://github.com/webcomponents/polyfills/blob/ee1db33d70400c89f0c7255f78d889c9b8eb88a7/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js). The idea is twofold:
+
+1. Have a mechanism to register a class extending `HTMLElement` that can dynamically change its behavior on-demand.
+2. Patch all relevant globals (`customElements.define`, `customElements.get`, `HTMLElement`) so that, to the outside observer, native custom element registry behavior is still respected.
+
+So for example, custom elements defined _outside_ of the scoped registry will still conflict:
+
+```js
+customElements.define('x-bar', class extends HTMLElement {});
+customElements.define('x-bar', class extends HTMLElement {}); // Error
+```
+
+... but elements defined within the scoped registry can conflict with those outside of it:
+
+```js
+createScopedConstructor('x-bar', class extends HTMLElement {});
+customElements.define('x-bar', class extends HTMLElement {}); // This is fine
+```
+
+... and elements defined internally are "hidden" to the outside observer (to some degree):
+
+```js
+createScopedConstructor('x-bar', class extends HTMLElement {});
+customElements.get('x-bar'); // undefined
+```
+
+## Gotchas
+
+You may want to cache the global `window.HTMLElement` after defining a scoped registry:
+
+```js
+const createScopedConstructor = createScopedRegistry();
+const CachedHTMLElement = window.HTMLElement;
+```
+
+Then you would use this `CachedHTMLElement` when defining userland constructors:
+
+```js
+class UserCtor extends CachedHTMLElement {}
+```
+
+This is helpful if there are multiple copies of `@lwc/scoped-registry` on the same page. Otherwise,
+you may end up with conflicting `HTMLElement` objects from different scoped registries, which can cause runtime errors.
+
+Caching after calling `createScopedRegistry()` ensures you are using the right `HTMLElement` for your registry.
+
+## Drawbacks
+
+### Partial leakage of private components
+
+In a sense, components created inside of the scoped registry are "invisible" to the outside observer. The abstraction does leak in some places – for instance, calling `document.createElement('x-foo')` when `x-foo` is registered by the scoped registry will necessarily create a custom element:
+
+```js
+createScopedConstructor('x-baz', class extends HTMLElement {});
+
+const elm = document.createElement('x-baz');
+console.log(elm.constructor); // "scoped" constructor
+```
+
+However, such an element is not completely upgraded (i.e. the userland `constructor`/`connectedCallback`/`disconnectedCallback`/etc will not apply). So it is effectively inert from the outside observer's perspective. In this way, elements defined inside the scoped registry are still private to a degree.
+
+Note that `new`-ing the scoped constructor without the corresponding userland constructor also results in an "inert" component.
+
+### Global patches
+
+To preserve native custom element semantics to the outside world, many globals (e.g. `customElements.define`, `customElements.get`, `HTMLElement`) need to be patched. This introduces the potential for conflicts with native browser behavior, and in some cases the native browser behavior cannot be perfectly emulated.
+
+One example is `observedAttributes` and `attributeChangedCallback`. Because a component only has one chance to communicate its `observedAttributes` to the browser (at `customElements.define()`), a second scoped element with its own `observedAttributes` cannot truly register those attributes to be observed.
+
+However, this library emulates the native browser behavior by overriding `setAttribute` and `removeAttribute` on the second element. It's not a perfect emulation, but it is functionally equivalent.
+
+### Not a "true" polyfill
+
+The goal of this library is not to implement the [Scoped Custom Element Registries](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md) spec one-to-one. Instead, it tries to provide the minimum API surface necessary to support custom elements that share the same global tag name.
+
+Potentially, you _could_ build a true polyfill on top of `@lwc/scoped-registry`. But that is considered out-of-scope for the library at this time.

--- a/packages/@lwc/scoped-registry/README.md
+++ b/packages/@lwc/scoped-registry/README.md
@@ -2,6 +2,8 @@
 
 Allows [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) to share the same tag name in the same DOM without conflicts. In a sense, it is a (partial) polyfill for [Scoped Custom Element Registries](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md).
 
+Note that this library only supports [browsers that support custom elements](https://caniuse.com/custom-elementsv1).
+
 ## Installation
 
 ```sh

--- a/packages/@lwc/scoped-registry/package.json
+++ b/packages/@lwc/scoped-registry/package.json
@@ -1,21 +1,22 @@
 {
-    "name": "@lwc/engine-dom",
+    "name": "@lwc/scoped-registry",
     "version": "2.25.1",
-    "description": "Renders LWC components in a DOM environment.",
+    "description": "Define different custom elements sharing the same tag name",
     "homepage": "https://lwc.dev/",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/lwc.git",
-        "directory": "packages/@lwc/engine-dom"
+        "directory": "packages/@lwc/scoped-registry"
     },
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "main": "dist/engine-dom.cjs.js",
-    "module": "dist/engine-dom.js",
-    "typings": "types/index.d.ts",
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.js",
     "license": "MIT",
+    "typings": "types/index.d.ts",
     "scripts": {
+        "clean": "rm -rf dist/ types/",
         "build": "rollup --config scripts/rollup.config.js",
         "dev": "rollup  --config scripts/rollup.config.js --watch --no-watch.clearScreen"
     },
@@ -23,21 +24,16 @@
         "dist/",
         "types/"
     ],
-    "devDependencies": {
-        "@lwc/engine-core": "2.25.1",
-        "@lwc/shared": "2.25.1",
-        "@lwc/scoped-registry": "2.25.1"
-    },
-    "lwc": {
-        "modules": [
-            {
-                "name": "lwc",
-                "path": "dist/engine-dom.js"
-            }
-        ],
-        "expose": [
-            "lwc"
-        ]
+    "keywords": [
+        "lwc",
+        "polyfill",
+        "custom",
+        "elements",
+        "scoped",
+        "registry"
+    ],
+    "dependencies": {
+        "@lwc/shared": "2.25.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/scoped-registry/scripts/rollup.config.js
+++ b/packages/@lwc/scoped-registry/scripts/rollup.config.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/* eslint-env node */
+
+const path = require('path');
+const typescript = require('../../../../scripts/rollup/typescript');
+const writeDistAndTypes = require('../../../../scripts/rollup/writeDistAndTypes');
+const { version, dependencies, peerDependencies } = require('../package.json');
+const banner = `/**\n * Copyright (C) 2018 salesforce.com, inc.\n */`;
+const footer = `/** version: ${version} */`;
+
+const formats = ['es', 'cjs'];
+
+module.exports = {
+    input: path.resolve(__dirname, '../src/index.ts'),
+
+    output: formats.map((format) => {
+        return {
+            file: `index${format === 'cjs' ? '.cjs' : ''}.js`,
+            format,
+            banner,
+            footer,
+        };
+    }),
+
+    plugins: [typescript(), writeDistAndTypes()],
+
+    onwarn({ code, message }) {
+        if (!process.env.ROLLUP_WATCH && code !== 'CIRCULAR_DEPENDENCY') {
+            throw new Error(message);
+        }
+    },
+
+    external: [...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
+};

--- a/packages/@lwc/scoped-registry/src/create-scoped-registry.ts
+++ b/packages/@lwc/scoped-registry/src/create-scoped-registry.ts
@@ -12,7 +12,6 @@ import {
     isFunction,
     StringToLowerCase,
 } from '@lwc/shared';
-import { hasCustomElements } from './has-custom-elements';
 
 export type CreateScopedConstructor = (
     tagName: string,
@@ -24,12 +23,6 @@ export type CreateScopedConstructor = (
  * do not conflict with vanilla custom elements having the same tag name.
  */
 export function createScopedRegistry(): CreateScopedConstructor {
-    if (!hasCustomElements) {
-        // This code should never be reached, because we don't use the pivot registry if
-        // custom elements are unavailable.
-        throw new Error('Custom elements are not supported in this environment.');
-    }
-
     const { HTMLElement: NativeHTMLElement } = window;
     const {
         hasAttribute: nativeHasAttribute,
@@ -490,17 +483,17 @@ export function createScopedRegistry(): CreateScopedConstructor {
     HTMLElement.prototype = NativeHTMLElement.prototype;
 
     /**
-     * Create a new PivotConstructor for the given tagName, which is capable of being constructed
+     * Create a new scoped (pivot) constructor for the given tagName, which is capable of being constructed
      * with a UserConstructor defining the behavior. Passing in the UserConstructor here
      * is a hint that can be used when registering a custom element with the global custom elements
      * registry for the first time, which provides certain optimizations. It also marks the UserConstructor
-     * as "safe" to be used when passed in to a PivotConstructor.
+     * as "safe" to be used when passed in to a scoped constructor.
      *
      * @param tagName - element tag name
      * @param UserCtor - userland custom element constructor
      * @returns a new custom element constructor
      */
-    return function createPivotConstructor(
+    return function createScopedConstructor(
         tagName: string,
         UserCtor: CustomElementConstructor
     ): CustomElementConstructor {

--- a/packages/@lwc/scoped-registry/src/index.ts
+++ b/packages/@lwc/scoped-registry/src/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export * from './create-scoped-registry';

--- a/packages/@lwc/scoped-registry/tsconfig.json
+++ b/packages/@lwc/scoped-registry/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+
+    "compilerOptions": {
+        "sourceMap": false,
+        "outDir": ".",
+        "lib": ["dom", "es2018"]
+    },
+
+    "include": ["src/", "typings/"]
+}

--- a/packages/@lwc/scoped-registry/typings/observedAttributes.d.ts
+++ b/packages/@lwc/scoped-registry/typings/observedAttributes.d.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// TypeScript seems to be missing this definition from dom.d.ts. It can be removed when
+// this is fixed: https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1338
+declare interface CustomElementConstructor {
+    observedAttributes?: string[];
+}


### PR DESCRIPTION
## Details

Fixes #3096. Creates a new package called `@lwc/scoped-registry`.

The actual functional behavior if modified as little as possible; this is just about making the package accessible for usage outside of LWC (e.g. Locker).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-11884700](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000018ToytYAC/view)
