### PR TITLE
chore: use PUPPETEER_SKIP_DOWNLOAD in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,7 @@ jobs:
       - restore_nx_cache
       - run:
           name: Install dependencies and build
+          # Puppeteer Chromium download is only needed for @best/runner-local, which is unused here
           command: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
       - run:
           name: Check missing file headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       - restore_nx_cache
       - run:
           name: Install dependencies and build
-          command: yarn install --frozen-lockfile
+          command: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
       - run:
           name: Check missing file headers
           command: node ./scripts/tasks/check-license-headers.js

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
 
       - name: Build benchmarks
         run: yarn build:performance

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
+        # Puppeteer Chromium download is only needed for @best/runner-local, which is unused here
         run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
 
       - name: Build benchmarks


### PR DESCRIPTION
## Details

Our builds keep failing because Puppeteer fails to download Chromium. We only need this for local `@best/runner-headless` testing, which is not used in any of our CI scripts (even our Best scripts, which use the remote runner).

This disables the download, using the `PUPPETEER_SKIP_DOWNLOAD` [env var](https://pptr.dev/api/puppeteer.configuration/#properties).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
