### PR TITLE
feat(engine-core): warn if developer mutates static stylesheets

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -23,7 +23,7 @@ import {
 } from '@lwc/shared';
 
 import { addErrorComponentStack } from '../shared/error';
-import { logError } from '../shared/logger';
+import { logError, logWarnOnce } from '../shared/logger';
 
 import { HostNode, HostElement, RendererAPI } from './renderer';
 import { renderComponent, markComponentAsDirty, getTemplateReactiveObserver } from './component';
@@ -411,7 +411,7 @@ function computeStylesheets(vm: VM, ctor: LightningElementConstructor) {
 
 function warnOnStylesheetsMutation(ctor: LightningElementConstructor) {
     if (process.env.NODE_ENV !== 'production') {
-        let stylesheets = ctor.stylesheets;
+        let { stylesheets } = ctor;
         defineProperty(ctor, 'stylesheets', {
             enumerable: true,
             configurable: true,
@@ -419,8 +419,8 @@ function warnOnStylesheetsMutation(ctor: LightningElementConstructor) {
                 return stylesheets;
             },
             set(newValue) {
-                logError(
-                    'Dynamically setting the stylesheets static property on a LightningElementConstructor ' +
+                logWarnOnce(
+                    `Dynamically setting the "stylesheets" static property on ${ctor.name} ` +
                         'will not affect the stylesheets injected.'
                 );
                 stylesheets = newValue;

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
@@ -242,8 +242,8 @@ describe('programmatic stylesheets', () => {
                     is: StylesheetsMutation,
                 });
                 document.body.appendChild(elm);
-            }).toLogErrorDev(
-                /\[LWC error]: Dynamically setting the stylesheets static property on a LightningElementConstructor will not affect the stylesheets injected./
+            }).toLogWarningDev(
+                /\[LWC warn]: Dynamically setting the "stylesheets" static property on StylesheetsMutation will not affect the stylesheets injected./
             );
 
             expect(elm.shadowRoot.querySelector('h1')).toBeTruthy(); // still renders the template correctly

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
@@ -12,6 +12,7 @@ import Multi from 'x/multi';
 import MultiScoped from 'x/multiScoped';
 import MultiStyles from 'x/multiStyles';
 import MixedScopedAndUnscoped from 'x/mixedScopedAndUnscoped';
+import StylesheetsMutation from 'x/stylesheetsMutation';
 
 describe('programmatic stylesheets', () => {
     beforeEach(() => {
@@ -231,6 +232,20 @@ describe('programmatic stylesheets', () => {
             );
 
             document.body.appendChild(elm);
+            expect(elm.shadowRoot.querySelector('h1')).toBeTruthy(); // still renders the template correctly
+        });
+
+        it('warn if stylesheets is mutated', () => {
+            let elm;
+            expect(() => {
+                elm = createElement('x-stylesheets-mutation', {
+                    is: StylesheetsMutation,
+                });
+                document.body.appendChild(elm);
+            }).toLogErrorDev(
+                /\[LWC error]: Dynamically setting the stylesheets static property on a LightningElementConstructor will not affect the stylesheets injected./
+            );
+
             expect(elm.shadowRoot.querySelector('h1')).toBeTruthy(); // still renders the template correctly
         });
 

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheet.css
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheet.css
@@ -1,0 +1,3 @@
+h1 {
+    color: red
+}

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.html
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.html
@@ -1,0 +1,3 @@
+<template>
+    <h1></h1>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.js
@@ -5,10 +5,6 @@ export default class StylesheetsMutation extends LightningElement {
     static stylesheets = [stylesheet];
 
     connectedCallback() {
-        StylesheetsMutation.stylesheets = [
-            () => {
-                return '';
-            },
-        ];
+        StylesheetsMutation.stylesheets = [stylesheet];
     }
 }

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/x/stylesheetsMutation/stylesheetsMutation.js
@@ -1,0 +1,14 @@
+import { LightningElement } from 'lwc';
+import stylesheet from './stylesheet.css';
+
+export default class StylesheetsMutation extends LightningElement {
+    static stylesheets = [stylesheet];
+
+    connectedCallback() {
+        StylesheetsMutation.stylesheets = [
+            () => {
+                return '';
+            },
+        ];
+    }
+}


### PR DESCRIPTION
## Details
Adds a warning if developer tries to mutate `static stylesheets` on `LightningElement`.

A developer can mutate `static stylesheets`, but this will have no effect because LWC only registers them once on the VM. As a DX improvement, we add a warning in dev mode if this happens.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
[W-12369133](https://gus.lightning.force.com/a07EE00001JD8b9YAD)
