### PR TITLE
fix(engine-dom): remove portal warnings for native shadow

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -10,14 +10,14 @@ import {
     assert,
     create,
     isArray,
-    isTrue,
     isFalse,
     isNull,
+    isTrue,
     isUndefined,
-    keys,
-    SVG_NAMESPACE,
     KEY__SHADOW_RESOLVER,
     KEY__SHADOW_STATIC,
+    keys,
+    SVG_NAMESPACE,
 } from '@lwc/shared';
 import features from '@lwc/features';
 
@@ -27,38 +27,38 @@ import { LifecycleCallback, RendererAPI } from './renderer';
 import { EmptyArray } from './utils';
 import { markComponentAsDirty } from './component';
 import { getScopeTokenClass } from './stylesheet';
-import { patchElementWithRestrictions, unlockDomMutation, lockDomMutation } from './restrictions';
+import { lockDomMutation, patchElementWithRestrictions, unlockDomMutation } from './restrictions';
 import {
-    createVM,
     appendVM,
-    removeVM,
-    rerenderVM,
+    connectRootElement,
+    createVM,
+    disconnectRootElement,
     getAssociatedVMIfPresent,
+    LwcDomMode,
+    removeVM,
+    RenderMode,
+    rerenderVM,
     runConnectedCallback,
+    ShadowMode,
     VM,
     VMState,
-    ShadowMode,
-    RenderMode,
-    LwcDomMode,
-    connectRootElement,
-    disconnectRootElement,
 } from './vm';
 import {
-    VNode,
-    VNodes,
-    VCustomElement,
-    VElement,
-    VText,
-    VComment,
-    Key,
-    VBaseElement,
-    isVBaseElement,
     isSameVnode,
-    VNodeType,
-    VStatic,
-    VFragment,
+    isVBaseElement,
     isVFragment,
     isVScopedSlotFragment,
+    Key,
+    VBaseElement,
+    VComment,
+    VCustomElement,
+    VElement,
+    VFragment,
+    VNode,
+    VNodes,
+    VNodeType,
+    VStatic,
+    VText,
 } from './vnodes';
 
 import { patchAttributes } from './modules/attrs';
@@ -584,12 +584,14 @@ function applyDomManual(elm: Element, vnode: VBaseElement) {
 
 function applyElementRestrictions(elm: Element, vnode: VElement | VStatic) {
     if (process.env.NODE_ENV !== 'production') {
+        const isSynthetic = vnode.owner.shadowMode === ShadowMode.Synthetic;
         const isPortal =
             vnode.type === VNodeType.Element && vnode.data.context?.lwc?.dom === LwcDomMode.Manual;
         const isLight = vnode.owner.renderMode === RenderMode.Light;
         patchElementWithRestrictions(elm, {
             isPortal,
             isLight,
+            isSynthetic,
         });
     }
 }

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -74,7 +74,7 @@ function logMissingPortalError(name: string, type: string) {
 
 export function patchElementWithRestrictions(
     elm: Element,
-    options: { isPortal: boolean; isLight: boolean }
+    options: { isPortal: boolean; isLight: boolean; isSynthetic: boolean }
 ): void {
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
@@ -94,7 +94,7 @@ export function patchElementWithRestrictions(
     };
 
     // Apply extra restriction related to DOM manipulation if the element is not a portal.
-    if (!options.isLight && !options.isPortal) {
+    if (!options.isLight && options.isSynthetic && !options.isPortal) {
         const { appendChild, insertBefore, removeChild, replaceChild } = elm;
 
         const originalNodeValueDescriptor = getPropertyDescriptor(elm, 'nodeValue')!;

--- a/packages/@lwc/integration-karma/test/shadow-dom/Element-properties/Element.innerHTML.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Element-properties/Element.innerHTML.spec.js
@@ -38,15 +38,20 @@ describe('Element.innerHTML - set', () => {
         }).toThrowError(TypeError);
     });
 
-    it('should log an error when invoking setter for an element in the shadow', () => {
+    it('should log an error when invoking setter for an element in the shadow only in synthetic mode', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
         const div = elm.shadowRoot.querySelector('div');
 
-        expect(() => {
+        // eslint-disable-next-line jest/valid-expect
+        let expected = expect(() => {
             div.innerHTML = '<span>Hello World!</span>';
-        }).toLogErrorDev(
+        });
+        if (process.env.NATIVE_SHADOW) {
+            expected = expected.not; // no error
+        }
+        expected.toLogErrorDev(
             /\[LWC error\]: The `innerHTML` property is available only on elements that use the `lwc:dom="manual"` directive./
         );
     });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.textContent.spec.js
@@ -37,15 +37,20 @@ describe('Node.textContent - setter', () => {
         }).toThrowError();
     });
 
-    it('should log an error when invoking setter for an element in the shadow', () => {
+    it('should log an error when invoking setter for an element in the shadow only in synthetic mode', () => {
         const elm = createElement('x-test', { is: Slotted });
         document.body.appendChild(elm);
 
         const div = elm.shadowRoot.querySelector('div');
 
-        expect(() => {
+        // eslint-disable-next-line jest/valid-expect
+        let expected = expect(() => {
             div.textContent = '<span>Hello World!</span>';
-        }).toLogErrorDev(
+        });
+        if (process.env.NATIVE_SHADOW) {
+            expected = expected.not; // no error
+        }
+        expected.toLogErrorDev(
             /\[LWC error\]: The `textContent` property is available only on elements that use the `lwc:dom="manual"` directive./
         );
     });

--- a/packages/@lwc/integration-karma/test/template/directive-lwc-dom-manual/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-lwc-dom-manual/index.spec.js
@@ -15,12 +15,17 @@ function waitForStyleToBeApplied() {
 
 describe('dom mutation without the lwc:dom="manual" directive', () => {
     function testErrorOnDomMutation(method, fn) {
-        it(`should log an error when calling ${method} on an element without the lwc:dom="manual" directive`, () => {
+        it(`should log an error when calling ${method} on an element without the lwc:dom="manual" directive only in synthetic mode`, () => {
             const root = createElement('x-without-lwc-dom-manual', { is: withoutLwcDomManual });
             document.body.appendChild(root);
             const elm = root.shadowRoot.querySelector('div');
 
-            expect(() => fn(elm)).toLogErrorDev(
+            // eslint-disable-next-line jest/valid-expect
+            let expected = expect(() => fn(elm));
+            if (process.env.NATIVE_SHADOW) {
+                expected = expected.not; // no error
+            }
+            expected.toLogErrorDev(
                 new RegExp(
                     `\\[LWC error\\]: The \`${method}\` method is available only on elements that use the \`lwc:dom="manual"\` directive.`
                 )


### PR DESCRIPTION
## Details

Fixes #3117

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

In dev mode, when using native shadow, there is no longer a console.error in certain cases. This is mildly observable and unlikely to break anything.

<!-- If yes, please describe the anticipated observable changes. -->

