### PR TITLE
chore: reuse "warn once" system

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -6,21 +6,11 @@
  */
 import { isNull, LWC_VERSION, LWC_VERSION_COMMENT_REGEX } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logErrorOnce } from '../shared/logger';
 
 import { Template } from './template';
 import { StylesheetFactory } from './stylesheet';
 import { LightningElementConstructor } from './base-lightning-element';
-
-let warned = false;
-
-// @ts-ignore
-if (process.env.NODE_ENV !== 'production' && typeof __karma__ !== 'undefined') {
-    // @ts-ignore
-    window.__lwcResetWarnedOnVersionMismatch = () => {
-        warned = false;
-    };
-}
 
 /**
  * Validate a template, stylesheet, or component to make sure that its compiled version matches
@@ -35,15 +25,14 @@ export function checkVersionMismatch(
     type: 'template' | 'stylesheet' | 'component'
 ) {
     const versionMatcher = func.toString().match(LWC_VERSION_COMMENT_REGEX);
-    if (!isNull(versionMatcher) && !warned) {
+    if (!isNull(versionMatcher)) {
         const version = versionMatcher[1];
         const [major, minor] = version.split('.');
         const [expectedMajor, expectedMinor] = LWC_VERSION.split('.');
         if (major !== expectedMajor || minor !== expectedMinor) {
-            warned = true; // only warn once to avoid flooding the console
             // stylesheets and templates do not have user-meaningful names, but components do
             const friendlyName = type === 'component' ? `${type} ${func.name}` : type;
-            logError(
+            logErrorOnce(
                 `LWC WARNING: current engine is v${LWC_VERSION}, but ${friendlyName} was compiled with v${version}.\nPlease update your compiled code or LWC engine so that the versions match.\nNo further warnings will appear.`
             );
         }

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -52,6 +52,10 @@ export function logError(message: string, vm?: VM) {
     log('error', message, vm, false);
 }
 
+export function logErrorOnce(message: string, vm?: VM) {
+    log('error', message, vm, true);
+}
+
 export function logWarn(message: string, vm?: VM) {
     log('warn', message, vm, false);
 }

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -40,10 +40,6 @@ if (!process.env.COMPAT) {
         });
 
         describe('version mismatch warning', () => {
-            beforeEach(() => {
-                window.__lwcResetWarnedOnVersionMismatch();
-            });
-
             it('template', () => {
                 function tmpl() {
                     return [];

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -106,5 +106,34 @@ if (!process.env.COMPAT) {
                 );
             });
         });
+
+        describe('only warns once', () => {
+            it('template', () => {
+                function tmpl() {
+                    return [];
+                    /*LWC compiler v987.654.321*/
+                }
+
+                expect(() => {
+                    registerTemplate(tmpl);
+                }).toLogErrorDev(
+                    new RegExp(
+                        `LWC WARNING: current engine is v${process.env.LWC_VERSION}, but template was compiled with v987.654.321`
+                    )
+                );
+
+                // use Promise.resolve to get a new scope for the function name
+                return Promise.resolve().then(() => {
+                    function tmpl() {
+                        return [];
+                        /*LWC compiler v987.654.321*/
+                    }
+
+                    expect(() => {
+                        registerTemplate(tmpl);
+                    }).not.toLogErrorDev();
+                });
+            });
+        });
     });
 }


### PR DESCRIPTION
## Details

#3214 added a new logging API for logging a warning/error only once. We can reuse that rather than building a custom one for every log message.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
