### PR TITLE
test(integration-karma): fix sourcemaps

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -43,6 +43,7 @@ function createPreprocessor(config, emitter, logger) {
 
         const plugins = [
             lwcRollupPlugin({
+                sourcemap: true,
                 experimentalDynamicComponent: {
                     loader: 'test-utils',
                     strict: true,
@@ -107,7 +108,6 @@ function createPreprocessor(config, emitter, logger) {
             // also adding the source map inline for browser debugging.
             // eslint-disable-next-line require-atomic-updates
             file.sourceMap = map;
-            code + `\n//# sourceMappingURL=${map.toUrl()}\n`;
 
             done(null, code);
         } catch (error) {


### PR DESCRIPTION
## Details

Fixes sourcemaps in our karma tests, in particular when running `yarn start` and debugging in the Karma debug mode.

Before (note how the little "tag" icons are messed up and inserted in the middle of words):

![Screen Shot 2022-12-19 at 4 20 01 PM](https://user-images.githubusercontent.com/283842/208552947-18e4a069-31b7-41d7-b7fb-c5f481a53d0b.png)

After:

![Screen Shot 2022-12-19 at 4 18 33 PM](https://user-images.githubusercontent.com/283842/208552991-f127b202-cd9e-4828-a607-478dfaadb958.png)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

