### PR TITLE
feat: add reporting for frozen template

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -11,6 +11,8 @@ export const enum ReportingEventId {
     CrossRootAriaInSyntheticShadow = 0,
     CompilerRuntimeVersionMismatch = 1,
     NonStandardAriaReflection = 2,
+    TemplateMutation = 3,
+    StylesheetMutation = 4,
 }
 
 type ReportingDispatcher = (

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -520,6 +520,8 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         CrossRootAriaInSyntheticShadow: 0,
         CompilerRuntimeVersionMismatch: 1,
         NonStandardAriaReflection: 2,
+        TemplateMutation: 3,
+        StylesheetMutation: 4,
     };
 
     return {

--- a/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
@@ -1,6 +1,23 @@
-import { registerTemplate, freezeTemplate, setFeatureFlagForTest } from 'lwc';
+import {
+    registerTemplate,
+    freezeTemplate,
+    setFeatureFlagForTest,
+    __unstable__ReportingControl as reportingControl,
+} from 'lwc';
+import { ReportingEventId } from 'test-utils';
 
 describe('freezeTemplate', () => {
+    let dispatcher;
+
+    beforeEach(() => {
+        dispatcher = jasmine.createSpy();
+        reportingControl.attachDispatcher(dispatcher);
+    });
+
+    afterEach(() => {
+        reportingControl.detachDispatcher();
+    });
+
     it('should warn when setting tmpl.stylesheetToken', () => {
         const template = registerTemplate(() => []);
         const stylesheet = () => 'div { color: red }';
@@ -12,11 +29,14 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.stylesheetToken = 'newToken';
-        }).toLogErrorDev(
-            /Dynamically setting the "stylesheetToken" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheetToken" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.stylesheetToken).toEqual('newToken');
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when setting tmpl.stylesheetTokens', () => {
@@ -36,14 +56,17 @@ describe('freezeTemplate', () => {
                 hostAttribute: 'newToken-host',
                 shadowAttribute: 'newToken',
             };
-        }).toLogErrorDev(
-            /Dynamically setting the "stylesheetTokens" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheetTokens" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.stylesheetTokens).toEqual({
             hostAttribute: 'newToken-host',
             shadowAttribute: 'newToken',
         });
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when setting tmpl.stylesheets', () => {
@@ -60,12 +83,15 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.stylesheets = [newStylesheet];
-        }).toLogErrorDev(
-            /Dynamically setting the "stylesheets" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(newStylesheet);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when mutating tmpl.stylesheets array', () => {
@@ -82,9 +108,11 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.stylesheets.push(newStylesheet);
-        }).toLogErrorDev(
-            /Mutating the "stylesheets" array on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
+
+        window.__lwcResetAlreadyLoggedMessages();
 
         expect(template.stylesheets.length).toEqual(2);
         expect(template.stylesheets[0]).toBe(stylesheet);
@@ -92,12 +120,16 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.stylesheets.pop();
-        }).toLogErrorDev(
-            /Mutating the "stylesheets" array on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(stylesheet);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when mutating a deep tmpl.stylesheets array', () => {
@@ -112,9 +144,12 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.stylesheets[1].push(newStylesheet);
-        }).toLogErrorDev(
-            /Mutating the "stylesheets" array on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when setting tmpl.slots', () => {
@@ -128,11 +163,14 @@ describe('freezeTemplate', () => {
         const newSlots = [];
         expect(() => {
             template.slots = newSlots;
-        }).toLogErrorDev(
-            /Dynamically setting the "slots" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "slots" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.slots).toBe(newSlots);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when setting tmpl.renderMOde', () => {
@@ -144,11 +182,14 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             template.renderMode = undefined;
-        }).toLogErrorDev(
-            /Dynamically setting the "renderMode" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "renderMode" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         expect(template.renderMode).toBe(undefined);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.TemplateMutation, undefined, undefined],
+        ]);
     });
 
     it('should warn when setting stylesheet.$scoped$', () => {
@@ -160,9 +201,12 @@ describe('freezeTemplate', () => {
 
         expect(() => {
             stylesheet.$scoped$ = true;
-        }).toLogErrorDev(
-            /Dynamically setting the "\$scoped\$" property on a stylesheet function is deprecated and may be removed in a future version of LWC\./
+        }).toLogWarningDev(
+            /Mutating the "\$scoped\$" property on a stylesheet is deprecated and will be removed in a future version of LWC\./
         );
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [ReportingEventId.StylesheetMutation, undefined, undefined],
+        ]);
     });
 
     it('tmpl expando props are enumerable and configurable', () => {
@@ -185,6 +229,7 @@ describe('freezeTemplate', () => {
             expect(descriptor.enumerable).toEqual(true);
             expect(descriptor.configurable).toEqual(true);
         }
+        expect(dispatcher).not.toHaveBeenCalled();
     });
 
     describe('ENABLE_FROZEN_TEMPLATE set to true', () => {
@@ -205,6 +250,7 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(Object.isFrozen(template.stylesheets)).toEqual(true);
+            expect(dispatcher).not.toHaveBeenCalled();
         });
 
         it('freezes a template with no stylesheets', () => {
@@ -213,6 +259,7 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(template.stylesheets).toEqual(undefined);
+            expect(dispatcher).not.toHaveBeenCalled();
         });
 
         it('deep-freezes the stylesheets', () => {
@@ -229,6 +276,7 @@ describe('freezeTemplate', () => {
             expect(Object.isFrozen(stylesheets[0])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1][0])).toEqual(true);
+            expect(dispatcher).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/legacy-stylesheet-api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-stylesheet-api/index.spec.js
@@ -8,9 +8,9 @@ describe('legacy undocumented stylesheetTokens API', () => {
         const elm = createElement('x-patches-stylesheet', { is: PatchesStylesheet });
         expect(() => {
             document.body.appendChild(elm);
-        }).toLogErrorDev([
-            /Dynamically setting the "stylesheets" property on a template function is deprecated and may be removed in a future version of LWC./,
-            /Dynamically setting the "stylesheetToken" property on a template function is deprecated and may be removed in a future version of LWC./,
+        }).toLogWarningDev([
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/,
+            /Mutating the "stylesheetToken" property on a template is deprecated and will be removed in a future version of LWC/,
         ]);
         const div = elm.shadowRoot.querySelector('div');
         expect(div.textContent).toEqual('without stylesheet');
@@ -23,9 +23,9 @@ describe('legacy undocumented stylesheetTokens API', () => {
         });
         expect(() => {
             document.body.appendChild(elm);
-        }).toLogErrorDev([
-            /Dynamically setting the "stylesheets" property on a template function is deprecated and may be removed in a future version of LWC./,
-            /Dynamically setting the "stylesheetToken" property on a template function is deprecated and may be removed in a future version of LWC./,
+        }).toLogWarningDev([
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/,
+            /Mutating the "stylesheetToken" property on a template is deprecated and will be removed in a future version of LWC/,
         ]);
         const div = elm.shadowRoot.querySelector('div');
         expect(div.textContent).toEqual('a');
@@ -56,8 +56,8 @@ describe('legacy undocumented stylesheetTokens API', () => {
         expect(() => {
             // patch the one with a stylesheet onto the one without
             withoutStylesheet.stylesheetTokens = withStylesheet.stylesheetTokens;
-        }).toLogErrorDev(
-            /Dynamically setting the "stylesheetTokens" property on a template function is deprecated and may be removed in a future version of LWC./
+        }).toLogWarningDev(
+            /Mutating the "stylesheetTokens" property on a template is deprecated and will be removed in a future version of LWC/
         );
 
         // stylesheetTokens should reflect stylesheetToken

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -45,14 +45,16 @@ describe('static content when stylesheets change', () => {
         const elm = createElement('x-container', { is: MultipleStyles });
 
         const stylesheetsWarning =
-            /Dynamically setting the "stylesheets" property on a template function is deprecated and may be removed in a future version of LWC./;
+            /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/;
 
         expect(() => {
             elm.updateTemplate({
                 name: 'a',
                 useScopedCss: false,
             });
-        }).toLogErrorDev(stylesheetsWarning);
+        }).toLogWarningDev(stylesheetsWarning);
+
+        window.__lwcResetAlreadyLoggedMessages();
 
         document.body.appendChild(elm);
 
@@ -64,7 +66,9 @@ describe('static content when stylesheets change', () => {
                 name: 'b',
                 useScopedCss: true,
             });
-        }).toLogErrorDev(stylesheetsWarning);
+        }).toLogWarningDev(stylesheetsWarning);
+
+        window.__lwcResetAlreadyLoggedMessages();
 
         return Promise.resolve()
             .then(() => {
@@ -76,7 +80,7 @@ describe('static content when stylesheets change', () => {
                         name: 'a',
                         useScopedCss: false,
                     });
-                }).toLogErrorDev(stylesheetsWarning);
+                }).toLogWarningDev(stylesheetsWarning);
             })
             .then(() => {
                 const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();


### PR DESCRIPTION
## Details

This is part 3 of the new reporting APIs. (Part 1 is #3287 and part 2 is #3288)

This adds reporting for frozen template (and frozen stylesheet) violations. So if anybody mutates these, we get a report.

[Related docs PR](https://github.com/salesforce-experience-platform/lwc-docs/pull/252)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12253834
