### PR TITLE
perf: remove HTMLElement accessor warning map in prod

### DIFF
--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -28,38 +28,11 @@ function offsetPropertyErrorMessage(name: string): string {
 //
 // If you update this list, check for test files that recapitulate the same list. Searching the codebase
 // for e.g. "dropzone" should suffice.
-export const globalHtmlElementPropertyNames = [
-    'accessKey',
-    'accessKeyLabel',
-    'className',
-    'contentEditable',
-    'dataset',
-    'dir',
-    'draggable',
-    'dropzone',
-    'hidden',
-    'id',
-    'inputMode',
-    'isContentEditable',
-    'lang',
-    'offsetHeight',
-    'offsetLeft',
-    'offsetParent',
-    'offsetTop',
-    'offsetWidth',
-    'role',
-    'slot',
-    'spellcheck',
-    'style',
-    'tabIndex',
-    'title',
-    'translate',
-] as const;
 
 // This mapping is deliberately kept separate from the array of property names above because the mapping object is
 // needed only for dev mode, whereas the above array is needed in prod mode too. This makes the bundle size lower.
 export const globalHTMLProperties: {
-    [Key in typeof globalHtmlElementPropertyNames[number]]: {
+    [prop: string]: {
         attribute?: string;
         error?: string;
         readOnly?: boolean;

--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assign, create } from '@lwc/shared';
 
 // These properties get added to LWCElement.prototype publicProps automatically
 export const defaultDefHTMLPropertyNames = [
@@ -29,13 +28,43 @@ function offsetPropertyErrorMessage(name: string): string {
 //
 // If you update this list, check for test files that recapitulate the same list. Searching the codebase
 // for e.g. "dropzone" should suffice.
+export const globalHtmlElementPropertyNames = [
+    'accessKey',
+    'accessKeyLabel',
+    'className',
+    'contentEditable',
+    'dataset',
+    'dir',
+    'draggable',
+    'dropzone',
+    'hidden',
+    'id',
+    'inputMode',
+    'isContentEditable',
+    'lang',
+    'offsetHeight',
+    'offsetLeft',
+    'offsetParent',
+    'offsetTop',
+    'offsetWidth',
+    'role',
+    'slot',
+    'spellcheck',
+    'style',
+    'tabIndex',
+    'title',
+    'translate',
+] as const;
+
+// This mapping is deliberately kept separate from the array of property names above because the mapping object is
+// needed only for dev mode, whereas the above array is needed in prod mode too. This makes the bundle size lower.
 export const globalHTMLProperties: {
-    [prop: string]: {
+    [Key in typeof globalHtmlElementPropertyNames[number]]: {
         attribute?: string;
         error?: string;
         readOnly?: boolean;
     };
-} = assign(create(null), {
+} = {
     accessKey: {
         attribute: 'accesskey',
     },
@@ -69,35 +98,15 @@ export const globalHTMLProperties: {
     id: {
         attribute: 'id',
     },
+    // additional "global attributes" that are not present in the link above.
+    isContentEditable: {
+        readOnly: true,
+    },
     inputMode: {
         attribute: 'inputmode',
     },
     lang: {
         attribute: 'lang',
-    },
-    slot: {
-        attribute: 'slot',
-        error: 'Using the `slot` property is an anti-pattern.',
-    },
-    spellcheck: {
-        attribute: 'spellcheck',
-    },
-    style: {
-        attribute: 'style',
-    },
-    tabIndex: {
-        attribute: 'tabindex',
-    },
-    title: {
-        attribute: 'title',
-    },
-    translate: {
-        attribute: 'translate',
-    },
-
-    // additional "global attributes" that are not present in the link above.
-    isContentEditable: {
-        readOnly: true,
     },
     offsetHeight: {
         readOnly: true,
@@ -121,7 +130,26 @@ export const globalHTMLProperties: {
     role: {
         attribute: 'role',
     },
-});
+    slot: {
+        attribute: 'slot',
+        error: 'Using the `slot` property is an anti-pattern.',
+    },
+    spellcheck: {
+        attribute: 'spellcheck',
+    },
+    style: {
+        attribute: 'style',
+    },
+    tabIndex: {
+        attribute: 'tabindex',
+    },
+    title: {
+        attribute: 'title',
+    },
+    translate: {
+        attribute: 'translate',
+    },
+};
 
 let controlledElement: Element | null = null;
 let controlledAttributeName: string | void;

--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -101,11 +101,32 @@ export const globalHTMLProperties: {
     inputMode: {
         attribute: 'inputmode',
     },
-    isContentEditable: {
-        readOnly: true,
-    },
     lang: {
         attribute: 'lang',
+    },
+    slot: {
+        attribute: 'slot',
+        error: 'Using the `slot` property is an anti-pattern.',
+    },
+    spellcheck: {
+        attribute: 'spellcheck',
+    },
+    style: {
+        attribute: 'style',
+    },
+    tabIndex: {
+        attribute: 'tabindex',
+    },
+    title: {
+        attribute: 'title',
+    },
+    translate: {
+        attribute: 'translate',
+    },
+
+    // additional "global attributes" that are not present in the link above.
+    isContentEditable: {
+        readOnly: true,
     },
     offsetHeight: {
         readOnly: true,
@@ -128,25 +149,6 @@ export const globalHTMLProperties: {
     },
     role: {
         attribute: 'role',
-    },
-    slot: {
-        attribute: 'slot',
-        error: 'Using the `slot` property is an anti-pattern.',
-    },
-    spellcheck: {
-        attribute: 'spellcheck',
-    },
-    style: {
-        attribute: 'style',
-    },
-    tabIndex: {
-        attribute: 'tabindex',
-    },
-    title: {
-        attribute: 'title',
-    },
-    translate: {
-        attribute: 'translate',
     },
 };
 

--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -98,12 +98,11 @@ export const globalHTMLProperties: {
     id: {
         attribute: 'id',
     },
-    // additional "global attributes" that are not present in the link above.
-    isContentEditable: {
-        readOnly: true,
-    },
     inputMode: {
         attribute: 'inputmode',
+    },
+    isContentEditable: {
+        readOnly: true,
     },
     lang: {
         attribute: 'lang',

--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -28,9 +28,6 @@ function offsetPropertyErrorMessage(name: string): string {
 //
 // If you update this list, check for test files that recapitulate the same list. Searching the codebase
 // for e.g. "dropzone" should suffice.
-
-// This mapping is deliberately kept separate from the array of property names above because the mapping object is
-// needed only for dev mode, whereas the above array is needed in prod mode too. This makes the bundle size lower.
 export const globalHTMLProperties: {
     [prop: string]: {
         attribute?: string;

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -10,7 +10,6 @@ import {
     assign,
     create,
     defineProperties,
-    forEach,
     getPropertyDescriptor,
     getPrototypeOf,
     isUndefined,
@@ -336,45 +335,41 @@ function getLightningElementPrototypeRestrictionsDescriptors(
         }),
     };
 
-    // Disable certain global HTMl properties and warn when getting/setting them
-    forEach.call(
-        globalHtmlElementPropertyNames,
-        (propName: typeof globalHtmlElementPropertyNames[number]) => {
-            if (propName in proto) {
-                return; // no need to redefine something that we are already exposing
-            }
-            descriptors[propName] = generateAccessorDescriptor({
-                get(this: LightningElement) {
-                    // No need to log in production mode. Just use an empty getter
-                    if (process.env.NODE_ENV !== 'production') {
-                        const { error, attribute } = globalHTMLProperties[propName];
-                        const msg: string[] = [];
-                        msg.push(`Accessing the global HTML property "${propName}" is disabled.`);
-                        if (error) {
-                            msg.push(error);
-                        } else if (attribute) {
-                            msg.push(
-                                `Instead access it via \`this.getAttribute("${attribute}")\`.`
-                            );
-                        }
-                        logError(msg.join('\n'), getAssociatedVM(this));
-                    }
-                },
-                set(this: LightningElement) {
-                    // No need to log in production mode. Just use an empty setter
-                    if (process.env.NODE_ENV !== 'production') {
-                        const { readOnly } = globalHTMLProperties[propName];
-                        if (readOnly) {
-                            logError(
-                                `The global HTML property \`${propName}\` is read-only.`,
-                                getAssociatedVM(this)
-                            );
-                        }
-                    }
-                },
-            });
+    // Disable certain global HTML properties (the getters/setters become a no-op)
+    // and warn when getting/setting them in non-prod mode.
+    for (const propName of globalHtmlElementPropertyNames) {
+        if (propName in proto) {
+            continue; // no need to redefine something that we are already exposing
         }
-    );
+        descriptors[propName] = generateAccessorDescriptor({
+            get(this: LightningElement) {
+                // No need to log in production mode. Just use an empty getter
+                if (process.env.NODE_ENV !== 'production') {
+                    const { error, attribute } = globalHTMLProperties[propName];
+                    const msg: string[] = [];
+                    msg.push(`Accessing the global HTML property "${propName}" is disabled.`);
+                    if (error) {
+                        msg.push(error);
+                    } else if (attribute) {
+                        msg.push(`Instead access it via \`this.getAttribute("${attribute}")\`.`);
+                    }
+                    logError(msg.join('\n'), getAssociatedVM(this));
+                }
+            },
+            set(this: LightningElement) {
+                // No need to log in production mode. Just use an empty setter
+                if (process.env.NODE_ENV !== 'production') {
+                    const { readOnly } = globalHTMLProperties[propName];
+                    if (readOnly) {
+                        logError(
+                            `The global HTML property \`${propName}\` is read-only.`,
+                            getAssociatedVM(this)
+                        );
+                    }
+                }
+            },
+        });
+    }
 
     return descriptors;
 }


### PR DESCRIPTION
## Details

This reduces the `engine-dom` bundle size slightly, by removing some code that is only needed in dev mode. The size is reduced from 64609 to 63098 bytes when minified (1511 bytes or **1.5kb saved**).

We emit several console warning when calling accessors for certain `HTMLElement` props like `title` and `className`. The object describing these warnings is [quite large](https://github.com/salesforce/lwc/blob/e2d97e567c16d7460ccddb34a0cfb6717b9af36e/packages/@lwc/engine-core/src/framework/attributes.ts#L32-L124), not to mention the code to generate the log messages.

Because of how we were constructing this object, Terser was not able to tree-shake it, even in prod mode. This fixes that.

Note that the tests in #3215 confirm the existing behavior (although our Karma tests only run in dev mode unfortunately #3158).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
