### PR TITLE
feat(versioning): remove registerDecorators for non-LightningElement classes

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/actual.js
@@ -1,0 +1,6 @@
+import { api } from "lwc";
+
+export default class {
+  @api
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-api-decorator-v59/expected.js
@@ -1,0 +1,11 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent } from "lwc";
+export default _registerComponent(class {
+  @api
+  foo;
+}, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});
+;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/actual.js
@@ -1,0 +1,6 @@
+import { track } from "lwc";
+
+export default class {
+  @track
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-track-decorator-v59/expected.js
@@ -1,0 +1,11 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent } from "lwc";
+export default _registerComponent(class {
+  @track
+  foo;
+}, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});
+;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/actual.js
@@ -1,0 +1,6 @@
+import {createElement, wire} from "lwc";
+
+export default class {
+  @wire(createElement) wiredProp;
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-for-non-lightning-element-class-with-wire-decorator-v59/expected.js
@@ -1,0 +1,12 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent, createElement } from "lwc";
+export default _registerComponent(class {
+  @wire(createElement)
+  wiredProp;
+  foo;
+}, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});
+;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/actual.js
@@ -1,0 +1,4 @@
+const foo = class {
+  foo;
+};
+export default foo;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-anonymous-class-has-no-superclass-v59/expected.js
@@ -1,0 +1,10 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent } from "lwc";
+const foo = class {
+  foo;
+};
+export default _registerComponent(foo, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/actual.js
@@ -1,0 +1,3 @@
+export default class MyClazz {
+  foo;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-not-register-decorators-if-named-class-has-no-superclass-v59/expected.js
@@ -1,0 +1,10 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent } from "lwc";
+class MyClazz {
+  foo;
+}
+export default _registerComponent(MyClazz, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/actual.js
@@ -1,0 +1,8 @@
+import { api } from "lwc";
+import MyCoolMixin from './mixin.js'
+
+const foo = class extends MyCoolMixin {
+  @api
+  foo;
+};
+export default foo;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-anonymous-class-that-extends-non-lightning-element-v59/expected.js
@@ -1,0 +1,18 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent, registerDecorators as _registerDecorators } from "lwc";
+import MyCoolMixin from './mixin.js';
+const foo = _registerDecorators(class extends MyCoolMixin {
+  foo;
+  /*LWC compiler vX.X.X*/
+}, {
+  publicProps: {
+    foo: {
+      config: 0
+    }
+  }
+});
+export default _registerComponent(foo, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/actual.js
@@ -1,0 +1,7 @@
+import { api } from "lwc";
+import MyCoolMixin from './mixin.js'
+
+export default class MyElement extends MyCoolMixin {
+  @api
+  foo;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 59
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-named-class-that-extends-non-lightning-element-v59/expected.js
@@ -1,0 +1,19 @@
+import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+import _tmpl from "./test.html";
+import MyCoolMixin from './mixin.js';
+class MyElement extends MyCoolMixin {
+  foo;
+  /*LWC compiler vX.X.X*/
+}
+_registerDecorators(MyElement, {
+  publicProps: {
+    foo: {
+      config: 0
+    }
+  }
+});
+export default _registerComponent(MyElement, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 59
+});

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/actual.js
@@ -1,0 +1,6 @@
+import { api } from "lwc";
+
+export default class {
+  @api
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 58
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-api-decorator-v58/expected.js
@@ -1,0 +1,16 @@
+import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+import _tmpl from "./test.html";
+export default _registerComponent(_registerDecorators(class {
+  foo;
+}, {
+  publicProps: {
+    foo: {
+      config: 0
+    }
+  }
+}), {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 58
+});
+;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/actual.js
@@ -1,0 +1,6 @@
+import { track } from "lwc";
+
+export default class {
+  @track
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 58
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-track-decorator-v58/expected.js
@@ -1,0 +1,14 @@
+import { registerDecorators as _registerDecorators, registerComponent as _registerComponent } from "lwc";
+import _tmpl from "./test.html";
+export default _registerComponent(_registerDecorators(class {
+  foo;
+}, {
+  track: {
+    foo: 1
+  }
+}), {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 58
+});
+;

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/actual.js
@@ -1,0 +1,6 @@
+import {createElement, wire} from "lwc";
+
+export default class {
+  @wire(createElement) wiredProp;
+  foo;
+};

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 58
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-register-decorators-for-non-lightning-element-class-with-wire-decorator-v58/expected.js
@@ -1,0 +1,21 @@
+import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, createElement } from "lwc";
+import _tmpl from "./test.html";
+export default _registerComponent(_registerDecorators(class {
+  wiredProp;
+  foo;
+}, {
+  wire: {
+    wiredProp: {
+      adapter: createElement,
+      config: function ($cmp) {
+        return {};
+      }
+    }
+  },
+  fields: ["foo"]
+}), {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  v: 58
+});
+;

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -62,7 +62,16 @@ export default function scriptTransform(
             ],
         })!;
     } catch (e) {
-        throw normalizeToCompilerError(TransformerErrors.JS_TRANSFORMER_ERROR, e, { filename });
+        let transformerError = TransformerErrors.JS_TRANSFORMER_ERROR;
+
+        // Sniff for a Babel decorator error, so we can provide a more helpful error message.
+        if (
+            (e as any).code === 'BABEL_TRANSFORM_ERROR' &&
+            (e as any).message?.includes('Decorators are not enabled.')
+        ) {
+            transformerError = TransformerErrors.JS_TRANSFORMER_DECORATOR_ERROR;
+        }
+        throw normalizeToCompilerError(transformerError, e, { filename });
     }
 
     return {

--- a/packages/@lwc/errors/src/compiler/error-info/compiler.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/compiler.ts
@@ -214,4 +214,12 @@ export const TransformerErrors = {
         level: DiagnosticLevel.Error,
         url: '',
     },
+
+    JS_TRANSFORMER_DECORATOR_ERROR: {
+        code: 1198,
+        message:
+            'Decorators like @api, @track, and @wire are only supported in LightningElement classes. {0}',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
 };

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1198
+ * Next error code: 1199
  */
 
 export * from './compiler';

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -59,6 +59,11 @@ export const enum APIFeature {
      * rather than synthetic events.
      */
     ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
+    /**
+     * If enabled, we do not emit unnecessary decorators for classes that cannot possibly be LightningElement
+     * classes
+     */
+    AVOID_DECORATORS_FOR_NON_LIGHTNING_ELEMENT_CLASSES,
 }
 
 export function isAPIFeatureEnabled(apiVersionFeature: APIFeature, apiVersion: APIVersion) {
@@ -66,6 +71,7 @@ export function isAPIFeatureEnabled(apiVersionFeature: APIFeature, apiVersion: A
         case APIFeature.DUMMY_FEATURE:
         case APIFeature.TREAT_ALL_PARSE5_ERRORS_AS_ERRORS:
         case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
+        case APIFeature.AVOID_DECORATORS_FOR_NON_LIGHTNING_ELEMENT_CLASSES:
             return apiVersion >= APIVersion.V59_246_WINTER_24;
     }
 }


### PR DESCRIPTION
## Details

Fixes #2701

This is a 4-part PR.

Part 1: basic scaffolding for versioning (https://github.com/salesforce/lwc/pull/3350)
Part 2: using it in the template compiler (https://github.com/salesforce/lwc/pull/3351)
Part 3: using it in the runtime (#3352)
Part 4: using it in the Babel plugin (this PR)

This PR demonstrates how we can use API versioning in `@babel/plugin-component`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12566318
