### PR TITLE
fix: use queueMicrotask in supported browsers

### DIFF
--- a/packages/@lwc/engine-core/src/framework/queue-microtask.ts
+++ b/packages/@lwc/engine-core/src/framework/queue-microtask.ts
@@ -1,0 +1,44 @@
+import { ArrayPush, isFunction, globalThis } from '@lwc/shared';
+
+type Callback = () => void;
+
+/* istanbul ignore next */
+function queueMicrotaskPolyfill() {
+    let nextTickCallbackQueue: Callback[] = [];
+
+    function flushCallbackQueue() {
+        if (process.env.NODE_ENV !== 'production') {
+            if (nextTickCallbackQueue.length === 0) {
+                throw new Error(
+                    `Internal Error: If callbackQueue is scheduled, it is because there must be at least one callback on this pending queue.`
+                );
+            }
+        }
+        const callbacks: Callback[] = nextTickCallbackQueue;
+        nextTickCallbackQueue = []; // reset to a new queue
+        for (let i = 0, len = callbacks.length; i < len; i += 1) {
+            callbacks[i]();
+        }
+    }
+
+    return function addCallbackToNextTick(callback: Callback) {
+        if (process.env.NODE_ENV !== 'production') {
+            if (!isFunction(callback)) {
+                throw new Error(
+                    `Internal Error: addCallbackToNextTick() can only accept a function callback`
+                );
+            }
+        }
+        if (nextTickCallbackQueue.length === 0) {
+            Promise.resolve().then(flushCallbackQueue);
+        }
+        ArrayPush.call(nextTickCallbackQueue, callback);
+    };
+}
+
+// This is supported in all modern browsers https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask#browser_compatibility
+// Basically the fallback is just for IE11
+/* istanbul ignore next */
+export const queueMicrotask = isFunction(globalThis.queueMicrotask)
+    ? globalThis.queueMicrotask
+    : queueMicrotaskPolyfill();

--- a/packages/@lwc/engine-core/src/framework/queue-microtask.ts
+++ b/packages/@lwc/engine-core/src/framework/queue-microtask.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import { ArrayPush, isFunction, globalThis } from '@lwc/shared';
 
 type Callback = () => void;

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -4,47 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayPush, create, isFunction, isUndefined, seal } from '@lwc/shared';
+import { create, isUndefined, seal } from '@lwc/shared';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
 import { RefVNodes, VM } from './vm';
 import { VBaseElement } from './vnodes';
 
-type Callback = () => void;
-
-let nextTickCallbackQueue: Callback[] = [];
 export const SPACE_CHAR = 32;
 
 export const EmptyObject = seal(create(null));
 export const EmptyArray = seal([]);
-
-function flushCallbackQueue() {
-    if (process.env.NODE_ENV !== 'production') {
-        if (nextTickCallbackQueue.length === 0) {
-            throw new Error(
-                `Internal Error: If callbackQueue is scheduled, it is because there must be at least one callback on this pending queue.`
-            );
-        }
-    }
-    const callbacks: Callback[] = nextTickCallbackQueue;
-    nextTickCallbackQueue = []; // reset to a new queue
-    for (let i = 0, len = callbacks.length; i < len; i += 1) {
-        callbacks[i]();
-    }
-}
-
-export function addCallbackToNextTick(callback: Callback) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!isFunction(callback)) {
-            throw new Error(
-                `Internal Error: addCallbackToNextTick() can only accept a function callback`
-            );
-        }
-    }
-    if (nextTickCallbackQueue.length === 0) {
-        Promise.resolve().then(flushCallbackQueue);
-    }
-    ArrayPush.call(nextTickCallbackQueue, callback);
-}
 
 export function guid(): string {
     function s4() {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -26,7 +26,7 @@ import { logError } from '../shared/logger';
 
 import { HostNode, HostElement, RendererAPI } from './renderer';
 import { renderComponent, markComponentAsDirty, getTemplateReactiveObserver } from './component';
-import { addCallbackToNextTick, EmptyArray, EmptyObject, flattenStylesheets } from './utils';
+import { EmptyArray, EmptyObject, flattenStylesheets } from './utils';
 import { invokeServiceHook, Services } from './services';
 import { invokeComponentCallback, invokeComponentConstructor } from './invoker';
 import { Template } from './template';
@@ -45,6 +45,7 @@ import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from
 import { removeActiveVM } from './hot-swaps';
 import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement } from './vnodes';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
+import { queueMicrotask } from './queue-microtask';
 
 type ShadowRootMode = 'open' | 'closed';
 
@@ -575,7 +576,7 @@ function flushRehydrationQueue() {
             if (i + 1 < len) {
                 // pieces of the queue are still pending to be rehydrated, those should have priority
                 if (rehydrateQueue.length === 0) {
-                    addCallbackToNextTick(flushRehydrationQueue);
+                    queueMicrotask(flushRehydrationQueue);
                 }
                 ArrayUnshift.apply(rehydrateQueue, ArraySlice.call(vms, i + 1));
             }
@@ -740,7 +741,7 @@ export function scheduleRehydration(vm: VM) {
 
     vm.isScheduled = true;
     if (rehydrateQueue.length === 0) {
-        addCallbackToNextTick(flushRehydrationQueue);
+        queueMicrotask(flushRehydrationQueue);
     }
 
     ArrayPush.call(rehydrateQueue, vm);


### PR DESCRIPTION
## Details

We have a function, `addCallbackToNextTick`, which is basically doing the same thing as [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask), which is supported in modern browsers. This refactors the code so that we prefer the native implementation and fall back to the polyfill.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

