### PR TITLE
Jtu/dynamic components integration tests

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -38,6 +38,7 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
         plugins: [
             lwcRollupPlugin({
                 enableScopedSlots: true,
+                enableDynamicComponents: true,
                 modules: [
                     {
                         dir: modulesDir,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/expected.html
@@ -1,0 +1,9 @@
+<x-dynamic-component>
+  <template shadowroot="open">
+    <x-test>
+      <template shadowroot="open">
+        Test dynamic component!
+      </template>
+    </x-test>
+  </template>
+</x-dynamic-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-dynamic-component';
+export { default } from 'x/dynamic';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/dynamic/dynamic.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/dynamic/dynamic.html
@@ -1,0 +1,3 @@
+<template>
+    <lwc:component lwc:is={customCtor}></lwc:component>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/dynamic/dynamic.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/dynamic/dynamic.js
@@ -1,0 +1,6 @@
+import { LightningElement, track } from 'lwc';
+import Test from 'x/test';
+
+export default class DynamicCtor extends LightningElement {
+    @track customCtor = Test;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/test/test.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/test/test.html
@@ -1,0 +1,3 @@
+<template>
+    Test dynamic component!
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/test/test.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-components/modules/x/test/test.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {
+
+}

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -58,6 +58,7 @@ async function getCompiledModule(dirName) {
                     loader: 'test-utils',
                     strict: true,
                 },
+                enableDynamicComponents: true,
             }),
         ],
         cache,

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -50,6 +50,7 @@ function createPreprocessor(config, emitter, logger) {
                 },
                 enableLwcSpread: true,
                 enableScopedSlots: true,
+                enableDynamicComponents: true,
                 disableSyntheticShadowSupport: DISABLE_SYNTHETIC_SHADOW_SUPPORT_IN_COMPILER,
             }),
         ];

--- a/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/index.spec.js
@@ -1,0 +1,22 @@
+export default {
+    props: {
+        label: 'dynamic',
+    },
+    snapshot(target) {
+        const cmp = target.shadowRoot.querySelector('x-child');
+        const p = cmp.shadowRoot.querySelector('p');
+
+        return {
+            cmp,
+            p,
+        };
+    },
+    test(target, snapshots) {
+        const cmp = target.shadowRoot.querySelector('x-child');
+        const p = cmp.shadowRoot.querySelector('p');
+
+        expect(cmp).toBe(snapshots.cmp);
+        expect(p).toBe(snapshots.p);
+        expect(p.textContent).toBe('dynamic');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <p>{label}</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Child extends LightningElement {
+    @api label;
+}

--- a/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <lwc:component lwc:is={Ctor} label={label}></lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/directives/lwc-is/x/main/main.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+import Child from 'x/child';
+
+export default class Main extends LightningElement {
+    @api label;
+    Ctor = Child;
+}

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/index.spec.js
@@ -1,0 +1,22 @@
+export default {
+    props: {
+        label: 'dynamic',
+    },
+    snapshot(target) {
+        const cmp = target.querySelector('x-child');
+        const p = cmp.querySelector('p');
+
+        return {
+            cmp,
+            p,
+        };
+    },
+    test(target, snapshots) {
+        const cmp = target.querySelector('x-child');
+        const p = cmp.querySelector('p');
+
+        expect(cmp).toBe(snapshots.cmp);
+        expect(p).toBe(snapshots.p);
+        expect(p.textContent).toBe('dynamic');
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/child/child.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <p>{label}</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/child/child.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Child extends LightningElement {
+    static renderMode = 'light';
+
+    @api label;
+}

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/main/main.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <lwc:component lwc:is={Ctor} label={label}></lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/directives/lwc-is/x/main/main.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+import Child from 'x/child';
+
+export default class Main extends LightningElement {
+    static renderMode = 'light';
+
+    @api label;
+    Ctor = Child;
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/index.spec.js
@@ -1,0 +1,267 @@
+import { createElement } from 'lwc';
+import Attributes from 'x/attributes';
+import Basic from 'x/basic';
+import Slotter from 'x/slotter';
+import List from 'x/list';
+import Nested from 'x/nested';
+import ScopedSlotParent from 'x/scopedSlotParent';
+import ForwardedScopedSlotParent from 'x/forwardedScopedSlotParent';
+import Conditional from 'x/conditional';
+
+describe('dynamic components', () => {
+    it('basic dynamic component', () => {
+        const elm = createElement('x-basic', { is: Basic });
+        document.body.appendChild(elm);
+
+        return Promise.resolve()
+            .then(() => {
+                // Constructor not set
+                const children = elm.shadowRoot.children;
+                expect(children.length).toBe(0);
+                elm.loadFoo();
+            })
+            .then(() => {
+                // Set constructor to foo
+                const children = elm.shadowRoot.children;
+                expect(children.length).toBe(1);
+                expect(children[0].tagName.toLowerCase()).toBe('x-foo');
+                elm.loadBar();
+            })
+            .then(() => {
+                // Change constructor to bar
+                const children = elm.shadowRoot.children;
+                expect(children.length).toBe(1);
+                expect(children[0].tagName.toLowerCase()).toBe('x-bar');
+                elm.clearCtor();
+            })
+            .then(() => {
+                // Change constructor to null
+                const children = elm.shadowRoot.children;
+                expect(children.length).toBe(0);
+            });
+    });
+
+    it('attributes assigned to dynamic components', () => {
+        const elm = createElement('x-attributes', { is: Attributes });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            const foo = elm.shadowRoot.querySelector('x-foo');
+            const bar = elm.shadowRoot.querySelector('x-bar');
+
+            expect(foo).not.toBeNull();
+            expect(bar).not.toBeNull();
+
+            spyOn(console, 'log');
+
+            // declaratively assigned
+            expect(foo.className).toContain('slds-snazzy');
+            foo.click();
+            // eslint-disable-next-line no-console
+            expect(console.log).toHaveBeenCalledWith('template click called');
+
+            // imperatively assigned
+            expect(bar.className).toContain('slds-more-snazzy');
+            bar.click();
+            // eslint-disable-next-line no-console
+            expect(console.log).toHaveBeenCalledWith('refs click called');
+        });
+    });
+
+    describe('dynamic list', () => {
+        let container;
+
+        beforeEach(() => {
+            container = createElement('x-list', { is: List });
+            document.body.appendChild(container);
+            // Wait for microtask queue
+            return Promise.resolve();
+        });
+
+        const verifyListContent = (expectedChildren) => {
+            const actualChildren = container.shadowRoot.children;
+            expect(actualChildren.length).toBe(expectedChildren.length);
+
+            for (let i = 0; i < expectedChildren.length; i++) {
+                expect(actualChildren[i].tagName.toLowerCase()).toBe(expectedChildren[i]);
+            }
+        };
+
+        it('renders the components in the correct order', () => {
+            // Original order at creation time
+            verifyListContent(['x-foo', 'x-bar', 'x-baz', 'x-fred']);
+        });
+
+        it('maintains correct order when constructor assigned to each item in the list changes', () => {
+            container.swapConstructors();
+            return Promise.resolve().then(() => {
+                // New order after each item changes constructor
+                verifyListContent(['x-baz', 'x-fred', 'x-foo', 'x-bar']);
+            });
+        });
+
+        it('renders components in correct order when constructors are removed', () => {
+            container.removeConstructors();
+            return Promise.resolve().then(() => {
+                // Set 2 of the constructors to null
+                verifyListContent(['x-bar', 'x-fred']);
+            });
+        });
+    });
+
+    describe('slots', () => {
+        let container;
+
+        beforeEach(() => {
+            container = createElement('x-slotter', { is: Slotter });
+            document.body.appendChild(container);
+            // Wait for microtask queue
+            return Promise.resolve();
+        });
+
+        it('properly renders default slot', () => {
+            const dynamicElm = container.shadowRoot.querySelector('x-slottable');
+            expect(dynamicElm).not.toBeNull();
+
+            const slot = dynamicElm.shadowRoot.querySelector('slot');
+            const assignedElements = slot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('default');
+        });
+
+        it('properly renders named slot', () => {
+            const dynamicElm = container.shadowRoot.querySelector('x-slottable');
+            expect(dynamicElm).not.toBeNull();
+
+            const slot = dynamicElm.shadowRoot.querySelector("slot[name='slot1']");
+            const assignedElements = slot.assignedElements();
+            expect(assignedElements.length).toBe(1);
+            expect(assignedElements[0].getAttribute('data-slot-id')).toBe('slot1');
+        });
+    });
+
+    describe('nested dynamic components', () => {
+        let container;
+
+        beforeEach(() => {
+            container = createElement('x-nested-slotter', { is: Nested });
+            document.body.appendChild(container);
+        });
+
+        it('renders parent dynamic component without children', () => {
+            container.loadParent();
+            return Promise.resolve().then(() => {
+                const parent = container.shadowRoot.querySelector('x-slottable');
+                expect(parent).not.toBeNull();
+
+                const child = container.shadowRoot.querySelector('x-foo');
+                expect(child).toBeNull();
+            });
+        });
+
+        it('renders parent and child dynamic elements properly', () => {
+            container.loadParent();
+            container.loadChild();
+            return Promise.resolve().then(() => {
+                const parent = container.shadowRoot.querySelector('x-slottable');
+                expect(parent).not.toBeNull();
+
+                const child = container.shadowRoot.querySelector('x-foo');
+                expect(child).not.toBeNull();
+            });
+        });
+
+        it('does not render children when parent does not have constructor', () => {
+            container.loadChild();
+            return Promise.resolve().then(() => {
+                const parent = container.shadowRoot.querySelector('x-slottable');
+                expect(parent).toBeNull();
+
+                const child = container.shadowRoot.querySelector('x-foo');
+                expect(child).toBeNull();
+            });
+        });
+    });
+
+    describe('scoped slots', () => {
+        it('properly renders dynamic components when constructor is passed from slot child to parent', () => {
+            const elm = createElement('x-scoped-slot-parent', { is: ScopedSlotParent });
+            document.body.appendChild(elm);
+            return Promise.resolve().then(() => {
+                const childSlot = elm.shadowRoot.querySelector('x-scoped-slot-child');
+                expect(childSlot).not.toBeNull();
+
+                const slottedContent = childSlot.children;
+                expect(slottedContent.length).toBe(3);
+                expect(slottedContent[0].tagName.toLowerCase()).toBe('x-foo');
+                expect(slottedContent[1].tagName.toLowerCase()).toBe('x-bar');
+                expect(slottedContent[2].tagName.toLowerCase()).toBe('x-fred');
+            });
+        });
+
+        it('properly renders slotted content inside a dynamically created scoped slot child', () => {
+            const elm = createElement('x-forwarded-scoped-slot-parent', {
+                is: ForwardedScopedSlotParent,
+            });
+            document.body.appendChild(elm);
+            return Promise.resolve().then(() => {
+                const childSlot = elm.shadowRoot.querySelector('x-forwarded-scoped-slot-child');
+                expect(childSlot).not.toBeNull();
+
+                const slottedContent = childSlot.querySelector('x-baz');
+                expect(slottedContent).not.toBeNull();
+            });
+        });
+    });
+
+    describe('conditional rendering', () => {
+        let container;
+
+        beforeEach(() => {
+            container = createElement('x-container', { is: Conditional });
+            document.body.appendChild(container);
+        });
+
+        it('properly renders inside lwc:if', () => {
+            expect(container.shadowRoot.children.length).toBe(0);
+            container.setIfCtor();
+            return Promise.resolve()
+                .then(() => {
+                    // Does not render until if condition is met
+                    expect(container.shadowRoot.children.length).toBe(0);
+                    container.showIf = true;
+                })
+                .then(() => {
+                    const children = container.shadowRoot.children;
+                    expect(children.length).toBe(1);
+                    expect(children[0].tagName.toLowerCase()).toBe('x-foo');
+                });
+        });
+
+        it('properly renders inside lwc:elseif', () => {
+            expect(container.shadowRoot.children.length).toBe(0);
+            container.setElseIfCtor();
+            return Promise.resolve()
+                .then(() => {
+                    // Does not render until elseif condition is met
+                    expect(container.shadowRoot.children.length).toBe(0);
+                    container.showElseIf = true;
+                })
+                .then(() => {
+                    const children = container.shadowRoot.children;
+                    expect(children.length).toBe(1);
+                    expect(children[0].tagName.toLowerCase()).toBe('x-bar');
+                });
+        });
+
+        it('properly renders inside lwc:else', () => {
+            expect(container.shadowRoot.children.length).toBe(0);
+            container.setElseCtor();
+            return Promise.resolve().then(() => {
+                const children = container.shadowRoot.children;
+                expect(children.length).toBe(1);
+                expect(children[0].tagName.toLowerCase()).toBe('x-baz');
+            });
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/attributes/attributes.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/attributes/attributes.html
@@ -1,0 +1,4 @@
+<template>
+    <lwc:component lwc:is={fooCtor} class="slds-snazzy" onclick={handleClick}></lwc:component>
+    <lwc:component lwc:is={barCtor} lwc:ref="barRef"></lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/attributes/attributes.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/attributes/attributes.js
@@ -1,0 +1,27 @@
+import { LightningElement, api } from 'lwc';
+import Bar from 'x/bar';
+import Foo from 'x/foo';
+
+export default class extends LightningElement {
+    fooCtor;
+    barCtor;
+
+    connectedCallback() {
+        this.fooCtor = Foo;
+        this.barCtor = Bar;
+    }
+
+    renderedCallback() {
+        if (this.refs.barRef) {
+            this.refs.barRef.classList.add('slds-more-snazzy');
+            // eslint-disable-next-line no-console
+            this.refs.barRef.addEventListener('click', () => console.log('refs click called'));
+        }
+    }
+
+    @api
+    handleClick() {
+        // eslint-disable-next-line no-console
+        console.log('template click called');
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/bar/bar.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/bar/bar.html
@@ -1,0 +1,3 @@
+<template>
+    I am Bar!
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/bar/bar.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/bar/bar.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/basic/basic.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/basic/basic.html
@@ -1,0 +1,3 @@
+<template>
+    <lwc:component lwc:is={ctor}></lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/basic/basic.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/basic/basic.js
@@ -1,0 +1,22 @@
+import { LightningElement, api } from 'lwc';
+import Foo from 'x/foo';
+import Bar from 'x/bar';
+
+export default class extends LightningElement {
+    ctor;
+
+    @api
+    loadFoo() {
+        this.ctor = Foo;
+    }
+
+    @api
+    loadBar() {
+        this.ctor = Bar;
+    }
+
+    @api
+    clearCtor() {
+        this.ctor = null;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/baz/baz.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/baz/baz.html
@@ -1,0 +1,3 @@
+<template>
+    <span>I am baz!</span>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/baz/baz.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/baz/baz.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/conditional/conditional.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/conditional/conditional.html
@@ -1,0 +1,11 @@
+<template>
+    <template lwc:if={showIf}>
+        <lwc:component lwc:is={ifCtor}></lwc:component>
+    </template>
+    <template lwc:elseif={showElseIf}>
+        <lwc:component lwc:is={elseIfCtor}></lwc:component>
+    </template>
+    <template lwc:else>
+        <lwc:component lwc:is={elseCtor}></lwc:component>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/conditional/conditional.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/conditional/conditional.js
@@ -1,0 +1,31 @@
+import { api, LightningElement } from 'lwc';
+import Foo from 'x/foo';
+import Bar from 'x/bar';
+import Baz from 'x/baz';
+
+export default class extends LightningElement {
+    ifCtor;
+    elseIfCtor;
+    elseCtor;
+
+    @api
+    showIf = false;
+
+    @api
+    showElseIf = false;
+
+    @api
+    setIfCtor() {
+        this.ifCtor = Foo;
+    }
+
+    @api
+    setElseIfCtor() {
+        this.elseIfCtor = Bar;
+    }
+
+    @api
+    setElseCtor() {
+        this.elseCtor = Baz;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/foo/foo.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/foo/foo.html
@@ -1,0 +1,3 @@
+<template>
+    I am foo, hear me roar!
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/foo/foo.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/foo/foo.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotChild/forwardedScopedSlotChild.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotChild/forwardedScopedSlotChild.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <lwc:component lwc:is={slotWrapperCtor}>
+        <slot lwc:slot-bind={childSlotData}></slot>
+    </lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotChild/forwardedScopedSlotChild.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotChild/forwardedScopedSlotChild.js
@@ -1,0 +1,16 @@
+import { LightningElement } from 'lwc';
+import Baz from 'x/baz';
+import Slottable from 'x/slottable';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    // This is a component containing a regular slot
+    slotWrapperCtor;
+    // Constructor that will be passed to the parent
+    childSlotData;
+
+    connectedCallback() {
+        this.slotWrapperCtor = Slottable;
+        this.childSlotData = Baz;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotParent/forwardedScopedSlotParent.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotParent/forwardedScopedSlotParent.html
@@ -1,0 +1,7 @@
+<template>
+    <x-forwarded-scoped-slot-child>
+        <template lwc:slot-data="childSlotCtor">
+            <lwc:component lwc:is={childSlotCtor}></lwc:component>
+        </template>
+    </x-forwarded-scoped-slot-child>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotParent/forwardedScopedSlotParent.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/forwardedScopedSlotParent/forwardedScopedSlotParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/fred/fred.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/fred/fred.html
@@ -1,0 +1,3 @@
+<template>
+    <span>I am fred!</span>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/fred/fred.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/fred/fred.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/list/list.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/list/list.html
@@ -1,0 +1,5 @@
+<template>
+    <template for:each={items} for:item="item">
+        <lwc:component lwc:is={item.ctor} key={item.key}></lwc:component>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/list/list.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/list/list.js
@@ -1,0 +1,29 @@
+import { LightningElement, api, track } from 'lwc';
+import Foo from 'x/foo';
+import Bar from 'x/bar';
+import Baz from 'x/baz';
+import Fred from 'x/fred';
+
+export default class extends LightningElement {
+    @track
+    items = [
+        { key: 2, ctor: Foo },
+        { key: 4, ctor: Bar },
+        { key: 1, ctor: Baz },
+        { key: 3, ctor: Fred },
+    ];
+
+    @api
+    swapConstructors() {
+        this.items[0].ctor = Baz;
+        this.items[1].ctor = Fred;
+        this.items[2].ctor = Foo;
+        this.items[3].ctor = Bar;
+    }
+
+    @api
+    removeConstructors() {
+        this.items[0].ctor = null;
+        this.items[2].ctor = null;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/nested/nested.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/nested/nested.html
@@ -1,0 +1,5 @@
+<template>
+    <lwc:component lwc:is={parentCtor}>
+        <lwc:component lwc:is={childCtor}></lwc:component>
+    </lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/nested/nested.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/nested/nested.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+import Parent from 'x/slottable';
+import Foo from 'x/foo';
+
+export default class extends LightningElement {
+    parentCtor;
+    childCtor;
+
+    @api
+    loadParent() {
+        this.parentCtor = Parent;
+    }
+
+    @api
+    loadChild() {
+        this.childCtor = Foo;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotChild/scopedSlotChild.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotChild/scopedSlotChild.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <slot lwc:slot-bind={slotData}></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotChild/scopedSlotChild.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotChild/scopedSlotChild.js
@@ -1,0 +1,17 @@
+import { LightningElement } from 'lwc';
+import Foo from 'x/foo';
+import Bar from 'x/bar';
+import Fred from 'x/fred';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    slotData;
+
+    connectedCallback() {
+        this.slotData = [
+            { key: 0, ctor: Foo },
+            { key: 1, ctor: Bar },
+            { key: 2, ctor: Fred },
+        ];
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotParent/scopedSlotParent.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotParent/scopedSlotParent.html
@@ -1,0 +1,9 @@
+<template>
+    <x-scoped-slot-child>
+        <template lwc:slot-data="defaultSlotData">
+            <template for:each={defaultSlotData} for:item="defaultSlotData">
+                <lwc:component lwc:is={defaultSlotData.ctor} key={defaultSlotData.key}></lwc:component>
+            </template>
+        </template>
+    </x-scoped-slot-child>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotParent/scopedSlotParent.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/scopedSlotParent/scopedSlotParent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/slottable/slottable.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/slottable/slottable.html
@@ -1,0 +1,6 @@
+<template>
+    <!-- default slot -->
+    <slot></slot>
+    <!-- name slot -->
+    <slot name="slot1"></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/slottable/slottable.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/slottable/slottable.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/slotter/slotter.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/slotter/slotter.html
@@ -1,0 +1,6 @@
+<template>
+    <lwc:component lwc:is={ctor}>
+        <x-foo data-slot-id='default'></x-foo>
+        <x-bar slot="slot1"  data-slot-id='slot1'></x-bar>
+    </lwc:component>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-component/x/slotter/slotter.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-component/x/slotter/slotter.js
@@ -1,0 +1,10 @@
+import { LightningElement } from 'lwc';
+import Slottable from 'x/slottable';
+
+export default class extends LightningElement {
+    ctor;
+
+    connectedCallback() {
+        this.ctor = Slottable;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
@@ -1,10 +1,12 @@
 import { createElement } from 'lwc';
 
-import Container from 'x/dynamic';
+import DynamicContainer from 'x/dynamic';
+import LwcDynamicContainer from 'x/lwcDynamic';
 import DynamicCtor from 'x/ctor';
 import AlterCtor from 'x/alter';
 
 import DynamicSlotted from 'x/dynamicSlotted';
+import LwcDynamicSlotted from 'x/lwcDynamicSlotted';
 import ContainerFoo from 'x/containerFoo';
 import ContainerBar from 'x/containerBar';
 
@@ -23,13 +25,15 @@ function waitForMacroTask(fn) {
     }).then(() => fn());
 }
 
-it('should call the loader', () => {
+// TODO [#3331]: remove lwc:dynamic portion of these tests in 246
+
+it('should call the loader using lwc:dynamic', () => {
     // note, using `x-` prefix instead of `x/` because these are
     // handled by `registerForLoad`
     registerForLoad('x-ctor', DynamicCtor);
     registerForLoad('x-alter', AlterCtor);
 
-    const elm = createElement('x-dynamic', { is: Container });
+    const elm = createElement('x-dynamic', { is: LwcDynamicContainer });
     document.body.appendChild(elm);
 
     return Promise.resolve().then(() => {
@@ -63,11 +67,11 @@ it('should call the loader', () => {
     });
 });
 
-it('should not reuse DOM elements', () => {
+it('should not reuse DOM elements using lwc:dynamic', () => {
     registerForLoad('x-ctor', DynamicCtor);
     registerForLoad('x-alter', AlterCtor);
 
-    const elm = createElement('x-dynamic', { is: Container });
+    const elm = createElement('x-dynamic', { is: LwcDynamicContainer });
     elm.enableCtor();
     document.body.appendChild(elm);
 
@@ -82,11 +86,151 @@ it('should not reuse DOM elements', () => {
     });
 });
 
+it('should not cache DOM elements using lwc:dynamic', () => {
+    registerForLoad('x-ctor', DynamicCtor);
+    registerForLoad('x-alter', AlterCtor);
+
+    const elm = createElement('x-dynamic', { is: LwcDynamicContainer });
+    elm.enableCtor();
+    document.body.appendChild(elm);
+
+    // from ctor to alter back to ctor, new elements should be created
+    return waitForMacroTask(() => {
+        const childElm = elm.shadowRoot.querySelector('x-ctor');
+        expect(childElm).not.toBeNull();
+        elm.enableAlter();
+        return waitForMacroTask(() => {
+            elm.enableCtor();
+            return waitForMacroTask(() => {
+                const secondCtorElm = elm.shadowRoot.querySelector('x-ctor');
+                expect(secondCtorElm).not.toBe(childElm);
+            });
+        });
+    });
+});
+
+describe('slotted content using lwc:dynamic', () => {
+    let consoleSpy;
+    beforeEach(() => {
+        consoleSpy = spyConsole();
+    });
+    afterEach(() => {
+        consoleSpy.reset();
+    });
+
+    it('reallocate slotted content after changing constructor', () => {
+        const elm = createElement('x-dynamic-slotted', { is: LwcDynamicSlotted });
+        elm.ctor = ContainerFoo;
+
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.querySelector('[data-id="slot-default"]').assignedSlot).toBeDefined();
+        expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBeDefined();
+
+        if (process.env.NATIVE_SHADOW) {
+            expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBe(null);
+        } else {
+            if (process.env.NODE_ENV === 'production') {
+                expect(consoleSpy.calls.error.length).toEqual(0);
+            } else {
+                expect(consoleSpy.calls.error[0][0].message).toContain(
+                    'Ignoring unknown provided slot name "bar"'
+                );
+            }
+        }
+
+        // Swap construstor and check if nodes have been reallocated.
+        elm.ctor = ContainerBar;
+
+        return Promise.resolve().then(() => {
+            expect(
+                elm.shadowRoot.querySelector('[data-id="slot-default"]').assignedSlot
+            ).toBeDefined();
+            expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBeDefined();
+
+            if (process.env.NATIVE_SHADOW) {
+                expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBe(
+                    null
+                );
+            } else {
+                if (process.env.NODE_ENV === 'production') {
+                    expect(consoleSpy.calls.error.length).toEqual(0);
+                } else {
+                    expect(consoleSpy.calls.error[1][0].message).toContain(
+                        'Ignoring unknown provided slot name "foo"'
+                    );
+                }
+            }
+        });
+    });
+});
+
+// Using <lwc:component lwc:is={}>
+
+it('should call the loader', () => {
+    // note, using `x-` prefix instead of `x/` because these are
+    // handled by `registerForLoad`
+    registerForLoad('x-ctor', DynamicCtor);
+    registerForLoad('x-alter', AlterCtor);
+
+    const elm = createElement('x-dynamic', { is: DynamicContainer });
+    document.body.appendChild(elm);
+
+    return Promise.resolve().then(() => {
+        const child = elm.shadowRoot.querySelector('x-ctor');
+        expect(child).toBeNull();
+        // first rendered with ctor set to undefined (nothing)
+        elm.enableCtor();
+        return waitForMacroTask(() => {
+            // second rendered with ctor set to x-ctor
+            const ctorElm = elm.shadowRoot.querySelector('x-ctor');
+            expect(ctorElm).not.toBeNull();
+            const span = ctorElm.shadowRoot.querySelector('span');
+            expect(span).not.toBeNull();
+            expect(span.textContent).toBe('ctor_html');
+            elm.enableAlter();
+            return waitForMacroTask(() => {
+                // third rendered with ctor set to x-alter
+                const alterElm = elm.shadowRoot.querySelector('x-alter');
+                expect(alterElm).not.toBeNull();
+                const span = alterElm.shadowRoot.querySelector('span');
+                expect(span).not.toBeNull();
+                expect(span.textContent).toBe('alter_html');
+                elm.disableAll();
+                return waitForMacroTask(() => {
+                    // third rendered with ctor set to null (nothing)
+                    const child = elm.shadowRoot.querySelector('x-ctor');
+                    expect(child).toBeNull();
+                });
+            });
+        });
+    });
+});
+
+it('should not reuse DOM elements', () => {
+    registerForLoad('x-ctor', DynamicCtor);
+    registerForLoad('x-alter', AlterCtor);
+
+    const elm = createElement('x-dynamic', { is: DynamicContainer });
+    elm.enableCtor();
+    document.body.appendChild(elm);
+
+    return waitForMacroTask(() => {
+        const childElm = elm.shadowRoot.querySelector('x-ctor');
+        expect(childElm).not.toBeNull();
+        elm.enableAlter();
+        return waitForMacroTask(() => {
+            const alterElm = elm.shadowRoot.querySelector('x-alter');
+            expect(alterElm).not.toBe(childElm);
+        });
+    });
+});
+
 it('should not cache DOM elements', () => {
     registerForLoad('x-ctor', DynamicCtor);
     registerForLoad('x-alter', AlterCtor);
 
-    const elm = createElement('x-dynamic', { is: Container });
+    const elm = createElement('x-dynamic', { is: DynamicContainer });
     elm.enableCtor();
     document.body.appendChild(elm);
 
@@ -135,7 +279,7 @@ describe('slotted content', () => {
             }
         }
 
-        // Swap construstor and check if nodes have been reallocated.
+        // Swap constructor and check if nodes have been reallocated.
         elm.ctor = ContainerBar;
 
         return Promise.resolve().then(() => {

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/dynamic/dynamic.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/dynamic/dynamic.html
@@ -1,3 +1,3 @@
 <template>
-    <x-ctor lwc:dynamic={customCtor}></x-ctor>
+    <lwc:component lwc:is={customCtor}></lwc:component>
 </template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamic/lwcDynamic.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamic/lwcDynamic.html
@@ -1,0 +1,3 @@
+<template>
+    <x-ctor lwc:dynamic={customCtor}></x-ctor>
+</template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamic/lwcDynamic.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamic/lwcDynamic.js
@@ -1,6 +1,5 @@
 import { LightningElement, track, api } from 'lwc';
-
-export default class extends LightningElement {
+export default class DynamicCtor extends LightningElement {
     @track customCtor = undefined;
 
     async loadCtor() {

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamicSlotted/lwcDynamicSlotted.html
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamicSlotted/lwcDynamicSlotted.html
@@ -1,7 +1,7 @@
 <template>
-    <lwc:component lwc:is={ctor}>
+    <x-ctor lwc:dynamic={ctor}>
         <div data-id="slot-default">Default</div>
         <div slot="foo" data-id="slot-foo">Foo</div>
         <div slot="bar" data-id="slot-bar">Bar</div>
-    </lwc:component>
+    </x-ctor>
 </template>

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamicSlotted/lwcDynamicSlotted.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/x/lwcDynamicSlotted/lwcDynamicSlotted.js
@@ -1,5 +1,5 @@
 import { LightningElement, api } from 'lwc';
 
-export default class extends LightningElement {
+export default class DynamicSlotted extends LightningElement {
     @api ctor = null;
 }

--- a/packages/@lwc/integration-karma/test/component/refs/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/refs/index.spec.js
@@ -10,6 +10,7 @@ import Conflict from 'x/conflict';
 import Parent from 'x/parent';
 import Light from 'x/light';
 import Dynamic from 'x/dynamic';
+import LwcDynamic from 'x/lwcDynamic';
 import Conditional from 'x/conditional';
 import Construct from 'x/construct';
 import Connect from 'x/connect';
@@ -178,12 +179,21 @@ describe('refs', () => {
         expect(elm.getRefTextContent('foo')).toEqual('foo');
     });
 
-    it('ref on a dynamic component', () => {
-        const elm = createElement('x-dynamic', { is: Dynamic });
+    it('ref on a dynamic component - lwc:dynamic', () => {
+        const elm = createElement('x-dynamic', { is: LwcDynamic });
         document.body.appendChild(elm);
 
         const dynamic = elm.getRef('dynamic');
         expect(dynamic.tagName.toLowerCase()).toEqual('x-dynamic-cmp');
+        expect(dynamic.getRefTextContent('first')).toEqual('first');
+    });
+
+    it('ref on a dynamic component - <lwc:component lwc:is={}>', () => {
+        const elm = createElement('x-dynamic', { is: Dynamic });
+        document.body.appendChild(elm);
+
+        const dynamic = elm.getRef('dynamic');
+        expect(dynamic.tagName.toLowerCase()).toEqual('x-basic');
         expect(dynamic.getRefTextContent('first')).toEqual('first');
     });
 

--- a/packages/@lwc/integration-karma/test/component/refs/x/dynamic/dynamic.html
+++ b/packages/@lwc/integration-karma/test/component/refs/x/dynamic/dynamic.html
@@ -1,3 +1,3 @@
 <template>
-    <x-dynamic-cmp lwc:dynamic={ctor} lwc:ref="dynamic"></x-dynamic-cmp>
+    <lwc:component lwc:is={ctor} lwc:ref="dynamic"></lwc:component>
 </template>

--- a/packages/@lwc/integration-karma/test/component/refs/x/lwcDynamic/lwcDynamic.html
+++ b/packages/@lwc/integration-karma/test/component/refs/x/lwcDynamic/lwcDynamic.html
@@ -1,0 +1,3 @@
+<template>
+    <x-dynamic-cmp lwc:dynamic={ctor} lwc:ref="dynamic"></x-dynamic-cmp>
+</template>

--- a/packages/@lwc/integration-karma/test/component/refs/x/lwcDynamic/lwcDynamic.js
+++ b/packages/@lwc/integration-karma/test/component/refs/x/lwcDynamic/lwcDynamic.js
@@ -1,11 +1,11 @@
 import { LightningElement, api } from 'lwc';
+import Basic from 'x/basic';
 
 export default class extends LightningElement {
-    show = false;
-    showFourth = false;
+    ctor = Basic;
 
     @api
-    triggerDiffingAlgo() {
-        this.show = true;
+    getRef(name) {
+        return this.refs[name];
     }
 }

--- a/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 import ForEachCmp from 'x/forEachCmp';
 import LwcDynamic from 'x/lwcDynamic';
+import Dynamic from 'x/dynamic';
 
 describe('for:each', () => {
     it('should remove/add elements when if is toggled', function () {
@@ -28,6 +29,29 @@ describe('for:each', () => {
 describe('lwc:dynamic', () => {
     it('should remove/add elements when if is toggled', function () {
         const elm = createElement('x-container', { is: LwcDynamic });
+        document.body.appendChild(elm);
+
+        const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
+        elm.shadowRoot.querySelector('button').click();
+
+        return Promise.resolve()
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('');
+                elm.shadowRoot.querySelector('button').click();
+            })
+            .then(() => {
+                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+            });
+    });
+});
+
+describe('dynamic components', () => {
+    it('should remove/add elements when if is toggled', function () {
+        const elm = createElement('x-container', { is: Dynamic });
         document.body.appendChild(elm);
 
         const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');

--- a/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/x/dynamic/dynamic.html
+++ b/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/x/dynamic/dynamic.html
@@ -1,0 +1,10 @@
+<template>
+    <button onclick={toggleSection}>toggle section</button>
+
+    <div>
+        <template if:true={sectionOpen}>
+            <p>item</p>
+            <lwc:component lwc:is={ctor}></lwc:component>
+        </template>
+    </div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/x/dynamic/dynamic.js
+++ b/packages/@lwc/integration-karma/test/rendering/dynamic-childrens-inside-if/x/dynamic/dynamic.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    sectionOpen = false;
+
+    toggleSection() {
+        this.sectionOpen = !this.sectionOpen;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/element-orders/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/element-orders/index.spec.js
@@ -1,7 +1,8 @@
 import { createElement } from 'lwc';
 import SlotFallback from 'x/slotFallback';
-import WithDynamic from 'x/withDynamic';
+import WithLwcDynamic from 'x/withLwcDynamic';
 import WithEach from 'x/withEach';
+import WithDynamic from 'x/WithDynamic';
 
 describe('updateDynamicChildren diffing algo', () => {
     it('should render slot default elements in correct order', function () {
@@ -19,6 +20,19 @@ describe('updateDynamicChildren diffing algo', () => {
 
     it('should render template with foreach in correct order', function () {
         const elm = createElement('x-with-each', { is: WithEach });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.textContent).toBe('25');
+        elm.triggerDiffingAlgo();
+
+        return Promise.resolve().then(() => {
+            const content = elm.shadowRoot.textContent;
+            expect(content).toBe('1235');
+        });
+    });
+
+    it('should render template with dynamic component in correct order using lwc:dynamic', function () {
+        const elm = createElement('x-with-dynamic', { is: WithLwcDynamic });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('25');

--- a/packages/@lwc/integration-karma/test/rendering/element-orders/x/withLwcDynamic/withLwcDynamic.html
+++ b/packages/@lwc/integration-karma/test/rendering/element-orders/x/withLwcDynamic/withLwcDynamic.html
@@ -5,5 +5,5 @@
     <p if:true={showFourth}>4</p>
     <p>5</p>
 
-    <lwc:component lwc:is={foo}></lwc:component>
+    <x-dyn lwc:dynamic={foo}></x-dyn>
 </template>

--- a/packages/@lwc/integration-karma/test/rendering/element-orders/x/withLwcDynamic/withLwcDynamic.js
+++ b/packages/@lwc/integration-karma/test/rendering/element-orders/x/withLwcDynamic/withLwcDynamic.js
@@ -1,6 +1,6 @@
 import { LightningElement, api } from 'lwc';
 
-export default class extends LightningElement {
+export default class WithDynamic extends LightningElement {
     show = false;
     showFourth = false;
 

--- a/packages/@lwc/integration-karma/test/spread/index.spec.js
+++ b/packages/@lwc/integration-karma/test/spread/index.spec.js
@@ -64,9 +64,16 @@ describe('lwc:spread', () => {
         await Promise.resolve();
         expect(elm.shadowRoot.querySelector('span').className).toEqual('');
     });
-    it('should assign props to dynamic elements', () => {
+    it('should assign props to dynamic elements using lwc:dynamic', () => {
         expect(
             elm.shadowRoot.querySelector('x-cmp').shadowRoot.querySelector('span').textContent
+        ).toEqual('Name: Dynamic');
+    });
+    it('should assign props to dynamic elements', () => {
+        expect(
+            elm.shadowRoot
+                .querySelector('[data-id="lwc-component"]')
+                .shadowRoot.querySelector('span').textContent
         ).toEqual('Name: Dynamic');
     });
 });

--- a/packages/@lwc/integration-karma/test/spread/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/spread/x/test/test.html
@@ -3,4 +3,5 @@
     <x-child class="x-child-overridden" name="lwc" onclick={templateClick} lwc:spread={overriddenProps}></x-child>
     <span lwc:spread={spanProps}>Hello</span>
     <x-cmp lwc:dynamic={dynamicCtor} lwc:spread={dynamicProps}></x-cmp>
+    <lwc:component data-id="lwc-component" lwc:is={dynamicCtor} lwc:spread={dynamicProps}></lwc:component>
 </template>


### PR DESCRIPTION
## Details

This PR contains integration tests for the dynamic components implementation.

This PR implements the changes to the babel-plugin and runtime from the dynamic components [RFC](https://github.com/jmsjtu/lwc-rfcs/blob/jtu/dynamic-component-creation/text/0119-dynamic-component-creation.md).

This is part 3 of 3 of the dynamic components implementation.

Part 1 (template compiler implementation) can be found [here](https://github.com/salesforce/lwc/pull/3337).
Part 2 (babel-plugin, runtime, and rollup config) can be found [here](https://github.com/salesforce/lwc/pull/3338)

I've grouped up the different types of tests into separate commits:

- @lwc/engine-server [unit tests](https://github.com/salesforce/lwc/commit/7a2fa74c54299c7bcdf9f0785e72afd3fafdafa6)
- hydration [tests](https://github.com/salesforce/lwc/commit/e07433aaf4a0759511dec94f3d53f26f9b3a7a1e)
- integration [tests](https://github.com/salesforce/lwc/commit/6a81fa3f7eda79bd77ed64d160ff584b5a7c4e98)

### PR structure

This implementation is broken down into 3 parts to make it easier to review and will be merged into the jtu/dynamic-components branch.

The reason for merging into the `jtu/dynamic-components` branch first is to ensure a single atomic commit for the dynamic components feature and to facilitate a clean coordinated release to `lwc-platform`, as this is a breaking change for lwc-platform.


This should reduce the number of files changed significantly.

## Does this pull request introduce a breaking change?
* ✅ No, it does introduce a breaking change.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.

## GUS work item
W-12190514
