### PR TITLE
feat: add reporting for version mismatches

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -11,6 +11,7 @@ import { logError } from '../shared/logger';
 import { Template } from './template';
 import { StylesheetFactory } from './stylesheet';
 import { LightningElementConstructor } from './base-lightning-element';
+import { report, ReportingEventId } from './reporting';
 
 let warned = false;
 
@@ -46,6 +47,7 @@ export function checkVersionMismatch(
             logError(
                 `LWC WARNING: current engine is v${LWC_VERSION}, but ${friendlyName} was compiled with v${version}.\nPlease update your compiled code or LWC engine so that the versions match.\nNo further warnings will appear.`
             );
+            report(ReportingEventId.CompilerRuntimeVersionMismatch);
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -28,6 +28,8 @@ export function registerComponent(
 ): any {
     if (isFunction(Ctor)) {
         if (process.env.NODE_ENV !== 'production') {
+            // There is no point in running this in production, because the version mismatch check relies
+            // on code comments which are stripped out in production by minifiers
             checkVersionMismatch(Ctor, 'component');
         }
         signedTemplateMap.set(Ctor, tmpl);

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -9,12 +9,13 @@ import { VM } from './vm';
 
 export const enum ReportingEventId {
     CrossRootAriaInSyntheticShadow = 0,
+    CompilerRuntimeVersionMismatch = 1,
 }
 
 type ReportingDispatcher = (
     reportingEventId: ReportingEventId,
-    tagName: string,
-    vmIndex: number
+    tagName?: string,
+    vmIndex?: number
 ) => void;
 
 type OnReportingEnabledCallback = () => void;
@@ -83,8 +84,8 @@ export function onReportingEnabled(callback: OnReportingEnabledCallback) {
  * @param reportingEventId
  * @param vm
  */
-export function report(reportingEventId: ReportingEventId, vm: VM) {
+export function report(reportingEventId: ReportingEventId, vm?: VM) {
     if (enabled) {
-        currentDispatcher(reportingEventId, vm.tagName, vm.idx);
+        currentDispatcher(reportingEventId, vm?.tagName, vm?.idx);
     }
 }

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -503,6 +503,12 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaAttributes.push(ariaPropertiesMapping[ariaProperties[i]]);
     }
 
+    // Should be kept in sync with the enum ReportingEventId in reporting.ts
+    var ReportingEventId = {
+        CrossRootAriaInSyntheticShadow: 0,
+        CompilerRuntimeVersionMismatch: 1,
+    };
+
     return {
         clearRegister: clearRegister,
         extractDataIds: extractDataIds,
@@ -519,5 +525,6 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaPropertiesMapping: ariaPropertiesMapping,
         ariaProperties: ariaProperties,
         ariaAttributes: ariaAttributes,
+        ReportingEventId: ReportingEventId,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -1,4 +1,11 @@
-import { createElement, LightningElement, registerTemplate, registerComponent } from 'lwc';
+import {
+    createElement,
+    LightningElement,
+    registerTemplate,
+    registerComponent,
+    __unstable__ReportingControl as reportingControl,
+} from 'lwc';
+import { ReportingEventId } from 'test-utils';
 import Component from 'x/component';
 import ComponentWithProp from 'x/componentWithProp';
 import ComponentWithTemplateAndStylesheet from 'x/componentWithTemplateAndStylesheet';
@@ -40,8 +47,16 @@ if (!process.env.COMPAT) {
         });
 
         describe('version mismatch warning', () => {
+            let dispatcher;
+
             beforeEach(() => {
                 window.__lwcResetWarnedOnVersionMismatch();
+                dispatcher = jasmine.createSpy();
+                reportingControl.attachDispatcher(dispatcher);
+            });
+
+            afterEach(() => {
+                reportingControl.detachDispatcher();
             });
 
             it('template', () => {
@@ -57,6 +72,13 @@ if (!process.env.COMPAT) {
                         `LWC WARNING: current engine is v${process.env.LWC_VERSION}, but template was compiled with v123.456.789`
                     )
                 );
+                if (process.env.NODE_ENV === 'production') {
+                    expect(dispatcher).not.toHaveBeenCalled();
+                } else {
+                    expect(dispatcher.calls.allArgs()).toEqual([
+                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                    ]);
+                }
             });
 
             it('stylesheet', () => {
@@ -83,6 +105,13 @@ if (!process.env.COMPAT) {
                         `LWC WARNING: current engine is v${process.env.LWC_VERSION}, but stylesheet was compiled with v123.456.789`
                     )
                 );
+                if (process.env.NODE_ENV === 'production') {
+                    expect(dispatcher).not.toHaveBeenCalled();
+                } else {
+                    expect(dispatcher.calls.allArgs()).toEqual([
+                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                    ]);
+                }
             });
 
             it('component', () => {
@@ -108,6 +137,13 @@ if (!process.env.COMPAT) {
                         `LWC WARNING: current engine is v${process.env.LWC_VERSION}, but component CustomElement was compiled with v123.456.789`
                     )
                 );
+                if (process.env.NODE_ENV === 'production') {
+                    expect(dispatcher).not.toHaveBeenCalled();
+                } else {
+                    expect(dispatcher.calls.allArgs()).toEqual([
+                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                    ]);
+                }
             });
         });
     });


### PR DESCRIPTION
## Details

This adds reporting for compiler/runtime version mismatches.

Unfortunately, because compiler version stamps were implemented as JS comments, this can only work in dev mode. (In prod mode, the minifier strips out comments.) But I think even reporting in dev mode is better than nothing.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12253834
