### PR TITLE
chore(perf-benchmarks): increase best iterations

### DIFF
--- a/packages/@lwc/perf-benchmarks/best.config.js
+++ b/packages/@lwc/perf-benchmarks/best.config.js
@@ -9,7 +9,7 @@ module.exports = {
     projectName: 'lwc',
     mainBranch: 'master',
     // This number is a tradeoff: higher = less variance, lower = less time spent running in CI
-    benchmarkIterations: 30,
+    benchmarkIterations: 60,
     // Refresh the browser between each iteration. This doesn't affect our benchmarks much
     // (since they already use for-loops, so we're only measuring peak performance, i.e. JITed performance),
     // but our tests assume that the DOM is fresh on each iteration


### PR DESCRIPTION
## Details

We got the okay from Best infra folks to bump the # of iterations from 30 to 60. The tests will take ~20 minutes instead of ~10 minutes, but we should have lower variance.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
