### PR TITLE
fix: clean up VFragments when resetting component root

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -6,7 +6,6 @@
  */
 import features from '@lwc/features';
 import {
-    ArrayPop,
     ArrayPush,
     ArraySlice,
     ArrayUnshift,
@@ -40,17 +39,8 @@ import {
 import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
-import { AccessorReactiveObserver } from './accessor-reactive-observer';
 import { removeActiveVM } from './hot-swaps';
-import {
-    VNodes,
-    VCustomElement,
-    VNode,
-    VNodeType,
-    VBaseElement,
-    VFragment,
-    isVFragment,
-} from './vnodes';
+import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement, isVFragment } from './vnodes';
 
 type ShadowRootMode = 'open' | 'closed';
 
@@ -681,50 +671,32 @@ function recursivelyDisconnectChildren(vnodes: VNodes) {
 // into snabbdom. Especially useful when the reset is a consequence of an error, in which case the
 // children VNodes might not be representing the current state of the DOM.
 export function resetComponentRoot(vm: VM) {
-    const {
-        children,
-        renderRoot,
-        renderer: { remove },
-    } = vm;
-
-    for (let i = 0, len = children.length; i < len; i++) {
-        const child = children[i];
-
-        // VFragments are special; their .elm property does not point to the root element since they have no root,
-        // so we have to clean them up differently.
-        if (!isNull(child)) {
-            if (isVFragment(child)) {
-                removeFragmentChildren(child, vm);
-            } else if (!isUndefined(child.elm)) {
-                remove(child.elm, renderRoot);
-            }
-        }
-    }
+    recursivelyRemoveChildren(vm.children, vm);
     vm.children = EmptyArray;
 
     runChildNodesDisconnectedCallback(vm);
     vm.velements = EmptyArray;
 }
 
-// Helper function to traverse a tree of VFragment nodes and remove all root children.
-// This is moved into a separate function to minimize the perf/mem impact of the stack traversal
-// on non-vfragment use cases
-function removeFragmentChildren(vnode: VFragment, vm: VM) {
+// Helper function to remove all children of the root node.
+// If the set of children includes VFragment nodes, we need to remove the children of those nodes too.
+// Since VFragments can contain other VFragments, we need to traverse the entire of tree of VFragments.
+// If the set contains no VFragment nodes, no traversal is needed.
+function recursivelyRemoveChildren(vnodes: VNodes, vm: VM) {
     const {
         renderRoot,
         renderer: { remove },
     } = vm;
 
-    const nodeStack: VNode[] = [];
-    ArrayPush.call(nodeStack, ...vnode.children);
+    for (let i = 0, len = vnodes.length; i < len; i += 1) {
+        const vnode = vnodes[i];
 
-    let currentNode: VNode | null | undefined;
-    while (!isUndefined((currentNode = ArrayPop.call(nodeStack)))) {
-        if (!isNull(currentNode)) {
-            if (isVFragment(currentNode)) {
-                ArrayPush.call(nodeStack, ...currentNode.children);
-            } else if (!isUndefined(currentNode.elm)) {
-                remove(currentNode.elm, renderRoot);
+        if (!isNull(vnode)) {
+            // VFragments are special; their .elm property does not point to the root element since they have no single root.
+            if (isVFragment(vnode)) {
+                recursivelyRemoveChildren(vnode.children, vm);
+            } else if (!isUndefined(vnode.elm)) {
+                remove(vnode.elm, renderRoot);
             }
         }
     }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -39,6 +39,7 @@ import {
 import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
+import { AccessorReactiveObserver } from './accessor-reactive-observer';
 import { removeActiveVM } from './hot-swaps';
 import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement, isVFragment } from './vnodes';
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -6,6 +6,7 @@
  */
 import features from '@lwc/features';
 import {
+    ArrayPop,
     ArrayPush,
     ArraySlice,
     ArrayUnshift,
@@ -41,7 +42,15 @@ import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { AccessorReactiveObserver } from './accessor-reactive-observer';
 import { removeActiveVM } from './hot-swaps';
-import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement } from './vnodes';
+import {
+    VNodes,
+    VCustomElement,
+    VNode,
+    VNodeType,
+    VBaseElement,
+    VFragment,
+    isVFragment,
+} from './vnodes';
 
 type ShadowRootMode = 'open' | 'closed';
 
@@ -681,14 +690,44 @@ export function resetComponentRoot(vm: VM) {
     for (let i = 0, len = children.length; i < len; i++) {
         const child = children[i];
 
-        if (!isNull(child) && !isUndefined(child.elm)) {
-            remove(child.elm, renderRoot);
+        // VFragments are special; their .elm property does not point to the root element since they have no root,
+        // so we have to clean them up differently.
+        if (!isNull(child)) {
+            if (isVFragment(child)) {
+                removeFragmentChildren(child, vm);
+            } else if (!isUndefined(child.elm)) {
+                remove(child.elm, renderRoot);
+            }
         }
     }
     vm.children = EmptyArray;
 
     runChildNodesDisconnectedCallback(vm);
     vm.velements = EmptyArray;
+}
+
+// Helper function to traverse a tree of VFragment nodes and remove all root children.
+// This is moved into a separate function to minimize the perf/mem impact of the stack traversal
+// on non-vfragment use cases
+function removeFragmentChildren(vnode: VFragment, vm: VM) {
+    const {
+        renderRoot,
+        renderer: { remove },
+    } = vm;
+
+    const nodeStack: VNode[] = [];
+    ArrayPush.call(nodeStack, ...vnode.children);
+
+    let currentNode: VNode | null | undefined;
+    while (!isUndefined((currentNode = ArrayPop.call(nodeStack)))) {
+        if (!isNull(currentNode)) {
+            if (isVFragment(currentNode)) {
+                ArrayPush.call(nodeStack, ...currentNode.children);
+            } else if (!isUndefined(currentNode.elm)) {
+                remove(currentNode.elm, renderRoot);
+            }
+        }
+    }
 }
 
 export function scheduleRehydration(vm: VM) {

--- a/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/multiTemplateConditionals.js
+++ b/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/multiTemplateConditionals.js
@@ -1,0 +1,25 @@
+import { LightningElement, api } from 'lwc';
+import template from './template.html';
+import template2 from './template2.html';
+
+export default class MultiTemplateConditionals extends LightningElement {
+    templateIndex = 0;
+    templateMapping = {
+        0: template,
+        1: template2,
+    };
+
+    @api
+    show = false;
+
+    render() {
+        return this.templateMapping[this.templateIndex];
+    }
+
+    @api
+    next() {
+        if (this.templateIndex < 1) {
+            this.templateIndex++;
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/template.html
+++ b/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/template.html
@@ -1,0 +1,14 @@
+<template>
+    <template lwc:if={show}>
+        <x-leaf name="T1-1"></x-leaf>
+        <template lwc:if={show}>
+            <x-leaf name="T1-2"></x-leaf>
+            <template lwc:if={show}>
+                <x-leaf name="T1-3"></x-leaf>
+                <x-leaf name="T1-4"></x-leaf>
+            </template>
+            <x-leaf name="T1-5"></x-leaf>
+        </template>
+        <x-leaf name="T1-6"></x-leaf>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/template2.html
+++ b/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/x/multiTemplateConditionals/template2.html
@@ -1,0 +1,14 @@
+<template>
+    <template lwc:if={show}>
+        <x-leaf name="T2-1"></x-leaf>
+        <template lwc:if={show}>
+            <x-leaf name="T2-2"></x-leaf>
+            <template lwc:if={show}>
+                <x-leaf name="T2-3"></x-leaf>
+                <x-leaf name="T2-4"></x-leaf>
+            </template>
+            <x-leaf name="T2-5"></x-leaf>
+        </template>
+        <x-leaf name="T2-6"></x-leaf>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -1,0 +1,14 @@
+import { createElement } from 'lwc';
+import CustomRender from 'x/customRender';
+
+describe('using custom renderer with lwc:if', () => {
+    it('should replace the entire template when switching templates in a custom render function', async function () {
+        const elm = createElement('x-custom-render', { is: CustomRender });
+        document.body.appendChild(elm);
+        elm.next();
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.textContent).toBe('TEMPLATE 2T2 nested 1T2 nested 2');
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
@@ -1,0 +1,23 @@
+import { LightningElement, api } from 'lwc';
+import template from './template.html';
+import template2 from './template2.html';
+
+export default class CustomRender extends LightningElement {
+    templateIndex = 0;
+    templateMapping = {
+        0: template,
+        1: template2,
+    };
+    showHeader = true;
+
+    render() {
+        return this.templateMapping[this.templateIndex];
+    }
+
+    @api
+    next() {
+        if (this.templateIndex < 1) {
+            this.templateIndex++;
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
@@ -1,0 +1,11 @@
+<template>
+    <h1 lwc:if={showHeader}>TEMPLATE 1</h1>
+    <template lwc:if={showHeader}>
+        <template lwc:if={showHeader}>
+            <div>T1 nested 1</div>
+            <template lwc:if={showHeader}>
+                <div>T1 nested 2</div>
+            </template>
+        </template>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
@@ -1,0 +1,11 @@
+<template>
+    <h1 lwc:if={showHeader}>TEMPLATE 2</h1>
+    <template lwc:if={showHeader}>
+        <template lwc:if={showHeader}>
+            <div>T2 nested 1</div>
+            <template lwc:if={showHeader}>
+                <div>T2 nested 2</div>
+            </template>
+        </template>
+    </template>
+</template>


### PR DESCRIPTION
## Details
VFragments are not cleaned up properly when resetting component root because their `.elm` points to the end delimiter text node, not the root element.

Backport of https://github.com/salesforce/lwc/pull/3363.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
