### PR TITLE
perf(engine-core): optimize slot iteration

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -21,7 +21,6 @@ import {
     isUndefined,
     StringReplace,
     toString,
-    ArrayConcat,
 } from '@lwc/shared';
 
 import { logError } from '../shared/logger';
@@ -189,8 +188,11 @@ function s(
         !isUndefined(slotset.slotAssignments[slotName]) &&
         slotset.slotAssignments[slotName].length !== 0
     ) {
-        children = slotset.slotAssignments[slotName].reduce((accumulator, vnode) => {
-            if (vnode) {
+        const newChildren: VNode[] = [];
+        const slotAssignments = slotset.slotAssignments[slotName];
+        for (let i = 0; i < slotAssignments.length; i++) {
+            const vnode = slotAssignments[i];
+            if (!isNull(vnode)) {
                 const assignedNodeIsScopedSlot = isVScopedSlotFragment(vnode);
                 // The only sniff test for a scoped <slot> element is the presence of `slotData`
                 const isScopedSlotElement = !isUndefined(data.slotData);
@@ -205,30 +207,28 @@ function s(
                         );
                     }
                     // Ignore slot content from parent
-                    return accumulator;
+                    continue;
                 }
                 // If the passed slot content is factory, evaluate it and add the produced vnodes
                 if (assignedNodeIsScopedSlot) {
                     const vmBeingRenderedInception = getVMBeingRendered();
-                    let scopedSlotChildren: VNodes = [];
                     // Evaluate in the scope of the slot content's owner
                     // if a slotset is provided, there will always be an owner. The only case where owner is
                     // undefined is for root components, but root components cannot accept slotted content
                     setVMBeingRendered(slotset.owner!);
                     try {
-                        scopedSlotChildren = vnode.factory(data.slotData);
+                        ArrayPush.apply(newChildren, vnode.factory(data.slotData) as VNode[]);
                     } finally {
                         setVMBeingRendered(vmBeingRenderedInception);
                     }
-                    return ArrayConcat.call(accumulator, scopedSlotChildren);
                 } else {
                     // If the slot content is standard type, the content is static, no additional
                     // processing needed on the vnode
-                    return ArrayConcat.call(accumulator, vnode);
+                    ArrayPush.call(newChildren, vnode);
                 }
             }
-            return accumulator;
-        }, [] as VNodes);
+        }
+        children = newChildren;
     }
     const vmBeingRendered = getVMBeingRendered()!;
     const { renderMode, shadowMode } = vmBeingRendered;


### PR DESCRIPTION
## Details

It turns out that https://github.com/salesforce/lwc/commit/2ada663f3858ea97065907835c1df8930b1b9870 and https://github.com/salesforce/lwc/commit/e983223755ed18060cdeff3059dc9f58ac041eca  [introduced](https://gus.lightning.force.com/lightning/r/0D5EE000012dtb90AA/view) a perf regression. The `dom-ss-slot-update-slotted-content-5k` benchmark regressed 16% comparing `master` to 240. The culprit is this `reduce` function:

https://github.com/salesforce/lwc/blob/63760138ee3f16ae5d8a339b89d26f742366cf5b/packages/@lwc/engine-core/src/framework/api.ts#L192

This PR improves the benchmark by 11-12% (comparing this PR to `master`):

![Remote Desktop Picture November 14, 2022 at 9 20 01 AM PST](https://user-images.githubusercontent.com/283842/201725344-2c78080c-1ea5-4b8b-84c0-838d56ae2629.png)

Improvements:

- use a for-loop instead of `Array.prototype.reduce`
- use `ArrayPush` instead of `ArrayConcat` (`ArrayConcat` creates a [brand-new copy of the array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), which we don't strictly need)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12028575
