### PR TITLE
fix(engine-server): missing static elements within foreach

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/expected.html
@@ -1,0 +1,30 @@
+<x-container>
+  <template shadowroot="open">
+    <ul>
+      <li>
+        <div>
+          <span>
+            static
+          </span>
+        </div>
+        Amy Taylor
+      </li>
+      <li>
+        <div>
+          <span>
+            static
+          </span>
+        </div>
+        Michael Jones
+      </li>
+      <li>
+        <div>
+          <span>
+            static
+          </span>
+        </div>
+        Jennifer Wu
+      </li>
+    </ul>
+  </template>
+</x-container>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-container';
+export { default } from 'x/container';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/modules/x/container/container.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/modules/x/container/container.html
@@ -1,0 +1,10 @@
+<template>
+    <ul>
+        <template for:each={contacts} for:item="contact">
+            <li key={contact.Id}>
+                <div><span>static</span></div>
+                {contact.Name}
+            </li>
+        </template>
+    </ul>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/modules/x/container/container.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/for-static-content/modules/x/container/container.js
@@ -1,0 +1,19 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {
+
+  contacts = [
+    {
+      Id: '003171931112854375',
+      Name: 'Amy Taylor',
+    },
+    {
+      Id: '003192301009134555',
+      Name: 'Michael Jones',
+    },
+    {
+      Id: '003848991274589432',
+      Name: 'Jennifer Wu',
+    },
+  ];
+}

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -81,8 +81,17 @@ function remove(node: N, parent: E) {
     parent[HostChildrenKey].splice(nodeIndex, 1);
 }
 
-function cloneNode(node: N): N {
-    return node;
+function cloneNode(node: HostChildNode): HostChildNode {
+    // Note: no need to deep clone as cloneNode is only used for nodes of type HostNodeType.Raw.
+    if (process.env.NODE_ENV !== 'production') {
+        if (node[HostTypeKey] !== HostNodeType.Raw) {
+            throw new TypeError(
+                `SSR: cloneNode was called with invalid NodeType <${node[HostTypeKey]}>, only HostNodeType.Raw is supported.`
+            );
+        }
+    }
+
+    return { ...node };
 }
 
 function createFragment(html: string): HostChildNode {

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -69,4 +69,4 @@ export interface HostElement {
 }
 
 export type HostNode = HostText | HostElement | HostComment;
-export type HostChildNode = HostElement | HostText | HostComment | HostRaw;
+export type HostChildNode = HostNode | HostRaw;


### PR DESCRIPTION
## Details
This fixes an issue in SSR for static content not appearing in the rendered HTML when it's within an iteration or there's multiple component instances on the same page.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
