### PR TITLE
chore: check for addl invalid hydration condition

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -446,12 +446,13 @@ function validateClassAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
     }
 
     let nodesAreCompatible = true;
-    let vnodeClassName;
+    let readableVnodeClassname;
 
-    if (!isUndefined(className) && String(className) !== getProperty(elm, 'className')) {
+    const elmClassName = getProperty(elm, 'className');
+    if (!isUndefined(className) && String(className) !== elmClassName) {
         // className is used when class is bound to an expr.
         nodesAreCompatible = false;
-        vnodeClassName = className;
+        readableVnodeClassname = className;
     } else if (!isUndefined(classMap)) {
         // classMap is used when class is set to static value.
         const classList = getClassList(elm);
@@ -465,11 +466,15 @@ function validateClassAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
             }
         }
 
-        vnodeClassName = computedClassName.trim();
+        readableVnodeClassname = computedClassName.trim();
 
         if (classList.length > keys(classMap).length) {
             nodesAreCompatible = false;
         }
+    } else if (isUndefined(className) && elmClassName !== '') {
+        // SSR contains a className but client-side VDOM does not
+        nodesAreCompatible = false;
+        readableVnodeClassname = '';
     }
 
     if (!nodesAreCompatible) {
@@ -478,10 +483,7 @@ function validateClassAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
                 `Mismatch hydrating element <${getProperty(
                     elm,
                     'tagName'
-                ).toLowerCase()}>: attribute "class" has different values, expected "${vnodeClassName}" but found "${getProperty(
-                    elm,
-                    'className'
-                )}"`,
+                ).toLowerCase()}>: attribute "class" has different values, expected "${readableVnodeClassname}" but found "${elmClassName}"`,
                 vnode.owner
             );
         }

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/index.spec.js
@@ -1,0 +1,21 @@
+export default {
+    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
+        // This simulates a condition where the server-rendered markup has
+        // a classname that is incorrectly missing in the client-side
+        // VDOM at the time of validation.
+        //
+        // Outside of this test, the tested condition should never be reached
+        // unless something in SSR or hydration logic is broken.
+        target.shadowRoot.querySelector('x-child').classList.add('foo');
+
+        hydrateComponent(target, Component, {});
+
+        expect(consoleSpy.calls.error).toHaveSize(2);
+        expect(consoleSpy.calls.error[0][0].message).toEqual(
+            '[LWC error]: Mismatch hydrating element <x-child>: attribute "class" has different values, expected "" but found "foo"\n'
+        );
+        expect(consoleSpy.calls.error[1][0].message).toEqual(
+            '[LWC error]: Hydration completed with errors.\n'
+        );
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+  <p>Are you pondering what I am pondering?</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/main/main.html
@@ -1,0 +1,4 @@
+<template>
+  <p>Pinky...</p>
+  <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

This PR addresses an issue that was discovered while digging into other SSR/hydration logic bugs. We found cases where SSR generated a classname that was not present in the corresponding client-side VDOM.

For example, this showed up when `classMap` was mutated in `connectedCallback`. However, based on recent discussion, this is not a pattern that we will allow in SSR in the future. As such, there are no known indelible cases where this the validation failure condition is reached.

However, it is still prudent to fill the gap in validation, which is done in this PR.

Fixes #3007.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

The observable change is nominal.

## GUS work item

W-11609056
