### PR TITLE
feat: add reporting for non-standard ARIA reflection

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -10,6 +10,7 @@ import { VM } from './vm';
 export const enum ReportingEventId {
     CrossRootAriaInSyntheticShadow = 0,
     CompilerRuntimeVersionMismatch = 1,
+    NonStandardAriaReflection = 2,
 }
 
 type ReportingDispatcher = (

--- a/packages/@lwc/engine-core/src/index.ts
+++ b/packages/@lwc/engine-core/src/index.ts
@@ -10,5 +10,6 @@ import './testFeatureFlag';
 
 // Patches ---------------------------------------------------------------------------------------
 import './patches/detect-synthetic-cross-root-aria';
+import './patches/detect-non-standard-aria';
 
 export * from './framework/main';

--- a/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import features from '@lwc/features';
+import { defineProperty, getOwnPropertyDescriptor, isNull, isUndefined } from '@lwc/shared';
+import { onReportingEnabled, report, ReportingEventId } from '../framework/reporting';
+import { LightningElement } from '../framework/base-lightning-element';
+import { logWarnOnce } from '../shared/logger';
+import { getAssociatedVMIfPresent, VM } from '../framework/vm';
+import { BaseBridgeElement } from '../framework/base-bridge-element';
+
+//
+// The goal of this code is to detect usages of non-standard reflected ARIA properties. These are caused by
+// legacy non-standard Element.prototype extensions added by the @lwc/aria-reflection package.
+//
+
+// See the README for @lwc/aria-reflection
+const NON_STANDARD_ARIA_PROPS = [
+    'ariaActiveDescendant',
+    'ariaControls',
+    'ariaDescribedBy',
+    'ariaDetails',
+    'ariaErrorMessage',
+    'ariaFlowTo',
+    'ariaLabelledBy',
+    'ariaOwns',
+];
+
+function isLightningElement(elm: Element) {
+    // The former case is for `this.prop` (inside component) and the latter is for `element.prop` (outside component).
+    // In both cases, we apply the non-standard prop even when the global polyfill is disabled, so this is kosher.
+    return elm instanceof LightningElement || elm instanceof BaseBridgeElement;
+}
+
+function findVM(elm: Element): VM | undefined {
+    // If it's a shadow DOM component, then it has a host
+    const { host } = elm.getRootNode() as ShadowRoot;
+    const vm = isUndefined(host) ? undefined : getAssociatedVMIfPresent(host);
+    if (!isUndefined(vm)) {
+        return vm;
+    }
+    // Else it might be a light DOM component. Walk up the tree trying to find the owner
+    let parentElement: Element | null = elm;
+    while (!isNull((parentElement = parentElement.parentElement))) {
+        if (isLightningElement(parentElement)) {
+            const vm = getAssociatedVMIfPresent(parentElement);
+            if (!isUndefined(vm)) {
+                return vm;
+            }
+        }
+    }
+    // If we return undefined, it's because the element was rendered wholly outside a LightningElement
+}
+
+function checkAndReportViolation(elm: Element, prop: string) {
+    if (!isLightningElement(elm)) {
+        const vm = findVM(elm);
+
+        if (process.env.NODE_ENV !== 'production') {
+            logWarnOnce(
+                `Element <${elm.tagName.toLowerCase()}> ` +
+                    (isUndefined(vm) ? '' : `owned by <${vm.elm.tagName.toLowerCase()}> `) +
+                    `uses non-standard property "${prop}". This will be removed in a future version of LWC. ` +
+                    `See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`
+            );
+        }
+        report(ReportingEventId.NonStandardAriaReflection, vm);
+    }
+}
+
+function enableDetection() {
+    const { prototype } = Element;
+    for (const prop of NON_STANDARD_ARIA_PROPS) {
+        const descriptor = getOwnPropertyDescriptor(prototype, prop);
+        // The descriptor should exist because the @lwc/aria-reflection polyfill has run by now.
+        // This happens automatically because of the ordering of imports.
+        if (process.env.NODE_ENV !== 'production') {
+            /* istanbul ignore if */
+            if (
+                isUndefined(descriptor) ||
+                isUndefined(descriptor.get) ||
+                isUndefined(descriptor.set)
+            ) {
+                // should never happen
+                throw new Error('detect-non-standard-aria.ts loaded before @lwc/aria-reflection');
+            }
+        }
+        // @ts-ignore
+        const { get, set } = descriptor;
+        defineProperty(prototype, prop, {
+            get() {
+                checkAndReportViolation(this, prop);
+                return get.call(this);
+            },
+            set(val) {
+                checkAndReportViolation(this, prop);
+                return set.call(this, val);
+            },
+            configurable: true,
+            enumerable: true,
+        });
+    }
+}
+
+// No point in running this code if we're not in a browser, or if the global polyfill is not loaded
+if (process.env.IS_BROWSER) {
+    if (!features.DISABLE_ARIA_REFLECTION_POLYFILL) {
+        // Always run detection in dev mode, so we can at least print to the console
+        if (process.env.NODE_ENV !== 'production') {
+            enableDetection();
+        } else {
+            // In prod mode, only enable detection if reporting is enabled
+            onReportingEnabled(enableDetection);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -495,6 +495,18 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         role: 'role',
     };
 
+    // See the README for @lwc/aria-reflection
+    var nonStandardAriaProperties = [
+        'ariaActiveDescendant',
+        'ariaControls',
+        'ariaDescribedBy',
+        'ariaDetails',
+        'ariaErrorMessage',
+        'ariaFlowTo',
+        'ariaLabelledBy',
+        'ariaOwns',
+    ];
+
     var ariaProperties = Object.keys(ariaPropertiesMapping);
 
     // Can't use Object.values because we need to support IE11
@@ -507,6 +519,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     var ReportingEventId = {
         CrossRootAriaInSyntheticShadow: 0,
         CompilerRuntimeVersionMismatch: 1,
+        NonStandardAriaReflection: 2,
     };
 
     return {
@@ -525,6 +538,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaPropertiesMapping: ariaPropertiesMapping,
         ariaProperties: ariaProperties,
         ariaAttributes: ariaAttributes,
+        nonStandardAriaProperties: nonStandardAriaProperties,
         ReportingEventId: ReportingEventId,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -1,0 +1,99 @@
+import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
+import { ReportingEventId, nonStandardAriaProperties } from 'test-utils';
+import Light from 'x/light';
+import Shadow from 'x/shadow';
+
+// This test only works if the ARIA reflection polyfill is loaded
+if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
+    describe('non-standard ARIA properties', () => {
+        let dispatcher;
+
+        beforeEach(() => {
+            dispatcher = jasmine.createSpy();
+            reportingControl.attachDispatcher(dispatcher);
+        });
+
+        afterEach(() => {
+            reportingControl.detachDispatcher();
+        });
+
+        nonStandardAriaProperties.forEach((prop) => {
+            describe(prop, () => {
+                const scenarios = [
+                    { name: 'light', Ctor: Light, tagName: 'x-light' },
+                    { name: 'shadow', Ctor: Shadow, tagName: 'x-shadow' },
+                ];
+
+                scenarios.forEach(({ name, Ctor, tagName }) => {
+                    const inComponentWarning = `Error: [LWC warn]: Element <div> owned by <${tagName}> uses non-standard property "${prop}". This will be removed in a future version of LWC. See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`;
+                    const outsideComponentWarning = `Error: [LWC warn]: Element <span> uses non-standard property "${prop}". This will be removed in a future version of LWC. See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`;
+
+                    describe(name, () => {
+                        let elm;
+
+                        beforeEach(() => {
+                            elm = createElement(tagName, { is: Ctor });
+                            document.body.appendChild(elm);
+                        });
+
+                        it('LightningElement - inside component', () => {
+                            expect(() => {
+                                elm.setProp(prop, 'foo');
+                                elm.getProp(prop);
+                            }).not.toLogWarningDev();
+
+                            expect(dispatcher).not.toHaveBeenCalled();
+                        });
+
+                        it('LightningElement - outside component', () => {
+                            expect(() => {
+                                elm[prop] = 'foo';
+                                const unused = elm[prop];
+                                return unused; // remove lint warning
+                            }).not.toLogWarningDev();
+
+                            expect(dispatcher).not.toHaveBeenCalled();
+                        });
+
+                        it('regular Element inside LightningElement', () => {
+                            expect(() => {
+                                elm.setPropOnElement(prop, 'foo');
+                                elm.getPropOnElement(prop);
+                            }).toLogWarningDev(inComponentWarning);
+
+                            expect(dispatcher).toHaveBeenCalledTimes(2);
+                            expect(dispatcher.calls.allArgs()).toEqual([
+                                [
+                                    ReportingEventId.NonStandardAriaReflection,
+                                    tagName,
+                                    jasmine.any(Number),
+                                ],
+                                [
+                                    ReportingEventId.NonStandardAriaReflection,
+                                    tagName,
+                                    jasmine.any(Number),
+                                ],
+                            ]);
+                        });
+
+                        it('regular Element outside LightningElement', () => {
+                            const span = document.createElement('span');
+                            document.body.appendChild(span);
+                            expect(() => {
+                                span[prop] = 'foo';
+                                const unused = span[prop];
+                                return unused; // remove lint warning
+                            }).toLogWarningDev(outsideComponentWarning);
+
+                            expect(dispatcher).toHaveBeenCalledTimes(2);
+                            expect(dispatcher.calls.allArgs()).toEqual([
+                                [ReportingEventId.NonStandardAriaReflection, undefined, undefined],
+                                [ReportingEventId.NonStandardAriaReflection, undefined, undefined],
+                            ]);
+                        });
+                    });
+                });
+            });
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/light/light.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <div lwc:ref="elm"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/light/light.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/light/light.js
@@ -1,0 +1,25 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+
+    @api
+    setProp(prop, val) {
+        this[prop] = val;
+    }
+
+    @api
+    getProp(prop) {
+        return this[prop];
+    }
+
+    @api
+    setPropOnElement(prop, val) {
+        this.refs.elm[prop] = val;
+    }
+
+    @api
+    getPropOnElement(prop) {
+        return this.refs.elm[prop];
+    }
+}

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/shadow/shadow.html
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/shadow/shadow.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:ref="elm"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/shadow/shadow.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/x/shadow/shadow.js
@@ -1,0 +1,23 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    setProp(prop, val) {
+        this[prop] = val;
+    }
+
+    @api
+    getProp(prop) {
+        return this[prop];
+    }
+
+    @api
+    setPropOnElement(prop, val) {
+        this.refs.elm[prop] = val;
+    }
+
+    @api
+    getPropOnElement(prop) {
+        return this.refs.elm[prop];
+    }
+}

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -1,11 +1,7 @@
 import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
+import { ReportingEventId } from 'test-utils';
 import AriaContainer from 'x/ariaContainer';
 import Valid from 'x/valid';
-
-// Should be kept in sync with the enum ReportingEventId in reporting.ts
-const ReportingEventId = {
-    CrossRootAriaInSyntheticShadow: 0,
-};
 
 const expectedMessage =
     'Error: [LWC warn]: Element <input> uses attribute "aria-labelledby" to reference element <label>, which is not in the same shadow root. This will break in native shadow DOM. For details, see: https://lwc.dev/guide/accessibility#link-ids-and-aria-attributes-from-different-templates\n<x-aria-source>';
@@ -13,6 +9,8 @@ const expectedMessageWithTargetAsVM =
     'Error: [LWC warn]: Element <input> uses attribute "aria-labelledby" to reference element <label>, which is not in the same shadow root. This will break in native shadow DOM. For details, see: https://lwc.dev/guide/accessibility#link-ids-and-aria-attributes-from-different-templates\n<x-aria-target>';
 const expectedMessageForSecondTarget =
     'Error: [LWC warn]: Element <input> uses attribute "aria-labelledby" to reference element <div>, which is not in the same shadow root. This will break in native shadow DOM. For details, see: https://lwc.dev/guide/accessibility#link-ids-and-aria-attributes-from-different-templates\n<x-aria-source>';
+const expectedMessageForNonStandardAria =
+    'Error: [LWC warn]: Element <input> owned by <x-aria-source> uses non-standard property "ariaLabelledBy". This will be removed in a future version of LWC. See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties';
 
 // These tests are designed to detect non-standard cross-root ARIA usage in synthetic shadow DOM
 // As for COMPAT, this detection logic is only enabled for modern browsers
@@ -42,6 +40,17 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
             });
 
             [false, true].forEach((usePropertyAccess) => {
+                function expectWarningForNonStandardPropertyAccess(callback) {
+                    // eslint-disable-next-line jest/valid-expect
+                    let expected = expect(callback);
+                    if (!usePropertyAccess) {
+                        expected = expected.not;
+                    }
+                    expected.toLogWarningDev(
+                        `Error: [LWC warn]: Element <input> owned by <x-aria-source> uses non-standard property "ariaLabelledBy". This will be removed in a future version of LWC. See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`
+                    );
+                }
+
                 describe(usePropertyAccess ? 'property' : 'attribute', () => {
                     beforeEach(() => {
                         elm.usePropertyAccess = usePropertyAccess;
@@ -51,23 +60,54 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                     it('setting aria-labelledby', () => {
                         expect(() => {
                             elm.linkUsingAriaLabelledBy();
-                        }).toLogWarningDev(expectedMessage);
-                        expect(dispatcher).toHaveBeenCalledWith(
-                            ReportingEventId.CrossRootAriaInSyntheticShadow,
-                            'x-aria-source',
-                            jasmine.any(Number)
-                        );
+                        }).toLogWarningDev([
+                            ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
+                            expectedMessage,
+                        ]);
+                        expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 2 : 1);
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            ...(usePropertyAccess
+                                ? [
+                                      [
+                                          ReportingEventId.NonStandardAriaReflection,
+                                          'x-aria-source',
+                                          jasmine.any(Number),
+                                      ],
+                                  ]
+                                : []),
+                            [
+                                ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                'x-aria-source',
+                                jasmine.any(Number),
+                            ],
+                        ]);
                     });
 
                     it('setting id', () => {
                         expect(() => {
                             elm.linkUsingId();
-                        }).toLogWarningDev(expectedMessage);
-                        expect(dispatcher).toHaveBeenCalledWith(
-                            ReportingEventId.CrossRootAriaInSyntheticShadow,
-                            'x-aria-source',
-                            jasmine.any(Number)
-                        );
+                        }).toLogWarningDev([
+                            ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
+                            expectedMessage,
+                        ]);
+                        expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 2 : 1);
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            ...(usePropertyAccess
+                                ? [
+                                      [
+                                          ReportingEventId.NonStandardAriaReflection,
+                                          'x-aria-source',
+                                          jasmine.any(Number),
+                                      ],
+                                  ]
+                                : []),
+
+                            [
+                                ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                'x-aria-source',
+                                jasmine.any(Number),
+                            ],
+                        ]);
                     });
 
                     it('linking to an element in global light DOM', () => {
@@ -76,12 +116,27 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         document.body.appendChild(label);
                         expect(() => {
                             sourceElm.setAriaLabelledBy('foo');
-                        }).toLogWarningDev(expectedMessage);
-                        expect(dispatcher).toHaveBeenCalledWith(
-                            ReportingEventId.CrossRootAriaInSyntheticShadow,
-                            'x-aria-source',
-                            jasmine.any(Number)
-                        );
+                        }).toLogWarningDev([
+                            ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
+                            expectedMessage,
+                        ]);
+                        expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 2 : 1);
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            ...(usePropertyAccess
+                                ? [
+                                      [
+                                          ReportingEventId.NonStandardAriaReflection,
+                                          'x-aria-source',
+                                          jasmine.any(Number),
+                                      ],
+                                  ]
+                                : []),
+                            [
+                                ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                'x-aria-source',
+                                jasmine.any(Number),
+                            ],
+                        ]);
                     });
 
                     it('linking from an element in global light DOM', () => {
@@ -92,11 +147,14 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         expect(() => {
                             targetElm.setId('foo');
                         }).toLogWarningDev(expectedMessageWithTargetAsVM);
-                        expect(dispatcher).toHaveBeenCalledWith(
-                            ReportingEventId.CrossRootAriaInSyntheticShadow,
-                            'x-aria-target',
-                            jasmine.any(Number)
-                        );
+                        expect(dispatcher).toHaveBeenCalledTimes(1);
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            [
+                                ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                'x-aria-target',
+                                jasmine.any(Number),
+                            ],
+                        ]);
                     });
 
                     [null, '', '  '].forEach((value) => {
@@ -106,14 +164,38 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         });
 
                         it(`ignores setting aria-labelledby to ${JSON.stringify(value)}`, () => {
-                            sourceElm.setAriaLabelledBy(value);
-                            expect(dispatcher).not.toHaveBeenCalled();
+                            expectWarningForNonStandardPropertyAccess(() => {
+                                sourceElm.setAriaLabelledBy(value);
+                            });
+                            if (usePropertyAccess) {
+                                expect(dispatcher).toHaveBeenCalledTimes(1);
+                                expect(dispatcher).toHaveBeenCalledWith(
+                                    ReportingEventId.NonStandardAriaReflection,
+                                    'x-aria-source',
+                                    jasmine.any(Number)
+                                );
+                            } else {
+                                expect(dispatcher).not.toHaveBeenCalled();
+                            }
                         });
                     });
 
                     it('ignores id that references nonexistent element', () => {
-                        sourceElm.setAriaLabelledBy('does-not-exist-at-all-lol');
-                        expect(dispatcher).not.toHaveBeenCalled();
+                        expectWarningForNonStandardPropertyAccess(() => {
+                            sourceElm.setAriaLabelledBy('does-not-exist-at-all-lol');
+                        });
+                        expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 1 : 0);
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            ...(usePropertyAccess
+                                ? [
+                                      [
+                                          ReportingEventId.NonStandardAriaReflection,
+                                          'x-aria-source',
+                                          jasmine.any(Number),
+                                      ],
+                                  ]
+                                : []),
+                        ]);
                     });
 
                     [
@@ -128,23 +210,52 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                             it('setting both id and aria-labelledby', () => {
                                 expect(() => {
                                     elm.linkUsingBoth(options);
-                                }).toLogWarningDev(expectedMessage);
-                                expect(dispatcher).toHaveBeenCalledWith(
-                                    ReportingEventId.CrossRootAriaInSyntheticShadow,
-                                    'x-aria-source',
-                                    jasmine.any(Number)
-                                );
+                                }).toLogWarningDev([
+                                    ...(usePropertyAccess
+                                        ? [expectedMessageForNonStandardAria]
+                                        : []),
+                                    expectedMessage,
+                                ]);
+                                expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 2 : 1);
+                                expect(dispatcher.calls.allArgs()).toEqual([
+                                    ...(usePropertyAccess
+                                        ? [
+                                              [
+                                                  ReportingEventId.NonStandardAriaReflection,
+                                                  'x-aria-source',
+                                                  jasmine.any(Number),
+                                              ],
+                                          ]
+                                        : []),
+                                    [
+                                        ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                        'x-aria-source',
+                                        jasmine.any(Number),
+                                    ],
+                                ]);
                             });
 
                             it('linking multiple targets', () => {
                                 expect(() => {
                                     elm.linkUsingBoth({ ...options, multipleTargets: true });
                                 }).toLogWarningDev([
+                                    ...(usePropertyAccess
+                                        ? [expectedMessageForNonStandardAria]
+                                        : []),
                                     expectedMessage,
                                     expectedMessageForSecondTarget,
                                 ]);
-                                expect(dispatcher).toHaveBeenCalledTimes(2);
+                                expect(dispatcher).toHaveBeenCalledTimes(usePropertyAccess ? 3 : 2);
                                 expect(dispatcher.calls.allArgs()).toEqual([
+                                    ...(usePropertyAccess
+                                        ? [
+                                              [
+                                                  ReportingEventId.NonStandardAriaReflection,
+                                                  'x-aria-source',
+                                                  jasmine.any(Number),
+                                              ],
+                                          ]
+                                        : []),
                                     [
                                         ReportingEventId.CrossRootAriaInSyntheticShadow,
                                         'x-aria-source',

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -1,6 +1,17 @@
-import { ariaPropertiesMapping } from 'test-utils';
+import { ariaPropertiesMapping, nonStandardAriaProperties } from 'test-utils';
 
 function testAriaProperty(property, attribute) {
+    function expectWarningIfNonStandard(callback) {
+        // eslint-disable-next-line jest/valid-expect
+        let expected = expect(callback);
+        if (!nonStandardAriaProperties.includes(property)) {
+            expected = expected.not;
+        }
+        expected.toLogWarningDev(
+            `Error: [LWC warn]: Element <div> uses non-standard property "${property}". This will be removed in a future version of LWC. See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`
+        );
+    }
+
     describe(property, () => {
         it(`should assign property ${property} to Element prototype`, () => {
             expect(Object.prototype.hasOwnProperty.call(Element.prototype, property)).toBe(true);
@@ -8,32 +19,44 @@ function testAriaProperty(property, attribute) {
 
         it(`should return null if the value is not set`, () => {
             const el = document.createElement('div');
-            expect(el[property]).toBe(null);
+            expectWarningIfNonStandard(() => {
+                expect(el[property]).toBe(null);
+            });
         });
 
         it('should return the right value from the getter', () => {
             const el = document.createElement('div');
-            el[property] = 'foo';
+            expectWarningIfNonStandard(() => {
+                el[property] = 'foo';
+            });
             expect(el[property]).toBe('foo');
         });
 
         it('should reflect the property to the associated attribute', () => {
             const el = document.createElement('div');
-            el[property] = 'foo';
+            expectWarningIfNonStandard(() => {
+                el[property] = 'foo';
+            });
             expect(el.getAttribute(attribute)).toBe('foo');
         });
 
         it('should reflect the attribute to the property', () => {
             const el = document.createElement('div');
             el.setAttribute(attribute, 'foo');
-            expect(el[property]).toBe('foo');
+            let value;
+            expectWarningIfNonStandard(() => {
+                value = el[property];
+            });
+            expect(value).toBe('foo');
         });
 
         it('should remove the attribute if the property is set to null', () => {
             const el = document.createElement('div');
             el.setAttribute(attribute, 'foo');
 
-            el[property] = null;
+            expectWarningIfNonStandard(() => {
+                el[property] = null;
+            });
             expect(el.hasAttribute(attribute)).toBe(false);
         });
     });


### PR DESCRIPTION
## Details

This is part 2 of the new reporting APIs. (Part 1 is #3287.)

This one covers non-standard ARIA properties. It includes new detection logic to understand when people are using these APIs.

See [related docs PR](https://github.com/salesforce-experience-platform/lwc-docs/pull/251).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
W-12253834
