### PR TITLE
fix(engine-core): add abstraction for moving vfragments

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -87,7 +87,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
         sel: undefined,
         key,
         elm: undefined,
-        children: [t('', true), ...children, t('', true)],
+        children: [t('', true), ...children, t('')],
         stable,
         owner: getVMBeingRendered()!,
     };
@@ -427,7 +427,7 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string, fragment = false): VText {
+function t(text: string, isLeadingFragmentAnchor = false): VText {
     let sel, key, elm;
     return {
         type: VNodeType.Text,
@@ -436,7 +436,7 @@ function t(text: string, fragment = false): VText {
         elm,
         key,
         owner: getVMBeingRendered()!,
-        fragment,
+        isLeadingFragmentAnchor,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -82,15 +82,18 @@ function st(fragment: Element, key: Key): VStatic {
 
 // [fr]agment node
 function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
+    const leading = t('');
+    const trailing = t('');
     return {
         type: VNodeType.Fragment,
         sel: undefined,
         key,
         elm: undefined,
-        children: [t(''), ...children, t('')],
+        children: [leading, ...children, trailing],
         stable,
         owner: getVMBeingRendered()!,
-        trailingAnchor: undefined,
+        leading,
+        trailing,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -90,6 +90,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
         children: [t(''), ...children, t('')],
         stable,
         owner: getVMBeingRendered()!,
+        trailingAnchor: undefined,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -87,7 +87,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
         sel: undefined,
         key,
         elm: undefined,
-        children: [t('', true), ...children, t('')],
+        children: [t(''), ...children, t('')],
         stable,
         owner: getVMBeingRendered()!,
     };
@@ -427,7 +427,7 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string, isLeadingFragmentAnchor = false): VText {
+function t(text: string): VText {
     let sel, key, elm;
     return {
         type: VNodeType.Text,
@@ -436,7 +436,6 @@ function t(text: string, isLeadingFragmentAnchor = false): VText {
         elm,
         key,
         owner: getVMBeingRendered()!,
-        isLeadingFragmentAnchor,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -87,7 +87,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
         sel: undefined,
         key,
         elm: undefined,
-        children: [t(''), ...children, t('')],
+        children: [t('', true), ...children, t('', true)],
         stable,
         owner: getVMBeingRendered()!,
     };
@@ -427,7 +427,7 @@ function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
 }
 
 // [t]ext node
-function t(text: string): VText {
+function t(text: string, fragment = false): VText {
     let sel, key, elm;
     return {
         type: VNodeType.Text,
@@ -436,6 +436,7 @@ function t(text: string): VText {
         elm,
         key,
         owner: getVMBeingRendered()!,
+        fragment,
     };
 }
 

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -222,7 +222,7 @@ function mountFragment(
     mountVNodes(children, parent, renderer, anchor);
 
     // children of a fragment will always have at least the two delimiters.
-    vnode.elm = children[children.length - 1]!.elm;
+    vnode.elm = children[0]!.elm;
 }
 
 function patchFragment(n1: VFragment, n2: VFragment, parent: ParentNode, renderer: RendererAPI) {
@@ -235,7 +235,7 @@ function patchFragment(n1: VFragment, n2: VFragment, parent: ParentNode, rendere
     }
 
     // Note: not reusing n1.elm, because during patching, it may be patched with another text node.
-    n2.elm = children[children.length - 1]!.elm;
+    n2.elm = children[0]!.elm;
 }
 
 function mountElement(

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -907,8 +907,9 @@ function updateDynamicChildren(
             patch(oldStartVnode, newEndVnode, parent, renderer);
             let elm = oldEndVnode.elm!;
 
-            // If this is a leading anchor for a vfragment, then we want to use the node after the
-            // trailing anchor: [..., [leading, ...content, trailing], nextSibling, ...]
+            // In the case of fragments, we want to use the trailing anchor as the argument to
+            // nextSibling() to determine the nextSibling of the fragment:
+            // [..., [leading, ...content, trailing], nextSibling, ...]
             if (LeadingToTrailingMap.has(elm)) {
                 const trailing = LeadingToTrailingMap.get(elm);
                 while (elm !== trailing) {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -901,12 +901,17 @@ function updateDynamicChildren(
         } else if (isSameVnode(oldStartVnode, newEndVnode)) {
             // Vnode moved right
             patch(oldStartVnode, newEndVnode, parent, renderer);
-            insertNode(
-                oldStartVnode.elm!,
-                parent,
-                renderer.nextSibling(oldEndVnode.elm!),
-                renderer
-            );
+
+            const elm = oldEndVnode.elm!;
+            let nextSibling = renderer.nextSibling(elm);
+            // If this is a leading anchor for a vfragment, then we want to use the node after the
+            // trailing anchor: [..., [leading, content, trailing], nextSibling, ...]
+            if (fragmentAnchors.has(elm)) {
+                const trailing = renderer.nextSibling(nextSibling);
+                nextSibling = renderer.nextSibling(trailing);
+            }
+
+            insertNode(oldStartVnode.elm!, parent, nextSibling, renderer);
             oldStartVnode = oldCh[++oldStartIdx];
             newEndVnode = newCh[--newEndIdx];
         } else if (isSameVnode(oldEndVnode, newStartVnode)) {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -559,7 +559,9 @@ function insertFragment(
             nodesToInsert.push(child.elm!);
         }
     }
-    nodesToInsert.forEach((node) => renderer.insert(node, parent, anchor));
+    for (let i = 0; i < nodesToInsert.length; i += 1) {
+        renderer.insert(nodesToInsert[i], parent, anchor);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
         lockDomMutation();

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -221,6 +221,7 @@ function mountFragment(
     const { children } = vnode;
     mountVNodes(children, parent, renderer, anchor);
     vnode.elm = children[0]!.elm!;
+    vnode.trailingAnchor = children[children.length - 1]!.elm!;
 }
 
 function patchFragment(n1: VFragment, n2: VFragment, parent: ParentNode, renderer: RendererAPI) {
@@ -914,8 +915,7 @@ function updateDynamicChildren(
             // [..., [leading, ...content, trailing], nextSibling, ...]
             let anchor: Node | null;
             if (isVFragment(oldEndVnode)) {
-                const trailing = oldEndVnode.children[oldEndVnode.children.length - 1]!.elm!;
-                anchor = renderer.nextSibling(trailing);
+                anchor = renderer.nextSibling(oldEndVnode.trailingAnchor);
             } else {
                 anchor = renderer.nextSibling(oldEndVnode.elm!);
             }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -905,19 +905,16 @@ function updateDynamicChildren(
         } else if (isSameVnode(oldStartVnode, newEndVnode)) {
             // Vnode moved right
             patch(oldStartVnode, newEndVnode, parent, renderer);
-            let elm = oldEndVnode.elm!;
-
-            // In the case of fragments, we want to use the trailing anchor as the argument to
-            // nextSibling() to determine the nextSibling of the fragment:
-            // [..., [leading, ...content, trailing], nextSibling, ...]
-            if (LeadingToTrailingMap.has(elm)) {
-                const trailing = LeadingToTrailingMap.get(elm);
-                while (elm !== trailing) {
-                    elm = renderer.nextSibling(elm);
-                }
-            }
-
-            insertNode(oldStartVnode.elm!, parent, renderer.nextSibling(elm), renderer);
+            // The env property of a vfragment points to the leading anchor. To compute the next
+            // sibling of the vfragment, we need to use the trailing anchor:
+            // [..., (leading, ...content, trailing), nextSibling, ...]
+            const trailing = LeadingToTrailingMap.get(oldEndVnode.elm!);
+            insertNode(
+                oldStartVnode.elm!,
+                parent,
+                renderer.nextSibling(trailing || oldEndVnode.elm!),
+                renderer
+            );
             oldStartVnode = oldCh[++oldStartIdx];
             newEndVnode = newCh[--newEndIdx];
         } else if (isSameVnode(oldEndVnode, newStartVnode)) {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -553,15 +553,11 @@ function insertFragmentOrNode(
 
     if (isVFragment(vnode)) {
         const children = vnode.children;
-        const nodesToInsert = [];
         for (let i = 0; i < children.length; i += 1) {
             const child = children[i];
             if (!isNull(child)) {
-                nodesToInsert.push(child.elm!);
+                renderer.insert(child.elm, parent, anchor);
             }
-        }
-        for (let i = 0; i < nodesToInsert.length; i += 1) {
-            renderer.insert(nodesToInsert[i], parent, anchor);
         }
     } else {
         renderer.insert(vnode.elm!, parent, anchor);

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -72,7 +72,7 @@ export interface VText extends BaseVNode {
     sel: undefined;
     text: string;
     key: undefined;
-    fragment: boolean;
+    isLeadingFragmentAnchor: boolean;
 }
 
 export interface VComment extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -65,7 +65,8 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
     // which diffing strategy to use.
     stable: 0 | 1;
-    trailingAnchor: Node | undefined;
+    leading: VText;
+    trailing: VText;
 }
 
 export interface VText extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -72,6 +72,7 @@ export interface VText extends BaseVNode {
     sel: undefined;
     text: string;
     key: undefined;
+    fragment: boolean;
 }
 
 export interface VComment extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -72,7 +72,6 @@ export interface VText extends BaseVNode {
     sel: undefined;
     text: string;
     key: undefined;
-    isLeadingFragmentAnchor: boolean;
 }
 
 export interface VComment extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -65,6 +65,7 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
     // which diffing strategy to use.
     stable: 0 | 1;
+    trailingAnchor: Node | undefined;
 }
 
 export interface VText extends BaseVNode {

--- a/packages/@lwc/integration-karma/test/rendering/issue-3377/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3377/index.spec.js
@@ -11,8 +11,8 @@ describe('issue-3377', () => {
 
         await Promise.resolve();
 
-        const items = elm.shadowRoot.querySelectorAll('.item');
-        expect(items.length).toBe(3);
-        expect(items[items.length - 1].className).toContain('lwc-if');
+        const childNodes = elm.shadowRoot.childNodes;
+        const contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['0', '1', '', 'lwc:if', '']);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/issue-3377/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3377/index.spec.js
@@ -1,0 +1,18 @@
+import { createElement } from 'lwc';
+import Test from 'x/test';
+
+describe('issue-3377', () => {
+    it('should render lwc:if content after iteration', async () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+
+        elm.addItem();
+        elm.addItem();
+
+        await Promise.resolve();
+
+        const items = elm.shadowRoot.querySelectorAll('.item');
+        expect(items.length).toBe(3);
+        expect(items[items.length - 1].className).toContain('lwc-if');
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.html
@@ -1,0 +1,8 @@
+<template>
+    <template for:each={items} for:item="item">
+        <div class="item" key={item}>{item}</div>
+    </template>
+    <template lwc:if={items}>
+        <div class="item lwc-if">lwc:if</div>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.html
@@ -1,8 +1,8 @@
 <template>
     <template for:each={items} for:item="item">
-        <div class="item" key={item}>{item}</div>
+        <div key={item}>{item}</div>
     </template>
     <template lwc:if={items}>
-        <div class="item lwc-if">lwc:if</div>
+        <div>lwc:if</div>
     </template>
 </template>

--- a/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3377/x/test/test.js
@@ -1,0 +1,13 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class CustomRender extends LightningElement {
+    @track
+    items = [];
+
+    @api
+    addItem() {
+        this.items.push(this.counter++);
+    }
+
+    counter = 0;
+}

--- a/packages/@lwc/integration-karma/test/rendering/issue-3396/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3396/index.spec.js
@@ -10,9 +10,8 @@ describe('issue-3396', () => {
 
         await Promise.resolve();
 
-        const items = elm.shadowRoot.querySelectorAll('.item');
-        const contents = Array.from(items).map((item) => item.innerText);
-
-        expect(contents).toEqual(['1', '2', '3']);
+        const childNodes = elm.shadowRoot.childNodes;
+        const contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['', '1', '', '', '2', '', '', '3', '']);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/issue-3396/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3396/index.spec.js
@@ -1,0 +1,18 @@
+import { createElement } from 'lwc';
+import Test from 'x/test';
+
+describe('issue-3396', () => {
+    it('should render lwc:if in correct order', async () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+
+        elm.show = true;
+
+        await Promise.resolve();
+
+        const items = elm.shadowRoot.querySelectorAll('.item');
+        const contents = Array.from(items).map((item) => item.innerText);
+
+        expect(contents).toEqual(['1', '2', '3']);
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.html
@@ -1,5 +1,5 @@
 <template>
-    <div lwc:if={show} class="item">1</div>
-    <div lwc:if={show} class="item">2</div>
-    <div lwc:if={show} class="item">3</div>
+    <div lwc:if={show}>1</div>
+    <div lwc:if={show}>2</div>
+    <div lwc:if={show}>3</div>
 </template>

--- a/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.html
@@ -1,0 +1,5 @@
+<template>
+    <div lwc:if={show} class="item">1</div>
+    <div lwc:if={show} class="item">2</div>
+    <div lwc:if={show} class="item">3</div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-3396/x/test/test.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class CustomRender extends LightningElement {
+    @api show;
+}

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
@@ -20,7 +20,7 @@ describe('vfragment sequential reordering', () => {
 
         const childNodes = elm.shadowRoot.childNodes;
         const contents = Array.from(childNodes).map((node) => node.textContent);
-        expect(contents).toEqual(['', 'fragment', '', '', 'bar', '']);
+        expect(contents).toEqual(['', '一', '二', '三', '', '', 'bar', '']);
     });
 
     it('move fragment right (["fragment", "foo"] => ["bar", "fragment"])', async () => {
@@ -40,6 +40,6 @@ describe('vfragment sequential reordering', () => {
 
         const childNodes = elm.shadowRoot.childNodes;
         const contents = Array.from(childNodes).map((node) => node.textContent);
-        expect(contents).toEqual(['', 'bar', '', '', 'fragment', '']);
+        expect(contents).toEqual(['', 'bar', '', '', '一', '二', '三', '']);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
@@ -3,39 +3,43 @@ import { createElement } from 'lwc';
 import Test from 'x/test';
 
 describe('vfragment sequential reordering', () => {
-    it('move left (["bar", "foo"] => ["foo", "baz"])', async () => {
+    it('move fragment left (["foo", "fragment"] => ["fragment", "bar"])', async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         await Promise.resolve();
 
         // Setup
-        elm.beforeItems = ['bar'];
+        elm.beforeItems = ['foo'];
+        elm.afterItems = [];
         await Promise.resolve();
 
         // Reorder
-        elm.afterItems = ['baz'];
-        await Promise.resolve();
-
-        const items = elm.shadowRoot.querySelectorAll('.item');
-        const contents = Array.from(items).map((item) => item.innerText);
-        expect(contents).toEqual(['foo', 'baz']);
-    });
-
-    it('move right (["foo", "bar"] => ["baz", "foo"])', async () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        await Promise.resolve();
-
-        // Setup
+        elm.beforeItems = [];
         elm.afterItems = ['bar'];
         await Promise.resolve();
 
-        // Reorder
-        elm.beforeItems = ['baz'];
+        const childNodes = elm.shadowRoot.childNodes;
+        const contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['', 'fragment', '', '', 'bar', '']);
+    });
+
+    it('move fragment right (["fragment", "foo"] => ["bar", "fragment"])', async () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
         await Promise.resolve();
 
-        const items = elm.shadowRoot.querySelectorAll('.item');
-        const contents = Array.from(items).map((item) => item.innerText);
-        expect(contents).toEqual(['baz', 'foo']);
+        // Setup
+        elm.beforeItems = [];
+        elm.afterItems = ['foo'];
+        await Promise.resolve();
+
+        // Reorder
+        elm.beforeItems = ['bar'];
+        elm.afterItems = [];
+        await Promise.resolve();
+
+        const childNodes = elm.shadowRoot.childNodes;
+        const contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['', 'bar', '', '', 'fragment', '']);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
@@ -3,7 +3,7 @@ import { createElement } from 'lwc';
 import Test from 'x/test';
 
 describe('vfragment sequential reordering', () => {
-    it('move fragment left (["foo", "fragment"] => ["fragment", "bar"])', async () => {
+    it('move fragment left', async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         await Promise.resolve();
@@ -13,17 +13,21 @@ describe('vfragment sequential reordering', () => {
         elm.afterItems = [];
         await Promise.resolve();
 
+        let childNodes = elm.shadowRoot.childNodes;
+        let contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['', 'foo', '', '', '一', '二', '三', '']);
+
         // Reorder
         elm.beforeItems = [];
         elm.afterItems = ['bar'];
         await Promise.resolve();
 
-        const childNodes = elm.shadowRoot.childNodes;
-        const contents = Array.from(childNodes).map((node) => node.textContent);
+        childNodes = elm.shadowRoot.childNodes;
+        contents = Array.from(childNodes).map((node) => node.textContent);
         expect(contents).toEqual(['', '一', '二', '三', '', '', 'bar', '']);
     });
 
-    it('move fragment right (["fragment", "foo"] => ["bar", "fragment"])', async () => {
+    it('move fragment right', async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         await Promise.resolve();
@@ -33,13 +37,17 @@ describe('vfragment sequential reordering', () => {
         elm.afterItems = ['foo'];
         await Promise.resolve();
 
+        let childNodes = elm.shadowRoot.childNodes;
+        let contents = Array.from(childNodes).map((node) => node.textContent);
+        expect(contents).toEqual(['', '一', '二', '三', '', '', 'foo', '']);
+
         // Reorder
         elm.beforeItems = ['bar'];
         elm.afterItems = [];
         await Promise.resolve();
 
-        const childNodes = elm.shadowRoot.childNodes;
-        const contents = Array.from(childNodes).map((node) => node.textContent);
+        childNodes = elm.shadowRoot.childNodes;
+        contents = Array.from(childNodes).map((node) => node.textContent);
         expect(contents).toEqual(['', 'bar', '', '', '一', '二', '三', '']);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/index.spec.js
@@ -1,0 +1,41 @@
+import { createElement } from 'lwc';
+
+import Test from 'x/test';
+
+describe('vfragment sequential reordering', () => {
+    it('move left (["bar", "foo"] => ["foo", "baz"])', async () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+
+        // Setup
+        elm.beforeItems = ['bar'];
+        await Promise.resolve();
+
+        // Reorder
+        elm.afterItems = ['baz'];
+        await Promise.resolve();
+
+        const items = elm.shadowRoot.querySelectorAll('.item');
+        const contents = Array.from(items).map((item) => item.innerText);
+        expect(contents).toEqual(['foo', 'baz']);
+    });
+
+    it('move right (["foo", "bar"] => ["baz", "foo"])', async () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+
+        // Setup
+        elm.afterItems = ['bar'];
+        await Promise.resolve();
+
+        // Reorder
+        elm.beforeItems = ['baz'];
+        await Promise.resolve();
+
+        const items = elm.shadowRoot.querySelectorAll('.item');
+        const contents = Array.from(items).map((item) => item.innerText);
+        expect(contents).toEqual(['baz', 'foo']);
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
@@ -1,12 +1,14 @@
 <template>
     <template for:each={beforeItems} for:item="beforeItem">
-        <div key={beforeItem} class="item">{beforeItem}</div>
+        <!-- lwc:if is only used to make this a vfragment -->
+        <div key={beforeItem} class="item" lwc:if={beforeItems}>{beforeItem}</div>
     </template>
 
-    <!-- lwc:if is only here to make this a vfragment -->
-    <div class="item" lwc:if={beforeItems}>foo</div>
+    <!-- lwc:if is only used to make this a vfragment -->
+    <div class="item" lwc:if={beforeItems}>fragment</div>
 
     <template for:each={afterItems} for:item="afterItem">
-        <div key={afterItem} class="item">{afterItem}</div>
+        <!-- lwc:if is only used to make this a vfragment -->
+        <div key={afterItem} class="item" lwc:if={afterItems}>{afterItem}</div>
     </template>
 </template>

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
@@ -1,0 +1,12 @@
+<template>
+    <template for:each={beforeItems} for:item="beforeItem">
+        <div key={beforeItem} class="item">{beforeItem}</div>
+    </template>
+
+    <!-- lwc:if is only here to make this a vfragment -->
+    <div class="item" lwc:if={beforeItems}>foo</div>
+
+    <template for:each={afterItems} for:item="afterItem">
+        <div key={afterItem} class="item">{afterItem}</div>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
@@ -5,7 +5,11 @@
     </template>
 
     <!-- lwc:if is only used to make this a vfragment -->
-    <div lwc:if={beforeItems}>fragment</div>
+    <template lwc:if={beforeItems}>
+        <div>一</div>
+        <div>二</div>
+        <div>三</div>
+    </template>
 
     <template for:each={afterItems} for:item="afterItem">
         <!-- lwc:if is only used to make this a vfragment -->

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.html
@@ -1,14 +1,14 @@
 <template>
     <template for:each={beforeItems} for:item="beforeItem">
         <!-- lwc:if is only used to make this a vfragment -->
-        <div key={beforeItem} class="item" lwc:if={beforeItems}>{beforeItem}</div>
+        <div key={beforeItem} lwc:if={beforeItems}>{beforeItem}</div>
     </template>
 
     <!-- lwc:if is only used to make this a vfragment -->
-    <div class="item" lwc:if={beforeItems}>fragment</div>
+    <div lwc:if={beforeItems}>fragment</div>
 
     <template for:each={afterItems} for:item="afterItem">
         <!-- lwc:if is only used to make this a vfragment -->
-        <div key={afterItem} class="item" lwc:if={afterItems}>{afterItem}</div>
+        <div key={afterItem} lwc:if={afterItems}>{afterItem}</div>
     </template>
 </template>

--- a/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.js
+++ b/packages/@lwc/integration-karma/test/rendering/sequential-reordering/x/test/test.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    beforeItems = [];
+
+    @api
+    afterItems = [];
+}


### PR DESCRIPTION
## Details

Implements an abstraction for moving vfragment-based nodes around and fixes both reported issues around insertion when the vfragment-based nodes are the reference node. Note that we already had logic for mounting/patching/removing.

Fixes #3396
Fixes #3377

## Does this pull request introduce a breaking change?

No

## Does this pull request introduce an observable change?

Yes

## GUS work item

W-12630370