### PR TITLE
fix(engine-core): tagNames generated by Java compiler than need to be lowercased

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -320,7 +320,17 @@ function mountCustomElement(
         }
     };
 
-    const elm = createCustomElement(sel, upgradeCallback, connectedCallback, disconnectedCallback);
+    // Should never get a tag with upper case letter at this point; the compiler
+    // should produce only tags with lowercase letters. However, the Java
+    // compiler may generate tagnames with uppercase letters so - for backwards
+    // compatibility, we lower case the tagname here.
+    const normalizedTagname = sel.toLowerCase();
+    const elm = createCustomElement(
+        normalizedTagname,
+        upgradeCallback,
+        connectedCallback,
+        disconnectedCallback
+    );
 
     vnode.elm = elm;
     vnode.vm = vm;


### PR DESCRIPTION
## Details

This fix is cherry-picked from the ephemeral 2.26.1 release branch. It resolves the issue seen in Salesforce platform relating to registration of tag-names that are not lowercased.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.


## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

This is bug fix for behavior that has not yet landed on platform. As such, it represents a nominal observable change.

W-11609119