### PR TITLE
fix: warn on using if:true and if:false on same node

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1182
+ * Next error code: 1183
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -842,7 +842,7 @@ export const ParserDiagnostics = {
 
     SINGLE_IF_DIRECTIVE_ALLOWED: {
         code: 1182,
-        message: 'Only one If directive is allowed. The rest are ignored.',
+        message: `Multiple if: directives found on '{0}'. Only one if: directive is allowed; the rest are ignored.Only one If directive is allowed. The rest are ignored.`,
         level: DiagnosticLevel.Warning,
         url: '',
     },

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -839,4 +839,11 @@ export const ParserDiagnostics = {
         level: DiagnosticLevel.Error,
         url: '',
     },
+
+    SINGLE_IF_DIRECTIVE_ALLOWED: {
+        code: 1182,
+        message: 'Only one If directive is allowed. The rest are ignored.',
+        level: DiagnosticLevel.Warning,
+        url: '',
+    },
 };

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/actual.html
@@ -1,0 +1,3 @@
+<template>
+    <c-hello if:true={ifTrue} if:false={ifFalse}></c-hello>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/ast.json
@@ -1,0 +1,102 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 12,
+            "start": 0,
+            "end": 82,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 3,
+                "startColumn": 1,
+                "endLine": 3,
+                "endColumn": 12,
+                "start": 71,
+                "end": 82
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "If",
+                "modifier": "true",
+                "condition": {
+                    "type": "Identifier",
+                    "start": 1,
+                    "end": 7,
+                    "name": "ifTrue",
+                    "location": {
+                        "startLine": 2,
+                        "startColumn": 14,
+                        "endLine": 2,
+                        "endColumn": 30,
+                        "start": 24,
+                        "end": 40
+                    }
+                },
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 60,
+                    "start": 15,
+                    "end": 70
+                },
+                "directiveLocation": {
+                    "startLine": 2,
+                    "startColumn": 14,
+                    "endLine": 2,
+                    "endColumn": 30,
+                    "start": 24,
+                    "end": 40
+                },
+                "children": [
+                    {
+                        "type": "Component",
+                        "name": "c-hello",
+                        "namespace": "http://www.w3.org/1999/xhtml",
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 5,
+                            "endLine": 2,
+                            "endColumn": 60,
+                            "start": 15,
+                            "end": 70,
+                            "startTag": {
+                                "startLine": 2,
+                                "startColumn": 5,
+                                "endLine": 2,
+                                "endColumn": 50,
+                                "start": 15,
+                                "end": 60
+                            },
+                            "endTag": {
+                                "startLine": 2,
+                                "startColumn": 50,
+                                "endLine": 2,
+                                "endColumn": 60,
+                                "start": 60,
+                                "end": 70
+                            }
+                        },
+                        "attributes": [],
+                        "properties": [],
+                        "directives": [],
+                        "listeners": [],
+                        "children": []
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/expected.js
@@ -1,0 +1,12 @@
+import _cHello from "c/hello";
+import { registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { c: api_custom_element } = $api;
+  return [$cmp.ifTrue ? api_custom_element("c-hello", _cHello, stc0) : null];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1054,
+            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 15,
+                "length": 55
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
@@ -1,8 +1,8 @@
 {
     "warnings": [
         {
-            "code": 1054,
-            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "code": 1182,
+            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1182,
-            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
+            "message": "LWC1182: Multiple if: directives found on 'c-hello'. Only one if: directive is allowed; the rest are ignored.Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/actual.html
@@ -1,0 +1,3 @@
+<template>
+    <h1 if:true={ifTrue} if:false={ifFalse}></h1>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/ast.json
@@ -1,0 +1,102 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 12,
+            "start": 0,
+            "end": 72,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 3,
+                "startColumn": 1,
+                "endLine": 3,
+                "endColumn": 12,
+                "start": 61,
+                "end": 72
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "If",
+                "modifier": "true",
+                "condition": {
+                    "type": "Identifier",
+                    "start": 1,
+                    "end": 7,
+                    "name": "ifTrue",
+                    "location": {
+                        "startLine": 2,
+                        "startColumn": 9,
+                        "endLine": 2,
+                        "endColumn": 25,
+                        "start": 19,
+                        "end": 35
+                    }
+                },
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 50,
+                    "start": 15,
+                    "end": 60
+                },
+                "directiveLocation": {
+                    "startLine": 2,
+                    "startColumn": 9,
+                    "endLine": 2,
+                    "endColumn": 25,
+                    "start": 19,
+                    "end": 35
+                },
+                "children": [
+                    {
+                        "type": "Element",
+                        "name": "h1",
+                        "namespace": "http://www.w3.org/1999/xhtml",
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 5,
+                            "endLine": 2,
+                            "endColumn": 50,
+                            "start": 15,
+                            "end": 60,
+                            "startTag": {
+                                "startLine": 2,
+                                "startColumn": 5,
+                                "endLine": 2,
+                                "endColumn": 45,
+                                "start": 15,
+                                "end": 55
+                            },
+                            "endTag": {
+                                "startLine": 2,
+                                "startColumn": 45,
+                                "endLine": 2,
+                                "endColumn": 50,
+                                "start": 55,
+                                "end": 60
+                            }
+                        },
+                        "attributes": [],
+                        "properties": [],
+                        "directives": [],
+                        "listeners": [],
+                        "children": []
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/expected.js
@@ -1,0 +1,9 @@
+import { parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<h1${3}></h1>`;
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { st: api_static_fragment } = $api;
+  return [$cmp.ifTrue ? api_static_fragment($fragment1(), 1) : null];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1054,
+            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 15,
+                "length": 45
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1182,
-            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
+            "message": "LWC1182: Multiple if: directives found on 'h1'. Only one if: directive is allowed; the rest are ignored.Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/metadata.json
@@ -1,8 +1,8 @@
 {
     "warnings": [
         {
-            "code": 1054,
-            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "code": 1182,
+            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/actual.html
@@ -1,0 +1,5 @@
+<template>
+    <template if:true={ifTrue} if:false={ifFalse}>
+        <h1></h1>
+    </template>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/ast.json
@@ -1,0 +1,102 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 12,
+            "start": 0,
+            "end": 107,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 5,
+                "startColumn": 1,
+                "endLine": 5,
+                "endColumn": 12,
+                "start": 96,
+                "end": 107
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "If",
+                "modifier": "true",
+                "condition": {
+                    "type": "Identifier",
+                    "start": 1,
+                    "end": 7,
+                    "name": "ifTrue",
+                    "location": {
+                        "startLine": 2,
+                        "startColumn": 15,
+                        "endLine": 2,
+                        "endColumn": 31,
+                        "start": 25,
+                        "end": 41
+                    }
+                },
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 4,
+                    "endColumn": 16,
+                    "start": 15,
+                    "end": 95
+                },
+                "directiveLocation": {
+                    "startLine": 2,
+                    "startColumn": 15,
+                    "endLine": 2,
+                    "endColumn": 31,
+                    "start": 25,
+                    "end": 41
+                },
+                "children": [
+                    {
+                        "type": "Element",
+                        "name": "h1",
+                        "namespace": "http://www.w3.org/1999/xhtml",
+                        "location": {
+                            "startLine": 3,
+                            "startColumn": 9,
+                            "endLine": 3,
+                            "endColumn": 18,
+                            "start": 70,
+                            "end": 79,
+                            "startTag": {
+                                "startLine": 3,
+                                "startColumn": 9,
+                                "endLine": 3,
+                                "endColumn": 13,
+                                "start": 70,
+                                "end": 74
+                            },
+                            "endTag": {
+                                "startLine": 3,
+                                "startColumn": 13,
+                                "endLine": 3,
+                                "endColumn": 18,
+                                "start": 74,
+                                "end": 79
+                            }
+                        },
+                        "attributes": [],
+                        "properties": [],
+                        "directives": [],
+                        "listeners": [],
+                        "children": []
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/expected.js
@@ -1,0 +1,9 @@
+import { parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<h1${3}></h1>`;
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { st: api_static_fragment } = $api;
+  return [$cmp.ifTrue ? api_static_fragment($fragment1(), 1) : null];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
@@ -1,8 +1,8 @@
 {
     "warnings": [
         {
-            "code": 1054,
-            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "code": 1182,
+            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
@@ -2,7 +2,7 @@
     "warnings": [
         {
             "code": 1182,
-            "message": "LWC1182: Only one If directive is allowed. The rest are ignored.",
+            "message": "LWC1182: Multiple if: directives found on 'template'. Only one if: directive is allowed; the rest are ignored.Only one If directive is allowed. The rest are ignored.",
             "level": 2,
             "location": {
                 "line": 2,

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1054,
+            "message": "LWC1054: Only one If directive is allowed. The rest are ignored.",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 15,
+                "length": 80
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -266,12 +266,24 @@ export class ParsedAttribute {
         }
     }
 
+    getAll(pattern: RegExp): Attribute[] {
+        return this.getKeys(pattern).map((key) => this.attributes.get(key)!);
+    }
+
     pick(pattern: string | RegExp): Attribute | undefined {
         const attr = this.get(pattern);
         if (attr) {
             this.attributes.delete(attr.name);
         }
         return attr;
+    }
+
+    pickAll(pattern: RegExp): Attribute[] {
+        const attrs = this.getAll(pattern);
+        for (const attr of attrs) {
+            this.attributes.delete(attr.name);
+        }
+        return attrs;
     }
 
     private getKey(pattern: string | RegExp): string | undefined {
@@ -282,6 +294,10 @@ export class ParsedAttribute {
             match = Array.from(this.attributes.keys()).find((name) => !!name.match(pattern));
         }
         return match;
+    }
+
+    private getKeys(pattern: RegExp): string[] {
+        return Array.from(this.attributes.keys()).filter((name) => !!name.match(pattern));
     }
 
     getAttributes(): Attribute[] {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -496,10 +496,20 @@ function parseIf(
     parent: ParentNode,
     parsedAttr: ParsedAttribute
 ): If | undefined {
-    const ifAttribute = parsedAttr.pick(IF_RE);
-    if (!ifAttribute) {
+    const ifAttributes = parsedAttr.pickAll(IF_RE);
+    if (ifAttributes.length === 0) {
         return;
     }
+
+    for (let i = 1; i < ifAttributes.length; i++) {
+        ctx.warnAtLocation(
+            ParserDiagnostics.SINGLE_IF_DIRECTIVE_ALLOWED,
+            ast.sourceLocation(parse5ElmLocation),
+            [ifAttributes[i].name]
+        );
+    }
+
+    const ifAttribute = ifAttributes[0];
 
     // if:true cannot be used with lwc:if, lwc:elseif, lwc:else
     const incompatibleDirective = ctx.findInCurrentElementScope(ast.isConditionalBlock);

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -491,7 +491,7 @@ function applyHandlers(ctx: ParserCtx, parsedAttr: ParsedAttribute, element: Bas
 
 function parseIf(
     ctx: ParserCtx,
-    _parse5Elm: parse5.Element,
+    parse5Elm: parse5.Element,
     parse5ElmLocation: parse5.ElementLocation,
     parent: ParentNode,
     parsedAttr: ParsedAttribute
@@ -505,7 +505,7 @@ function parseIf(
         ctx.warnAtLocation(
             ParserDiagnostics.SINGLE_IF_DIRECTIVE_ALLOWED,
             ast.sourceLocation(parse5ElmLocation),
-            [ifAttributes[i].name]
+            [parse5Elm.tagName]
         );
     }
 


### PR DESCRIPTION
## Details
Fixes https://github.com/salesforce/lwc/issues/3277.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
