### PR TITLE
fix(shared): simplify globalThis polyfill

### DIFF
--- a/packages/@lwc/shared/src/global-this.ts
+++ b/packages/@lwc/shared/src/global-this.ts
@@ -5,42 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-// Inspired from: https://mathiasbynens.be/notes/globalthis
-const _globalThis = /*@__PURE__*/ (function (): any {
-    // On recent browsers, `globalThis` is already defined. In this case return it directly.
-    if (typeof globalThis === 'object') {
-        return globalThis;
-    }
+// See browser support for globalThis:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility
 
-    let _globalThis: any;
-    try {
-        // eslint-disable-next-line no-extend-native
-        Object.defineProperty(Object.prototype, '__magic__', {
-            get: function () {
-                return this;
-            },
-            configurable: true,
-        });
-
-        // __magic__ is undefined in Safari 10 and IE10 and older.
-        // @ts-ignore
-        // eslint-disable-next-line no-undef
-        _globalThis = __magic__;
-
-        // @ts-ignore
-        delete Object.prototype.__magic__;
-    } catch (ex) {
-        // In IE8, Object.defineProperty only works on DOM objects.
-    } finally {
-        // If the magic above fails for some reason we assume that we are in a legacy browser.
-        // Assume `window` exists in this case.
-        if (typeof _globalThis === 'undefined') {
-            // @ts-ignore
-            _globalThis = window;
-        }
-    }
-
-    return _globalThis;
-})();
+/* istanbul ignore next */
+// @ts-ignore
+const _globalThis = typeof globalThis === 'object' ? globalThis : window;
 
 export { _globalThis as globalThis };


### PR DESCRIPTION
## Details

Trims the code in this polyfill. I don't think most of it is necessary.

If you're running LWC in a legacy browser, it's probably on the main thread. So `window` will work fine.

I'm not aware of anyone running LWC in a web worker.

As for Node, `globalThis` is supported [since Node 12.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
