### PR TITLE
refactor(engine): rename "vanilla" to "upgradable constructor"

### DIFF
--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-using-upgradable-constructor.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element-using-upgradable-constructor.ts
@@ -11,7 +11,7 @@ const cachedConstructors = new Map<string, CustomElementConstructor>();
 const elementsUpgradedOutsideLWC = new WeakSet<HTMLElement>();
 let elementBeingUpgradedByLWC = false;
 
-// Creates a constructor that is intended to be used as a vanilla custom element, except that the upgradeCallback is
+// Creates a constructor that is intended to be used directly as a custom element, except that the upgradeCallback is
 // passed in to the constructor so LWC can reuse the same custom element constructor for multiple components.
 // Another benefit is that only LWC can create components that actually do anything – if you do
 // `customElements.define('x-foo')`, then you don't have access to the upgradeCallback, so it's a dummy custom element.
@@ -64,7 +64,7 @@ const createUpgradableConstructor = (
     return UpgradableConstructor;
 };
 
-export const createCustomElementVanilla = (
+export const createCustomElementUsingUpgradableConstructor = (
     tagName: string,
     upgradeCallback: LifecycleCallback,
     connectedCallback?: LifecycleCallback,

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -7,7 +7,7 @@
 import features from '@lwc/features';
 import { hasCustomElements } from './has-custom-elements';
 import { createCustomElementCompat } from './create-custom-element-compat';
-import { createCustomElementVanilla } from './create-custom-element-vanilla';
+import { createCustomElementUsingUpgradableConstructor } from './create-custom-element-using-upgradable-constructor';
 import { createCustomElementScoped } from './create-custom-element-scoped';
 import type { LifecycleCallback } from '@lwc/engine-core';
 
@@ -15,10 +15,10 @@ import type { LifecycleCallback } from '@lwc/engine-core';
  * We have three modes for creating custom elements:
  *
  * 1. Compat (legacy) browser support (e.g. IE11). Totally custom, doesn't rely on native browser APIs.
- * 2. "Vanilla" custom elements registry. This system actually still allows us to have two LWC components with the
- *    same tag name, via a simple trick: every custom element constructor we define in the registry is basically
- *    the same. It's essentially a dummy `class extends HTMLElement` that accepts an `upgradeCallback` in its
- *    constructor, which allows us to have completely customized functionality for different components.
+ * 2. "Upgradable constructor" custom element. This allows us to have two LWC components with the same tag name,
+ *    via a trick: every custom element constructor we define in the registry is basically the same. It's essentially
+ *    a dummy `class extends HTMLElement` that accepts an `upgradeCallback` in its constructor ("upgradable
+ *    constructor"), which allows us to have completely customized functionality for different components.
  * 3. "Scoped" (or "pivot") custom elements. This relies on a sophisticated system that emulates the "scoped custom
  *    elements registry" proposal, with support for avoiding conflicts in tag names both between LWC components and
  *    between LWC components and third-party elements. This uses a similar trick to #2, but is much more complex
@@ -35,8 +35,8 @@ if (hasCustomElements) {
     if (features.ENABLE_SCOPED_CUSTOM_ELEMENT_REGISTRY) {
         createCustomElement = createCustomElementScoped;
     } else {
-        // use global custom elements registry (vanilla)
-        createCustomElement = createCustomElementVanilla;
+        // use the global registry, with an upgradable constructor for the defined custom element
+        createCustomElement = createCustomElementUsingUpgradableConstructor;
     }
 } else {
     // no registry available here

--- a/packages/@lwc/engine-dom/src/custom-elements/create-scoped-registry.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-scoped-registry.ts
@@ -40,7 +40,7 @@ interface Definition {
 
 /**
  * Create a scoped registry, i.e. a function that can create custom elements whose tag names
- * do not conflict with vanilla custom elements having the same tag name.
+ * do not conflict with third-party custom elements having the same tag name.
  */
 export function createScopedRegistry(): CreateScopedConstructor {
     if (!hasCustomElements) {


### PR DESCRIPTION
## Details

"Vanilla" is a terrible name, especially given that the implementation is not truly "vanilla." A truly vanilla implementation is described in #3202.

Instead, the implementation here should be called "upgradable constructor," because that's what it does.

There are no functional changes in this PR; it's just a renaming.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
