### PR TITLE
fix(engine): provide more details in deprecation reports

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -47,7 +47,10 @@ export function checkVersionMismatch(
             logError(
                 `LWC WARNING: current engine is v${LWC_VERSION}, but ${friendlyName} was compiled with v${version}.\nPlease update your compiled code or LWC engine so that the versions match.\nNo further warnings will appear.`
             );
-            report(ReportingEventId.CompilerRuntimeVersionMismatch);
+            report(ReportingEventId.CompilerRuntimeVersionMismatch, {
+                compilerVersion: version,
+                runtimeVersion: LWC_VERSION,
+            });
         }
     }
 }

--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -99,7 +99,7 @@ function reportViolation(
                 `See: https://lwc.dev/guide/css#deprecated-template-mutation`
         );
     }
-    report(eventId);
+    report(eventId, { propertyName: prop });
 }
 
 function reportTemplateViolation(prop: TemplateProp) {

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -45,7 +45,7 @@ export type ReportingPayloadMapping = {
     [ReportingEventId.NonStandardAriaReflection]: NonStandardAriaReflectionPayload;
     [ReportingEventId.TemplateMutation]: TemplateMutationPayload;
     [ReportingEventId.StylesheetMutation]: StylesheetMutationPayload;
-}
+};
 
 export type ReportingDispatcher<T extends ReportingEventId = ReportingEventId> = (
     reportingEventId: T,
@@ -57,7 +57,7 @@ type OnReportingEnabledCallback = () => void;
 const onReportingEnabledCallbacks: OnReportingEnabledCallback[] = [];
 
 /** The currently assigned reporting dispatcher. */
-let currentDispatcher: ReportingDispatcher<ReportingEventId> = noop;
+let currentDispatcher: ReportingDispatcher = noop;
 
 /**
  * Whether reporting is enabled.
@@ -117,7 +117,10 @@ export function onReportingEnabled(callback: OnReportingEnabledCallback) {
  * @param reportingEventId
  * @param payload - data to report
  */
-export function report<T extends ReportingEventId>(reportingEventId: T, payload: Payload<T>) {
+export function report<T extends ReportingEventId>(
+    reportingEventId: T,
+    payload: ReportingPayloadMapping[T]
+) {
     if (enabled) {
         currentDispatcher(reportingEventId, payload);
     }

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -76,7 +76,7 @@ export const reportingControl = {
      *
      * @param dispatcher - reporting control
      */
-    attachDispatcher(dispatcher: ReportingDispatcher<ReportingEventId>): void {
+    attachDispatcher(dispatcher: ReportingDispatcher): void {
         enabled = true;
         currentDispatcher = dispatcher;
         for (const callback of onReportingEnabledCallbacks) {

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -39,20 +39,17 @@ export interface StylesheetMutationPayload extends BasePayload {
     propertyName: string;
 }
 
-export type Payload<T extends ReportingEventId> =
-    T extends ReportingEventId.CrossRootAriaInSyntheticShadow
-        ? CrossRootAriaInSyntheticShadowPayload
-        : T extends ReportingEventId.CompilerRuntimeVersionMismatch
-        ? CompilerRuntimeVersionMismatchPayload
-        : T extends ReportingEventId.NonStandardAriaReflection
-        ? NonStandardAriaReflectionPayload
-        : T extends ReportingEventId.TemplateMutation
-        ? TemplateMutationPayload
-        : /* T extends ReportingEventId.StylesheetMutation */ StylesheetMutationPayload;
+export type ReportingPayloadMapping = {
+    [ReportingEventId.CrossRootAriaInSyntheticShadow]: CrossRootAriaInSyntheticShadowPayload;
+    [ReportingEventId.CompilerRuntimeVersionMismatch]: CompilerRuntimeVersionMismatchPayload;
+    [ReportingEventId.NonStandardAriaReflection]: NonStandardAriaReflectionPayload;
+    [ReportingEventId.TemplateMutation]: TemplateMutationPayload;
+    [ReportingEventId.StylesheetMutation]: StylesheetMutationPayload;
+}
 
-export type ReportingDispatcher<T extends ReportingEventId> = (
+export type ReportingDispatcher<T extends ReportingEventId = ReportingEventId> = (
     reportingEventId: T,
-    payload: Payload<T>
+    payload: ReportingPayloadMapping[T]
 ) => void;
 
 /** Callbacks to invoke when reporting is enabled **/

--- a/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
@@ -68,7 +68,10 @@ function checkAndReportViolation(elm: Element, prop: string) {
                     `See https://lwc.dev/guide/accessibility#deprecated-aria-reflected-properties`
             );
         }
-        report(ReportingEventId.NonStandardAriaReflection, vm);
+        report(ReportingEventId.NonStandardAriaReflection, {
+            tagName: vm?.tagName,
+            propertyName: prop,
+        });
     }
 }
 

--- a/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
@@ -55,7 +55,10 @@ function reportViolation(source: Element, target: Element, attrName: string) {
         // vm should never be undefined here, but just to be safe, bail out and don't report
         return;
     }
-    report(ReportingEventId.CrossRootAriaInSyntheticShadow, vm);
+    report(ReportingEventId.CrossRootAriaInSyntheticShadow, {
+        tagName: vm.tagName,
+        attributeName: attrName,
+    });
     if (process.env.NODE_ENV !== 'production') {
         // Avoid excessively logging to the console in the case of duplicates.
         logWarnOnce(

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -65,13 +65,17 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
                             expect(dispatcher.calls.allArgs()).toEqual([
                                 [
                                     ReportingEventId.NonStandardAriaReflection,
-                                    tagName,
-                                    jasmine.any(Number),
+                                    {
+                                        tagName,
+                                        propertyName: prop,
+                                    },
                                 ],
                                 [
                                     ReportingEventId.NonStandardAriaReflection,
-                                    tagName,
-                                    jasmine.any(Number),
+                                    {
+                                        tagName,
+                                        propertyName: prop,
+                                    },
                                 ],
                             ]);
                         });
@@ -87,8 +91,20 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
 
                             expect(dispatcher).toHaveBeenCalledTimes(2);
                             expect(dispatcher.calls.allArgs()).toEqual([
-                                [ReportingEventId.NonStandardAriaReflection, undefined, undefined],
-                                [ReportingEventId.NonStandardAriaReflection, undefined, undefined],
+                                [
+                                    ReportingEventId.NonStandardAriaReflection,
+                                    {
+                                        tagName: undefined,
+                                        propertyName: prop,
+                                    },
+                                ],
+                                [
+                                    ReportingEventId.NonStandardAriaReflection,
+                                    {
+                                        tagName: undefined,
+                                        propertyName: prop,
+                                    },
+                                ],
                             ]);
                         });
                     });

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -50,15 +50,19 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         ? [
                               [
                                   ReportingEventId.NonStandardAriaReflection,
-                                  'x-aria-source',
-                                  jasmine.any(Number),
+                                  {
+                                      tagName: 'x-aria-source',
+                                      propertyName: 'ariaLabelledBy',
+                                  },
                               ],
                           ]
                         : []),
                     [
                         ReportingEventId.CrossRootAriaInSyntheticShadow,
-                        'x-aria-source',
-                        jasmine.any(Number),
+                        {
+                            tagName: 'x-aria-source',
+                            attributeName: 'aria-labelledby',
+                        },
                     ],
                 ];
 
@@ -114,8 +118,10 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         expect(dispatcher.calls.allArgs()).toEqual([
                             [
                                 ReportingEventId.CrossRootAriaInSyntheticShadow,
-                                'x-aria-target',
-                                jasmine.any(Number),
+                                {
+                                    tagName: 'x-aria-target',
+                                    attributeName: 'aria-labelledby',
+                                },
                             ],
                         ]);
                     });
@@ -135,8 +141,10 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                                     ? [
                                           [
                                               ReportingEventId.NonStandardAriaReflection,
-                                              'x-aria-source',
-                                              jasmine.any(Number),
+                                              {
+                                                  tagName: 'x-aria-source',
+                                                  propertyName: 'ariaLabelledBy',
+                                              },
                                           ],
                                       ]
                                     : []),
@@ -153,8 +161,10 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                                 ? [
                                       [
                                           ReportingEventId.NonStandardAriaReflection,
-                                          'x-aria-source',
-                                          jasmine.any(Number),
+                                          {
+                                              tagName: 'x-aria-source',
+                                              propertyName: 'ariaLabelledBy',
+                                          },
                                       ],
                                   ]
                                 : []),
@@ -188,8 +198,10 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                                     ...expectedDispatcherCalls,
                                     [
                                         ReportingEventId.CrossRootAriaInSyntheticShadow,
-                                        'x-aria-source',
-                                        jasmine.any(Number),
+                                        {
+                                            tagName: 'x-aria-source',
+                                            attributeName: 'aria-labelledby',
+                                        },
                                     ],
                                 ]);
                             });
@@ -215,13 +227,17 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
             expect(dispatcher.calls.allArgs()).toEqual([
                 [
                     ReportingEventId.CrossRootAriaInSyntheticShadow,
-                    'x-aria-source',
-                    jasmine.any(Number),
+                    {
+                        tagName: 'x-aria-source',
+                        attributeName: 'aria-labelledby',
+                    },
                 ],
                 [
                     ReportingEventId.CrossRootAriaInSyntheticShadow,
-                    'x-aria-source',
-                    jasmine.any(Number),
+                    {
+                        tagName: 'x-aria-source',
+                        attributeName: 'aria-labelledby',
+                    },
                 ],
             ]);
         });

--- a/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
@@ -35,7 +35,7 @@ describe('freezeTemplate', () => {
 
         expect(template.stylesheetToken).toEqual('newToken');
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheetToken' }],
         ]);
     });
 
@@ -65,7 +65,7 @@ describe('freezeTemplate', () => {
             shadowAttribute: 'newToken',
         });
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheetTokens' }],
         ]);
     });
 
@@ -90,7 +90,7 @@ describe('freezeTemplate', () => {
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(newStylesheet);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -127,8 +127,8 @@ describe('freezeTemplate', () => {
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(stylesheet);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -148,7 +148,7 @@ describe('freezeTemplate', () => {
             /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -169,7 +169,7 @@ describe('freezeTemplate', () => {
 
         expect(template.slots).toBe(newSlots);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'slots' }],
         ]);
     });
 
@@ -188,7 +188,7 @@ describe('freezeTemplate', () => {
 
         expect(template.renderMode).toBe(undefined);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, undefined, undefined],
+            [ReportingEventId.TemplateMutation, { propertyName: 'renderMode' }],
         ]);
     });
 
@@ -205,7 +205,7 @@ describe('freezeTemplate', () => {
             /Mutating the "\$scoped\$" property on a stylesheet is deprecated and will be removed in a future version of LWC\./
         );
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.StylesheetMutation, undefined, undefined],
+            [ReportingEventId.StylesheetMutation, { propertyName: '$scoped$' }],
         ]);
     });
 

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -76,7 +76,13 @@ if (!process.env.COMPAT) {
                     expect(dispatcher).not.toHaveBeenCalled();
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
-                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                        [
+                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            {
+                                runtimeVersion: process.env.LWC_VERSION,
+                                compilerVersion: '123.456.789',
+                            },
+                        ],
                     ]);
                 }
             });
@@ -109,7 +115,13 @@ if (!process.env.COMPAT) {
                     expect(dispatcher).not.toHaveBeenCalled();
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
-                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                        [
+                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            {
+                                runtimeVersion: process.env.LWC_VERSION,
+                                compilerVersion: '123.456.789',
+                            },
+                        ],
                     ]);
                 }
             });
@@ -141,7 +153,13 @@ if (!process.env.COMPAT) {
                     expect(dispatcher).not.toHaveBeenCalled();
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
-                        [ReportingEventId.CompilerRuntimeVersionMismatch, undefined, undefined],
+                        [
+                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            {
+                                runtimeVersion: process.env.LWC_VERSION,
+                                compilerVersion: '123.456.789',
+                            },
+                        ],
                     ]);
                 }
             });


### PR DESCRIPTION
## Details

As discussed [here](https://github.com/salesforce/lwc/pull/3287#discussion_r1069876017), we should provide more detail in our deprecation reporting. This PR adds a new Payload type that is unique per type of deprecation report.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* 🚨 Yes, it does introduce a breaking change.

Technically this is a breaking change for anyone using `__unstable__ReportingControl` since the API signature changed. But since it should only be used by us, and anyway it's called "unstable," and also we just released it, I think we're fine.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

See above.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12390195
