### PR TITLE
feat: forward `ownerDocument` in `LightningElement`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -169,6 +169,7 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
         | 'lang'
         | 'lastChild'
         | 'lastElementChild'
+        | 'ownerDocument'
         | 'querySelector'
         | 'querySelectorAll'
         | 'removeAttribute'
@@ -636,6 +637,15 @@ LightningElement.prototype = {
             warnIfInvokedDuringConstruction(vm, 'lastElementChild');
         }
         return renderer.getLastElementChild(vm.elm);
+    },
+
+    get ownerDocument() {
+        const vm = getAssociatedVM(this);
+        const renderer = vm.renderer;
+        if (process.env.NODE_ENV !== 'production') {
+            warnIfInvokedDuringConstruction(vm, 'ownerDocument');
+        }
+        return renderer.ownerDocument(vm.elm);
     },
 
     render(): Template {

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -65,4 +65,6 @@ export interface RendererAPI {
         connectedCallback?: LifecycleCallback,
         disconnectedCallback?: LifecycleCallback
     ) => E;
+
+    ownerDocument(elm: E): Document;
 }

--- a/packages/@lwc/engine-dom/src/renderer/index.ts
+++ b/packages/@lwc/engine-dom/src/renderer/index.ts
@@ -241,6 +241,10 @@ function assertInstanceOfHTMLElement(elm: any, msg: string) {
     assert.invariant(elm instanceof HTMLElement, msg);
 }
 
+function ownerDocument(element: Element): Document {
+    return element.ownerDocument;
+}
+
 export {
     insert,
     remove,
@@ -275,4 +279,5 @@ export {
     getLastElementChild,
     isConnected,
     assertInstanceOfHTMLElement,
+    ownerDocument,
 };

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -408,6 +408,8 @@ function createCustomElement(tagName: string, upgradeCallback: LifecycleCallback
     return new (UpgradableConstructor as any)(upgradeCallback);
 }
 
+const ownerDocument = unsupportedMethod('ownerDocument') as (element: HostElement) => Document;
+
 export const renderer = {
     isNativeShadowDefined,
     isSyntheticShadowDefined,
@@ -446,4 +448,5 @@ export const renderer = {
     isConnected,
     insertStylesheet,
     assertInstanceOfHTMLElement,
+    ownerDocument,
 };

--- a/packages/@lwc/integration-karma/test/component/owner-document/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/owner-document/index.spec.js
@@ -1,0 +1,11 @@
+import { createElement } from 'lwc';
+
+import ShadowDom from 'x/shadow-dom';
+
+describe('ownerDocument', () => {
+    it('should return ownerDocument in shadow DOM components', () => {
+        const elm = createElement('x-shadow', { is: ShadowDom });
+        document.body.appendChild(elm);
+        expect(elm.getOwnerDocument()).toEqual(document);
+    });
+});

--- a/packages/@lwc/integration-karma/test/component/owner-document/x/shadow-dom/shadow-dom.html
+++ b/packages/@lwc/integration-karma/test/component/owner-document/x/shadow-dom/shadow-dom.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/@lwc/integration-karma/test/component/owner-document/x/shadow-dom/shadow-dom.js
+++ b/packages/@lwc/integration-karma/test/component/owner-document/x/shadow-dom/shadow-dom.js
@@ -1,0 +1,8 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    getOwnerDocument() {
+        return this.ownerDocument;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/properties/index.spec.js
@@ -28,6 +28,7 @@ const expectedEnumerableProps = [
     'lang',
     'lastChild',
     'lastElementChild',
+    'ownerDocument',
     'querySelector',
     'querySelectorAll',
     'refs',


### PR DESCRIPTION
## Details
`this.ownerDocument` in `LightningElement` didn't return the ownerDocument because it was not forwarded to the underlying host element. We fix that in this PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
