### PR TITLE
test(pivots): test instanceof custom element

### DIFF
--- a/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
@@ -208,6 +208,34 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
                 });
         });
 
+        it('vanilla element should be an instance of the right class', () => {
+            const tagName = 'x-check-ctor-instanceof';
+            class MyElement extends HTMLElement {}
+
+            const whenDefinedPromiseBeforeDefine = customElements.whenDefined(tagName);
+
+            customElements.define(tagName, MyElement);
+            const elm = document.createElement(tagName);
+
+            // check element prototype
+            expect(elm instanceof MyElement).toEqual(true);
+            expect(elm.constructor).toBe(MyElement);
+
+            // check cE.get()
+            const Ctor = customElements.get(tagName);
+            expect(Ctor).toBe(MyElement);
+
+            // check cE.whenDefined()
+            return whenDefinedPromiseBeforeDefine
+                .then((Ctor) => {
+                    expect(Ctor).toBe(MyElement);
+                    return customElements.whenDefined(tagName);
+                })
+                .then((Ctor) => {
+                    expect(Ctor).toBe(MyElement);
+                });
+        });
+
         describe('defining an invalid tag name', () => {
             const scenarios = [
                 {


### PR DESCRIPTION
## Details

This adds a test case suggested by @ravijayaramappa (https://github.com/salesforce/lwc/pull/2724). It works both with and without pivots.

The "constructor call trick" is the magic that makes this work:

https://github.com/salesforce/lwc/blob/db08f90017ec6bd28cc6234423ee130e5dbadaa9/packages/%40lwc/engine-dom/src/custom-elements/create-scoped-registry.ts#L320

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
