### PR TITLE
fix: allow  attribute on light DOM slots

### DIFF
--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -106,4 +106,14 @@ describe('Slotting', () => {
             '<x-forwarded-slot><x-light-container><p slot="upper">Upper slot content forwarded</p><p>Default slot forwarded</p><p slot="lower">Lower slot content forwarded</p></x-light-container></x-forwarded-slot>'
         );
     });
+    it('should render default content in forwarded slots', async () => {
+        const nodes = createTestElement('x-forwarded-slot-consumer', ForwardedSlotConsumer);
+        const elm = nodes['x-forwarded-slot-consumer'];
+        elm.shouldSlot(false);
+
+        await Promise.resolve();
+        expect(elm.innerHTML).toEqual(
+            '<x-forwarded-slot><x-light-container><p data-id="container-upper-slot-default">Upper slot default</p>Default slot not yet forwarded<p data-id="container-lower-slot-default">Lower slot default</p></x-light-container></x-forwarded-slot>'
+        );
+    });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -7,6 +7,7 @@ import LightConsumer from 'x/lightConsumer';
 import ShadowConsumer from 'x/shadowConsumer';
 import ConditionalSlot from 'x/conditionalSlot';
 import ConditionalSlotted from 'x/conditionalSlotted';
+import ForwardedSlotConsumer from 'x/forwardedSlotConsumer';
 
 function createTestElement(tag, component) {
     const elm = createElement(tag, { is: component });
@@ -95,6 +96,14 @@ describe('Slotting', () => {
         await Promise.resolve();
         expect(elm.innerHTML).toEqual(
             '<x-conditional-slot data-id="conditional-slot"><button data-id="button">Toggle</button></x-conditional-slot>'
+        );
+    });
+
+    it('should forward slots', () => {
+        const nodes = createTestElement('x-forwarded-slot-consumer', ForwardedSlotConsumer);
+        const elm = nodes['x-forwarded-slot-consumer'];
+        expect(elm.innerHTML).toEqual(
+            '<x-forwarded-slot><x-light-container><p slot="upper">Upper slot content forwarded</p><p>Default slot forwarded</p><p slot="lower">Lower slot content forwarded</p></x-light-container></x-forwarded-slot>'
         );
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlot/forwardedSlot.html
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlot/forwardedSlot.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    <x-light-container>
+        <slot slot="upper" name="upper"></slot>
+        <slot>Default slot not yet forwarded</slot>
+        <slot slot="lower" name="lower"></slot>
+    </x-light-container>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlot/forwardedSlot.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlot/forwardedSlot.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.html
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    <x-forwarded-slot>
+        <p slot="upper">Upper slot content forwarded</p>
+        <p>Default slot forwarded</p>
+        <p slot="lower">Lower slot content forwarded</p>
+    </x-forwarded-slot>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.html
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.html
@@ -1,7 +1,9 @@
 <template lwc:render-mode="light">
     <x-forwarded-slot>
-        <p slot="upper">Upper slot content forwarded</p>
-        <p>Default slot forwarded</p>
-        <p slot="lower">Lower slot content forwarded</p>
+        <template lwc:if={slot}>
+            <p slot="upper">Upper slot content forwarded</p>
+            <p>Default slot forwarded</p>
+            <p slot="lower">Lower slot content forwarded</p>
+        </template>
     </x-forwarded-slot>
 </template>

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/x/forwardedSlotConsumer/forwardedSlotConsumer.js
@@ -1,5 +1,11 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 
 export default class extends LightningElement {
     static renderMode = 'light';
+    slot = true;
+
+    @api
+    shouldSlot(shouldSlot) {
+        this.slot = shouldSlot;
+    }
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-attributes/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-attributes/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1134,
-            "message": "LWC1134: Invalid attribute(s) 'class' on slot. Slots in Light DOM templates (which have 'lwc:render-mode' directive) can only have [name, slot, lwc:slot-bind, key] attributes",
+            "message": "LWC1134: Invalid attribute(s) 'class' on slot. Slots in Light DOM templates (which have 'lwc:render-mode' directive) can only have [key, lwc:slot-bind, name, slot] attributes",
             "level": 1,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-attributes/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/error-slots-attributes/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1134,
-            "message": "LWC1134: Invalid attribute(s) 'class' on slot. Slots in Light DOM templates (which have 'lwc:render-mode' directive) can only have [name, lwc:slot-bind, key] attributes",
+            "message": "LWC1134: Invalid attribute(s) 'class' on slot. Slots in Light DOM templates (which have 'lwc:render-mode' directive) can only have [name, slot, lwc:slot-bind, key] attributes",
             "level": 1,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/actual.html
@@ -2,4 +2,5 @@
     <p>Root</p>
     <slot>Default</slot>
     <slot name="named">Named</slot>
+    <slot name="forwarded" slot="forward">Forwarded</slot>
 </template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/ast.json
@@ -4,10 +4,10 @@
         "location": {
             "startLine": 1,
             "startColumn": 1,
-            "endLine": 5,
+            "endLine": 6,
             "endColumn": 12,
             "start": 0,
-            "end": 123,
+            "end": 182,
             "startTag": {
                 "startLine": 1,
                 "startColumn": 1,
@@ -17,12 +17,12 @@
                 "end": 34
             },
             "endTag": {
-                "startLine": 5,
+                "startLine": 6,
                 "startColumn": 1,
-                "endLine": 5,
+                "endLine": 6,
                 "endColumn": 12,
-                "start": 112,
-                "end": 123
+                "start": 171,
+                "end": 182
             }
         },
         "directives": [
@@ -212,6 +212,91 @@
                             "endColumn": 29,
                             "start": 99,
                             "end": 104
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "Slot",
+                "name": "slot",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "slotName": "forwarded",
+                "location": {
+                    "startLine": 5,
+                    "startColumn": 5,
+                    "endLine": 5,
+                    "endColumn": 59,
+                    "start": 116,
+                    "end": 170,
+                    "startTag": {
+                        "startLine": 5,
+                        "startColumn": 5,
+                        "endLine": 5,
+                        "endColumn": 43,
+                        "start": 116,
+                        "end": 154
+                    },
+                    "endTag": {
+                        "startLine": 5,
+                        "startColumn": 52,
+                        "endLine": 5,
+                        "endColumn": 59,
+                        "start": 163,
+                        "end": 170
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "name",
+                        "value": {
+                            "type": "Literal",
+                            "value": "forwarded"
+                        },
+                        "location": {
+                            "startLine": 5,
+                            "startColumn": 11,
+                            "endLine": 5,
+                            "endColumn": 27,
+                            "start": 122,
+                            "end": 138
+                        }
+                    },
+                    {
+                        "type": "Attribute",
+                        "name": "slot",
+                        "value": {
+                            "type": "Literal",
+                            "value": "forward"
+                        },
+                        "location": {
+                            "startLine": 5,
+                            "startColumn": 28,
+                            "endLine": 5,
+                            "endColumn": 42,
+                            "start": 139,
+                            "end": 153
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": [
+                    {
+                        "type": "Text",
+                        "raw": "Forwarded",
+                        "value": {
+                            "type": "Literal",
+                            "value": "Forwarded"
+                        },
+                        "location": {
+                            "startLine": 5,
+                            "startColumn": 43,
+                            "endLine": 5,
+                            "endColumn": 52,
+                            "start": 154,
+                            "end": 163
                         }
                     }
                 ]

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -9,6 +9,13 @@ const stc1 = {
   },
   key: 3,
 };
+const stc2 = {
+  attrs: {
+    name: "forwarded",
+    slot: "forward",
+  },
+  key: 4,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {
     st: api_static_fragment,
@@ -20,10 +27,11 @@ function tmpl($api, $cmp, $slotset, $ctx) {
     api_static_fragment($fragment1(), 1),
     api_slot("", stc0, [api_text("Default")], $slotset),
     api_slot("named", stc1, [api_text("Named")], $slotset),
+    api_slot("forwarded", stc2, [api_text("Forwarded")], $slotset),
   ]);
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);
-tmpl.slots = ["", "named"];
+tmpl.slots = ["", "forwarded", "named"];
 tmpl.stylesheets = [];
 tmpl.renderMode = "light";

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -1206,7 +1206,12 @@ function applyKey(ctx: ParserCtx, parsedAttr: ParsedAttribute, element: BaseElem
 }
 
 const RESTRICTED_DIRECTIVES_ON_SLOT = Object.values(TemplateDirectiveName).join(', ');
-const ALLOWED_SLOT_ATTRIBUTES = ['name', ElementDirectiveName.SlotBind, ElementDirectiveName.Key];
+const ALLOWED_SLOT_ATTRIBUTES = [
+    'name',
+    'slot',
+    ElementDirectiveName.SlotBind,
+    ElementDirectiveName.Key,
+];
 const ALLOWED_SLOT_ATTRIBUTES_SET = new Set<string>(ALLOWED_SLOT_ATTRIBUTES);
 function parseSlot(
     ctx: ParserCtx,

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -1207,10 +1207,10 @@ function applyKey(ctx: ParserCtx, parsedAttr: ParsedAttribute, element: BaseElem
 
 const RESTRICTED_DIRECTIVES_ON_SLOT = Object.values(TemplateDirectiveName).join(', ');
 const ALLOWED_SLOT_ATTRIBUTES = [
+    ElementDirectiveName.Key,
+    ElementDirectiveName.SlotBind,
     'name',
     'slot',
-    ElementDirectiveName.SlotBind,
-    ElementDirectiveName.Key,
 ];
 const ALLOWED_SLOT_ATTRIBUTES_SET = new Set<string>(ALLOWED_SLOT_ATTRIBUTES);
 function parseSlot(


### PR DESCRIPTION
## Details
As part of restricting attributes on light DOM slots (since they are not rendered), we also disallowed the `slot` attribute. This prevents forwarding slots from parent component to child component. We remove that restriction in this PR.


## Does this pull request introduce a breaking change?
<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-11308178
