### PR TITLE
test(pivots): add test for attributeChangedCallback during upgrade

### DIFF
--- a/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
@@ -862,7 +862,7 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
                 // The LWC component observes nothing, but the vanilla component observes foo
                 const tagName = 'x-attr-change-on-upgrade';
                 const lwcElm = createElement(tagName, {
-                    is: ObserveNothing,
+                    is: ObserveNothingThrow, // throws if invoked, which should not happen
                 });
                 document.body.appendChild(lwcElm);
                 const nativeElm = document.createElement(tagName);

--- a/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
@@ -871,6 +871,9 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
 
                 const invocations = [];
 
+                // At this point, because we've already defined an LWC component with the same tag
+                // name, the native element should be forced to use the manual attributeChangedCallback
+                // logic. It should be called during the upgrade, since the attribute was already set.
                 customElements.define(
                     tagName,
                     class extends HTMLElement {

--- a/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
@@ -858,6 +858,40 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
                 expect(lwcElm.getAttribute('foo')).toBeNull();
             });
 
+            it('attributeChangedCallback fires on upgrade', () => {
+                // The LWC component observes nothing, but the vanilla component observes foo
+                const tagName = 'x-attr-change-on-upgrade';
+                const lwcElm = createElement(tagName, {
+                    is: ObserveNothing,
+                });
+                document.body.appendChild(lwcElm);
+                const nativeElm = document.createElement(tagName);
+                nativeElm.setAttribute('foo', '1');
+                document.body.appendChild(nativeElm);
+
+                const invocations = [];
+
+                customElements.define(
+                    tagName,
+                    class extends HTMLElement {
+                        static observedAttributes = ['foo'];
+
+                        attributeChangedCallback(name, oldVal, newVal) {
+                            invocations.push([name, oldVal, newVal]);
+                        }
+                    }
+                );
+
+                nativeElm.setAttribute('foo', '2');
+
+                return new Promise((resolve) => setTimeout(resolve)).then(() => {
+                    expect(invocations).toEqual([
+                        ['foo', null, '1'],
+                        ['foo', '1', '2'],
+                    ]);
+                });
+            });
+
             describe('attributeChangedCallback timing', () => {
                 let originalOnError;
                 let errors;


### PR DESCRIPTION
## Details

Just adds a test to ensure we are doing this correctly.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
