### PR TITLE
chore: update git2gus release and nucleus for 244 clco

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,5 +1,5 @@
 {
   "productTag": "a1aB0000000g309IAA",
-  "defaultBuild": "242",
+  "defaultBuild": "244",
   "hideWorkItemUrl": true
 }

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -45,6 +45,9 @@ branches:
   winter23:
     pull-request:
       <<: *branch-definition
+  spring23:
+    pull-request:
+      <<: *branch-definition
 steps:
   node-conformance:
     run:


### PR DESCRIPTION
## Details


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
[W-11466097](https://gus.lightning.force.com/a07EE000011woQMYAY)