### PR TITLE
fix: clean up usage of process.env.NODE_ENV

### DIFF
--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -16,6 +16,13 @@ function log(method: 'warn' | 'error', message: string, vm?: VM) {
         msg = `${msg}\n${getComponentStack(vm)}`;
     }
 
+    // In Jest tests, reduce the warning and error verbosity by not printing the callstack
+    if (process.env.NODE_ENV === 'test') {
+        /* eslint-disable-next-line no-console */
+        console[method](msg);
+        return;
+    }
+
     try {
         throw new Error(msg);
     } catch (e) {

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -16,12 +16,6 @@ function log(method: 'warn' | 'error', message: string, vm?: VM) {
         msg = `${msg}\n${getComponentStack(vm)}`;
     }
 
-    if (process.env.NODE_ENV === 'test') {
-        /* eslint-disable-next-line no-console */
-        console[method](msg);
-        return;
-    }
-
     try {
         throw new Error(msg);
     } catch (e) {

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -60,7 +60,8 @@ const stylesheetCache: Map<String, CacheData> = new Map();
 // Test utilities
 //
 
-if (process.env.NODE_ENV === 'development') {
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     // @ts-ignore
     window.__lwcResetGlobalStylesheets = () => {
         stylesheetCache.clear();

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -60,6 +60,7 @@ const stylesheetCache: Map<String, CacheData> = new Map();
 // Test utilities
 //
 
+// Only used in LWC's Karma tests
 // @ts-ignore
 if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
     // @ts-ignore

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -350,53 +350,65 @@ defineProperties(Element.prototype, {
     },
 });
 
-defineProperties(Element.prototype, {
-    getElementsByClassName: {
-        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            const elements = arrayFromCollection(
-                elementGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [string])
-            );
+// The following APIs are used directly by Jest internally so we avoid patching them during testing.
+if (process.env.NODE_ENV !== 'test') {
+    defineProperties(Element.prototype, {
+        getElementsByClassName: {
+            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+                const elements = arrayFromCollection(
+                    elementGetElementsByClassName.apply(
+                        this,
+                        ArraySlice.call(arguments) as [string]
+                    )
+                );
 
-            // Note: we deviate from native shadow here, but are not fixing
-            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
+                // Note: we deviate from native shadow here, but are not fixing
+                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            },
+            writable: true,
+            enumerable: true,
+            configurable: true,
         },
-        writable: true,
-        enumerable: true,
-        configurable: true,
-    },
-    getElementsByTagName: {
-        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            const elements = arrayFromCollection(
-                elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
-            );
+        getElementsByTagName: {
+            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+                const elements = arrayFromCollection(
+                    elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
+                );
 
-            // Note: we deviate from native shadow here, but are not fixing
-            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
+                // Note: we deviate from native shadow here, but are not fixing
+                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            },
+            writable: true,
+            enumerable: true,
+            configurable: true,
         },
-        writable: true,
-        enumerable: true,
-        configurable: true,
-    },
-    getElementsByTagNameNS: {
-        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-            const elements = arrayFromCollection(
-                elementGetElementsByTagNameNS.apply(
-                    this,
-                    ArraySlice.call(arguments) as [string, string]
-                )
-            );
+        getElementsByTagNameNS: {
+            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+                const elements = arrayFromCollection(
+                    elementGetElementsByTagNameNS.apply(
+                        this,
+                        ArraySlice.call(arguments) as [string, string]
+                    )
+                );
 
-            // Note: we deviate from native shadow here, but are not fixing
-            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
+                // Note: we deviate from native shadow here, but are not fixing
+                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+                return createStaticHTMLCollection(
+                    getNonPatchedFilteredArrayOfNodes(this, elements)
+                );
+            },
+            writable: true,
+            enumerable: true,
+            configurable: true,
         },
-        writable: true,
-        enumerable: true,
-        configurable: true,
-    },
-});
+    });
+}
 
 // IE11 extra patches for wrong prototypes
 if (hasOwnProperty.call(HTMLElement.prototype, 'getElementsByClassName')) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -350,65 +350,53 @@ defineProperties(Element.prototype, {
     },
 });
 
-// The following APIs are used directly by Jest internally so we avoid patching them during testing.
-if (process.env.NODE_ENV !== 'test') {
-    defineProperties(Element.prototype, {
-        getElementsByClassName: {
-            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-                const elements = arrayFromCollection(
-                    elementGetElementsByClassName.apply(
-                        this,
-                        ArraySlice.call(arguments) as [string]
-                    )
-                );
+defineProperties(Element.prototype, {
+    getElementsByClassName: {
+        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            const elements = arrayFromCollection(
+                elementGetElementsByClassName.apply(this, ArraySlice.call(arguments) as [string])
+            );
 
-                // Note: we deviate from native shadow here, but are not fixing
-                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-                return createStaticHTMLCollection(
-                    getNonPatchedFilteredArrayOfNodes(this, elements)
-                );
-            },
-            writable: true,
-            enumerable: true,
-            configurable: true,
+            // Note: we deviate from native shadow here, but are not fixing
+            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         },
-        getElementsByTagName: {
-            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-                const elements = arrayFromCollection(
-                    elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
-                );
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    },
+    getElementsByTagName: {
+        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            const elements = arrayFromCollection(
+                elementGetElementsByTagName.apply(this, ArraySlice.call(arguments) as [string])
+            );
 
-                // Note: we deviate from native shadow here, but are not fixing
-                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-                return createStaticHTMLCollection(
-                    getNonPatchedFilteredArrayOfNodes(this, elements)
-                );
-            },
-            writable: true,
-            enumerable: true,
-            configurable: true,
+            // Note: we deviate from native shadow here, but are not fixing
+            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         },
-        getElementsByTagNameNS: {
-            value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
-                const elements = arrayFromCollection(
-                    elementGetElementsByTagNameNS.apply(
-                        this,
-                        ArraySlice.call(arguments) as [string, string]
-                    )
-                );
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    },
+    getElementsByTagNameNS: {
+        value(this: HTMLBodyElement): HTMLCollectionOf<Element> {
+            const elements = arrayFromCollection(
+                elementGetElementsByTagNameNS.apply(
+                    this,
+                    ArraySlice.call(arguments) as [string, string]
+                )
+            );
 
-                // Note: we deviate from native shadow here, but are not fixing
-                // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
-                return createStaticHTMLCollection(
-                    getNonPatchedFilteredArrayOfNodes(this, elements)
-                );
-            },
-            writable: true,
-            enumerable: true,
-            configurable: true,
+            // Note: we deviate from native shadow here, but are not fixing
+            // due to backwards compat: https://github.com/salesforce/lwc/pull/3103
+            return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         },
-    });
-}
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    },
+});
 
 // IE11 extra patches for wrong prototypes
 if (hasOwnProperty.call(HTMLElement.prototype, 'getElementsByClassName')) {


### PR DESCRIPTION
## Details

In general, I think we should strive to avoid any reference to a `process.env.NODE_ENV` value other than `"production"`. The other possible values (`"development"`, `"test"`, etc.) are unreliable in my experience.

There are only three places we're doing this. The `"test"` usage is undoubtedly [just to target Jest](https://jestjs.io/docs/environment-variables#node_env).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
