### PR TITLE
chore(perf-benchmarks): improve benchmark names

### DIFF
--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-ss/ss-slot-create-container-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-ss/ss-slot-create-container-5k.benchmark.js
@@ -13,7 +13,7 @@ import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
 const NUMBER_OF_ROWS = 5000;
 
-benchmark(`benchmark-slot-ss/synthetic-shadow-create/5k`, () => {
+benchmark(`dom/slot/synthetic-shadow/create/5k`, () => {
     let slottingComponent;
     let rowsOfComponentWithSlot;
     let rowsOfSlottedContent;

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-ss/ss-slot-update-slotted-content-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-ss/ss-slot-update-slotted-content-5k.benchmark.js
@@ -13,7 +13,7 @@ import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
 const NUMBER_OF_ROWS = 5000;
 
-benchmark(`benchmark-slot-ss/synthetic-shadow-slot-update-slotted-content/5k`, () => {
+benchmark(`dom/slot/synthetic-shadow/update-slotted-content/5k`, () => {
     let slottingComponent;
     let nextData;
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/light-styled-component-create-10k-same.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/light-styled-component-create-10k-same.benchmark.js
@@ -13,7 +13,7 @@ const NUM_COMPONENTS = 10000;
 // Create 10k components with the same CSS in each component
 // These are light DOM components running in native mode
 styledComponentBenchmark(
-    `benchmark-styled-component/create/10k/same`,
+    `dom/styled-component/light/create-same/10k`,
     NUM_COMPONENTS,
     StyledComponent,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/light-styled-component-create-1k-different.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/light-styled-component-create-1k-different.benchmark.js
@@ -13,7 +13,7 @@ const NUM_COMPONENTS = 1000;
 // Create 1k components with different CSS in each component
 // These are light DOM components running in native mode
 styledComponentBenchmark(
-    `benchmark-styled-component/create/1k/different`,
+    `dom/styled-component/light/create-different/1k`,
     NUM_COMPONENTS,
     components,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-10k-same.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-10k-same.benchmark.js
@@ -12,7 +12,7 @@ const NUM_COMPONENTS = 10000;
 
 // Create 10k components with the same CSS in each component
 styledComponentBenchmark(
-    `ss-benchmark-styled-component/create/10k/same`,
+    `dom/styled-component/synthetic-shadow/create-same/10k`,
     NUM_COMPONENTS,
     StyledComponent,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-different.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/ss-styled-component-create-1k-different.benchmark.js
@@ -12,7 +12,7 @@ const NUM_COMPONENTS = 1000;
 
 // Create 1k components with different CSS in each component
 styledComponentBenchmark(
-    `ss-benchmark-styled-component/create/1k/different`,
+    `dom/styled-component/synthetic-shadow/create-different/1k`,
     NUM_COMPONENTS,
     components,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-10k-same.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-10k-same.benchmark.js
@@ -12,7 +12,7 @@ const NUM_COMPONENTS = 10000;
 
 // Create 10k components with the same CSS in each component
 styledComponentBenchmark(
-    `benchmark-styled-component/create/10k/same`,
+    `dom/styled-component/shadow/create-same/10k`,
     NUM_COMPONENTS,
     StyledComponent,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-different.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-styled-component/styled-component-create-1k-different.benchmark.js
@@ -12,7 +12,7 @@ const NUM_COMPONENTS = 1000;
 
 // Create 1k components with different CSS in each component
 styledComponentBenchmark(
-    `benchmark-styled-component/create/1k/different`,
+    `dom/styled-component/shadow/create-different/1k`,
     NUM_COMPONENTS,
     components,
     { after, before, benchmark, run }

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-append-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-append-1k.benchmark.js
@@ -11,7 +11,7 @@ import Table from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tableCompo
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
-benchmark(`benchmark-table-component/append/1k`, () => {
+benchmark(`dom/table-component/append/1k`, () => {
     let tableElement;
     let store;
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-create-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-create-10k.benchmark.js
@@ -11,7 +11,7 @@ import Table from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tableCompo
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
-benchmark(`benchmark-table-component/create/10k`, () => {
+benchmark(`dom/table-component/create/10k`, () => {
     let tableElement;
 
     before(() => {

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-create-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table-component/tablecmp-create-1k.benchmark.js
@@ -11,7 +11,7 @@ import Table from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tableCompo
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
-benchmark(`benchmark-table-component/create/1k`, () => {
+benchmark(`dom/table-component/create/1k`, () => {
     let tableElement;
 
     before(() => {

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table/table-create-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-table/table-create-10k.benchmark.js
@@ -11,7 +11,7 @@ import Table from '@lwc/perf-benchmarks-components/dist/dom/benchmark/table/tabl
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
-benchmark(`benchmark-table/create/10k`, () => {
+benchmark(`dom/table/create/10k`, () => {
     let tableElement;
 
     before(() => {

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tracked-component/trackedcmp-create-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tracked-component/trackedcmp-create-10k.benchmark.js
@@ -10,7 +10,7 @@ import TrackedComponent from '@lwc/perf-benchmarks-components/dist/dom/benchmark
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
 
-benchmark(`benchmark-tracked-component/create/10k`, () => {
+benchmark(`dom/tracked-component/create/10k`, () => {
     let trackedComponent;
 
     before(() => {

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
@@ -14,7 +14,7 @@ import Store from '@lwc/perf-benchmarks-components/dist/server/benchmark/store/s
 import TableClient from '@lwc/perf-benchmarks-components/dist/dom/benchmark/cardComponent/cardComponent.js';
 import { insertComponent } from '../../utils/utils';
 
-benchmark(`benchmark-table/hydrate/1k`, () => {
+benchmark(`hydrate/table/hydrate/1k`, () => {
     let tableElement;
     let props;
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
@@ -14,7 +14,7 @@ import TableClient from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tabl
 import Store from '@lwc/perf-benchmarks-components/dist/server/benchmark/store/store.js';
 import { insertComponent } from '../../utils/utils';
 
-benchmark(`benchmark-table-component/hydrate/1k`, () => {
+benchmark(`hydrate/table-component/hydrate/1k`, () => {
     let props;
     let tableElement;
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/table-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/table-render-10k.benchmark.js
@@ -10,7 +10,7 @@ import { renderComponent } from '@lwc/engine-server';
 import Table from '@lwc/perf-benchmarks-components/dist/server/benchmark/cardComponent/cardComponent.js';
 import Store from '@lwc/perf-benchmarks-components/dist/server/benchmark/store/store.js';
 
-benchmark(`benchmark-table/render/10k`, () => {
+benchmark(`server/table/render/10k`, () => {
     run(() => {
         const store = new Store();
         store.runLots();

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/tablecmp-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/tablecmp-render-10k.benchmark.js
@@ -10,7 +10,7 @@ import { renderComponent } from '@lwc/engine-server';
 import Table from '@lwc/perf-benchmarks-components/dist/server/benchmark/tableComponent/tableComponent.js';
 import Store from '@lwc/perf-benchmarks-components/dist/server/benchmark/store/store.js';
 
-benchmark(`benchmark-table-component/render/10k`, () => {
+benchmark(`server/table-component/render/10k`, () => {
     run(() => {
         const store = new Store();
         store.runLots();


### PR DESCRIPTION
## Details

Renames the benchmarks so that they are easier to read in the Best UI.

Fixes:

- Some benchmarks have duplicate names (Whoops 🤦‍♂️)
- Can't tell which ones are `server` vs `dom`
- It's not obvious that `ss` means "synthetic shadow"
- Names are inconsistent

Names before:

```
benchmark-slot-ss/synthetic-shadow-create/5k
benchmark-slot-ss/synthetic-shadow-slot-update-slotted-content/5k
benchmark-styled-component/create/10k/same
benchmark-styled-component/create/10k/same
benchmark-styled-component/create/1k/different
benchmark-styled-component/create/1k/different
benchmark-table-component/append/1k
benchmark-table-component/create/10k
benchmark-table-component/create/1k
benchmark-table-component/hydrate/1k
benchmark-table-component/render/10k
benchmark-table/create/10k
benchmark-table/hydrate/1k
benchmark-table/render/10k
benchmark-tracked-component/create/10k
ss-benchmark-styled-component/create/10k/same
ss-benchmark-styled-component/create/1k/different
```

Names after:

```
dom/slot/synthetic-shadow/create/5k
dom/slot/synthetic-shadow/update-slotted-content/5k
dom/styled-component/light/create-different/1k
dom/styled-component/light/create-same/10k
dom/styled-component/shadow/create-different/1k
dom/styled-component/shadow/create-same/10k
dom/styled-component/synthetic-shadow/create-different/1k
dom/styled-component/synthetic-shadow/create-same/10k
dom/table-component/append/1k
dom/table-component/create/10k
dom/table-component/create/1k
dom/table/create/10k
dom/tracked-component/create/10k
hydrate/table-component/hydrate/1k
hydrate/table/hydrate/1k
server/table-component/render/10k
server/table/render/10k
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
