### PR TITLE
fix(engine-core): tagNames generated by Java compiler need to be lowercased

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc-monorepo",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "private": true,
     "description": "Lightning Web Components",
     "repository": {

--- a/packages/@lwc/aria-reflection-polyfill/package.json
+++ b/packages/@lwc/aria-reflection-polyfill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/aria-reflection-polyfill",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "ARIA element reflection polyfill for strings",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -34,7 +34,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lwc/shared": "2.26.0"
+        "@lwc/shared": "2.26.1"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.26.0",
+    "version": "2.26.1",
     "main": "src/index.js",
     "typings": "src/index.d.ts",
     "license": "MIT",
@@ -21,8 +21,8 @@
     ],
     "dependencies": {
         "@babel/helper-module-imports": "~7.18.6",
-        "@lwc/errors": "2.26.0",
-        "@lwc/shared": "2.26.0",
+        "@lwc/errors": "2.26.1",
+        "@lwc/shared": "2.26.1",
         "line-column": "~1.0.2"
     },
     "peerDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/compiler",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "LWC compiler",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,11 +25,11 @@
         "@babel/core": "~7.19.1",
         "@babel/plugin-proposal-class-properties": "~7.18.6",
         "@babel/plugin-proposal-object-rest-spread": "~7.18.9",
-        "@lwc/babel-plugin-component": "2.26.0",
-        "@lwc/errors": "2.26.0",
-        "@lwc/shared": "2.26.0",
-        "@lwc/style-compiler": "2.26.0",
-        "@lwc/template-compiler": "2.26.0"
+        "@lwc/babel-plugin-component": "2.26.1",
+        "@lwc/errors": "2.26.1",
+        "@lwc/shared": "2.26.1",
+        "@lwc/style-compiler": "2.26.1",
+        "@lwc/template-compiler": "2.26.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-core",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Core LWC engine APIs.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/features": "2.26.0",
-        "@lwc/shared": "2.26.0"
+        "@lwc/features": "2.26.1",
+        "@lwc/shared": "2.26.1"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -316,7 +316,17 @@ function mountCustomElement(
         }
     };
 
-    const elm = createCustomElement(sel, upgradeCallback, connectedCallback, disconnectedCallback);
+    // Should never get a tag with upper case letter at this point; the compiler
+    // should produce only tags with lowercase letters. However, the Java
+    // compiler may generate tagnames with uppercase letters so - for backwards
+    // compatibility, we lower case the tagname here.
+    const normalizedTagname = sel.toLowerCase();
+    const elm = createCustomElement(
+        normalizedTagname,
+        upgradeCallback,
+        connectedCallback,
+        disconnectedCallback
+    );
 
     vnode.elm = elm;
     vnode.vm = vm;

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-dom",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Renders LWC components in a DOM environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.26.0",
-        "@lwc/shared": "2.26.0"
+        "@lwc/engine-core": "2.26.1",
+        "@lwc/shared": "2.26.1"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-server",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Renders LWC components in a server environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,9 +24,9 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.26.0",
-        "@lwc/rollup-plugin": "2.26.0",
-        "@lwc/shared": "2.26.0",
+        "@lwc/engine-core": "2.26.1",
+        "@lwc/rollup-plugin": "2.26.1",
+        "@lwc/shared": "2.26.1",
         "@rollup/plugin-virtual": "^2.1.0",
         "parse5": "^6.0.1"
     },

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/errors",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "LWC Error Utilities",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/features",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "LWC Features Flags",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,7 +24,7 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.26.0"
+        "@lwc/shared": "2.26.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-karma",
     "private": true,
-    "version": "2.26.0",
+    "version": "2.26.1",
     "scripts": {
         "start": "karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
@@ -17,11 +17,11 @@
         "karma-jasmine must be kept at v4 because it is only compatible with jasmine-core@4, which we need for IE11"
     ],
     "devDependencies": {
-        "@lwc/compiler": "2.26.0",
-        "@lwc/engine-dom": "2.26.0",
-        "@lwc/engine-server": "2.26.0",
-        "@lwc/rollup-plugin": "2.26.0",
-        "@lwc/synthetic-shadow": "2.26.0",
+        "@lwc/compiler": "2.26.1",
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/engine-server": "2.26.1",
+        "@lwc/rollup-plugin": "2.26.1",
+        "@lwc/synthetic-shadow": "2.26.1",
         "chokidar": "^3.5.3",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-tests",
     "private": true,
-    "version": "2.26.0",
+    "version": "2.26.1",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -20,7 +20,7 @@
         "sauce:prod_compat": "MODE=prod_compat yarn build:prod_compat && MODE=prod_compat wdio ./scripts/wdio.sauce.conf.js"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.26.0",
+        "@lwc/rollup-plugin": "2.26.1",
         "@wdio/cli": "^7.24.0",
         "@wdio/local-runner": "^7.24.0",
         "@wdio/mocha-framework": "^7.24.0",
@@ -30,7 +30,7 @@
         "@wdio/static-server-service": "^7.24.0",
         "deepmerge": "^4.2.2",
         "dotenv": "^16.0.2",
-        "lwc": "2.26.0",
+        "lwc": "2.26.1",
         "minimist": "^1.2.5",
         "webdriverio": "^7.24.0"
     }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.26.0",
+    "version": "2.26.1",
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "scripts": {

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lwc/perf-benchmarks-components",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.26.0"
+        "@lwc/rollup-plugin": "2.26.1"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/perf-benchmarks",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -13,10 +13,10 @@
         "Also note we are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0."
     ],
     "dependencies": {
-        "@lwc/engine-dom": "2.26.0",
-        "@lwc/engine-server": "2.26.0",
-        "@lwc/perf-benchmarks-components": "2.26.0",
-        "@lwc/synthetic-shadow": "2.26.0"
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/engine-server": "2.26.1",
+        "@lwc/perf-benchmarks-components": "2.26.1",
+        "@lwc/synthetic-shadow": "2.26.1"
     },
     "devDependencies": {
         "glob-hash": "^1.0.5",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/rollup-plugin",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Rollup plugin to compile LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,12 +22,12 @@
         "dist/"
     ],
     "devDependencies": {
-        "@lwc/compiler": "2.26.0",
-        "@lwc/engine-dom": "2.26.0",
-        "@lwc/errors": "2.26.0"
+        "@lwc/compiler": "2.26.1",
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/errors": "2.26.1"
     },
     "dependencies": {
-        "@lwc/module-resolver": "2.26.0",
+        "@lwc/module-resolver": "2.26.1",
         "@rollup/pluginutils": "~4.2.1"
     },
     "peerDependencies": {

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/shared",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Utilities and methods that are shared across packages",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/style-compiler",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,7 +22,7 @@
         "dist/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.26.0",
+        "@lwc/shared": "2.26.1",
         "postcss": "~8.4.16",
         "postcss-selector-parser": "~6.0.9",
         "postcss-value-parser": "~4.2.0",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/synthetic-shadow",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Synthetic Shadow Root for LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -36,8 +36,8 @@
         "access": "public"
     },
     "devDependencies": {
-        "@lwc/features": "2.26.0",
-        "@lwc/shared": "2.26.0"
+        "@lwc/features": "2.26.1",
+        "@lwc/shared": "2.26.1"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/template-compiler",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Template compiler package",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,8 +25,8 @@
     },
     "//": "Currently can't upgrade: estree-walker to v3.0.0 because it dropped CommonJS support: https://git.io/JXguS, parse5 dropped cjs support in v7.0.0 https://github.com/inikulin/parse5/releases/tag/v7.0.0",
     "dependencies": {
-        "@lwc/errors": "2.26.0",
-        "@lwc/shared": "2.26.0",
+        "@lwc/errors": "2.26.1",
+        "@lwc/shared": "2.26.1",
         "acorn": "~8.8.0",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/wire-service",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "@wire service",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.26.0",
-        "@lwc/shared": "2.26.0"
+        "@lwc/engine-core": "2.26.1",
+        "@lwc/shared": "2.26.1"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -41,12 +41,12 @@
         ]
     },
     "dependencies": {
-        "@lwc/compiler": "2.26.0",
-        "@lwc/engine-dom": "2.26.0",
-        "@lwc/engine-server": "2.26.0",
-        "@lwc/features": "2.26.0",
-        "@lwc/synthetic-shadow": "2.26.0",
-        "@lwc/wire-service": "2.26.0"
+        "@lwc/compiler": "2.26.1",
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/engine-server": "2.26.1",
+        "@lwc/features": "2.26.1",
+        "@lwc/synthetic-shadow": "2.26.1",
+        "@lwc/wire-service": "2.26.1"
     },
     "nx": {
         "targets": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,16 +1,16 @@
 {
     "private": true,
     "name": "lwc-playground",
-    "version": "2.26.0",
+    "version": "2.26.1",
     "description": "Playground project to experiment with LWC.",
     "scripts": {
         "dev": "rollup -c --watch",
         "build": "NODE_ENV=production rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.26.0",
+        "@lwc/rollup-plugin": "2.26.1",
         "@rollup/plugin-replace": "^4.0.0",
-        "lwc": "2.26.0",
+        "lwc": "2.26.1",
         "rollup": "^2.79.0",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.1"


### PR DESCRIPTION
## Details

This PR does not target master. Instead, it targets a new branch with HEAD at 2.26.0. Once this PR is approved & CI passes, we will manually bump the version in branch `dbustad/2.26.1-out-of-band` and release 2.26.1 to NPM. That release will be incorporated into a platform release, and the fix included in this PR will be cherry-picked into LWC master.


## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

This is a bug fix for functionality that isn't yet in front of customers. So there is a nominal observable change with no practical impact.

@W-11609119
