### PR TITLE
fix(engine-server): expose createElement API

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/create-element.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/create-element.spec.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from '../index';
+
+describe('createElement', () => {
+    it('throws an error', () => {
+        expect(createElement).toThrow(
+            'createElement is not supported in @lwc/engine-server, only @lwc/engine-dom.'
+        );
+    });
+});

--- a/packages/@lwc/engine-server/src/apis/create-element.ts
+++ b/packages/@lwc/engine-server/src/apis/create-element.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * This API is equivalent to the createElement function exposed by @lwc/engine-dom. It doesn't do anything on
+ * the server side, however, you may import it.
+ *
+ * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
+ * an error being thrown by the import itself.
+ */
+export function createElement() {
+    throw new Error('createElement is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+}

--- a/packages/@lwc/engine-server/src/index.ts
+++ b/packages/@lwc/engine-server/src/index.ts
@@ -34,3 +34,4 @@ export {
 export { renderComponent } from './apis/render-component';
 export { LightningElement } from './apis/lightning-element';
 export { renderer } from './renderer';
+export { createElement } from './apis/create-element';


### PR DESCRIPTION
## Details

This is to support isomorphic code that uses `createElement` on the client. Importing the function throws currently; with this PR, you can at least import it. However, it will throw an error if you try to run it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
