### PR TITLE
fix(engine): fix styling of static SVGs (backport)

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/svgs/expected.html
@@ -3,8 +3,8 @@
     <svg height="150" width="400">
       <defs>
         <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop class="static" offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"/>
-          <stop class="static" offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"/>
+          <stop class="static" style="stop-color: rgb(255,255,0); stop-opacity: 1" offset="0%"/>
+          <stop class="static" style="stop-color: rgb(255,0,0); stop-opacity: 1" offset="100%"/>
         </linearGradient>
       </defs>
       <ellipse class="static" cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"/>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/index.spec.js
@@ -1,0 +1,55 @@
+import { createElement } from 'lwc';
+
+import StaticSvg from 'x/staticSvg';
+import StaticSvgInDiv from 'x/staticSvgInDiv';
+import StaticSvgInDivScoped from 'x/staticSvgInDivScoped';
+import StaticSvgScoped from 'x/staticSvgScoped';
+import StaticText from 'x/staticText';
+import StaticTextScoped from 'x/staticTextScoped';
+
+describe('styling svg', () => {
+    const scenarios = [
+        {
+            name: 'static svg',
+            Ctor: StaticSvg,
+            tag: 'x-static-svg',
+        },
+        {
+            name: 'static svg in div',
+            Ctor: StaticSvgInDiv,
+            tag: 'x-static-svg-in-div',
+        },
+        {
+            name: 'static text',
+            Ctor: StaticText,
+            tag: 'x-static-text',
+        },
+        {
+            name: 'static svg - scoped css',
+            Ctor: StaticSvgScoped,
+            tag: 'x-static-svg',
+        },
+        {
+            name: 'static svg in div - scoped css',
+            Ctor: StaticSvgInDivScoped,
+            tag: 'x-static-svg-in-div',
+        },
+        {
+            name: 'static text - scoped css',
+            Ctor: StaticTextScoped,
+            tag: 'x-static-text',
+        },
+    ];
+
+    for (const { name, Ctor, tag } of scenarios) {
+        it(name, async () => {
+            const elm = createElement(tag, { is: Ctor });
+            document.body.appendChild(elm);
+            await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            expect(getComputedStyle(elm.shadowRoot.querySelector('svg')).fill).toEqual(
+                'rgb(255, 0, 0)'
+            );
+            expect(getComputedStyle(elm.shadowRoot.querySelector('text')).display).toEqual('none');
+        });
+    }
+});

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.html
@@ -1,0 +1,8 @@
+<template>
+    <!-- entire <svg> is static -->
+    <svg viewBox="0 0 240 80">
+        <text x="20" y="35">
+            I should not be visible
+        </text>
+    </svg>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvg/staticSvg.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.html
@@ -1,0 +1,10 @@
+<template>
+    <!-- entire <div> is static -->
+    <div>
+        <svg viewBox="0 0 240 80">
+            <text x="20" y="35">
+                I should not be visible
+            </text>
+        </svg>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDiv/staticSvgInDiv.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.html
@@ -1,0 +1,10 @@
+<template>
+    <!-- entire <div> is static -->
+    <div>
+        <svg viewBox="0 0 240 80">
+            <text x="20" y="35">
+                I should not be visible
+            </text>
+        </svg>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.scoped.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgInDivScoped/staticSvgInDivScoped.scoped.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.html
@@ -1,0 +1,8 @@
+<template>
+    <!-- entire <svg> is static -->
+    <svg viewBox="0 0 240 80">
+        <text x="20" y="35">
+            I should not be visible
+        </text>
+    </svg>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.scoped.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticSvgScoped/staticSvgScoped.scoped.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.html
@@ -1,0 +1,8 @@
+<template>
+    <!-- <svg> is dynamic, but the <text> is static -->
+    <svg viewBox="0 0 240 80" data-dynamic={foo}>
+        <text x="20" y="35">
+            I should not be visible
+        </text>
+    </svg>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticText/staticText.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class App extends LightningElement {
+    foo = 'foo';
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.html
@@ -1,0 +1,8 @@
+<template>
+    <!-- <svg> is dynamic, but the <text> is static -->
+    <svg viewBox="0 0 240 80" data-dynamic={foo}>
+        <text x="20" y="35">
+            I should not be visible
+        </text>
+    </svg>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class App extends LightningElement {
+    foo = 'foo';
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.scoped.css
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/style-svg/x/staticTextScoped/staticTextScoped.scoped.css
@@ -1,0 +1,7 @@
+text {
+    display: none;
+}
+
+svg {
+    fill: rgb(255, 0, 0);
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
@@ -1,8 +1,18 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><ellipse${3}/></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  key: 1,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [api_element("svg", stc0, [api_element("ellipse", stc1)])];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
@@ -1,8 +1,32 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/><path${3}/></svg></div>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+};
+const stc1 = {
+  attrs: {
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  key: 2,
+  svg: true,
+};
+const stc3 = {
+  key: 3,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [
+    api_element("div", stc0, [
+      api_element("svg", stc1, [
+        api_element("path", stc2),
+        api_element("path", stc3),
+      ]),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
@@ -1,8 +1,38 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<div${3}><svg xmlns="http://www.w3.org/2000/svg"${3}><g${3}><path${3}/><path${3}/></g></svg></div>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+};
+const stc1 = {
+  attrs: {
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  key: 2,
+  svg: true,
+};
+const stc3 = {
+  key: 3,
+  svg: true,
+};
+const stc4 = {
+  key: 4,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [
+    api_element("div", stc0, [
+      api_element("svg", stc1, [
+        api_element("g", stc2, [
+          api_element("path", stc3),
+          api_element("path", stc4),
+        ]),
+      ]),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
@@ -1,8 +1,27 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/><path${3}/></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  key: 2,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [
+    api_element("svg", stc0, [
+      api_element("path", stc1),
+      api_element("path", stc2),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -1,20 +1,4 @@
-import { parseSVGFragment, registerTemplate } from "lwc";
-const $fragment1 = parseSVGFragment`<feFlood x="25%" y="25%" width="50%" height="50%" flood-color="green" flood-opacity="0.75"${3}/>`;
-const $fragment2 = parseSVGFragment`<feBlend x="25%" y="25%" width="50%" height="50%" in2="SourceGraphic" mode="multiply"${3}/>`;
-const $fragment3 = parseSVGFragment`<feMerge x="25%" y="25%" width="50%" height="50%"${3}><feMergeNode in="SourceGraphic"${3}/><feMergeNode in="FillPaint"${3}/></feMerge>`;
-const $fragment4 = parseSVGFragment`<g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g>`;
-const $fragment5 = parseSVGFragment`<circle fill="green" filter="url(#flood)" cx="100" cy="100" r="90"${3}/>`;
-const $fragment6 = parseSVGFragment`<g transform="translate(200 0)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g><circle fill="green" filter="url(#blend)" cx="100" cy="100" r="90"${3}/></g>`;
-const $fragment7 = parseSVGFragment`<g transform="translate(0 200)"${3}><g fill="none" stroke="blue" stroke-width="4"${3}><rect width="200" height="200"${3}/><line x2="200" y2="200"${3}/><line x1="200" y2="200"${3}/></g><circle fill="green" fill-opacity="0.5" filter="url(#merge)" cx="100" cy="100" r="90"${3}/></g>`;
-const $fragment8 = parseSVGFragment`<rect fill="none" stroke="blue" x="1" y="1" width="598" height="248"${3}/>`;
-const $fragment9 = parseSVGFragment`<g${3}><rect x="50" y="25" width="100" height="200" filter="url(#Default)"${3}/><rect x="50" y="25" width="100" height="200" fill="none" stroke="green"${3}/><rect x="250" y="25" width="100" height="200" filter="url(#Fitted)"${3}/><rect x="250" y="25" width="100" height="200" fill="none" stroke="green"${3}/><rect x="450" y="25" width="100" height="200" filter="url(#Shifted)"${3}/><rect x="450" y="25" width="100" height="200" fill="none" stroke="green"${3}/></g>`;
-const $fragment10 = parseSVGFragment`<desc${3}>Produces a 3D lighting effect.</desc>`;
-const $fragment11 = parseSVGFragment`<feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"${3}/>`;
-const $fragment12 = parseSVGFragment`<feOffset in="blur" dx="4" dy="4" result="offsetBlur"${3}/>`;
-const $fragment13 = parseSVGFragment`<feSpecularLighting in="blur" surfaceScale="5" specularConstant=".75" specularExponent="20" lighting-color="#bbbbbb" result="specOut"${3}><fePointLight x="-5000" y="-10000" z="20000"${3}/></feSpecularLighting>`;
-const $fragment14 = parseSVGFragment`<feComposite in="specOut" in2="SourceAlpha" operator="in" result="specOut"${3}/>`;
-const $fragment15 = parseSVGFragment`<feComposite in="SourceGraphic" in2="specOut" operator="arithmetic" k1="0" k2="1" k3="1" k4="0" result="litPaint"${3}/>`;
-const $fragment16 = parseSVGFragment`<feMerge${3}><feMergeNode in="offsetBlur"${3}/><feMergeNode in="litPaint"${3}/></feMerge>`;
+import { registerTemplate } from "lwc";
 const stc0 = {
   attrs: {
     width: "400",
@@ -30,17 +14,383 @@ const stc1 = {
 };
 const stc2 = {
   attrs: {
+    x: "25%",
+    y: "25%",
+    width: "50%",
+    height: "50%",
+    "flood-color": "green",
+    "flood-opacity": "0.75",
+  },
+  key: 3,
+  svg: true,
+};
+const stc3 = {
+  attrs: {
+    x: "25%",
+    y: "25%",
+    width: "50%",
+    height: "50%",
+    in2: "SourceGraphic",
+    mode: "multiply",
+  },
+  key: 5,
+  svg: true,
+};
+const stc4 = {
+  attrs: {
+    x: "25%",
+    y: "25%",
+    width: "50%",
+    height: "50%",
+  },
+  key: 7,
+  svg: true,
+};
+const stc5 = {
+  attrs: {
+    in: "SourceGraphic",
+  },
+  key: 8,
+  svg: true,
+};
+const stc6 = {
+  attrs: {
+    in: "FillPaint",
+  },
+  key: 9,
+  svg: true,
+};
+const stc7 = {
+  attrs: {
+    fill: "none",
+    stroke: "blue",
+    "stroke-width": "4",
+  },
+  key: 10,
+  svg: true,
+};
+const stc8 = {
+  attrs: {
+    width: "200",
+    height: "200",
+  },
+  key: 11,
+  svg: true,
+};
+const stc9 = {
+  attrs: {
+    x2: "200",
+    y2: "200",
+  },
+  key: 12,
+  svg: true,
+};
+const stc10 = {
+  attrs: {
+    x1: "200",
+    y2: "200",
+  },
+  key: 13,
+  svg: true,
+};
+const stc11 = {
+  attrs: {
+    fill: "green",
+    filter: "url(#flood)",
+    cx: "100",
+    cy: "100",
+    r: "90",
+  },
+  key: 14,
+  svg: true,
+};
+const stc12 = {
+  attrs: {
+    transform: "translate(200 0)",
+  },
+  key: 15,
+  svg: true,
+};
+const stc13 = {
+  attrs: {
+    fill: "none",
+    stroke: "blue",
+    "stroke-width": "4",
+  },
+  key: 16,
+  svg: true,
+};
+const stc14 = {
+  attrs: {
+    width: "200",
+    height: "200",
+  },
+  key: 17,
+  svg: true,
+};
+const stc15 = {
+  attrs: {
+    x2: "200",
+    y2: "200",
+  },
+  key: 18,
+  svg: true,
+};
+const stc16 = {
+  attrs: {
+    x1: "200",
+    y2: "200",
+  },
+  key: 19,
+  svg: true,
+};
+const stc17 = {
+  attrs: {
+    fill: "green",
+    filter: "url(#blend)",
+    cx: "100",
+    cy: "100",
+    r: "90",
+  },
+  key: 20,
+  svg: true,
+};
+const stc18 = {
+  attrs: {
+    transform: "translate(0 200)",
+  },
+  key: 21,
+  svg: true,
+};
+const stc19 = {
+  attrs: {
+    fill: "none",
+    stroke: "blue",
+    "stroke-width": "4",
+  },
+  key: 22,
+  svg: true,
+};
+const stc20 = {
+  attrs: {
+    width: "200",
+    height: "200",
+  },
+  key: 23,
+  svg: true,
+};
+const stc21 = {
+  attrs: {
+    x2: "200",
+    y2: "200",
+  },
+  key: 24,
+  svg: true,
+};
+const stc22 = {
+  attrs: {
+    x1: "200",
+    y2: "200",
+  },
+  key: 25,
+  svg: true,
+};
+const stc23 = {
+  attrs: {
+    fill: "green",
+    "fill-opacity": "0.5",
+    filter: "url(#merge)",
+    cx: "100",
+    cy: "100",
+    r: "90",
+  },
+  key: 26,
+  svg: true,
+};
+const stc24 = {
+  attrs: {
     width: "600",
     height: "250",
     viewBox: "0 0 600 250",
     xmlns: "http://www.w3.org/2000/svg",
     "xmlns:xlink": "http://www.w3.org/1999/xlink",
   },
-  key: 19,
+  key: 27,
+  svg: true,
+};
+const stc25 = {
+  attrs: {
+    fill: "none",
+    stroke: "blue",
+    x: "1",
+    y: "1",
+    width: "598",
+    height: "248",
+  },
+  key: 28,
+  svg: true,
+};
+const stc26 = {
+  key: 29,
+  svg: true,
+};
+const stc27 = {
+  attrs: {
+    x: "50",
+    y: "25",
+    width: "100",
+    height: "200",
+    filter: "url(#Default)",
+  },
+  key: 30,
+  svg: true,
+};
+const stc28 = {
+  attrs: {
+    x: "50",
+    y: "25",
+    width: "100",
+    height: "200",
+    fill: "none",
+    stroke: "green",
+  },
+  key: 31,
+  svg: true,
+};
+const stc29 = {
+  attrs: {
+    x: "250",
+    y: "25",
+    width: "100",
+    height: "200",
+    filter: "url(#Fitted)",
+  },
+  key: 32,
+  svg: true,
+};
+const stc30 = {
+  attrs: {
+    x: "250",
+    y: "25",
+    width: "100",
+    height: "200",
+    fill: "none",
+    stroke: "green",
+  },
+  key: 33,
+  svg: true,
+};
+const stc31 = {
+  attrs: {
+    x: "450",
+    y: "25",
+    width: "100",
+    height: "200",
+    filter: "url(#Shifted)",
+  },
+  key: 34,
+  svg: true,
+};
+const stc32 = {
+  attrs: {
+    x: "450",
+    y: "25",
+    width: "100",
+    height: "200",
+    fill: "none",
+    stroke: "green",
+  },
+  key: 35,
+  svg: true,
+};
+const stc33 = {
+  key: 37,
+  svg: true,
+};
+const stc34 = {
+  attrs: {
+    in: "SourceAlpha",
+    stdDeviation: "4",
+    result: "blur",
+  },
+  key: 38,
+  svg: true,
+};
+const stc35 = {
+  attrs: {
+    in: "blur",
+    dx: "4",
+    dy: "4",
+    result: "offsetBlur",
+  },
+  key: 39,
+  svg: true,
+};
+const stc36 = {
+  attrs: {
+    in: "blur",
+    surfaceScale: "5",
+    specularConstant: ".75",
+    specularExponent: "20",
+    "lighting-color": "#bbbbbb",
+    result: "specOut",
+  },
+  key: 40,
+  svg: true,
+};
+const stc37 = {
+  attrs: {
+    x: "-5000",
+    y: "-10000",
+    z: "20000",
+  },
+  key: 41,
+  svg: true,
+};
+const stc38 = {
+  attrs: {
+    in: "specOut",
+    in2: "SourceAlpha",
+    operator: "in",
+    result: "specOut",
+  },
+  key: 42,
+  svg: true,
+};
+const stc39 = {
+  attrs: {
+    in: "SourceGraphic",
+    in2: "specOut",
+    operator: "arithmetic",
+    k1: "0",
+    k2: "1",
+    k3: "1",
+    k4: "0",
+    result: "litPaint",
+  },
+  key: 43,
+  svg: true,
+};
+const stc40 = {
+  key: 44,
+  svg: true,
+};
+const stc41 = {
+  attrs: {
+    in: "offsetBlur",
+  },
+  key: 45,
+  svg: true,
+};
+const stc42 = {
+  attrs: {
+    in: "litPaint",
+  },
+  key: 46,
   svg: true,
 };
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, st: api_static_fragment, h: api_element } = $api;
+  const { gid: api_scoped_id, h: api_element, t: api_text } = $api;
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [
@@ -58,7 +408,7 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [api_static_fragment($fragment1(), 4)]
+          [api_element("feFlood", stc2)]
         ),
         api_element(
           "filter",
@@ -67,10 +417,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               id: api_scoped_id("blend"),
               primitiveUnits: "objectBoundingBox",
             },
-            key: 5,
+            key: 4,
             svg: true,
           },
-          [api_static_fragment($fragment2(), 7)]
+          [api_element("feBlend", stc3)]
         ),
         api_element(
           "filter",
@@ -79,20 +429,50 @@ function tmpl($api, $cmp, $slotset, $ctx) {
               id: api_scoped_id("merge"),
               primitiveUnits: "objectBoundingBox",
             },
-            key: 8,
+            key: 6,
             svg: true,
           },
-          [api_static_fragment($fragment3(), 10)]
+          [
+            api_element("feMerge", stc4, [
+              api_element("feMergeNode", stc5),
+              api_element("feMergeNode", stc6),
+            ]),
+          ]
         ),
       ]),
-      api_static_fragment($fragment4(), 12),
-      api_static_fragment($fragment5(), 14),
-      api_static_fragment($fragment6(), 16),
-      api_static_fragment($fragment7(), 18),
+      api_element("g", stc7, [
+        api_element("rect", stc8),
+        api_element("line", stc9),
+        api_element("line", stc10),
+      ]),
+      api_element("circle", stc11),
+      api_element("g", stc12, [
+        api_element("g", stc13, [
+          api_element("rect", stc14),
+          api_element("line", stc15),
+          api_element("line", stc16),
+        ]),
+        api_element("circle", stc17),
+      ]),
+      api_element("g", stc18, [
+        api_element("g", stc19, [
+          api_element("rect", stc20),
+          api_element("line", stc21),
+          api_element("line", stc22),
+        ]),
+        api_element("circle", stc23),
+      ]),
     ]),
-    api_element("svg", stc2, [
-      api_static_fragment($fragment8(), 21),
-      api_static_fragment($fragment9(), 23),
+    api_element("svg", stc24, [
+      api_element("rect", stc25),
+      api_element("g", stc26, [
+        api_element("rect", stc27),
+        api_element("rect", stc28),
+        api_element("rect", stc29),
+        api_element("rect", stc30),
+        api_element("rect", stc31),
+        api_element("rect", stc32),
+      ]),
       api_element(
         "filter",
         {
@@ -104,17 +484,24 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             width: "200",
             height: "120",
           },
-          key: 24,
+          key: 36,
           svg: true,
         },
         [
-          api_static_fragment($fragment10(), 26),
-          api_static_fragment($fragment11(), 28),
-          api_static_fragment($fragment12(), 30),
-          api_static_fragment($fragment13(), 32),
-          api_static_fragment($fragment14(), 34),
-          api_static_fragment($fragment15(), 36),
-          api_static_fragment($fragment16(), 38),
+          api_element("desc", stc33, [
+            api_text("Produces a 3D lighting effect."),
+          ]),
+          api_element("feGaussianBlur", stc34),
+          api_element("feOffset", stc35),
+          api_element("feSpecularLighting", stc36, [
+            api_element("fePointLight", stc37),
+          ]),
+          api_element("feComposite", stc38),
+          api_element("feComposite", stc39),
+          api_element("feMerge", stc40, [
+            api_element("feMergeNode", stc41),
+            api_element("feMergeNode", stc42),
+          ]),
         ]
       ),
     ]),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -1,8 +1,54 @@
 import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<div${3}><svg width="706" height="180"${3}><g transform="translate(3,3)"${3}><g transform="translate(250,0)"${3}><foreignObject width="200" height="36" xlink:href="javascript:alert(1)"${3}><a${3}>x</a></foreignObject></g></g></svg></div>`;
+const $fragment1 = parseFragment`<a${3}>x</a>`;
+const stc0 = {
+  key: 0,
+};
+const stc1 = {
+  attrs: {
+    width: "706",
+    height: "180",
+  },
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  attrs: {
+    transform: "translate(3,3)",
+  },
+  key: 2,
+  svg: true,
+};
+const stc3 = {
+  attrs: {
+    transform: "translate(250,0)",
+  },
+  key: 3,
+  svg: true,
+};
+const stc4 = {
+  attrs: {
+    width: "200",
+    height: "36",
+    "xlink:href": "javascript:alert(1)",
+  },
+  key: 4,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { st: api_static_fragment, h: api_element } = $api;
+  return [
+    api_element("div", stc0, [
+      api_element("svg", stc1, [
+        api_element("g", stc2, [
+          api_element("g", stc3, [
+            api_element("foreignObject", stc4, [
+              api_static_fragment($fragment1(), 6),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -1,7 +1,4 @@
-import { parseSVGFragment, registerTemplate } from "lwc";
-const $fragment1 = parseSVGFragment`<stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1"${3}/>`;
-const $fragment2 = parseSVGFragment`<stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1"${3}/>`;
-const $fragment3 = parseSVGFragment`<ellipse cx="200" cy="70" rx="85" ry="55" fill="url(#grad1)"${3}/>`;
+import { registerTemplate } from "lwc";
 const stc0 = {
   attrs: {
     height: "150",
@@ -14,8 +11,41 @@ const stc1 = {
   key: 1,
   svg: true,
 };
+const stc2 = {
+  styleDecls: [
+    ["stop-color", "rgb(255,255,0)", false],
+    ["stop-opacity", "1", false],
+  ],
+  attrs: {
+    offset: "0%",
+  },
+  key: 3,
+  svg: true,
+};
+const stc3 = {
+  styleDecls: [
+    ["stop-color", "rgb(255,0,0)", false],
+    ["stop-opacity", "1", false],
+  ],
+  attrs: {
+    offset: "100%",
+  },
+  key: 4,
+  svg: true,
+};
+const stc4 = {
+  attrs: {
+    cx: "200",
+    cy: "70",
+    rx: "85",
+    ry: "55",
+    fill: "url(#grad1)",
+  },
+  key: 5,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { gid: api_scoped_id, st: api_static_fragment, h: api_element } = $api;
+  const { gid: api_scoped_id, h: api_element } = $api;
   return [
     api_element("svg", stc0, [
       api_element("defs", stc1, [
@@ -32,13 +62,10 @@ function tmpl($api, $cmp, $slotset, $ctx) {
             key: 2,
             svg: true,
           },
-          [
-            api_static_fragment($fragment1(), 4),
-            api_static_fragment($fragment2(), 6),
-          ]
+          [api_element("stop", stc2), api_element("stop", stc3)]
         ),
       ]),
-      api_static_fragment($fragment3(), 8),
+      api_element("ellipse", stc4),
     ]),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -1,8 +1,54 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"${3}><rect width="100%" height="100%" fill="red"${3}/><circle cx="150" cy="100" r="80" fill="green"${3}/><text x="150" y="125" font-size="60" text-anchor="middle" fill="white"${3}>SVG</text></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    version: "1.1",
+    baseProfile: "full",
+    width: "300",
+    height: "200",
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  attrs: {
+    width: "100%",
+    height: "100%",
+    fill: "red",
+  },
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  attrs: {
+    cx: "150",
+    cy: "100",
+    r: "80",
+    fill: "green",
+  },
+  key: 2,
+  svg: true,
+};
+const stc3 = {
+  attrs: {
+    x: "150",
+    y: "125",
+    "font-size": "60",
+    "text-anchor": "middle",
+    fill: "white",
+  },
+  key: 3,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element, t: api_text } = $api;
+  return [
+    api_element("svg", stc0, [
+      api_element("rect", stc1),
+      api_element("circle", stc2),
+      api_element("text", stc3, [api_text("SVG")]),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -1,8 +1,18 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg xmlns="http://www.w3.org/2000/svg"${3}><path${3}/></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    xmlns: "http://www.w3.org/2000/svg",
+  },
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  key: 1,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [api_element("svg", stc0, [api_element("path", stc1)])];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -1,8 +1,26 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg width="200" height="200"${3}><image xlink:href="/foo.png" x="1" y="2" height="200" width="200"${3}/></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    width: "200",
+    height: "200",
+  },
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  attrs: {
+    "xlink:href": "/foo.png",
+    x: "1",
+    y: "2",
+    height: "200",
+    width: "200",
+  },
+  key: 1,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [api_element("svg", stc0, [api_element("image", stc1)])];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -1,8 +1,119 @@
-import { parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<svg${3}><a${3}/><circle${3}/><defs${3}/><desc${3}/><ellipse${3}/><filter${3}/><g${3}/><line${3}/><marker${3}/><mask${3}/><path${3}/><pattern${3}/><polygon${3}/><polyline${3}/><rect${3}/><stop${3}/><symbol${3}/><text${3}/><title${3}/><tspan${3}/><use${3}/></svg>`;
+import { registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+  svg: true,
+};
+const stc1 = {
+  key: 1,
+  svg: true,
+};
+const stc2 = {
+  key: 2,
+  svg: true,
+};
+const stc3 = {
+  key: 3,
+  svg: true,
+};
+const stc4 = {
+  key: 4,
+  svg: true,
+};
+const stc5 = {
+  key: 5,
+  svg: true,
+};
+const stc6 = {
+  key: 6,
+  svg: true,
+};
+const stc7 = {
+  key: 7,
+  svg: true,
+};
+const stc8 = {
+  key: 8,
+  svg: true,
+};
+const stc9 = {
+  key: 9,
+  svg: true,
+};
+const stc10 = {
+  key: 10,
+  svg: true,
+};
+const stc11 = {
+  key: 11,
+  svg: true,
+};
+const stc12 = {
+  key: 12,
+  svg: true,
+};
+const stc13 = {
+  key: 13,
+  svg: true,
+};
+const stc14 = {
+  key: 14,
+  svg: true,
+};
+const stc15 = {
+  key: 15,
+  svg: true,
+};
+const stc16 = {
+  key: 16,
+  svg: true,
+};
+const stc17 = {
+  key: 17,
+  svg: true,
+};
+const stc18 = {
+  key: 18,
+  svg: true,
+};
+const stc19 = {
+  key: 19,
+  svg: true,
+};
+const stc20 = {
+  key: 20,
+  svg: true,
+};
+const stc21 = {
+  key: 21,
+  svg: true,
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment } = $api;
-  return [api_static_fragment($fragment1(), 1)];
+  const { h: api_element } = $api;
+  return [
+    api_element("svg", stc0, [
+      api_element("a", stc1),
+      api_element("circle", stc2),
+      api_element("defs", stc3),
+      api_element("desc", stc4),
+      api_element("ellipse", stc5),
+      api_element("filter", stc6),
+      api_element("g", stc7),
+      api_element("line", stc8),
+      api_element("marker", stc9),
+      api_element("mask", stc10),
+      api_element("path", stc11),
+      api_element("pattern", stc12),
+      api_element("polygon", stc13),
+      api_element("polyline", stc14),
+      api_element("rect", stc15),
+      api_element("stop", stc16),
+      api_element("symbol", stc17),
+      api_element("text", stc18),
+      api_element("title", stc19),
+      api_element("tspan", stc20),
+      api_element("use", stc21),
+    ]),
+  ];
   /*LWC compiler vX.X.X*/
 }
 export default registerTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { HTML_NAMESPACE } from '@lwc/shared';
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
 import { BaseElement, ChildNode, LWCDirectiveRenderMode, Node, Root } from '../shared/types';
@@ -220,6 +221,11 @@ export function parseClassNames(classNames: string): string[] {
 function isStaticNode(node: BaseElement): boolean {
     let result = true;
     const { name: nodeName, namespace = '', attributes, directives, properties, listeners } = node;
+
+    if (namespace !== HTML_NAMESPACE) {
+        // TODO [#3313]: re-enable static optimization for SVGs once scope token is always lowercase
+        return false;
+    }
 
     result &&= isElement(node);
 


### PR DESCRIPTION
## Details

Same as #3312, but a backport.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
