### PR TITLE
feat: add DISABLE_REPORTING runtime flag

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { noop } from '@lwc/shared';
+import features from '@lwc/features';
 import { VM } from './vm';
 
 export const enum ReportingEventId {
@@ -85,6 +86,15 @@ export function onReportingEnabled(callback: OnReportingEnabledCallback) {
  */
 export function report(reportingEventId: ReportingEventId, vm: VM) {
     if (enabled) {
-        currentDispatcher(reportingEventId, vm.tagName, vm.idx);
+        if (!features.DISABLE_REPORTING) {
+            // reporting becomes a no-op if this flag is true
+            currentDispatcher(reportingEventId, vm.tagName, vm.idx);
+        }
     }
+}
+
+// @ts-ignore
+if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
+    // @ts-ignore
+    window.__lwcReport = report; // expose report() API only to karma tests
 }

--- a/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
@@ -22,6 +22,7 @@ import {
     hasOwnProperty,
     KEY__SHADOW_TOKEN,
 } from '@lwc/shared';
+import features from '@lwc/features';
 import { onReportingEnabled, report, ReportingEventId } from '../framework/reporting';
 import { getAssociatedVMIfPresent, VM } from '../framework/vm';
 import { logWarnOnce } from '../shared/logger';
@@ -173,12 +174,15 @@ function isSyntheticShadowLoaded() {
 }
 
 // Detecting cross-root ARIA in synthetic shadow only makes sense for the browser
-if (process.env.IS_BROWSER && supportsCssEscape() && isSyntheticShadowLoaded()) {
-    // Always run detection in dev mode, so we can at least print to the console
-    if (process.env.NODE_ENV !== 'production') {
-        enableDetection();
-    } else {
-        // In prod mode, only enable detection if reporting is enabled
-        onReportingEnabled(enableDetection);
+if (!features.DISABLE_REPORTING) {
+    // disable any detection if DISABLE_REPORTING is true
+    if (process.env.IS_BROWSER && supportsCssEscape() && isSyntheticShadowLoaded()) {
+        // Always run detection in dev mode, so we can at least print to the console
+        if (process.env.NODE_ENV !== 'production') {
+            enableDetection();
+        } else {
+            // In prod mode, only enable detection if reporting is enabled
+            onReportingEnabled(enableDetection);
+        }
     }
 }

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -19,6 +19,7 @@ const features: FeatureFlagMap = {
     ENABLE_FROZEN_TEMPLATE: null,
     DISABLE_ARIA_REFLECTION_POLYFILL: null,
     ENABLE_PROGRAMMATIC_STYLESHEETS: null,
+    DISABLE_REPORTING: null,
 };
 
 if (!globalThis.lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -88,6 +88,13 @@ export interface FeatureFlagMap {
      * stylsheets.
      */
     ENABLE_PROGRAMMATIC_STYLESHEETS: FeatureFlagValue;
+
+    /**
+     * Flag to disable the reporting API (`__unstable__ReportingControl`). If set to true, any code related to
+     * reporting will be disabled, including detection logic. Calling the `__unstable__ReportingControl` API
+     * will be a no-op.
+     */
+    DISABLE_REPORTING: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/reporting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/reporting/index.spec.js
@@ -1,0 +1,36 @@
+import { __unstable__ReportingControl as reportingControl, setFeatureFlagForTest } from 'lwc';
+
+describe('reporting', () => {
+    let dispatcher;
+
+    beforeEach(() => {
+        dispatcher = jasmine.createSpy();
+        reportingControl.attachDispatcher(dispatcher);
+    });
+
+    afterEach(() => {
+        reportingControl.detachDispatcher();
+    });
+
+    describe('lwcRuntimeFlags.DISABLE_REPORTING=false', () => {
+        it('reporting is enabled', () => {
+            window.__lwcReport(0, /* fake VM */ { tagName: 'x-foo', idx: 1 });
+            expect(dispatcher).toHaveBeenCalledWith(0, 'x-foo', 1);
+        });
+    });
+
+    describe('lwcRuntimeFlags.DISABLE_REPORTING=true', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('DISABLE_REPORTING', true);
+        });
+
+        afterEach(() => {
+            setFeatureFlagForTest('DISABLE_REPORTING', false);
+        });
+
+        it('reporting is disabled', () => {
+            window.__lwcReport(0, /* fake VM */ { tagName: 'x-foo', idx: 1 });
+            expect(dispatcher).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -23,6 +23,7 @@ import {
     getPrototypeOf,
     isObject,
 } from '@lwc/shared';
+import features from '@lwc/features';
 
 import { innerHTMLSetter } from '../env/element';
 import { dispatchEvent } from '../env/event-target';
@@ -107,15 +108,19 @@ defineProperty(globalThis, KEY__IS_NATIVE_SHADOW_ROOT_DEFINED, {
     value: isNativeShadowRootDefined,
 });
 
-// The isUndefined check is because two copies of synthetic shadow may be loaded on the same page, and this
-// would throw an error if we tried to redefine it. Plus the whole point is to expose the native method.
-if (isUndefined(globalThis[KEY__NATIVE_GET_ELEMENT_BY_ID])) {
-    defineProperty(globalThis, KEY__NATIVE_GET_ELEMENT_BY_ID, { value: getElementById });
-}
+if (!features.DISABLE_REPORTING) {
+    // This code is only needed for the CrossRootAriaInSyntheticShadow reporting API.
 
-// See note above.
-if (isUndefined(globalThis[KEY__NATIVE_QUERY_SELECTOR_ALL])) {
-    defineProperty(globalThis, KEY__NATIVE_QUERY_SELECTOR_ALL, { value: querySelectorAll });
+    // The isUndefined check is because two copies of synthetic shadow may be loaded on the same page, and this
+    // would throw an error if we tried to redefine it. Plus the whole point is to expose the native method.
+    if (isUndefined(globalThis[KEY__NATIVE_GET_ELEMENT_BY_ID])) {
+        defineProperty(globalThis, KEY__NATIVE_GET_ELEMENT_BY_ID, { value: getElementById });
+    }
+
+    // See note above.
+    if (isUndefined(globalThis[KEY__NATIVE_QUERY_SELECTOR_ALL])) {
+        defineProperty(globalThis, KEY__NATIVE_QUERY_SELECTOR_ALL, { value: querySelectorAll });
+    }
 }
 
 // Function created per shadowRoot instance, it returns the shadowRoot, and is attached


### PR DESCRIPTION
## Details

It occurred to me that it may be a good idea to add a runtime flag to disable reporting (added in #3214).

This serves two purposes:

1. We can potentially tree-shake the reporting code for environments that don't need it (e.g. off-core LWR)
2. We can use it as a kill switch on-platform in case there is a problem with the reporting code (e.g. perf overhead).


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
