### PR TITLE
fix(hydration): properly handle nullish attribute values

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -379,6 +379,26 @@ function isMatchingElement(vnode: VBaseElement, elm: Element, renderer: Renderer
     return hasIncompatibleAttrs && hasIncompatibleClass && hasIncompatibleStyle;
 }
 
+function attributeValuesAreEqual(
+    vnodeValue: string | number | boolean | undefined,
+    value: string | null
+) {
+    const vnodeValueAsString = String(vnodeValue);
+
+    if (vnodeValueAsString === value) {
+        return true;
+    }
+
+    // If the expected value is null, this means that the attribute does not exist. In that case,
+    // we accept any nullish value (undefined or null).
+    if (isNull(value) && (isUndefined(vnodeValue) || isNull(vnodeValue))) {
+        return true;
+    }
+
+    // In all other cases, the two values are not considered equal
+    return false;
+}
+
 function validateAttrs(vnode: VBaseElement, elm: Element, renderer: RendererAPI): boolean {
     const {
         data: { attrs = {} },
@@ -392,14 +412,16 @@ function validateAttrs(vnode: VBaseElement, elm: Element, renderer: RendererAPI)
         const { owner } = vnode;
         const { getAttribute } = renderer;
         const elmAttrValue = getAttribute(elm, attrName);
-        if (String(attrValue) !== elmAttrValue) {
+        if (!attributeValuesAreEqual(attrValue, elmAttrValue)) {
             if (process.env.NODE_ENV !== 'production') {
                 const { getProperty } = renderer;
                 logError(
                     `Mismatch hydrating element <${getProperty(
                         elm,
                         'tagName'
-                    ).toLowerCase()}>: attribute "${attrName}" has different values, expected "${attrValue}" but found "${elmAttrValue}"`,
+                    ).toLowerCase()}>: attribute "${attrName}" has different values, expected "${attrValue}" but found ${
+                        isNull(elmAttrValue) ? 'null' : `"${elmAttrValue}"`
+                    }`,
                     owner
                 );
             }

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -380,7 +380,7 @@ function isMatchingElement(vnode: VBaseElement, elm: Element, renderer: Renderer
 }
 
 function attributeValuesAreEqual(
-    vnodeValue: string | number | boolean | undefined,
+    vnodeValue: string | number | boolean | null | undefined,
     value: string | null
 ) {
     const vnodeValueAsString = String(vnodeValue);

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -104,7 +104,7 @@ export interface VNodeData {
     // All props are readonly because VElementData may be shared across VNodes
     // due to hoisting optimizations
     readonly props?: Readonly<Record<string, any>>;
-    readonly attrs?: Readonly<Record<string, string | number | boolean>>;
+    readonly attrs?: Readonly<Record<string, string | number | boolean | undefined>>;
     readonly className?: string;
     readonly style?: string;
     readonly classMap?: Readonly<Record<string, boolean>>;

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -104,7 +104,7 @@ export interface VNodeData {
     // All props are readonly because VElementData may be shared across VNodes
     // due to hoisting optimizations
     readonly props?: Readonly<Record<string, any>>;
-    readonly attrs?: Readonly<Record<string, string | number | boolean | undefined>>;
+    readonly attrs?: Readonly<Record<string, string | number | boolean | null | undefined>>;
     readonly className?: string;
     readonly style?: string;
     readonly classMap?: Readonly<Record<string, boolean>>;

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/index.spec.js
@@ -1,0 +1,41 @@
+export default {
+    props: {
+        isFalse: false,
+        isUndefined: undefined,
+        isNull: null,
+        isTrue: true,
+        isEmptyString: '',
+        isZero: 0,
+        isNaN: NaN,
+    },
+    clientProps: {
+        isFalse: 'false',
+        isUndefined: 'undefined', // mismatch. should be literally `null`, not the string `"undefined"`
+        isNull: 'null', // mismatch. should be literally `null`, not the string `"null"`
+        isTrue: 'true',
+        isEmptyString: '',
+        isZero: '0',
+        isNaN: 'NaN',
+    },
+    test(target, snapshots, consoleCalls) {
+        const divs = target.shadowRoot.querySelectorAll('div');
+
+        const expectedAttrValues = ['false', 'undefined', 'null', 'true', '', '0', 'NaN'];
+
+        expect(divs).toHaveSize(expectedAttrValues.length);
+
+        for (let i = 0; i < expectedAttrValues.length; i++) {
+            expect(divs[i].getAttribute('data-foo')).toEqual(expectedAttrValues[i]);
+        }
+
+        expect(consoleCalls.warn).toHaveSize(0);
+        expect(consoleCalls.error).toHaveSize(3);
+        expect(consoleCalls.error[0][0].message).toContain(
+            'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "undefined" but found null'
+        );
+        expect(consoleCalls.error[1][0].message).toContain(
+            'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "null" but found null'
+        );
+        expect(consoleCalls.error[2][0].message).toContain('Hydration completed with errors.');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/x/main/main.html
@@ -1,0 +1,9 @@
+<template>
+    <div data-foo={isFalse}></div>
+    <div data-foo={isUndefined}></div>
+    <div data-foo={isNull}></div>
+    <div data-foo={isTrue}></div>
+    <div data-foo={isEmptyString}></div>
+    <div data-foo={isZero}></div>
+    <div data-foo={isNaN}></div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/x/main/main.js
@@ -1,0 +1,11 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Main extends LightningElement {
+    @api isFalse;
+    @api isUndefined;
+    @api isNull;
+    @api isTrue;
+    @api isEmptyString;
+    @api isZero;
+    @api isNaN;
+}

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy/index.spec.js
@@ -1,7 +1,5 @@
 export default {
-    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
-        hydrateComponent(target, Component, {});
-
+    test(target, snapshots, consoleCalls) {
         const divs = target.shadowRoot.querySelectorAll('div');
 
         const expectedAttrValues = ['false', null, null, 'true', '', '0', 'NaN'];
@@ -12,7 +10,6 @@ export default {
             expect(divs[i].getAttribute('data-foo')).toEqual(expectedAttrValues[i]);
         }
 
-        const consoleCalls = consoleSpy.calls;
         expect(consoleCalls.warn).toHaveSize(0);
         expect(consoleCalls.error).toHaveSize(0);
     },

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy/index.spec.js
@@ -1,0 +1,19 @@
+export default {
+    advancedTest(target, { Component, hydrateComponent, consoleSpy }) {
+        hydrateComponent(target, Component, {});
+
+        const divs = target.shadowRoot.querySelectorAll('div');
+
+        const expectedAttrValues = ['false', null, null, 'true', '', '0', 'NaN'];
+
+        expect(divs).toHaveSize(expectedAttrValues.length);
+
+        for (let i = 0; i < expectedAttrValues.length; i++) {
+            expect(divs[i].getAttribute('data-foo')).toEqual(expectedAttrValues[i]);
+        }
+
+        const consoleCalls = consoleSpy.calls;
+        expect(consoleCalls.warn).toHaveSize(0);
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy/x/main/main.html
@@ -1,0 +1,9 @@
+<template>
+    <div data-foo={isFalse}></div>
+    <div data-foo={isUndefined}></div>
+    <div data-foo={isNull}></div>
+    <div data-foo={isTrue}></div>
+    <div data-foo={isEmptyString}></div>
+    <div data-foo={isZero}></div>
+    <div data-foo={isNaN}></div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy/x/main/main.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    isFalse = false;
+    isUndefined = undefined;
+    isNull = null;
+    isTrue = true;
+    isEmptyString = '';
+    isZero = 0;
+    isNaN = NaN;
+}


### PR DESCRIPTION
## Details

The attribute values `undefined` and `null` (i.e. nullish values) are special cases. When used on the server side, they become `null` on the client side (i.e. the attribute does not exist).

This fixes it so that we don't have hydration mismatches in this special case. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12477772