### PR TITLE
fix(engine-core): remove feature flag for programmatic stylesheets

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -390,20 +390,18 @@ function validateComponentStylesheets(vm: VM, stylesheets: TemplateStylesheetFac
 
 // Validate and flatten any stylesheets defined as `static stylesheets`
 function computeStylesheets(vm: VM, ctor: LightningElementConstructor) {
-    if (features.ENABLE_PROGRAMMATIC_STYLESHEETS) {
-        warnOnStylesheetsMutation(ctor);
-        const { stylesheets } = ctor;
-        if (!isUndefined(stylesheets)) {
-            const valid = validateComponentStylesheets(vm, stylesheets);
+    warnOnStylesheetsMutation(ctor);
+    const { stylesheets } = ctor;
+    if (!isUndefined(stylesheets)) {
+        const valid = validateComponentStylesheets(vm, stylesheets);
 
-            if (valid) {
-                return flattenStylesheets(stylesheets);
-            } else if (process.env.NODE_ENV !== 'production') {
-                logError(
-                    `static stylesheets must be an array of CSS stylesheets. Found invalid stylesheets on <${vm.tagName}>`,
-                    vm
-                );
-            }
+        if (valid) {
+            return flattenStylesheets(stylesheets);
+        } else if (process.env.NODE_ENV !== 'production') {
+            logError(
+                `static stylesheets must be an array of CSS stylesheets. Found invalid stylesheets on <${vm.tagName}>`,
+                vm
+            );
         }
     }
     return null;

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -17,7 +17,6 @@ const features: FeatureFlagMap = {
     DISABLE_LIGHT_DOM_UNSCOPED_CSS: null,
     ENABLE_FROZEN_TEMPLATE: null,
     DISABLE_ARIA_REFLECTION_POLYFILL: null,
-    ENABLE_PROGRAMMATIC_STYLESHEETS: null,
 };
 
 if (!globalThis.lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -73,13 +73,6 @@ export interface FeatureFlagMap {
      * and HTMLBridgeElement base classes, not on every Element.
      */
     DISABLE_ARIA_REFLECTION_POLYFILL: FeatureFlagValue;
-
-    /**
-     * Flag to enable programmatic stylesheets, aka dynamic stylesheet injection, aka CSS extensibility. Allows
-     * for a `static stylesheets` property at the component level that injects stylesheets alongside the template
-     * stylsheets.
-     */
-    ENABLE_PROGRAMMATIC_STYLESHEETS: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import Basic from 'x/basic';
 import Direct from 'x/direct';
 import Scoped from 'x/scoped';
@@ -15,26 +15,6 @@ import MixedScopedAndUnscoped from 'x/mixedScopedAndUnscoped';
 import StylesheetsMutation from 'x/stylesheetsMutation';
 
 describe('programmatic stylesheets', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_PROGRAMMATIC_STYLESHEETS', true);
-    });
-
-    afterAll(() => {
-        setFeatureFlagForTest('ENABLE_PROGRAMMATIC_STYLESHEETS', false);
-    });
-
-    it('does not override styles if flag is not set', () => {
-        setFeatureFlagForTest('ENABLE_PROGRAMMATIC_STYLESHEETS', false);
-        const elm = createElement('x-basic', { is: Basic });
-        document.body.appendChild(elm);
-
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                'rgb(0, 0, 0)'
-            );
-        });
-    });
-
     it('works for a basic usage of static stylesheets', () => {
         const elm = createElement('x-basic', { is: Basic });
         document.body.appendChild(elm);


### PR DESCRIPTION
## Details
Remove feature flag for programmatic stylesheets.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
[W-12394260](https://gus.lightning.force.com/a07EE00001JYs7SYAT)