### PR TITLE
test(aria-reflection): test existing setter behavior

### DIFF
--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -59,10 +59,9 @@ function testAriaProperty(property, attribute) {
         // TODO [#3284]: The spec and our polyfill are inconsistent with WebKit/Chromium on setting undefined
         // Here we detect the native WebKit/Chromium behavior and either align with that or our polyfill
         // See also: https://github.com/w3c/aria/issues/1858
-        const isNative =
-            Object.getOwnPropertyDescriptor(Element.prototype, property)
-                .set.toString()
-                .indexOf('[native code]') !== -1;
+        const isNative = Object.getOwnPropertyDescriptor(Element.prototype, property)
+            .set.toString()
+            .includes('[native code]');
         const settingUndefinedRemoves = () => {
             // This test is just in case Chromium/WebKit change their behavior, or Firefox ships their version
             const div = document.createElement('div');
@@ -112,7 +111,9 @@ function testAriaProperty(property, attribute) {
     });
 }
 
-if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
+// These tests don't make sense if the global polyfill is not loaded
+// Also IE11 has some bugs, so we disable for COMPAT mode
+if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL && !process.env.COMPAT) {
     for (const [ariaProperty, ariaAttribute] of Object.entries(ariaPropertiesMapping)) {
         testAriaProperty(ariaProperty, ariaAttribute);
     }


### PR DESCRIPTION
## Details

See #3284

Our polyfill aligns with the spec, but WebKit/Chromium do not. We can't change it right now because of backwards compat. This test just confirms the existing behavior.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
