### PR TITLE
fix: @W-12593632 clean up VFragments when resetting component root

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
+    ArrayPop,
     ArrayPush,
     ArraySlice,
     ArrayUnshift,
@@ -43,7 +44,7 @@ import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { removeActiveVM } from './hot-swaps';
-import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement } from './vnodes';
+import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement, VFragment, isVFragment } from './vnodes';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
 
 type ShadowRootMode = 'open' | 'closed';
@@ -739,7 +740,11 @@ export function resetComponentRoot(vm: VM) {
     for (let i = 0, len = children.length; i < len; i++) {
         const child = children[i];
 
-        if (!isNull(child) && !isUndefined(child.elm)) {
+        // VFragments are special; their .elm property does not point to the root element since they have no root,
+        // so we have to clean them up differently.
+        if (!isNull(child) && isVFragment(child)) {
+            removeFragmentChildren(child, vm);
+        } else if (!isNull(child) && !isUndefined(child.elm)) {
             remove(child.elm, renderRoot);
         }
     }
@@ -747,6 +752,28 @@ export function resetComponentRoot(vm: VM) {
 
     runChildNodesDisconnectedCallback(vm);
     vm.velements = EmptyArray;
+}
+
+// Helper function to traverse a tree of VFragment nodes and remove all root children.
+// This is moved into a separate function to minimize the perf/mem impact of the stack traversal
+// on non-vfragment use cases
+function removeFragmentChildren(vnode: VFragment, vm: VM) {
+    const {
+        renderRoot,
+        renderer: { remove },
+    } = vm;
+
+    const nodeStack: VNode[] = [];
+    ArrayPush.call(nodeStack, ...vnode.children);
+
+    let currentNode: VNode | null | undefined;
+    while (!isUndefined((currentNode = ArrayPop.call(nodeStack)))) {
+        if (!isNull(currentNode) && isVFragment(currentNode)) {
+            ArrayPush.call(nodeStack, ...currentNode.children);
+        } else if (!isNull(currentNode) && !isUndefined(currentNode.elm)) {
+            remove(currentNode.elm, renderRoot);
+        }
+    }
 }
 
 export function scheduleRehydration(vm: VM) {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -44,7 +44,15 @@ import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import { removeActiveVM } from './hot-swaps';
-import { VNodes, VCustomElement, VNode, VNodeType, VBaseElement, VFragment, isVFragment } from './vnodes';
+import {
+    VNodes,
+    VCustomElement,
+    VNode,
+    VNodeType,
+    VBaseElement,
+    VFragment,
+    isVFragment,
+} from './vnodes';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
 
 type ShadowRootMode = 'open' | 'closed';

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -750,10 +750,12 @@ export function resetComponentRoot(vm: VM) {
 
         // VFragments are special; their .elm property does not point to the root element since they have no root,
         // so we have to clean them up differently.
-        if (!isNull(child) && isVFragment(child)) {
-            removeFragmentChildren(child, vm);
-        } else if (!isNull(child) && !isUndefined(child.elm)) {
-            remove(child.elm, renderRoot);
+        if (!isNull(child)) {
+            if (isVFragment(child)) {
+                removeFragmentChildren(child, vm);
+            } else if (!isUndefined(child.elm)) {
+                remove(child.elm, renderRoot);
+            }
         }
     }
     vm.children = EmptyArray;
@@ -776,10 +778,12 @@ function removeFragmentChildren(vnode: VFragment, vm: VM) {
 
     let currentNode: VNode | null | undefined;
     while (!isUndefined((currentNode = ArrayPop.call(nodeStack)))) {
-        if (!isNull(currentNode) && isVFragment(currentNode)) {
-            ArrayPush.call(nodeStack, ...currentNode.children);
-        } else if (!isNull(currentNode) && !isUndefined(currentNode.elm)) {
-            remove(currentNode.elm, renderRoot);
+        if (!isNull(currentNode)) {
+            if (isVFragment(currentNode)) {
+                ArrayPush.call(nodeStack, ...currentNode.children);
+            } else if (!isUndefined(currentNode.elm)) {
+                remove(currentNode.elm, renderRoot);
+            }
         }
     }
 }

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -8,7 +8,7 @@ describe('using custom renderer with lwc:if', () => {
         elm.next();
 
         return Promise.resolve().then(() => {
-            expect(elm.innerText).toBe('TEMPLATE 2\nT2 nested 1\nT2 nested 2\nT2 nested 3');
+            expect(elm.innerText).toBe('TEMPLATE 2\nT2 nested 1\nT2 nested 2');
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -8,7 +8,7 @@ describe('using custom renderer with lwc:if', () => {
         elm.next();
 
         return Promise.resolve().then(() => {
-            expect(elm.innerText).toBe('TEMPLATE 2\nT2 nested 1\nT2 nested 2');
+            expect(elm.shadowRoot.textContent).toBe('TEMPLATE 2T2 nested 1T2 nested 2');
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -5,11 +5,10 @@ describe('using custom renderer with lwc:if', () => {
     it('should just work test debug', async function () {
         const elm = createElement('x-custom-render', { is: CustomRender });
         document.body.appendChild(elm);
-
         elm.next();
 
         return Promise.resolve().then(() => {
-            expect(elm.innerText).toBe('TEMPLATE 2');
+            expect(elm.innerText).toBe('TEMPLATE 2\nT2 nested 1\nT2 nested 2\nT2 nested 3');
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import CustomRender from 'x/customRender';
+
+describe('using custom renderer with lwc:if', () => {
+    it('should just work test debug', async function () {
+        const elm = createElement('x-custom-render', { is: CustomRender });
+        document.body.appendChild(elm);
+
+        elm.next();
+
+        return Promise.resolve().then(() => {
+            expect(elm.innerText).toBe('TEMPLATE 2');
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 import CustomRender from 'x/customRender';
 
 describe('using custom renderer with lwc:if', () => {
-    it('should just work test debug', async function () {
+    it('should replace the entire template when switching templates in a custom render function', async function () {
         const elm = createElement('x-custom-render', { is: CustomRender });
         document.body.appendChild(elm);
         elm.next();

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
@@ -1,0 +1,30 @@
+import { LightningElement, api } from 'lwc';
+import template from './template.html';
+import template2 from './template2.html';
+
+export default class CustomRender extends LightningElement {
+    templateIndex = 0;
+    templateMapping = {
+        0: template,
+        1: template2,
+    };
+    showHeader = true;
+
+    render() {
+        return this.templateMapping[this.templateIndex];
+    }
+
+    @api
+    back() {
+        if (this.templateIndex > 0) {
+            this.templateIndex--;
+        }
+    }
+
+    @api
+    next() {
+        if (this.templateIndex < 2) {
+            this.templateIndex++;
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/customRender.js
@@ -15,15 +15,8 @@ export default class CustomRender extends LightningElement {
     }
 
     @api
-    back() {
-        if (this.templateIndex > 0) {
-            this.templateIndex--;
-        }
-    }
-
-    @api
     next() {
-        if (this.templateIndex < 2) {
+        if (this.templateIndex < 1) {
             this.templateIndex++;
         }
     }

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
@@ -1,3 +1,14 @@
 <template>
     <h1 lwc:if={showHeader}>TEMPLATE 1</h1>
+    <template lwc:if={showHeader}>
+        <template lwc:if={showHeader}>
+            <div>T1 nested 1</div>
+            <template lwc:if={showHeader}>
+                <div>T1 nested 2</div>
+                <template lwc:if={showHeader}>
+                    <div>T1 nested 3</div>
+                </template>
+            </template>
+        </template>
     </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
@@ -5,9 +5,6 @@
             <div>T1 nested 1</div>
             <template lwc:if={showHeader}>
                 <div>T1 nested 2</div>
-                <template lwc:if={showHeader}>
-                    <div>T1 nested 3</div>
-                </template>
             </template>
         </template>
     </template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template.html
@@ -1,0 +1,3 @@
+<template>
+    <h1 lwc:if={showHeader}>TEMPLATE 1</h1>
+    </template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
@@ -5,9 +5,6 @@
             <div>T2 nested 1</div>
             <template lwc:if={showHeader}>
                 <div>T2 nested 2</div>
-                <template lwc:if={showHeader}>
-                    <div>T2 nested 3</div>
-                </template>
             </template>
         </template>
     </template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
@@ -1,0 +1,3 @@
+<template>
+    <h1 lwc:if={showHeader}>TEMPLATE 2</h1>
+    </template>

--- a/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
+++ b/packages/@lwc/integration-karma/test/rendering/if-inside-custom-render/x/customRender/template2.html
@@ -1,3 +1,14 @@
 <template>
     <h1 lwc:if={showHeader}>TEMPLATE 2</h1>
+    <template lwc:if={showHeader}>
+        <template lwc:if={showHeader}>
+            <div>T2 nested 1</div>
+            <template lwc:if={showHeader}>
+                <div>T2 nested 2</div>
+                <template lwc:if={showHeader}>
+                    <div>T2 nested 3</div>
+                </template>
+            </template>
+        </template>
     </template>
+</template>

--- a/scripts/bundlesize/bundlesize.config.json
+++ b/scripts/bundlesize/bundlesize.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "packages/lwc/dist/engine-dom/umd/es2017/engine-dom.min.js",
-            "maxSize": "20.02KB"
+            "maxSize": "20.5KB"
         },
         {
             "path": "packages/lwc/dist/synthetic-shadow/umd/es2017/synthetic-shadow.min.js",

--- a/scripts/bundlesize/bundlesize.config.json
+++ b/scripts/bundlesize/bundlesize.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "packages/lwc/dist/engine-dom/umd/es2017/engine-dom.min.js",
-            "maxSize": "20KB"
+            "maxSize": "20.02KB"
         },
         {
             "path": "packages/lwc/dist/synthetic-shadow/umd/es2017/synthetic-shadow.min.js",


### PR DESCRIPTION
## Details
VFragments are not cleaned up properly when resetting component root because their .elm points to the end delimiter text node, not the root element.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
