### PR TITLE
test(integration-karma): add tests for dev warning

### DIFF
--- a/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-external/index.spec.js
@@ -13,6 +13,9 @@ import './custom-elements/ce-with-children';
 import './custom-elements/ce-with-event';
 import './custom-elements/ce-with-property';
 
+const unknownPropTokyo =
+    /Error: \[LWC warn]: Unknown public property "tokyo" of element <ce-with-property>\. This is either a typo on the corresponding attribute "tokyo", or the attribute does not exist in this browser or DOM implementation\./;
+
 if (!process.env.COMPAT) {
     describe('lwc:external directive basic tests', () => {
         it('should render a Custom Element without children', () => {
@@ -108,7 +111,9 @@ if (!process.env.COMPAT) {
 
             beforeEach(() => {
                 elm = createElement('x-with-property', { is: XWithProperty });
-                document.body.appendChild(elm);
+                expect(() => {
+                    document.body.appendChild(elm);
+                }).toLogWarningDev(unknownPropTokyo);
             });
 
             it('should be stringified when set as an attribute', () => {
@@ -133,7 +138,9 @@ if (!process.env.COMPAT) {
 
         it('should work with lwc:spread', () => {
             const elm = createElement('x-with-property', { is: XWithProperty });
-            document.body.appendChild(elm);
+            expect(() => {
+                document.body.appendChild(elm);
+            }).toLogWarningDev(unknownPropTokyo);
 
             return Promise.resolve().then(() => {
                 const ce = elm.shadowRoot.querySelector('ce-with-property');


### PR DESCRIPTION
## Details

The tests in #3144 emit a console warning when running `yarn test`:

```
Unknown public property "tokyo" of element <ce-with-property>. [...]
```

 By adding `toLogWarningDev`, these don't get logged to the console, and as a bonus, we add a test to ensure that the warning is logged.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->