### PR TITLE
fix: don't throw error for tagName getter in Jest

### DIFF
--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -268,6 +268,11 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
 
 function getComponentRestrictionsDescriptors(): PropertyDescriptorMap {
     assertNotProd(); // this method should never leak to prod
+    if (process.env.NODE_ENV === 'test') {
+        // In Jest, throwing an error for the tagName breaks certain Jest built-in functionality:
+        // https://github.com/salesforce/sfdx-lwc-jest/issues/299
+        return {};
+    }
     return {
         tagName: generateAccessorDescriptor({
             get(this: LightningElement) {


### PR DESCRIPTION
## Details

Fixes https://github.com/salesforce/sfdx-lwc-jest/issues/299

I believe that, long-term, we should do https://github.com/salesforce/lwc/issues/3245 and eliminate functional differences between dev mode and prod mode. However, that is a larger effort, whereas this is a quick fix.

It is currently not possible to write a test for this, because we don't run any `engine-dom` or `engine-core` tests in Jest.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
