### PR TITLE
fix(engine-core): guard wire debug routine to run in non-production mode only  @W-9111066

### DIFF
--- a/packages/@lwc/engine-core/src/framework/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring.ts
@@ -358,7 +358,9 @@ export function installWireAdapters(vm: VM) {
         def: { wire },
     } = vm;
 
-    vm.debugInfo![WIRE_DEBUG_ENTRY] = create(null);
+    if (process.env.NODE_ENV !== 'production') {
+        vm.debugInfo![WIRE_DEBUG_ENTRY] = create(null);
+    }
 
     const wiredConnecting = (context.wiredConnecting = []);
     const wiredDisconnecting = (context.wiredDisconnecting = []);


### PR DESCRIPTION
## Details
All access to vm.debugInfo is guarded to only work in non-production mode except one. This PR addresses that issue by adding the guard.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-9111066
