### PR TITLE
feat(rollup-plugin): warn stylesheet import for CSS extensibility

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/missing-css/missing-css.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/missing-css/missing-css.js
@@ -1,6 +1,6 @@
 import { LightningElement } from 'lwc';
 import stylesheet from './stylesheet.css';
 
-export default class ImplicitCss extends LightningElement {
+export default class MissingCss extends LightningElement {
     static stylesheets = [stylesheet];
 }

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/missing-css/missing-css.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/missing-css/missing-css.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+import stylesheet from './stylesheet.css';
+
+export default class ImplicitCss extends LightningElement {
+    static stylesheets = [stylesheet];
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -163,14 +163,19 @@ describe('resolver', () => {
     });
 
     it('should throw an error when import stylesheet file is missing', async () => {
-        try {
-            await rollup({
-                input: path.resolve(__dirname, 'fixtures/missing-css/missing-css.js'),
-                plugins: [lwc()],
-            });
-        } catch (error: any) {
-            expect(error.pluginCode).toBe(1004);
-            expect(error.filename).toContain('missing-css/stylesheet.css');
-        }
+        const warnings: any = [];
+
+        await rollup({
+            input: path.resolve(__dirname, 'fixtures/missing-css/missing-css.js'),
+            plugins: [lwc()],
+            onwarn(warning) {
+                warnings.push(warning);
+            },
+        });
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toMatch(
+            /The imported CSS file .+\/stylesheet.css does not exist: Importing it as undefined./
+        );
     });
 });

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -162,10 +162,10 @@ describe('resolver', () => {
         expect(warnings).toHaveLength(0);
     });
 
-    it('should throw an error when import stylesheet file is missing', async () => {
+    it('should emit a warning when import stylesheet file is missing', async () => {
         const warnings: any = [];
 
-        await rollup({
+        const bundle = await rollup({
             input: path.resolve(__dirname, 'fixtures/missing-css/missing-css.js'),
             plugins: [lwc()],
             onwarn(warning) {
@@ -173,9 +173,14 @@ describe('resolver', () => {
             },
         });
 
+        const { output } = await bundle.generate({
+            format: 'esm',
+        });
+
         expect(warnings).toHaveLength(1);
         expect(warnings[0].message).toMatch(
             /The imported CSS file .+\/stylesheet.css does not exist: Importing it as undefined./
         );
+        expect(output[0].code).toContain('var stylesheet = undefined;');
     });
 });

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -161,4 +161,16 @@ describe('resolver', () => {
 
         expect(warnings).toHaveLength(0);
     });
+
+    it('should throw an error when import stylesheet file is missing', async () => {
+        try {
+            await rollup({
+                input: path.resolve(__dirname, 'fixtures/missing-css/missing-css.js'),
+                plugins: [lwc()],
+            });
+        } catch (error: any) {
+            expect(error.pluginCode).toBe(1004);
+            expect(error.filename).toContain('missing-css/stylesheet.css');
+        }
+    });
 });

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -220,7 +220,9 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                     return fs.readFileSync(id, 'utf8');
                 } else {
                     this.warn(
-                        `The imported CSS file ${id} does not exist: Importing it as undefined.`
+                        `The imported CSS file ${id} does not exist: Importing it as undefined. ` +
+                            `This behavior may be removed in a future version of LWC. Please avoid importing a ` +
+                            `CSS file that does not exist.`
                     );
                     return EMPTY_IMPLICIT_CSS_CONTENT;
                 }

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -12,6 +12,7 @@ import { Plugin, SourceMapInput, RollupWarning } from 'rollup';
 import pluginUtils, { FilterPattern } from '@rollup/pluginutils';
 import { transformSync, StylesheetConfig, DynamicComponentConfig } from '@lwc/compiler';
 import { resolveModule, ModuleRecord } from '@lwc/module-resolver';
+import { generateCompilerError, ModuleResolutionErrors } from '@lwc/errors';
 import type { CompilerDiagnostic } from '@lwc/errors';
 
 export interface RollupLwcOptions {
@@ -47,6 +48,8 @@ const DEFAULT_MODULES = [
 
 const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
+const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
+const EMPTY_IMPLICIT_CSS_CONTENT = '';
 
 function isImplicitHTMLImport(importee: string, importer: string): boolean {
     return (
@@ -54,6 +57,15 @@ function isImplicitHTMLImport(importee: string, importer: string): boolean {
         path.extname(importee) === '.html' &&
         path.dirname(importer) === path.dirname(importee) &&
         path.basename(importer, '.js') === path.basename(importee, '.html')
+    );
+}
+
+function isImplicitCssImport(importee: string, importer: string) {
+    return (
+        path.extname(importee) === '.css' &&
+        path.extname(importer) === '.html' &&
+        (path.basename(importee, '.css') === path.basename(importer, '.html') ||
+            path.basename(importee, '.scoped.css') === path.basename(importer, '.html'))
     );
 }
 
@@ -158,10 +170,19 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 const ext = path.extname(importee) || importerExt;
 
                 const normalizedPath = path.resolve(path.dirname(importer), importee);
-                const absPath = pluginUtils.addExtension(normalizedPath, ext);
+                let absPath = pluginUtils.addExtension(normalizedPath, ext);
 
-                if (isImplicitHTMLImport(normalizedPath, importer) && !fs.existsSync(absPath)) {
+                const { scoped, filename } = parseQueryParamsForScopedOption(absPath);
+                if (scoped) {
+                    absPath = filename; // remove query param
+                }
+
+                if (isImplicitHTMLImport(absPath, importer) && !fs.existsSync(absPath)) {
                     return IMPLICIT_DEFAULT_HTML_PATH;
+                }
+
+                if (isImplicitCssImport(absPath, importer) && !fs.existsSync(absPath)) {
+                    return IMPLICIT_DEFAULT_CSS_PATH;
                 }
 
                 return pluginUtils.addExtension(normalizedPath, ext);
@@ -185,18 +206,25 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 return EMPTY_IMPLICIT_HTML_CONTENT;
             }
 
+            if (id === IMPLICIT_DEFAULT_CSS_PATH) {
+                return EMPTY_IMPLICIT_CSS_CONTENT;
+            }
+
             // Have to parse the `?scoped=true` in `load`, because it's not guaranteed
             // that `resolveId` will always be called (e.g. if another plugin resolves it first)
             const { scoped, filename } = parseQueryParamsForScopedOption(id);
             if (scoped) {
                 id = filename; // remove query param
             }
-            const isCSS = path.extname(id) === '.css';
 
-            if (isCSS) {
-                const exists = fs.existsSync(id);
-                const code = exists ? fs.readFileSync(id, 'utf8') : '';
-                return code;
+            const exists = fs.existsSync(id);
+            if (exists) {
+                return fs.readFileSync(id, 'utf8');
+            } else {
+                throw generateCompilerError(ModuleResolutionErrors.NONEXISTENT_FILE, {
+                    messageArgs: [filename],
+                    origin: { filename },
+                });
             }
         },
 


### PR DESCRIPTION
## Details

This PR updates `rollup-plugin` on stylesheet imports so that if a component imports an non-existing CSS file it will ~~throw an error~~ log a warning message, while keep the current behavior treating any non-existing CSS file as empty string (compiled to `export default undefined`). 

The previous behavior can be problematic because the new [CSS extensibility feature (a.k.a. programmatic style injection)](https://github.com/salesforce/lwc/pull/3123) allows users to override a component's style by programmatically importing a stylesheet module from JavaScript using an import statement. ~~We should enforce that the imported CSS file must exist and if not the compilation should fail instead of treating it as an empty string so that developers can be informed the issue during build time.~~ We should warn developers that the imported CSS file does not exist.

More details can be found in the [LWC stylesheets modules section](https://github.com/salesforce/lwc-rfcs/pull/56) of the RFC.

The RFC proposes to use a new query parameter `optional=true` to indicate that an imported CSS is optional as following example.

```js
// Required LWC stylesheet import. Fails during compilation when missing.
import styles from "./styles.css";
// Optional LWC stylesheet import. Resolve to an empty stylesheet if missing.
import styles from "./styles.css?optional=true";
```

This can be achieved by changing the template compiler to include the new `optional` query param in the implicit stylesheet imports. However, during implementation I find that it might be tricky for the case where component JS file also imports the same implicit stylesheet as following.

```js
// app.js
import { LightningElement } from 'lwc';
import block from './app.css';
export default class App extends LightningElement {
    static blockStyle = block;
    // ...
}
```

Note that this component `app` also imports its implicit CSS `app.css` and its compiled HTML file will have `import _implicitStylesheets from "./app.css?optional=true";` thus the rollup plugin needs to handle both  `app.css` and `app.css?optional=true` properly to make sure it is the exact same file. And it can be confusing as in HTML it is marked as optional but in JS its marked as required. This case can be special handled but it could be slightly more complicated and could cause confusion in the future. 

Instead I propose to simply check if a CSS import if implicit similar to how [lwc-plaform does the check](https://git.soma.salesforce.com/lwc/lwc-platform/blob/129a5aa73af7428678d9bf8933453f30ba6fa878/packages/sfdc-lwc-compiler/src/compiler/plugins/resolve.ts#L32). Although this can be less explicit, this approach has some benefits:

- This will not involve any compiler changes so it is less impactful for downstream projects.
- The logic of CSS module resolving is still in one place inside rollup plugin.
- It better aligns with how lwc-platform or lwr where they do the similar check.
- Avoid adding too many query params as there is already one for `scoped`.
- It would make it easier in the future to refactor common module resolution for different projects.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ~~⚠️ Yes, it does include an observable change.~~
* Update: after resolving the PR comment, this should not have any observable changes.

<!-- If yes, please describe the anticipated observable changes. -->
~~This would be an observable change if existing components are importing a non-existing CSS module. But I think this should be a rare case and if it happens it is more likely an unnoticed error by component author and should be fixed by removing the import of non-existing CSS module.~~

## GUS work item
<!-- Work ID in text, if applicable. -->
[W-10183295](https://gus.lightning.force.com/a07EE00000PclVnYAJ)