### PR TITLE
fix(synthetic-shadow): apply iframe-content-window polyfill only in IE11

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/detect.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/detect.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { isUndefined } from '@lwc/shared';
+
 export default function detect(): boolean {
     // Note: when using this in mobile apps, we might have a DOM that does not support iframes.
-    return typeof HTMLIFrameElement !== 'undefined';
+    const hasIframe = typeof HTMLIFrameElement !== 'undefined';
+
+    // Detect IE, via https://stackoverflow.com/a/9851769
+    const isIE11 = !isUndefined((document as any).documentMode);
+
+    return hasIframe && isIE11;
 }

--- a/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/detect.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/iframe-content-window/detect.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isUndefined } from '@lwc/shared';
+import { isTrue } from '@lwc/shared';
 
 export default function detect(): boolean {
     // Note: when using this in mobile apps, we might have a DOM that does not support iframes.
     const hasIframe = typeof HTMLIFrameElement !== 'undefined';
 
-    // Detect IE, via https://stackoverflow.com/a/9851769
-    const isIE11 = !isUndefined((document as any).documentMode);
+    // This polyfill should only apply in compat mode; see https://github.com/salesforce/lwc/issues/1513
+    const isCompat = typeof Proxy !== 'undefined' && isTrue((Proxy as any).isCompat);
 
-    return hasIframe && isIE11;
+    return hasIframe && isCompat;
 }


### PR DESCRIPTION
## Details

Fixes #1513

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

Non-IE11 browsers will no longer get this iframe polyfill.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12067861
