### PR TITLE
test(integration-karma): add basic test cases for lwc:external directive

### DIFF
--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
@@ -1,0 +1,14 @@
+class CEWithChildren extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+          <h1>Test h1</h1>
+          <div>
+            <p>Test p</p>
+          </div>
+          <slot></slot>
+        `;
+    }
+}
+'customElements' in window && customElements.define('ce-with-children', CEWithChildren);

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
@@ -1,14 +1,16 @@
-class CEWithChildren extends HTMLElement {
-    constructor() {
-        super();
-        this.attachShadow({ mode: 'open' });
-        this.shadowRoot.innerHTML = `
-          <h1>Test h1</h1>
-          <div>
-            <p>Test p</p>
-          </div>
-          <slot></slot>
-        `;
+if (!process.env.COMPAT) {
+    class CEWithChildren extends HTMLElement {
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this.shadowRoot.innerHTML = `
+            <h1>Test h1</h1>
+            <div>
+                <p>Test p</p>
+            </div>
+            <slot></slot>
+            `;
+        }
     }
+    'customElements' in window && customElements.define('ce-with-children', CEWithChildren);
 }
-'customElements' in window && customElements.define('ce-with-children', CEWithChildren);

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-children.js
@@ -12,5 +12,5 @@ if (!process.env.COMPAT) {
             `;
         }
     }
-    'customElements' in window && customElements.define('ce-with-children', CEWithChildren);
+    customElements.define('ce-with-children', CEWithChildren);
 }

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
@@ -1,0 +1,12 @@
+class CEWithEvent extends HTMLElement {
+    constructor() {
+        super();
+        this.addEventListener('click', this.onClick);
+    }
+    onClick() {
+        this.dispatchEvent(new CustomEvent('lowercaseevent'));
+        this.dispatchEvent(new CustomEvent('camelEvent'));
+    }
+}
+
+'customElements' in window && customElements.define('ce-with-event', CEWithEvent);

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
@@ -1,12 +1,14 @@
-class CEWithEvent extends HTMLElement {
-    constructor() {
-        super();
-        this.addEventListener('click', this.onClick);
+if (!process.env.COMPAT) {
+    class CEWithEvent extends HTMLElement {
+        constructor() {
+            super();
+            this.addEventListener('click', this.onClick);
+        }
+        onClick() {
+            this.dispatchEvent(new CustomEvent('lowercaseevent'));
+            this.dispatchEvent(new CustomEvent('camelEvent'));
+        }
     }
-    onClick() {
-        this.dispatchEvent(new CustomEvent('lowercaseevent'));
-        this.dispatchEvent(new CustomEvent('camelEvent'));
-    }
-}
 
-'customElements' in window && customElements.define('ce-with-event', CEWithEvent);
+    'customElements' in window && customElements.define('ce-with-event', CEWithEvent);
+}

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-with-event.js
@@ -10,5 +10,5 @@ if (!process.env.COMPAT) {
         }
     }
 
-    'customElements' in window && customElements.define('ce-with-event', CEWithEvent);
+    customElements.define('ce-with-event', CEWithEvent);
 }

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
@@ -4,5 +4,5 @@ if (!process.env.COMPAT) {
             super();
         }
     }
-    'customElements' in window && customElements.define('ce-without-children', CEWithoutChildren);
+    customElements.define('ce-without-children', CEWithoutChildren);
 }

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
@@ -1,0 +1,6 @@
+class CEWithoutChildren extends HTMLElement {
+    constructor() {
+        super();
+    }
+}
+'customElements' in window && customElements.define('ce-without-children', CEWithoutChildren);

--- a/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/custom-elements/ce-without-children.js
@@ -1,6 +1,8 @@
-class CEWithoutChildren extends HTMLElement {
-    constructor() {
-        super();
+if (!process.env.COMPAT) {
+    class CEWithoutChildren extends HTMLElement {
+        constructor() {
+            super();
+        }
     }
+    'customElements' in window && customElements.define('ce-without-children', CEWithoutChildren);
 }
-'customElements' in window && customElements.define('ce-without-children', CEWithoutChildren);

--- a/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
@@ -1,0 +1,93 @@
+import { createElement } from 'lwc';
+import XWithoutChildren from 'x/WithoutChildren';
+import XWithChildren from 'x/withChildren';
+import XWithDifferentViews from 'x/withDifferentViews';
+import XWithImperativeEvent from 'x/withImperativeEvent';
+import XWithDeclarativeEvent from 'x/withDeclarativeEvent';
+import XWithUnregisteredWC from 'x/withUnregisteredWC';
+
+import './custom-elements/ce-without-children';
+import './custom-elements/ce-with-children';
+import './custom-elements/ce-with-event';
+
+const SUPPORTS_CUSTOM_ELEMENTS = !process.env.COMPAT && 'customElements' in window;
+
+if (SUPPORTS_CUSTOM_ELEMENTS) {
+    describe('lwc:external directive basic tests', () => {
+        it('should render a Custom Element without children', () => {
+            const elm = createElement('x-without-children', { is: XWithoutChildren });
+            document.body.appendChild(elm);
+
+            expect(elm.shadowRoot.querySelector('ce-without-children')).not.toBeNull();
+        });
+
+        it('should render a Custom Element with children', () => {
+            const elm = createElement('x-with-children', { is: XWithChildren });
+            document.body.appendChild(elm);
+
+            const ce = elm.shadowRoot.querySelector('ce-with-children');
+            const heading = ce.shadowRoot.querySelector('h1');
+            expect(heading).not.toBeNull();
+            expect(heading.textContent).toBe('Test h1');
+            const paragraph = ce.shadowRoot.querySelector('p');
+            expect(paragraph).not.toBeNull();
+            expect(paragraph.textContent).toBe('Test p');
+
+            const slotContent = ce.shadowRoot.querySelector('slot').assignedNodes();
+            expect(slotContent.length).toBe(1);
+            expect(slotContent[0].textContent).toBe('slot content');
+        });
+
+        it('should render a Custom Element and handle hiding and showing the element', () => {
+            const elm = createElement('x-with-different-views', { is: XWithDifferentViews });
+            document.body.appendChild(elm);
+
+            let ce = elm.shadowRoot.querySelector('ce-with-children');
+            expect(ce).toBeNull();
+
+            elm.showWC = true;
+            return Promise.resolve().then(() => {
+                ce = elm.shadowRoot.querySelector('ce-with-children');
+                expect(ce).not.toBeNull();
+            });
+        });
+
+        it('should imperatively listen to a DOM event dispatched by a Custom Element', () => {
+            const elm = createElement('x-with-imperative-event', { is: XWithImperativeEvent });
+            document.body.appendChild(elm);
+
+            const handled = elm.shadowRoot.querySelector('div');
+            expect(handled.textContent).toBe('false');
+
+            const ce = elm.shadowRoot.querySelector('ce-with-event');
+            ce.click();
+            return Promise.resolve().then(() => {
+                expect(handled.textContent).toBe('true');
+            });
+        });
+
+        it('should declaratively listen to a DOM event dispatched by a Custom Element', () => {
+            const elm = createElement('x-with-declarative-event', { is: XWithDeclarativeEvent });
+            document.body.appendChild(elm);
+
+            const handled = elm.shadowRoot.querySelector('div');
+            expect(handled.textContent).toBe('false');
+
+            const ce = elm.shadowRoot.querySelector('ce-with-event');
+            ce.click();
+            return Promise.resolve().then(() => {
+                expect(handled.textContent).toBe('true');
+            });
+        });
+
+        it('should use unresolved HTMLElement if Custom Element is not registered', () => {
+            const elm = createElement('x-with-unregsitered-wc', { is: XWithUnregisteredWC });
+            document.body.appendChild(elm);
+
+            const ce = elm.shadowRoot.querySelector('ce-not-registered');
+            expect(ce).not.toBeNull();
+            expect(ce instanceof HTMLElement).toBe(true);
+            expect(customElements.get('ce-not-registered')).toBe(undefined);
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
@@ -10,9 +10,7 @@ import './custom-elements/ce-without-children';
 import './custom-elements/ce-with-children';
 import './custom-elements/ce-with-event';
 
-const SUPPORTS_CUSTOM_ELEMENTS = !process.env.COMPAT && 'customElements' in window;
-
-if (SUPPORTS_CUSTOM_ELEMENTS) {
+if (!process.env.COMPAT) {
     describe('lwc:external directive basic tests', () => {
         it('should render a Custom Element without children', () => {
             const elm = createElement('x-without-children', { is: XWithoutChildren });

--- a/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import XWithoutChildren from 'x/WithoutChildren';
+import XWithoutChildren from 'x/withoutChildren';
 import XWithChildren from 'x/withChildren';
 import XWithDifferentViews from 'x/withDifferentViews';
 import XWithImperativeEvent from 'x/withImperativeEvent';

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withChildren/withChildren.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withChildren/withChildren.html
@@ -1,0 +1,7 @@
+<template>
+    <div>
+        <ce-with-children lwc:external>
+            <div>slot content</div>
+        </ce-with-children>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withChildren/withChildren.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withChildren/withChildren.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class WithChildren extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withDeclarativeEvent/withDeclarativeEvent.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withDeclarativeEvent/withDeclarativeEvent.html
@@ -1,0 +1,4 @@
+<template>
+    <div>{eventHandled}</div>
+    <ce-with-event lwc:external onlowercaseevent={handleTestEvent}></ce-with-event>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withDeclarativeEvent/withDeclarativeEvent.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withDeclarativeEvent/withDeclarativeEvent.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class WithDeclarativeEvent extends LightningElement {
+    eventHandled = false;
+
+    handleTestEvent() {
+        this.eventHandled = true;
+    }
+}

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withDifferentViews/withDifferentViews.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withDifferentViews/withDifferentViews.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <ce-with-children lwc:external if:true={showWC}></ce-with-children>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withDifferentViews/withDifferentViews.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withDifferentViews/withDifferentViews.js
@@ -1,0 +1,6 @@
+import { LightningElement, api } from 'lwc';
+
+export default class WithDifferentViews extends LightningElement {
+    @api
+    showWC = false;
+}

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withImperativeEvent/withImperativeEvent.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withImperativeEvent/withImperativeEvent.html
@@ -1,0 +1,4 @@
+<template>
+    <div>{eventHandled}</div>
+    <ce-with-event lwc:external></ce-with-event>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withImperativeEvent/withImperativeEvent.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withImperativeEvent/withImperativeEvent.js
@@ -1,0 +1,15 @@
+import { LightningElement } from 'lwc';
+
+export default class WithImperativeEvent extends LightningElement {
+    eventHandled = false;
+
+    renderedCallback() {
+        this.template
+            .querySelector('ce-with-event')
+            .addEventListener('camelEvent', this.handleTestEvent.bind(this));
+    }
+
+    handleTestEvent() {
+        this.eventHandled = true;
+    }
+}

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withUnregisteredWC/withUnregisteredWC.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withUnregisteredWC/withUnregisteredWC.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <ce-not-registered lwc:external></ce-not-registered>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withUnregisteredWC/withUnregisteredWC.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withUnregisteredWC/withUnregisteredWC.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class WithUnregisteredWC extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withoutChildren/withoutChildren.html
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withoutChildren/withoutChildren.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <ce-without-children lwc:external></ce-without-children>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/directive-external/x/withoutChildren/withoutChildren.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/x/withoutChildren/withoutChildren.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class WithoutChildren extends LightningElement {}


### PR DESCRIPTION
## Details
Add basic integration tests for `lwc:external` directive.

Tests on data passing between LWC and custom elements will be added later.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
[W-11912243](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000018peSSYAY/view)
