### PR TITLE
fix: update attribute parsing to account for '=' in attribute value (backport)

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <x-foo props="\{url: https://example.com/over/there?name=ferret}"></x-foo>
+    <div props="\{url: https://example.com/over/there?name=ferret}"></div>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/ast.json
@@ -1,0 +1,135 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 12,
+            "start": 0,
+            "end": 176,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 4,
+                "startColumn": 1,
+                "endLine": 4,
+                "endColumn": 12,
+                "start": 165,
+                "end": 176
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Component",
+                "name": "x-foo",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 79,
+                    "start": 15,
+                    "end": 89,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 71,
+                        "start": 15,
+                        "end": 81
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 71,
+                        "endLine": 2,
+                        "endColumn": 79,
+                        "start": 81,
+                        "end": 89
+                    }
+                },
+                "attributes": [],
+                "properties": [
+                    {
+                        "type": "Property",
+                        "name": "props",
+                        "attributeName": "props",
+                        "value": {
+                            "type": "Literal",
+                            "value": "{url: https://example.com/over/there?name=ferret}"
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 12,
+                            "endLine": 2,
+                            "endColumn": 70,
+                            "start": 22,
+                            "end": 80
+                        }
+                    }
+                ],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            },
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 3,
+                    "startColumn": 5,
+                    "endLine": 3,
+                    "endColumn": 75,
+                    "start": 94,
+                    "end": 164,
+                    "startTag": {
+                        "startLine": 3,
+                        "startColumn": 5,
+                        "endLine": 3,
+                        "endColumn": 69,
+                        "start": 94,
+                        "end": 158
+                    },
+                    "endTag": {
+                        "startLine": 3,
+                        "startColumn": 69,
+                        "endLine": 3,
+                        "endColumn": 75,
+                        "start": 158,
+                        "end": 164
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "props",
+                        "value": {
+                            "type": "Literal",
+                            "value": "{url: https://example.com/over/there?name=ferret}"
+                        },
+                        "location": {
+                            "startLine": 3,
+                            "startColumn": 10,
+                            "endLine": 3,
+                            "endColumn": 68,
+                            "start": 99,
+                            "end": 157
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
@@ -1,0 +1,19 @@
+import _xFoo from "x/foo";
+import { parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<div props="{url: https://example.com/over/there?name=ferret}"${3}></div>`;
+const stc0 = {
+  props: {
+    props: "{url: https://example.com/over/there?name=ferret}",
+  },
+  key: 0,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { c: api_custom_element, st: api_static_fragment } = $api;
+  return [
+    api_custom_element("x-foo", _xFoo, stc0),
+    api_static_fragment($fragment1(), 2),
+  ];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1057,
+            "message": "LWC1057: props is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 10,
+                "start": 99,
+                "length": 58
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -38,14 +38,12 @@ import {
     TEMPLATE_DIRECTIVES,
 } from './constants';
 
-function isQuotedAttribute(rawAttribute: string) {
-    const [, value] = rawAttribute.split('=');
-    return value && value.startsWith('"') && value.endsWith('"');
+function isQuotedAttribute(attrVal: string) {
+    return attrVal && attrVal.startsWith('"') && attrVal.endsWith('"');
 }
 
-function isEscapedAttribute(rawAttribute: string) {
-    const [, value] = rawAttribute.split('=');
-    return !value || !(value.includes('{') && value.includes('}'));
+function isEscapedAttribute(attrVal: string) {
+    return !attrVal || !(attrVal.includes('{') && attrVal.includes('}'));
 }
 
 export function isIdReferencingAttribute(attrName: string): boolean {
@@ -107,8 +105,9 @@ export function normalizeAttributeValue(
         }
     }
 
-    const isQuoted = isQuotedAttribute(raw);
-    const isEscaped = isEscapedAttribute(raw);
+    const rawAttrVal = raw.slice(raw.indexOf('=') + 1);
+    const isQuoted = isQuotedAttribute(rawAttrVal);
+    const isEscaped = isEscapedAttribute(rawAttrVal);
     if (!isEscaped && isExpression(value)) {
         if (isQuoted) {
             // <input value="{myValue}" />


### PR DESCRIPTION
## Details
This is a backport of #3185 to Spring23.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

See the description in #3185 

## GUS work item
W-12107374