### PR TITLE
fix: delete global shadow DOM bypass functions

### DIFF
--- a/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
@@ -40,6 +40,11 @@ const querySelectorAll = globalThis[
     KEY__NATIVE_QUERY_SELECTOR_ALL
 ] as typeof document.querySelectorAll;
 
+// This is a "handoff" from synthetic-shadow to engine-core – we want to clean up after ourselves
+// so nobody else can misuse these global APIs.
+delete globalThis[KEY__NATIVE_GET_ELEMENT_BY_ID];
+delete globalThis[KEY__NATIVE_QUERY_SELECTOR_ALL];
+
 function isSyntheticShadowRootInstance(rootNode: Node): rootNode is ShadowRoot {
     return rootNode !== document && isTrue((rootNode as any).synthetic);
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -110,12 +110,18 @@ defineProperty(globalThis, KEY__IS_NATIVE_SHADOW_ROOT_DEFINED, {
 // The isUndefined check is because two copies of synthetic shadow may be loaded on the same page, and this
 // would throw an error if we tried to redefine it. Plus the whole point is to expose the native method.
 if (isUndefined(globalThis[KEY__NATIVE_GET_ELEMENT_BY_ID])) {
-    defineProperty(globalThis, KEY__NATIVE_GET_ELEMENT_BY_ID, { value: getElementById });
+    defineProperty(globalThis, KEY__NATIVE_GET_ELEMENT_BY_ID, {
+        value: getElementById,
+        configurable: true,
+    });
 }
 
 // See note above.
 if (isUndefined(globalThis[KEY__NATIVE_QUERY_SELECTOR_ALL])) {
-    defineProperty(globalThis, KEY__NATIVE_QUERY_SELECTOR_ALL, { value: querySelectorAll });
+    defineProperty(globalThis, KEY__NATIVE_QUERY_SELECTOR_ALL, {
+        value: querySelectorAll,
+        configurable: true,
+    });
 }
 
 // Function created per shadowRoot instance, it returns the shadowRoot, and is attached


### PR DESCRIPTION
## Details

It occurred to me that we do not want people to take a dependency on these global `getElementById`/`querySelectorAll` bypass functions added to the `window`. They're defined in `synthetic-shadow`, so `engine-dom` can delete them as soon as it grabs them.

This is not really a breaking change, because we only shipped this change this release (#3214), and most likely nobody has taken a dependency on it yet. (And if they did, they really should not.)

Also note that only non-Lockerized components can even possibly take a dependency on this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

See above.

<!-- If yes, please describe the anticipated observable changes. -->
