### PR TITLE
fix: missing semicolon in stylesheetToken assignment

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -27,7 +27,21 @@ describe('transformSync', () => {
         `;
         const { code } = transformSync(template, 'foo.html', TRANSFORMATION_OPTIONS);
 
-        expect(code).toContain(`tmpl.stylesheets = []`);
+        expect(code).toContain(`tmpl.stylesheets = [];`);
+    });
+
+    it('should serialize the template with the correct scopeToken', () => {
+        const template = `
+            <template>
+                <div>Hello</div>
+            </template>
+        `;
+        const { code } = transformSync(template, 'foo.html', {
+            namespace: 'ns',
+            name: 'foo',
+        });
+
+        expect(code).toContain(`tmpl.stylesheetToken = "ns-foo_foo";`);
     });
 
     it('should hoist static vnodes when enableStaticContentOptimization is set to true', () => {

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -92,12 +92,12 @@ function serialize(
     buffer += code;
     buffer += '\n\n';
     buffer += 'if (_implicitStylesheets) {\n';
-    buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets)\n`;
+    buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);\n`;
     buffer += `}\n`;
     buffer += 'if (_implicitScopedStylesheets) {\n';
-    buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets)\n`;
+    buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);\n`;
     buffer += `}\n`;
-    buffer += `tmpl.stylesheetToken = "${scopeToken}"\n`;
+    buffer += `tmpl.stylesheetToken = "${scopeToken}";\n`;
     // Note that `renderMode` and `slots` are already rendered in @lwc/template-compiler and appear
     // as `code` above. At this point, no more expando props should be added to `tmpl`.
     buffer += 'freezeTemplate(tmpl);\n';


### PR DESCRIPTION
## Details
Fixes missing semicolons in tmpl.stylesheets and stylesheetToken assignments

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
W-12242450