### PR TITLE
fix(engine-core): remove dev-only errors for decorators

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -74,15 +74,10 @@ export function createPublicAccessorDescriptor(
     descriptor: PropertyDescriptor
 ): PropertyDescriptor {
     const { get, set, enumerable, configurable } = descriptor;
-    if (!isFunction(get)) {
-        if (process.env.NODE_ENV !== 'production') {
-            assert.invariant(
-                isFunction(get),
-                `Invalid compiler output for public accessor ${toString(key)} decorated with @api`
-            );
-        }
-        throw new Error();
-    }
+    assert.invariant(
+        isFunction(get),
+        `Invalid compiler output for public accessor ${toString(key)} decorated with @api`
+    );
     return {
         get(this: LightningElement): any {
             if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -76,7 +76,9 @@ export function createPublicAccessorDescriptor(
     const { get, set, enumerable, configurable } = descriptor;
     assert.invariant(
         isFunction(get),
-        `Invalid compiler output for public accessor ${toString(key)} decorated with @api`
+        `Invalid public accessor ${toString(
+            key
+        )} decorated with @api. The property is missing a getter.`
     );
     return {
         get(this: LightningElement): any {

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -125,8 +125,7 @@ function validateMethodDecoratedWithWire(
 ) {
     assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
-        // TODO [#3408]: this should throw, not log
-        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        // TODO [#3441]: This line of code does not seem possible to reach.
         logError(
             `Invalid @wire ${methodName} field. The field should have a valid writable descriptor.`
         );
@@ -155,20 +154,17 @@ function validateAccessorDecoratedWithApi(
 ) {
     assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor)) {
-        // TODO [#3408]: this should throw, not log
-        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        // TODO [#3441]: This line of code does not seem possible to reach.
         logError(`Invalid @api get ${fieldName} accessor.`);
     } else if (isFunction(descriptor.set)) {
         if (!isFunction(descriptor.get)) {
-            // TODO [#3408]: this should throw, not log
-            // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+            // TODO [#3441]: This line of code does not seem possible to reach.
             logError(
                 `Missing getter for property ${fieldName} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
             );
         }
     } else if (!isFunction(descriptor.get)) {
-        // TODO [#3408]: this should throw, not log
-        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        // TODO [#3441]: This line of code does not seem possible to reach.
         logError(`Missing @api get ${fieldName} accessor.`);
     }
 }
@@ -180,8 +176,7 @@ function validateMethodDecoratedWithApi(
 ) {
     assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
-        // TODO [#3408]: this should throw, not log
-        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        // TODO [#3441]: This line of code does not seem possible to reach.
         logError(`Invalid @api ${methodName} method.`);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -150,13 +150,10 @@ function validateFieldDecoratedWithApi(
 function validateAccessorDecoratedWithApi(
     Ctor: LightningElementConstructor,
     fieldName: string,
-    descriptor: PropertyDescriptor | undefined
+    descriptor: PropertyDescriptor
 ) {
     assertNotProd(); // this method should never leak to prod
-    if (isUndefined(descriptor)) {
-        // TODO [#3441]: This line of code does not seem possible to reach.
-        logError(`Invalid @api get ${fieldName} accessor.`);
-    } else if (isFunction(descriptor.set)) {
+    if (isFunction(descriptor.set)) {
         if (!isFunction(descriptor.get)) {
             // TODO [#3441]: This line of code does not seem possible to reach.
             logError(
@@ -205,12 +202,13 @@ export function registerDecorators(
 
             descriptor = getOwnPropertyDescriptor(proto, fieldName);
             if (propConfig.config > 0) {
+                if (isUndefined(descriptor)) {
+                    // TODO [#3441]: This line of code does not seem possible to reach.
+                    throw new Error();
+                }
                 // accessor declaration
                 if (process.env.NODE_ENV !== 'production') {
                     validateAccessorDecoratedWithApi(Ctor, fieldName, descriptor);
-                }
-                if (isUndefined(descriptor)) {
-                    throw new Error();
                 }
                 descriptor = createPublicAccessorDescriptor(fieldName, descriptor);
             } else {

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
-    assert,
     create,
     isFunction,
     isUndefined,
@@ -16,7 +15,7 @@ import {
 } from '@lwc/shared';
 import { LightningElementConstructor } from '../base-lightning-element';
 
-import { EmptyObject } from '../utils';
+import { assertNotProd, EmptyObject } from '../utils';
 import { logError } from '../../shared/logger';
 import { createObservedFieldPropertyDescriptor } from '../observed-fields';
 import {
@@ -81,17 +80,13 @@ function validateObservedField(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
         const message = `Invalid observed ${fieldName} field. Found a duplicate ${type} with the same name.`;
 
-        // [W-9927596] Ideally we always throw an error when detecting duplicate observed field.
-        // This branch is only here for backward compatibility reasons.
-        if (type === DescriptorType.Accessor) {
-            logError(message);
-        } else {
-            assert.fail(message);
-        }
+        // TODO [#3408]: this should throw, not log
+        logError(message);
     }
 }
 
@@ -100,9 +95,11 @@ function validateFieldDecoratedWithTrack(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
-        assert.fail(
+        // TODO [#3408]: this should throw, not log
+        logError(
             `Invalid @track ${fieldName} field. Found a duplicate ${type} with the same name.`
         );
     }
@@ -113,11 +110,11 @@ function validateFieldDecoratedWithWire(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
-        assert.fail(
-            `Invalid @wire ${fieldName} field. Found a duplicate ${type} with the same name.`
-        );
+        // TODO [#3408]: this should throw, not log
+        logError(`Invalid @wire ${fieldName} field. Found a duplicate ${type} with the same name.`);
     }
 }
 
@@ -126,8 +123,13 @@ function validateMethodDecoratedWithWire(
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
-        assert.fail(`Invalid @wire ${methodName} method.`);
+        // TODO [#3408]: this should throw, not log
+        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        logError(
+            `Invalid @wire ${methodName} field. The field should have a valid writable descriptor.`
+        );
     }
 }
 
@@ -136,17 +138,13 @@ function validateFieldDecoratedWithApi(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
         const message = `Invalid @api ${fieldName} field. Found a duplicate ${type} with the same name.`;
 
-        // [W-9927596] Ideally we always throw an error when detecting duplicate public properties.
-        // This branch is only here for backward compatibility reasons.
-        if (type === DescriptorType.Accessor) {
-            logError(message);
-        } else {
-            assert.fail(message);
-        }
+        // TODO [#3408]: this should throw, not log
+        logError(message);
     }
 }
 
@@ -155,15 +153,23 @@ function validateAccessorDecoratedWithApi(
     fieldName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor)) {
-        assert.fail(`Invalid @api get ${fieldName} accessor.`);
+        // TODO [#3408]: this should throw, not log
+        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        logError(`Invalid @api get ${fieldName} accessor.`);
     } else if (isFunction(descriptor.set)) {
-        assert.isTrue(
-            isFunction(descriptor.get),
-            `Missing getter for property ${fieldName} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
-        );
+        if (!isFunction(descriptor.get)) {
+            // TODO [#3408]: this should throw, not log
+            // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+            logError(
+                `Missing getter for property ${fieldName} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
+            );
+        }
     } else if (!isFunction(descriptor.get)) {
-        assert.fail(`Missing @api get ${fieldName} accessor.`);
+        // TODO [#3408]: this should throw, not log
+        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        logError(`Missing @api get ${fieldName} accessor.`);
     }
 }
 
@@ -172,8 +178,11 @@ function validateMethodDecoratedWithApi(
     methodName: string,
     descriptor: PropertyDescriptor | undefined
 ) {
+    assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
-        assert.fail(`Invalid @api ${methodName} method.`);
+        // TODO [#3408]: this should throw, not log
+        // This line of code does not seem possible to reach. Maybe when native decorators are supported?
+        logError(`Invalid @api ${methodName} method.`);
     }
 }
 
@@ -251,10 +260,12 @@ export function registerDecorators(
             descriptor = getOwnPropertyDescriptor(proto, fieldOrMethodName);
             if (method === 1) {
                 if (process.env.NODE_ENV !== 'production') {
-                    assert.isTrue(
-                        adapter,
-                        `@wire on method "${fieldOrMethodName}": adapter id must be truthy.`
-                    );
+                    if (!adapter) {
+                        // TODO [#3408]: this should throw, not log
+                        logError(
+                            `@wire on method "${fieldOrMethodName}": adapter id must be truthy.`
+                        );
+                    }
                     validateMethodDecoratedWithWire(Ctor, fieldOrMethodName, descriptor);
                 }
                 if (isUndefined(descriptor)) {
@@ -264,10 +275,12 @@ export function registerDecorators(
                 storeWiredMethodMeta(descriptor, adapter, configCallback, dynamic);
             } else {
                 if (process.env.NODE_ENV !== 'production') {
-                    assert.isTrue(
-                        adapter,
-                        `@wire on field "${fieldOrMethodName}": adapter id must be truthy.`
-                    );
+                    if (!adapter) {
+                        // TODO [#3408]: this should throw, not log
+                        logError(
+                            `@wire on field "${fieldOrMethodName}": adapter id must be truthy.`
+                        );
+                    }
                     validateFieldDecoratedWithWire(Ctor, fieldOrMethodName, descriptor);
                 }
                 descriptor = internalWireFieldDecorator(fieldOrMethodName);

--- a/packages/@lwc/engine-core/src/framework/readonly.ts
+++ b/packages/@lwc/engine-core/src/framework/readonly.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert } from '@lwc/shared';
+import { logError } from '../shared/logger';
 import { getReadOnlyProxy } from './membrane';
 
 /**
@@ -16,7 +16,7 @@ export function readonly(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {
         // TODO [#1292]: Remove the readonly decorator
         if (arguments.length !== 1) {
-            assert.fail(
+            logError(
                 '@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value.'
             );
         }

--- a/packages/@lwc/integration-karma/test/api/readonly/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/readonly/index.spec.js
@@ -1,15 +1,13 @@
 import { readonly } from 'lwc';
 
 it('should throw if no argument is provided', () => {
-    expect(() => readonly()).toThrowErrorDev(
-        Error,
+    expect(() => readonly()).toLogErrorDev(
         /@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value./
     );
 });
 
 it('should throw if more than one argument is passed', () => {
-    expect(() => readonly({}, {})).toThrowErrorDev(
-        Error,
+    expect(() => readonly({}, {})).toLogErrorDev(
         /@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value./
     );
 });

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -142,7 +142,9 @@ describe('restrictions', () => {
                         this._foo = val;
                     }
                 }
-            }).toThrowError(/Invalid compiler output for public accessor foo decorated with @api/);
+            }).toThrowError(
+                /Invalid public accessor foo decorated with @api\. The property is missing a getter\./
+            );
         }).toLogErrorDev(
             /Missing getter for property foo decorated with @api in (class|function) Invalid/
         );

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -115,7 +115,7 @@ it('should not log an error when initializing api value to null', () => {
 });
 
 describe('restrictions', () => {
-    it('throws a property error when a public field conflicts with a method', () => {
+    it('logs a property error when a public field conflicts with a method', () => {
         expect(() => {
             // The following class is wrapped by the compiler with registerDecorators. We check
             // here if the fields are validated properly.
@@ -125,9 +125,39 @@ describe('restrictions', () => {
                 // eslint-disable-next-line no-dupe-class-members
                 showFeatures() {}
             }
-        }).toThrowErrorDev(
-            'Invalid @api showFeatures field. Found a duplicate method with the same name.'
+        }).toLogErrorDev(
+            /Invalid @api showFeatures field\. Found a duplicate method with the same name\./
         );
+    });
+
+    it('throws an error when an @api field has a setter but no getter', () => {
+        expect(() => {
+            expect(() => {
+                // The following class is wrapped by the compiler with registerDecorators. We check here
+                // if the fields are validated properly.
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                class Invalid extends LightningElement {
+                    @api
+                    set foo(val) {
+                        this._foo = val;
+                    }
+                }
+            }).toThrowError(/Invalid compiler output for public accessor foo decorated with @api/);
+        }).toLogErrorDev(/Missing getter for property foo decorated with @api in class Invalid/);
+    });
+
+    it('does not throw or log an error when an @api field has a getter but no setter', () => {
+        expect(() => {
+            // The following class is wrapped by the compiler with registerDecorators. We check here
+            // if the fields are validated properly.
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            class Invalid extends LightningElement {
+                @api
+                get foo() {
+                    return this._foo;
+                }
+            }
+        }).not.toLogError(); // if it throws an error, that will also fail this test
     });
 });
 

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -143,7 +143,9 @@ describe('restrictions', () => {
                     }
                 }
             }).toThrowError(/Invalid compiler output for public accessor foo decorated with @api/);
-        }).toLogErrorDev(/Missing getter for property foo decorated with @api in class Invalid/);
+        }).toLogErrorDev(
+            /Missing getter for property foo decorated with @api in (class|function) Invalid/
+        );
     });
 
     it('does not throw or log an error when an @api field has a getter but no setter', () => {

--- a/packages/@lwc/integration-karma/test/component/decorators/track/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/track/index.spec.js
@@ -43,7 +43,7 @@ describe('restrictions', () => {
         );
     });
 
-    it('throws a property error when a track field conflicts with a method', () => {
+    it('logs a property error when a track field conflicts with a method', () => {
         expect(() => {
             // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
@@ -53,12 +53,12 @@ describe('restrictions', () => {
                 // eslint-disable-next-line no-dupe-class-members
                 showFeatures() {}
             }
-        }).toThrowErrorDev(
-            'Invalid @track showFeatures field. Found a duplicate method with the same name.'
+        }).toLogErrorDev(
+            /Invalid @track showFeatures field\. Found a duplicate method with the same name\./
         );
     });
 
-    it('throws a property error when a track field conflicts with an accessor', () => {
+    it('logs a property error when a track field conflicts with an accessor', () => {
         expect(() => {
             // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
@@ -72,8 +72,8 @@ describe('restrictions', () => {
                 // eslint-disable-next-line no-dupe-class-members
                 set showFeatures(v) {}
             }
-        }).toThrowErrorDev(
-            'Invalid @track showFeatures field. Found a duplicate accessor with the same name.'
+        }).toLogErrorDev(
+            /Invalid @track showFeatures field\. Found a duplicate accessor with the same name\./
         );
     });
 });

--- a/packages/@lwc/integration-karma/test/component/decorators/wire/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/wire/index.spec.js
@@ -4,7 +4,7 @@ import { adapter } from 'x/adapter';
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
 
 describe('restrictions', () => {
-    it('throws a property error when a wired field conflicts with a method', () => {
+    it('logs a property error when a wired field conflicts with a method', () => {
         expect(() => {
             // The following class is wrapped by the compiler with registerDecorators. We check here
             // if the fields are validated properly.
@@ -14,8 +14,8 @@ describe('restrictions', () => {
                 // eslint-disable-next-line no-dupe-class-members
                 showFeatures() {}
             }
-        }).toThrowErrorDev(
-            'Invalid @wire showFeatures field. Found a duplicate method with the same name.'
+        }).toLogErrorDev(
+            /Invalid @wire showFeatures field\. Found a duplicate method with the same name\./
         );
     });
 });

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -134,7 +134,7 @@ describe('observed-fields', () => {
     });
 
     describe('restrictions', () => {
-        it('throws a property error when a reactive field conflicts with a method', () => {
+        it('logs a property error when a reactive field conflicts with a method', () => {
             expect(() => {
                 // The following class is wrapped by the compiler with registerDecorators. We check
                 // here if the fields are validated properly.
@@ -144,8 +144,8 @@ describe('observed-fields', () => {
                     // eslint-disable-next-line no-dupe-class-members
                     showFeatures() {}
                 }
-            }).toThrowErrorDev(
-                'Invalid observed showFeatures field. Found a duplicate method with the same name.'
+            }).toLogErrorDev(
+                /Invalid observed showFeatures field\. Found a duplicate method with the same name\./
             );
         });
     });


### PR DESCRIPTION
## Details

Partially addresses #3245

Anytime we throw an error in dev mode but not in prod mode, that's a bug. This PR gets us one step closer to fixing that, by making decorator validation errors _log_ rather than throw.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

