### PR TITLE
fix: use shared Object/Array functions

### DIFF
--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayPush, create, isFunction, isUndefined, seal } from '@lwc/shared';
+import { ArrayPush, create, isArray, isFunction, isUndefined, keys, seal } from '@lwc/shared';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
 import { RefVNodes, VM } from './vm';
 import { VBaseElement } from './vnodes';
@@ -81,7 +81,7 @@ export function parseStyleText(cssText: string): { [name: string]: string } {
 // Make a shallow copy of an object but omit the given key
 export function cloneAndOmitKey(object: { [key: string]: any }, keyToOmit: string) {
     const result: { [key: string]: any } = {};
-    for (const key of Object.keys(object)) {
+    for (const key of keys(object)) {
         if (key !== keyToOmit) {
             result[key] = object[key];
         }
@@ -92,7 +92,7 @@ export function cloneAndOmitKey(object: { [key: string]: any }, keyToOmit: strin
 export function flattenStylesheets(stylesheets: TemplateStylesheetFactories): StylesheetFactory[] {
     const list: StylesheetFactory[] = [];
     for (const stylesheet of stylesheets) {
-        if (!Array.isArray(stylesheet)) {
+        if (!isArray(stylesheet)) {
             list.push(stylesheet);
         } else {
             list.push(...flattenStylesheets(stylesheet));


### PR DESCRIPTION
## Details

Tiny fix. Found a couple cases where we weren't pulling in these functions from `@lwc/shared`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

