### PR TITLE
fix: update attribute parsing to account for '=' in attribute value

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <x-foo props="\{url: https://example.com/over/there?name=ferret}"></x-foo>
+    <div props="\{url: https://example.com/over/there?name=ferret}"></div>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/ast.json
@@ -1,0 +1,135 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 12,
+            "start": 0,
+            "end": 176,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 4,
+                "startColumn": 1,
+                "endLine": 4,
+                "endColumn": 12,
+                "start": 165,
+                "end": 176
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Component",
+                "name": "x-foo",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 79,
+                    "start": 15,
+                    "end": 89,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 71,
+                        "start": 15,
+                        "end": 81
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 71,
+                        "endLine": 2,
+                        "endColumn": 79,
+                        "start": 81,
+                        "end": 89
+                    }
+                },
+                "attributes": [],
+                "properties": [
+                    {
+                        "type": "Property",
+                        "name": "props",
+                        "attributeName": "props",
+                        "value": {
+                            "type": "Literal",
+                            "value": "{url: https://example.com/over/there?name=ferret}"
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 12,
+                            "endLine": 2,
+                            "endColumn": 70,
+                            "start": 22,
+                            "end": 80
+                        }
+                    }
+                ],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            },
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 3,
+                    "startColumn": 5,
+                    "endLine": 3,
+                    "endColumn": 75,
+                    "start": 94,
+                    "end": 164,
+                    "startTag": {
+                        "startLine": 3,
+                        "startColumn": 5,
+                        "endLine": 3,
+                        "endColumn": 69,
+                        "start": 94,
+                        "end": 158
+                    },
+                    "endTag": {
+                        "startLine": 3,
+                        "startColumn": 69,
+                        "endLine": 3,
+                        "endColumn": 75,
+                        "start": 158,
+                        "end": 164
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "props",
+                        "value": {
+                            "type": "Literal",
+                            "value": "{url: https://example.com/over/there?name=ferret}"
+                        },
+                        "location": {
+                            "startLine": 3,
+                            "startColumn": 10,
+                            "endLine": 3,
+                            "endColumn": 68,
+                            "start": 99,
+                            "end": 157
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
@@ -1,0 +1,19 @@
+import _xFoo from "x/foo";
+import { parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<div props="{url: https://example.com/over/there?name=ferret}"${3}></div>`;
+const stc0 = {
+  props: {
+    props: "{url: https://example.com/over/there?name=ferret}",
+  },
+  key: 0,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { c: api_custom_element, st: api_static_fragment } = $api;
+  return [
+    api_custom_element("x-foo", _xFoo, stc0),
+    api_static_fragment($fragment1(), 2),
+  ];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1057,
+            "message": "LWC1057: props is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 10,
+                "start": 99,
+                "length": 58
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -39,13 +39,13 @@ import {
 } from './constants';
 
 function isQuotedAttribute(rawAttribute: string) {
-    const [, value] = rawAttribute.split('=');
-    return value && value.startsWith('"') && value.endsWith('"');
+    const attrVal = rawAttribute.slice(rawAttribute.indexOf('=') + 1);
+    return attrVal && attrVal.startsWith('"') && attrVal.endsWith('"');
 }
 
 function isEscapedAttribute(rawAttribute: string) {
-    const [, value] = rawAttribute.split('=');
-    return !value || !(value.includes('{') && value.includes('}'));
+    const attrVal = rawAttribute.slice(rawAttribute.indexOf('=') + 1);
+    return !attrVal || !(attrVal.includes('{') && attrVal.includes('}'));
 }
 
 export function isIdReferencingAttribute(attrName: string): boolean {

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -38,13 +38,11 @@ import {
     TEMPLATE_DIRECTIVES,
 } from './constants';
 
-function isQuotedAttribute(rawAttribute: string) {
-    const attrVal = rawAttribute.slice(rawAttribute.indexOf('=') + 1);
+function isQuotedAttribute(attrVal: string) {
     return attrVal && attrVal.startsWith('"') && attrVal.endsWith('"');
 }
 
-function isEscapedAttribute(rawAttribute: string) {
-    const attrVal = rawAttribute.slice(rawAttribute.indexOf('=') + 1);
+function isEscapedAttribute(attrVal: string) {
     return !attrVal || !(attrVal.includes('{') && attrVal.includes('}'));
 }
 
@@ -107,8 +105,9 @@ export function normalizeAttributeValue(
         }
     }
 
-    const isQuoted = isQuotedAttribute(raw);
-    const isEscaped = isEscapedAttribute(raw);
+    const rawAttrVal = raw.slice(raw.indexOf('=') + 1);
+    const isQuoted = isQuotedAttribute(rawAttrVal);
+    const isEscaped = isEscapedAttribute(rawAttrVal);
     if (!isEscaped && isExpression(value)) {
         if (isQuoted) {
             // <input value="{myValue}" />


### PR DESCRIPTION
## Details
The [`normalizeAttributeValue`](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/template-compiler/src/parser/attribute.ts#L83-L163) function does not account for a '=' character in the attribute value when validating against [escaped](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/template-compiler/src/parser/attribute.ts#L46-L49) and [quoted](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/template-compiler/src/parser/attribute.ts#L41-L44) attributes.

Currently, the logic to split the attribute name and value is the following:

```
const [, value] = rawAttribute.split('=');
```

When the attribute's value contains an '=' the `rawAttribute` will be split multiple times. 

In this case, the validation logic does not execute on the full attribute value which causes incorrect output from the compiler.

This is an issue for JSON objects that are stored as string values on an attribute.  The value should flow through the [escaped expression path](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/template-compiler/src/parser/attribute.ts#L143-L148) and have the escaped character removed.

For example:

```
<template>
   // Use a escape character to convert the JSON to a string
    <x-foo props="\{url: https://example.com/over/there?name=ferret}"></x-foo>
</template>
```

outputs:

```
...
const stc0 = {
  props: {
    props: "\{url: https://example.com/over/there?name=ferret}",
  },
  key: 0,
};
function tmpl($api, $cmp, $slotset, $ctx) {
  const { c: api_custom_element, st: api_static_fragment } = $api;
  return [
    api_custom_element("x-foo", _xFoo, stc0),
    api_static_fragment($fragment1(), 2),
  ];
  /*LWC compiler vX.X.X*/
}
...
```
Notice the extra '\\' in the props string.

After this change the output will correctly be rendered as:

```
...
const stc0 = {
  props: {
    props: "{url: https://example.com/over/there?name=ferret}",
  },
  key: 0,
};
function tmpl($api, $cmp, $slotset, $ctx) {
  const { c: api_custom_element, st: api_static_fragment } = $api;
  return [
    api_custom_element("x-foo", _xFoo, stc0),
    api_static_fragment($fragment1(), 2),
  ];
  /*LWC compiler vX.X.X*/
}
...
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


## Does this pull request introduce an observable change?
* ⚠️ Yes, it does include an observable change.

This change will modify the output of the compiler to remove the escape character at the beginning of the string.

## GUS work item
W-12006674
