### PR TITLE
chore(nucleus): remove failing downstreams

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -18,7 +18,6 @@ branches:
         - communities/shared-experience-components
         - communities/talon-template-byo
         - communities/ui-b2b-components
-        - communities/ui-cms-components
         - communities/ui-commerce-components
         - communities/ui-dxp-components
         - communities/ui-feeds-components
@@ -36,7 +35,6 @@ branches:
         - salesforce-experience-platform/lwr-recipes
         - salesforce/o11y-sample-app
         - salesforcedevs/doc-framework-monorepo
-        - uiplatform/aura-hotswap-bundle
   release:
     pull-request:
       <<: *branch-definition


### PR DESCRIPTION
## Details

These two downstreams seem to be failing for spurious reasons. (Snapshots, some kind of WebDriver error.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
