### PR TITLE
fix(engine-core): remove unused refs code

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -184,8 +184,6 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
 
 type RefNodes = { [name: string]: Element };
 
-const EMPTY_REFS: RefNodes = freeze(create(null));
-
 const refsCache: WeakMap<RefVNodes, RefNodes> = new WeakMap();
 
 export interface LightningElement extends HTMLElementTheGoodParts, AccessibleElementProperties {
@@ -553,11 +551,6 @@ LightningElement.prototype = {
         // because a template may have `lwc:ref` defined within a falsy `if:true` block.
         if (!hasRefVNodes) {
             return;
-        }
-        // For templates that are using `lwc:ref`, if there are no refs currently available
-        // (e.g. refs inside of a falsy `if:true` block), we return an empty object.
-        if (isNull(refVNodes)) {
-            return EMPTY_REFS;
         }
 
         // The refNodes can be cached based on the refVNodes, since the refVNodes

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -523,7 +523,7 @@ LightningElement.prototype = {
             warnIfInvokedDuringConstruction(vm, 'refs');
         }
 
-        const { refVNodes, hasRefVNodes, cmpTemplate } = vm;
+        const { refVNodes, cmpTemplate } = vm;
 
         // If the `cmpTemplate` is null, that means that the template has not been rendered yet. Most likely this occurs
         // if `this.refs` is called during the `connectedCallback` phase. The DOM elements have not been rendered yet,
@@ -547,9 +547,8 @@ LightningElement.prototype = {
         // were introduced, we return undefined if the template has no refs defined
         // anywhere. This fixes components that may want to add an expando called `refs`
         // and are checking if it exists with `if (this.refs)`  before adding it.
-        // Note it is not sufficient to just check if `refVNodes` is null or empty,
-        // because a template may have `lwc:ref` defined within a falsy `if:true` block.
-        if (!hasRefVNodes) {
+        // Note we use a null refVNodes to indicate that the template has no refs defined.
+        if (isNull(refVNodes)) {
             return;
         }
 

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -273,9 +273,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 }
 
                 // reset the refs; they will be set during the tmpl() instantiation
-                const hasRefVNodes = Boolean(html.hasRefs);
-                vm.hasRefVNodes = hasRefVNodes;
-                vm.refVNodes = hasRefVNodes ? create(null) : null;
+                vm.refVNodes = html.hasRefs ? create(null) : null;
 
                 // right before producing the vnodes, we clear up all internal references
                 // to custom elements from the template.

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -118,8 +118,6 @@ export interface VM<N = HostNode, E = HostElement> {
     readonly owner: VM<N, E> | null;
     /** References to elements rendered using lwc:ref (template refs) */
     refVNodes: RefVNodes | null;
-    /** Whether this template has any references to elements (template refs) */
-    hasRefVNodes: boolean;
     /** Whether or not the VM was hydrated */
     readonly hydrated: boolean;
     /** Rendering operations associated with the VM */
@@ -300,7 +298,6 @@ export function createVM<HostNode, HostElement>(
         mode,
         owner,
         refVNodes: null,
-        hasRefVNodes: false,
         children: EmptyArray,
         aChildren: EmptyArray,
         velements: EmptyArray,


### PR DESCRIPTION
## Details

Found some unused code while doing a coverage audit.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
