### PR TITLE
test(features): add tests for setFeatureFlag

### DIFF
--- a/packages/@lwc/features/src/__tests__/features.spec.ts
+++ b/packages/@lwc/features/src/__tests__/features.spec.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import features from '../flags';
+
+describe('features', () => {
+    it('known flags in the features map are null', () => {
+        expect(features.DUMMY_TEST_FLAG).toBeNull();
+        for (const value of Object.values(features)) {
+            expect(value).toBeNull();
+        }
+    });
+
+    it('unknown flags in the features map are undefined', () => {
+        // @ts-ignore
+        expect(features.DOES_NOT_EXIST).toBeUndefined();
+    });
+});

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { lwcRuntimeFlags, default as features } from '../flags';
+
+describe('lwcRuntimeFlags', () => {
+    it('known flags default to undefined', () => {
+        expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toBeUndefined();
+    });
+
+    it('unknown flags default to undefined', () => {
+        // @ts-ignore
+        expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
+    });
+
+    it('known flags in the features map are null', () => {
+        expect(features.DUMMY_TEST_FLAG).toBeNull();
+        for (const value of Object.values(features)) {
+            expect(value).toBeNull();
+        }
+    });
+
+    it('unknown flags in the features map are undefined', () => {
+        // @ts-ignore
+        expect(features.DOES_NOT_EXIST).toBeUndefined();
+    });
+});

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -16,7 +16,9 @@ describe('lwcRuntimeFlags', () => {
         // @ts-ignore
         expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
     });
+});
 
+describe('features', () => {
     it('known flags in the features map are null', () => {
         expect(features.DUMMY_TEST_FLAG).toBeNull();
         for (const value of Object.values(features)) {

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { lwcRuntimeFlags, default as features } from '../flags';
+import { lwcRuntimeFlags } from '../flags';
 
 describe('lwcRuntimeFlags', () => {
     it('known flags default to undefined', () => {
@@ -15,19 +15,5 @@ describe('lwcRuntimeFlags', () => {
     it('unknown flags default to undefined', () => {
         // @ts-ignore
         expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
-    });
-});
-
-describe('features', () => {
-    it('known flags in the features map are null', () => {
-        expect(features.DUMMY_TEST_FLAG).toBeNull();
-        for (const value of Object.values(features)) {
-            expect(value).toBeNull();
-        }
-    });
-
-    it('unknown flags in the features map are undefined', () => {
-        // @ts-ignore
-        expect(features.DOES_NOT_EXIST).toBeUndefined();
     });
 });

--- a/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
+++ b/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { lwcRuntimeFlags, setFeatureFlag } from '../flags';
+
+describe('setFeatureFlag', () => {
+    ['development', 'production'].forEach((env) => {
+        describe(`${env} mode`, () => {
+            let originalNodeEnv: any;
+            let warn: jest.SpyInstance;
+            let error: jest.SpyInstance;
+
+            beforeEach(() => {
+                originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = env;
+                warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+                error = jest.spyOn(console, 'error').mockImplementation(() => {});
+            });
+
+            afterEach(() => {
+                process.env.NODE_ENV = originalNodeEnv;
+                lwcRuntimeFlags.DUMMY_TEST_FLAG = undefined; // reset
+                warn.mockReset();
+                error.mockReset();
+            });
+
+            it('throws/logs and does nothing when set to a non-boolean', () => {
+                const expectedError =
+                    'Failed to set the value "foo" for the runtime feature flag "DUMMY_TEST_FLAG". Runtime feature flags can only be set to a boolean value.';
+                const callback = () => {
+                    // @ts-ignore
+                    setFeatureFlag('DUMMY_TEST_FLAG', 'foo');
+                };
+                if (env === 'production') {
+                    callback();
+                    expect(error).toHaveBeenCalledWith(expectedError);
+                } else {
+                    expect(callback).toThrowError(expectedError);
+                }
+
+                // value is not changed
+                expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toBeUndefined();
+            });
+
+            it('logs and does nothing when the flag is unknown', () => {
+                // @ts-ignore
+                setFeatureFlag('DOES_NOT_EXIST', true);
+                expect(warn).toHaveBeenCalledWith(
+                    expect.stringMatching(
+                        /Failed to set the value "true" for the runtime feature flag "DOES_NOT_EXIST" because it is undefined\./
+                    )
+                );
+
+                // value is not changed
+                // @ts-ignore
+                expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
+            });
+
+            it('disallows setting a flag more than once', () => {
+                setFeatureFlag('DUMMY_TEST_FLAG', true);
+                expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(true);
+                setFeatureFlag('DUMMY_TEST_FLAG', false);
+                if (env === 'production') {
+                    expect(error).toHaveBeenCalledWith(
+                        'Failed to set the value "false" for the runtime feature flag "DUMMY_TEST_FLAG". "DUMMY_TEST_FLAG" has already been set with the value "true".'
+                    );
+                    expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(true);
+                } else {
+                    expect(error).not.toHaveBeenCalled();
+                    expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(false);
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Details

There is logic in `@lwc/features` to test for scenarios like setting a non-boolean, or trying to set a flag that's undefined, but we don't have tests for this behavior (in either Jest or Karma). This adds Jest tests for this behavior.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
