### PR TITLE
fix(reporting): report string enums

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -7,11 +7,11 @@
 import { noop } from '@lwc/shared';
 
 export const enum ReportingEventId {
-    CrossRootAriaInSyntheticShadow = 0,
-    CompilerRuntimeVersionMismatch = 1,
-    NonStandardAriaReflection = 2,
-    TemplateMutation = 3,
-    StylesheetMutation = 4,
+    CrossRootAriaInSyntheticShadow = 'CrossRootAriaInSyntheticShadow',
+    CompilerRuntimeVersionMismatch = 'CompilerRuntimeVersionMismatch',
+    NonStandardAriaReflection = 'NonStandardAriaReflection',
+    TemplateMutation = 'TemplateMutation',
+    StylesheetMutation = 'StylesheetMutation',
 }
 
 export interface BasePayload {

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -515,15 +515,6 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaAttributes.push(ariaPropertiesMapping[ariaProperties[i]]);
     }
 
-    // Should be kept in sync with the enum ReportingEventId in reporting.ts
-    var ReportingEventId = {
-        CrossRootAriaInSyntheticShadow: 0,
-        CompilerRuntimeVersionMismatch: 1,
-        NonStandardAriaReflection: 2,
-        TemplateMutation: 3,
-        StylesheetMutation: 4,
-    };
-
     return {
         clearRegister: clearRegister,
         extractDataIds: extractDataIds,
@@ -541,6 +532,5 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaProperties: ariaProperties,
         ariaAttributes: ariaAttributes,
         nonStandardAriaProperties: nonStandardAriaProperties,
-        ReportingEventId: ReportingEventId,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
-import { ReportingEventId, nonStandardAriaProperties } from 'test-utils';
+import { nonStandardAriaProperties } from 'test-utils';
 import Light from 'x/light';
 import Shadow from 'x/shadow';
 
@@ -64,7 +64,7 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
                             expect(dispatcher).toHaveBeenCalledTimes(2);
                             expect(dispatcher.calls.allArgs()).toEqual([
                                 [
-                                    ReportingEventId.NonStandardAriaReflection,
+                                    'NonStandardAriaReflection',
                                     {
                                         tagName,
                                         propertyName: prop,
@@ -73,7 +73,7 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
                                     },
                                 ],
                                 [
-                                    ReportingEventId.NonStandardAriaReflection,
+                                    'NonStandardAriaReflection',
                                     {
                                         tagName,
                                         propertyName: prop,
@@ -96,7 +96,7 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
                             expect(dispatcher).toHaveBeenCalledTimes(2);
                             expect(dispatcher.calls.allArgs()).toEqual([
                                 [
-                                    ReportingEventId.NonStandardAriaReflection,
+                                    'NonStandardAriaReflection',
                                     {
                                         tagName: undefined,
                                         propertyName: prop,
@@ -105,7 +105,7 @@ if (!window.lwcRuntimeFlags.DISABLE_ARIA_REFLECTION_POLYFILL) {
                                     },
                                 ],
                                 [
-                                    ReportingEventId.NonStandardAriaReflection,
+                                    'NonStandardAriaReflection',
                                     {
                                         tagName: undefined,
                                         propertyName: prop,

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -1,5 +1,4 @@
 import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
-import { ReportingEventId } from 'test-utils';
 import AriaContainer from 'x/ariaContainer';
 import Valid from 'x/valid';
 
@@ -49,7 +48,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                     ...(usePropertyAccess
                         ? [
                               [
-                                  ReportingEventId.NonStandardAriaReflection,
+                                  'NonStandardAriaReflection',
                                   {
                                       tagName: 'x-aria-source',
                                       propertyName: 'ariaLabelledBy',
@@ -60,7 +59,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                           ]
                         : []),
                     [
-                        ReportingEventId.CrossRootAriaInSyntheticShadow,
+                        'CrossRootAriaInSyntheticShadow',
                         {
                             tagName: 'x-aria-source',
                             attributeName: 'aria-labelledby',
@@ -125,7 +124,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                         }).toLogWarningDev(expectedMessageForCrossRootWithTargetAsVM);
                         expect(dispatcher.calls.allArgs()).toEqual([
                             [
-                                ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                'CrossRootAriaInSyntheticShadow',
                                 {
                                     tagName: 'x-aria-target',
                                     attributeName: 'aria-labelledby',
@@ -148,7 +147,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                                 ...(usePropertyAccess
                                     ? [
                                           [
-                                              ReportingEventId.NonStandardAriaReflection,
+                                              'NonStandardAriaReflection',
                                               {
                                                   tagName: 'x-aria-source',
                                                   propertyName: 'ariaLabelledBy',
@@ -171,7 +170,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                             ...(usePropertyAccess
                                 ? [
                                       [
-                                          ReportingEventId.NonStandardAriaReflection,
+                                          'NonStandardAriaReflection',
                                           {
                                               tagName: 'x-aria-source',
                                               propertyName: 'ariaLabelledBy',
@@ -212,7 +211,7 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
                                 expect(dispatcher.calls.allArgs()).toEqual([
                                     ...getExpectedDispatcherCalls(true),
                                     [
-                                        ReportingEventId.CrossRootAriaInSyntheticShadow,
+                                        'CrossRootAriaInSyntheticShadow',
                                         {
                                             tagName: 'x-aria-source',
                                             attributeName: 'aria-labelledby',
@@ -241,14 +240,14 @@ if (!process.env.NATIVE_SHADOW && !process.env.COMPAT) {
             // dispatcher is still called twice
             expect(dispatcher.calls.allArgs()).toEqual([
                 [
-                    ReportingEventId.CrossRootAriaInSyntheticShadow,
+                    'CrossRootAriaInSyntheticShadow',
                     {
                         tagName: 'x-aria-source',
                         attributeName: 'aria-labelledby',
                     },
                 ],
                 [
-                    ReportingEventId.CrossRootAriaInSyntheticShadow,
+                    'CrossRootAriaInSyntheticShadow',
                     {
                         tagName: 'x-aria-source',
                         attributeName: 'aria-labelledby',

--- a/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
@@ -4,7 +4,6 @@ import {
     setFeatureFlagForTest,
     __unstable__ReportingControl as reportingControl,
 } from 'lwc';
-import { ReportingEventId } from 'test-utils';
 
 describe('freezeTemplate', () => {
     let dispatcher;
@@ -35,7 +34,7 @@ describe('freezeTemplate', () => {
 
         expect(template.stylesheetToken).toEqual('newToken');
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheetToken' }],
+            ['TemplateMutation', { propertyName: 'stylesheetToken' }],
         ]);
     });
 
@@ -65,7 +64,7 @@ describe('freezeTemplate', () => {
             shadowAttribute: 'newToken',
         });
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheetTokens' }],
+            ['TemplateMutation', { propertyName: 'stylesheetTokens' }],
         ]);
     });
 
@@ -90,7 +89,7 @@ describe('freezeTemplate', () => {
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(newStylesheet);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
+            ['TemplateMutation', { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -127,8 +126,8 @@ describe('freezeTemplate', () => {
         expect(template.stylesheets.length).toEqual(1);
         expect(template.stylesheets[0]).toBe(stylesheet);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
+            ['TemplateMutation', { propertyName: 'stylesheets' }],
+            ['TemplateMutation', { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -148,7 +147,7 @@ describe('freezeTemplate', () => {
             /Mutating the "stylesheets" property on a template is deprecated and will be removed in a future version of LWC/
         );
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'stylesheets' }],
+            ['TemplateMutation', { propertyName: 'stylesheets' }],
         ]);
     });
 
@@ -169,7 +168,7 @@ describe('freezeTemplate', () => {
 
         expect(template.slots).toBe(newSlots);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'slots' }],
+            ['TemplateMutation', { propertyName: 'slots' }],
         ]);
     });
 
@@ -188,7 +187,7 @@ describe('freezeTemplate', () => {
 
         expect(template.renderMode).toBe(undefined);
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.TemplateMutation, { propertyName: 'renderMode' }],
+            ['TemplateMutation', { propertyName: 'renderMode' }],
         ]);
     });
 
@@ -205,7 +204,7 @@ describe('freezeTemplate', () => {
             /Mutating the "\$scoped\$" property on a stylesheet is deprecated and will be removed in a future version of LWC\./
         );
         expect(dispatcher.calls.allArgs()).toEqual([
-            [ReportingEventId.StylesheetMutation, { propertyName: '$scoped$' }],
+            ['StylesheetMutation', { propertyName: '$scoped$' }],
         ]);
     });
 

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -1,4 +1,4 @@
-import { ariaPropertiesMapping, nonStandardAriaProperties, ReportingEventId } from 'test-utils';
+import { ariaPropertiesMapping, nonStandardAriaProperties } from 'test-utils';
 import { __unstable__ReportingControl as reportingControl } from 'lwc';
 
 function testAriaProperty(property, attribute) {
@@ -29,7 +29,7 @@ function testAriaProperty(property, attribute) {
             if (nonStandardAriaProperties.includes(property)) {
                 expect(dispatcher.calls.allArgs()).toEqual([
                     [
-                        ReportingEventId.NonStandardAriaReflection,
+                        'NonStandardAriaReflection',
                         {
                             tagName: undefined,
                             propertyName: property,
@@ -47,7 +47,7 @@ function testAriaProperty(property, attribute) {
             if (nonStandardAriaProperties.includes(property)) {
                 expect(dispatcher.calls.allArgs()).toEqual([
                     [
-                        ReportingEventId.NonStandardAriaReflection,
+                        'NonStandardAriaReflection',
                         {
                             tagName: undefined,
                             propertyName: property,

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -5,7 +5,6 @@ import {
     registerComponent,
     __unstable__ReportingControl as reportingControl,
 } from 'lwc';
-import { ReportingEventId } from 'test-utils';
 import Component from 'x/component';
 import ComponentWithProp from 'x/componentWithProp';
 import ComponentWithTemplateAndStylesheet from 'x/componentWithTemplateAndStylesheet';
@@ -77,7 +76,7 @@ if (!process.env.COMPAT) {
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
                         [
-                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            'CompilerRuntimeVersionMismatch',
                             {
                                 runtimeVersion: process.env.LWC_VERSION,
                                 compilerVersion: '123.456.789',
@@ -116,7 +115,7 @@ if (!process.env.COMPAT) {
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
                         [
-                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            'CompilerRuntimeVersionMismatch',
                             {
                                 runtimeVersion: process.env.LWC_VERSION,
                                 compilerVersion: '123.456.789',
@@ -154,7 +153,7 @@ if (!process.env.COMPAT) {
                 } else {
                     expect(dispatcher.calls.allArgs()).toEqual([
                         [
-                            ReportingEventId.CompilerRuntimeVersionMismatch,
+                            'CompilerRuntimeVersionMismatch',
                             {
                                 runtimeVersion: process.env.LWC_VERSION,
                                 compilerVersion: '123.456.789',


### PR DESCRIPTION
## Details

As discussed, we're switching from int enums to string enums for the reporting API.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

This is an unstable API used only by us; we can do what we want.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12505852
