### PR TITLE
perf(engine-dom): optimize connected/disconnected callbacks

### DIFF
--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -62,7 +62,7 @@ export interface RendererAPI {
     createCustomElement: (
         tagName: string,
         upgradeCallback: LifecycleCallback,
-        connectedCallback: LifecycleCallback,
-        disconnectedCallback: LifecycleCallback
+        connectedCallback?: LifecycleCallback,
+        disconnectedCallback?: LifecycleCallback
     ) => E;
 }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -23,7 +23,7 @@ import features from '@lwc/features';
 
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
-import { RendererAPI } from './renderer';
+import { LifecycleCallback, RendererAPI } from './renderer';
 import { EmptyArray } from './utils';
 import { markComponentAsDirty } from './component';
 import { getScopeTokenClass } from './stylesheet';
@@ -309,17 +309,17 @@ function mountCustomElement(
         vm = createViewModelHook(elm, vnode, renderer);
     };
 
-    const connectedCallback = (elm: HTMLElement) => {
-        if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-            connectRootElement(elm);
-        }
-    };
+    let connectedCallback: LifecycleCallback | undefined;
+    let disconnectedCallback: LifecycleCallback | undefined;
 
-    const disconnectedCallback = (elm: HTMLElement) => {
-        if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+    if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+        connectedCallback = (elm: HTMLElement) => {
+            connectRootElement(elm);
+        };
+        disconnectedCallback = (elm: HTMLElement) => {
             disconnectRootElement(elm);
-        }
-    };
+        };
+    }
 
     // Should never get a tag with upper case letter at this point; the compiler
     // should produce only tags with lowercase letters. However, the Java

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -20,6 +20,7 @@ import {
     connectRootElement,
     disconnectRootElement,
     LightningElement,
+    LifecycleCallback,
 } from '@lwc/engine-core';
 import { renderer } from '../renderer';
 
@@ -131,17 +132,17 @@ export function createElement(
         }
     };
 
-    const connectedCallback = (elm: HTMLElement) => {
-        if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-            connectRootElement(elm);
-        }
-    };
+    let connectedCallback: LifecycleCallback | undefined;
+    let disconnectedCallback: LifecycleCallback | undefined;
 
-    const disconnectedCallback = (elm: HTMLElement) => {
-        if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+    if (features.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+        connectedCallback = (elm: HTMLElement) => {
+            connectRootElement(elm);
+        };
+        disconnectedCallback = (elm: HTMLElement) => {
             disconnectRootElement(elm);
-        }
-    };
+        };
+    }
 
     const element = createCustomElement(
         tagName,

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
@@ -61,6 +61,7 @@ const createUserConstructor = (
     }
 
     // Do not unnecessarily add a connectedCallback/disconnectedCallback, as it introduces perf overhead
+    // See: https://github.com/salesforce/lwc/pull/3162#issuecomment-1311851174
     if (!isUndefined(connectedCallback)) {
         (UserConstructor.prototype as any).connectedCallback = function () {
             connectedCallback(this);

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-scoped.ts
@@ -47,33 +47,40 @@ if (features.ENABLE_SCOPED_CUSTOM_ELEMENT_REGISTRY) {
 // In this case, the upgradeCallback only needs to be defined once because we create these on-demand,
 // multiple times per tag name.
 const createUserConstructor = (
+    HTMLElementToExtend: typeof HTMLElement,
     upgradeCallback: LifecycleCallback,
-    connectedCallback: LifecycleCallback,
-    disconnectedCallback: LifecycleCallback,
-    HTMLElementToExtend: typeof HTMLElement
+    connectedCallback?: LifecycleCallback,
+    disconnectedCallback?: LifecycleCallback
 ) => {
     // TODO [#2972]: this class should expose observedAttributes as necessary
-    return class UserConstructor extends HTMLElementToExtend {
+    class UserConstructor extends HTMLElementToExtend {
         constructor() {
             super();
             upgradeCallback(this);
         }
+    }
 
-        connectedCallback() {
+    // Do not unnecessarily add a connectedCallback/disconnectedCallback, as it introduces perf overhead
+    if (!isUndefined(connectedCallback)) {
+        (UserConstructor.prototype as any).connectedCallback = function () {
             connectedCallback(this);
-        }
+        };
+    }
 
-        disconnectedCallback() {
+    if (!isUndefined(disconnectedCallback)) {
+        (UserConstructor.prototype as any).disconnectedCallback = function () {
             disconnectedCallback(this);
-        }
-    };
+        };
+    }
+
+    return UserConstructor;
 };
 
 export function createCustomElementScoped(
     tagName: string,
     upgradeCallback: LifecycleCallback,
-    connectedCallback: LifecycleCallback,
-    disconnectedCallback: LifecycleCallback
+    connectedCallback?: LifecycleCallback,
+    disconnectedCallback?: LifecycleCallback
 ) {
     if (isUndefined(createScopedConstructor) || isUndefined(CachedHTMLElement)) {
         // This error should be impossible to hit
@@ -83,10 +90,10 @@ export function createCustomElementScoped(
     }
 
     const UserConstructor = createUserConstructor(
+        CachedHTMLElement,
         upgradeCallback,
         connectedCallback,
-        disconnectedCallback,
-        CachedHTMLElement
+        disconnectedCallback
     );
     const ScopedConstructor = createScopedConstructor(tagName, UserConstructor);
     return new ScopedConstructor(UserConstructor);

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-vanilla.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-vanilla.ts
@@ -43,6 +43,7 @@ const createUpgradableConstructor = (
     }
 
     // Do not unnecessarily add a connectedCallback/disconnectedCallback, as it introduces perf overhead
+    // See: https://github.com/salesforce/lwc/pull/3162#issuecomment-1311851174
     if (hasConnectedCallback) {
         (UpgradableConstructor.prototype as any).connectedCallback = function () {
             if (!elementsUpgradedOutsideLWC.has(this)) {

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-vanilla.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-vanilla.ts
@@ -31,9 +31,10 @@ const createUpgradableConstructor = (
             // then elementBeingUpgraded will be false
             if (elementBeingUpgradedByLWC) {
                 upgradeCallback(this);
-            } else if (hasConnectedCallback && hasDisconnectedCallback) {
-                // keep track of elements that were not created by lwc.createElement,
-                // so we can ignore their lifecycle hooks (assuming it has lifecycle hooks)
+            } else if (hasConnectedCallback || hasDisconnectedCallback) {
+                // If this element has connected or disconnected callbacks, then we need to keep track of
+                // instances that were created outside LWC (i.e. not created by `lwc.createElement()`).
+                // If the element has no connected or disconnected callbacks, then we don't need to track this.
                 elementsUpgradedOutsideLWC.add(this);
 
                 // TODO [#2970]: LWC elements cannot be upgraded via new Ctor()

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -27,8 +27,8 @@ import type { LifecycleCallback } from '@lwc/engine-core';
 export let createCustomElement: (
     tagName: string,
     upgradeCallback: LifecycleCallback,
-    connectedCallback: LifecycleCallback,
-    disconnectedCallback: LifecycleCallback
+    connectedCallback?: LifecycleCallback,
+    disconnectedCallback?: LifecycleCallback
 ) => HTMLElement;
 
 if (hasCustomElements) {


### PR DESCRIPTION
## Details

As it turns out, #2724 introduced perf overhead by adding `connectedCallback`s and `disconnectedCallback`s to every LWC Element prototype.

I toyed around with it, and the overhead is there even if the callback is a (nearly-empty) function:

![Screen Shot 2022-11-11 at 7 02 01 AM](https://user-images.githubusercontent.com/283842/201368059-59ac218e-9814-4dc7-9c45-c61a4ce533ca.png)

This is driven by `ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE`. Since this is an experimental feature, we can disable the `connectedCallback`/`disconnectedCallback` entirely if it is `false`. (This is basically what we were doing before #2724.)

This improves the perf by 14-17%:

![Screen Shot 2022-11-11 at 6 41 08 AM](https://user-images.githubusercontent.com/283842/201368168-6a96d240-87b9-46d2-b7ef-57fdd89e9ae7.png)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-12028575](https://gus.lightning.force.com/lightning/r/a07EE00001BsZ0hYAF/view)
