### PR TITLE
chore: disable mem leak test for now

### DIFF
--- a/packages/@lwc/integration-tests/src/components/memory-leaks/test-lifecycle-leak/test-lifecycle-leak.spec.js
+++ b/packages/@lwc/integration-tests/src/components/memory-leaks/test-lifecycle-leak/test-lifecycle-leak.spec.js
@@ -21,7 +21,8 @@ const assert = require('assert');
 // tunnelIdentifier exists, we know we're running in Sauce Labs and should bail out.
 // See: https://webdriver.io/docs/devtools-service/
 if (browser.capabilities.browserName === 'chrome' && !browser.capabilities.tunnelIdentifier) {
-    describe('Component does not leak', () => {
+    // TODO [#3393]: re-enable once SauceLabs can handle CDP again
+    describe.skip('Component does not leak', () => {
         const URL = '/lifecycle-leak';
 
         // Count the number of objects using queryObjects(). Based on:

--- a/packages/@lwc/integration-tests/src/components/memory-leaks/test-lifecycle-leak/test-lifecycle-leak.spec.js
+++ b/packages/@lwc/integration-tests/src/components/memory-leaks/test-lifecycle-leak/test-lifecycle-leak.spec.js
@@ -21,7 +21,7 @@ const assert = require('assert');
 // tunnelIdentifier exists, we know we're running in Sauce Labs and should bail out.
 // See: https://webdriver.io/docs/devtools-service/
 if (browser.capabilities.browserName === 'chrome' && !browser.capabilities.tunnelIdentifier) {
-    // TODO [#3393]: re-enable once SauceLabs can handle CDP again
+    // TODO [#3393]: re-enable once Circle CI can handle CDP again
     describe.skip('Component does not leak', () => {
         const URL = '/lifecycle-leak';
 


### PR DESCRIPTION
## Details

Temporary workaround for #3393

It breaks my heart because I _just_ wrote this test, but Circle CI is no bueno with CDP anymore, so let's disable this test for now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

