### PR TITLE
feat(engine-core): introducing DynamicLightningElement

### DIFF
--- a/packages/@lwc/engine-core/src/framework/components/dynamic.ts
+++ b/packages/@lwc/engine-core/src/framework/components/dynamic.ts
@@ -1,0 +1,103 @@
+import { create, defineProperty } from '@lwc/shared';
+import { defaultEmptyTemplate } from '../secure-template';
+import { registerComponent } from '../component';
+import { LightningElement, LightningElementConstructor } from '../base-lightning-element';
+import { ComponentDef, getComponentInternalDef } from '../def';
+import {
+    appendVM,
+    computeShadowMode,
+    createVMContext,
+    getAssociatedVMIfPresent,
+    hasWireAdapters,
+    resetComponentRoot,
+    runConnectedCallback,
+    runDisconnectedCallback,
+    VM,
+    VMState,
+} from '../vm';
+import { invokeComponentConstructor } from '../invoker';
+import { installWireAdapters } from '../wiring';
+
+function replaceDefinitionForVM(vm: VM, newDef: ComponentDef, replacedCallback: () => void) {
+    if (vm.state === VMState.connected) {
+        runDisconnectedCallback(vm);
+    }
+    if (vm.state === VMState.disconnected) {
+        // there is a possibility that the elm is disconnected, and the content
+        // inside its shadow is still visible to the new component, since the
+        // element is reused and runDisconnectedCallback doesn't remove its
+        // content, we need to do it manually.
+        resetComponentRoot(vm);
+    }
+    // remove content of the shadow if any and any internal cache
+    vm.def = newDef;
+    vm.context = createVMContext();
+    vm.cmpProps = create(null);
+    vm.cmpFields = create(null);
+    vm.refVNodes = null;
+
+    // validation of the mode... it must match the mode of the original implementation
+    // users can extend DynamicLightingElement to adjust the mode at will.
+    // do we need the same thing for cm.renderMode? I believe we do!
+    if (vm.shadowMode !== computeShadowMode(vm)) {
+        throw new TypeError(`Incompatible ShadowMode`);
+    }
+    // Create a new component instance associated to the vm and the element.
+    invokeComponentConstructor(vm, newDef.ctor);
+    // Initializing the wire decorator per instance only when really needed
+    if (hasWireAdapters(vm)) {
+        installWireAdapters(vm);
+    }
+
+    // what about existing props? should that be carry on by the diffing algo?
+    replacedCallback();
+
+    if (vm.elm.isConnected) {
+        // virtual re-insertion of the component into the DOM, by faking it.
+        runConnectedCallback(vm);
+        appendVM(vm);
+    }
+}
+
+function getVMFromComponent(obj: any): VM {
+    const vm = getAssociatedVMIfPresent(obj);
+    if (!vm) {
+        throw TypeError(`Invalid Invocation`);
+    }
+    return vm;
+}
+
+export class DynamicLightingElement extends LightningElement {
+    constructor() {
+        super();
+        let ctor: LightningElementConstructor | null = null;
+        const { replacedCallback } = this;
+        // installing the elm.ctor public property, it is not reflective to an attribute,
+        // and it is not configurable to avoid something messing with its public API. The
+        // fact that it is installed on instance guarantees that changing the proto-chain
+        // will not affect its behavior.
+        defineProperty(getVMFromComponent(this).elm, 'ctor', {
+            get(): LightningElementConstructor | null {
+                getVMFromComponent(this); // validation only
+                return ctor;
+            },
+            set(newCtor: LightningElementConstructor) {
+                const def = getComponentInternalDef(newCtor);
+                if (ctor === newCtor) {
+                    return;
+                }
+                const vm = getVMFromComponent(this); // additionally validation
+                ctor = newCtor;
+                // kick in the replacement
+                replaceDefinitionForVM(vm.elm, def, () => replacedCallback.apply(this));
+            },
+            configurable: false,
+        });
+    }
+    replacedCallback(): void {
+        // this is useful for subclasses to get a notification every time the
+        // component is swapped after setting `ctor` property.
+    }
+}
+
+registerComponent(DynamicLightingElement, { tmpl: defaultEmptyTemplate });

--- a/packages/@lwc/engine-core/src/framework/components/dynamic.ts
+++ b/packages/@lwc/engine-core/src/framework/components/dynamic.ts
@@ -71,7 +71,7 @@ export class DynamicLightingElement extends LightningElement {
     constructor() {
         super();
         let ctor: LightningElementConstructor | null = null;
-        const { replacedCallback } = this;
+        const replacedCallback: () => void | undefined = (this as any).replacedCallback;
         // installing the elm.ctor public property, it is not reflective to an attribute,
         // and it is not configurable to avoid something messing with its public API. The
         // fact that it is installed on instance guarantees that changing the proto-chain
@@ -89,14 +89,10 @@ export class DynamicLightingElement extends LightningElement {
                 const vm = getVMFromComponent(this); // additionally validation
                 ctor = newCtor;
                 // kick in the replacement
-                replaceDefinitionForVM(vm.elm, def, () => replacedCallback.apply(this));
+                replaceDefinitionForVM(vm.elm, def, () => replacedCallback?.apply(this));
             },
             configurable: false,
         });
-    }
-    replacedCallback(): void {
-        // this is useful for subclasses to get a notification every time the
-        // component is swapped after setting `ctor` property.
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -107,9 +107,9 @@ export interface VM<N = HostNode, E = HostElement> {
     /** The host element tag name */
     readonly tagName: string;
     /** The component definition */
-    readonly def: ComponentDef;
+    def: ComponentDef;
     /** The component context object. */
-    readonly context: Context;
+    context: Context;
     /** The owner VM or null for root elements. */
     readonly owner: VM<N, E> | null;
     /** References to elements rendered using lwc:ref (template refs) */
@@ -269,6 +269,19 @@ function getNearestShadowAncestor(vm: VM): VM | null {
     return ancestor;
 }
 
+export function createVMContext() {
+    return {
+        stylesheetToken: undefined,
+        hasTokenInClass: undefined,
+        hasTokenInAttribute: undefined,
+        hasScopedStyles: undefined,
+        styleVNodes: null,
+        tplCache: EmptyObject,
+        wiredConnecting: EmptyArray,
+        wiredDisconnecting: EmptyArray,
+    };
+}
+
 export function createVM<HostNode, HostElement>(
     elm: HostElement,
     ctor: LightningElementConstructor,
@@ -305,16 +318,7 @@ export function createVM<HostNode, HostElement>(
         hydrated: Boolean(hydrated),
 
         renderMode: def.renderMode,
-        context: {
-            stylesheetToken: undefined,
-            hasTokenInClass: undefined,
-            hasTokenInAttribute: undefined,
-            hasScopedStyles: undefined,
-            styleVNodes: null,
-            tplCache: EmptyObject,
-            wiredConnecting: EmptyArray,
-            wiredDisconnecting: EmptyArray,
-        },
+        context: createVMContext(),
 
         // Properties set right after VM creation.
         tro: null!,
@@ -336,7 +340,7 @@ export function createVM<HostNode, HostElement>(
         vm.debugInfo = create(null);
     }
 
-    vm.shadowMode = computeShadowMode(vm, renderer);
+    vm.shadowMode = computeShadowMode(vm);
     vm.tro = getTemplateReactiveObserver(vm);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -359,8 +363,8 @@ export function createVM<HostNode, HostElement>(
     return vm;
 }
 
-function computeShadowMode(vm: VM, renderer: RendererAPI) {
-    const { def } = vm;
+export function computeShadowMode(vm: VM) {
+    const { def, renderer } = vm;
     const { isSyntheticShadowDefined, isNativeShadowDefined } = renderer;
 
     let shadowMode;
@@ -564,11 +568,11 @@ export function runConnectedCallback(vm: VM) {
     }
 }
 
-function hasWireAdapters(vm: VM): boolean {
+export function hasWireAdapters(vm: VM): boolean {
     return getOwnPropertyNames(vm.def.wire).length > 0;
 }
 
-function runDisconnectedCallback(vm: VM) {
+export function runDisconnectedCallback(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(vm.state !== VMState.disconnected, `${vm} must be inserted.`);
     }


### PR DESCRIPTION
## Details

POC on how can we create a magical `<dynamic-lightning-element lwc:dynamic={ctor}>` that accepts a `ctor` property to be passed in with an arbitrary `LightningElement` constructor. This implements dynamic elements in templates without the issues of previous implementations that were attempting to reuse the name of the element while replacing the custom element associated to it.

## How do it work?

This new element, that is NOT an abstract class, but it is not final either, can be extended if needed. This element can be used in templates (compiler will know how to resolve it). Once the element is created (via the diffing algo), it will expect a property (ctor) to be provided... if provided, it should be a qualifying LightningElement, and a definition will be procured in the process.

Then the already created VM, and the already created and linked element, can be used to reset the state of the VM, replacing the associated definition, and boot up the component again by creating a new instance of it. The old instance will be collected by the GC, and the new instance will take control over the element. This process can be repeated as many times as you want.

Few other considerations:

1. The compiler can remove the element via diffing algo (vnode to be removed) if the ctor is not qualifying, or is pending (promise) to be resolved.
2. Any expando, or work on the actual element instance (which are rare) will be preserved even after replacing the constructor associated to it since the `element` instance is reused, only the component (cmp) is replaced.
3. The VM needs to be refreshed (reset), or at least parts of it to avoid creating a new VM all together. This should be fine since this is a controlled process.
4. The compiler can also trigger the reset of the properties (or spread) right after setting the ctor property (if we can guarantee that the `ctor` prop goes first, then we can just set the others right after). This is important... even if the old props are the same. Attributes on the other hand, don't need to be reset. Finally, listeners could be tricky.
5. If you want to observe the replacement process in user-land, you can rely on a new callback called `replacedCallback`, which give us a hook into the replacing process to accommodate the new instance.

## Will this work when using web components?

Yes, `<dynamic-lightning-element>` can be registered as web components, as well as subclasses of it. This will work fine, of course, a constructor cannot be set from HTML, meaning only the property can be set, without reflection into the `ctor` attribute, instead we use the magical `lwc:dynamic` directive, which also allows the compiler to identify that this component is actually a dynamic component that needs special handling. Now, the `ctor` value can only be a `LightningElement`, attempting to pass a CustomElement Constructor will throw a type error.

## What other work is needed for this to function?

The compiler work is pending. `<dynamic-lightning-element>` must be recognized by the parser, and the resolution for the constructor must be the internal `DynamicLightingElement`, which is exported from LWC the same way `LightningElement` is. The work of the compiler is very similar to what we do today with lwc:dynamic directive. The difference is that promises must be controlled by the output code, or a method in api.ts (that's TBD).

## How to transition from the current implementation into this?

Additionally, we should be able to transform existing lwc:dynamic syntax into the new syntax to avoid breaking existing customers. We can make it very easy by allowing other tagNames with lwc:dynamic, to inherit from dynamic-lightning-element, and that way, they can continue using the same syntax. Remember that only a very small group of people are allowed to use this. Eventually, a lot of code can be removed to eliminate the lwc:dynamic directive all together from compiler and runtime.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

## GUS work item

TBD