### PR TITLE
chore: v2.41.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc-monorepo",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "private": true,
     "description": "Lightning Web Components",
     "repository": {

--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/aria-reflection",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "ARIA element reflection polyfill for strings",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -34,7 +34,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lwc/shared": "2.41.1"
+        "@lwc/shared": "2.41.2"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.41.1",
+    "version": "2.41.2",
     "main": "src/index.js",
     "typings": "src/index.d.ts",
     "license": "MIT",
@@ -21,8 +21,8 @@
     ],
     "dependencies": {
         "@babel/helper-module-imports": "~7.18.6",
-        "@lwc/errors": "2.41.1",
-        "@lwc/shared": "2.41.1",
+        "@lwc/errors": "2.41.2",
+        "@lwc/shared": "2.41.2",
         "line-column": "~1.0.2"
     },
     "peerDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/compiler",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "LWC compiler",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,11 +25,11 @@
         "@babel/core": "~7.21.0",
         "@babel/plugin-proposal-class-properties": "~7.18.6",
         "@babel/plugin-proposal-object-rest-spread": "~7.20.2",
-        "@lwc/babel-plugin-component": "2.41.1",
-        "@lwc/errors": "2.41.1",
-        "@lwc/shared": "2.41.1",
-        "@lwc/style-compiler": "2.41.1",
-        "@lwc/template-compiler": "2.41.1"
+        "@lwc/babel-plugin-component": "2.41.2",
+        "@lwc/errors": "2.41.2",
+        "@lwc/shared": "2.41.2",
+        "@lwc/style-compiler": "2.41.2",
+        "@lwc/template-compiler": "2.41.2"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-core",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Core LWC engine APIs.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,9 +24,9 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/aria-reflection": "2.41.1",
-        "@lwc/features": "2.41.1",
-        "@lwc/shared": "2.41.1"
+        "@lwc/aria-reflection": "2.41.2",
+        "@lwc/features": "2.41.2",
+        "@lwc/shared": "2.41.2"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-dom",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Renders LWC components in a DOM environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,9 +24,9 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/aria-reflection": "2.41.1",
-        "@lwc/engine-core": "2.41.1",
-        "@lwc/shared": "2.41.1",
+        "@lwc/aria-reflection": "2.41.2",
+        "@lwc/engine-core": "2.41.2",
+        "@lwc/shared": "2.41.2",
         "magic-string": "^0.30.0"
     },
     "lwc": {

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-server",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Renders LWC components in a server environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -27,9 +27,9 @@
         "parse5": "Currently can't upgrade parse5: dropped cjs support in v7.0.0 https://github.com/inikulin/parse5/releases/tag/v7.0.0"
     },
     "devDependencies": {
-        "@lwc/engine-core": "2.41.1",
-        "@lwc/rollup-plugin": "2.41.1",
-        "@lwc/shared": "2.41.1",
+        "@lwc/engine-core": "2.41.2",
+        "@lwc/rollup-plugin": "2.41.2",
+        "@lwc/shared": "2.41.2",
         "@rollup/plugin-virtual": "^3.0.1",
         "parse5": "^6.0.1"
     },

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/errors",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "LWC Error Utilities",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/features",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "LWC Features Flags",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,7 +24,7 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.41.1"
+        "@lwc/shared": "2.41.2"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-karma",
     "private": true,
-    "version": "2.41.1",
+    "version": "2.41.2",
     "scripts": {
         "start": "karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
@@ -16,11 +16,11 @@
         "karma-jasmine": "must be kept at v4 because it is only compatible with jasmine-core@4, which we need for IE11"
     },
     "devDependencies": {
-        "@lwc/compiler": "2.41.1",
-        "@lwc/engine-dom": "2.41.1",
-        "@lwc/engine-server": "2.41.1",
-        "@lwc/rollup-plugin": "2.41.1",
-        "@lwc/synthetic-shadow": "2.41.1",
+        "@lwc/compiler": "2.41.2",
+        "@lwc/engine-dom": "2.41.2",
+        "@lwc/engine-server": "2.41.2",
+        "@lwc/rollup-plugin": "2.41.2",
+        "@lwc/synthetic-shadow": "2.41.2",
         "chokidar": "^3.5.3",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-tests",
     "private": true,
-    "version": "2.41.1",
+    "version": "2.41.2",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -23,7 +23,7 @@
         "webdriverio, @wdio/cli": "Currently can't upgrade @wdio namespaced dependencies to v8.0.0 because it dropped CommonJS support https://github.com/webdriverio/webdriverio/releases/tag/v8.0.0"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.41.1",
+        "@lwc/rollup-plugin": "2.41.2",
         "@wdio/cli": "^7.26.0",
         "@wdio/devtools-service": "^7.30.1",
         "@wdio/local-runner": "^7.26.0",
@@ -34,7 +34,7 @@
         "@wdio/static-server-service": "^7.26.0",
         "deepmerge": "^4.3.0",
         "dotenv": "^16.0.3",
-        "lwc": "2.41.1",
+        "lwc": "2.41.2",
         "minimist": "^1.2.8",
         "webdriverio": "^7.26.0"
     }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.41.1",
+    "version": "2.41.2",
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "scripts": {

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lwc/perf-benchmarks-components",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c ./rollup.config.mjs"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.41.1"
+        "@lwc/rollup-plugin": "2.41.2"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/perf-benchmarks",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c  ./rollup.config.mjs && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -17,10 +17,10 @@
         "Also note that we use rollup-plugin-node-resolve-v13 because Best uses an old version of Rollup."
     ],
     "dependencies": {
-        "@lwc/engine-dom": "2.41.1",
-        "@lwc/engine-server": "2.41.1",
-        "@lwc/perf-benchmarks-components": "2.41.1",
-        "@lwc/synthetic-shadow": "2.41.1"
+        "@lwc/engine-dom": "2.41.2",
+        "@lwc/engine-server": "2.41.2",
+        "@lwc/perf-benchmarks-components": "2.41.2",
+        "@lwc/synthetic-shadow": "2.41.2"
     },
     "devDependencies": {
         "@best/cli": "^8.1.3",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/rollup-plugin",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Rollup plugin to compile LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,12 +22,12 @@
         "dist/"
     ],
     "devDependencies": {
-        "@lwc/compiler": "2.41.1",
-        "@lwc/engine-dom": "2.41.1",
-        "@lwc/errors": "2.41.1"
+        "@lwc/compiler": "2.41.2",
+        "@lwc/engine-dom": "2.41.2",
+        "@lwc/errors": "2.41.2"
     },
     "dependencies": {
-        "@lwc/module-resolver": "2.41.1",
+        "@lwc/module-resolver": "2.41.2",
         "@rollup/pluginutils": "~5.0.2"
     },
     "peerDependencies": {

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/shared",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Utilities and methods that are shared across packages",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/style-compiler",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,7 +22,7 @@
         "dist/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.41.1",
+        "@lwc/shared": "2.41.2",
         "postcss": "~8.4.20",
         "postcss-selector-parser": "~6.0.11",
         "postcss-value-parser": "~4.2.0",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/synthetic-shadow",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Synthetic Shadow Root for LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -36,8 +36,8 @@
         "access": "public"
     },
     "devDependencies": {
-        "@lwc/features": "2.41.1",
-        "@lwc/shared": "2.41.1"
+        "@lwc/features": "2.41.2",
+        "@lwc/shared": "2.41.2"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/template-compiler",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Template compiler package",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -30,8 +30,8 @@
         "@types/source-map": "0.5.7"
     },
     "dependencies": {
-        "@lwc/errors": "2.41.1",
-        "@lwc/shared": "2.41.1",
+        "@lwc/errors": "2.41.2",
+        "@lwc/shared": "2.41.2",
         "acorn": "~8.8.2",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/wire-service",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "@wire service",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.41.1",
-        "@lwc/shared": "2.41.1"
+        "@lwc/engine-core": "2.41.2",
+        "@lwc/shared": "2.41.2"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -41,12 +41,12 @@
         ]
     },
     "dependencies": {
-        "@lwc/compiler": "2.41.1",
-        "@lwc/engine-dom": "2.41.1",
-        "@lwc/engine-server": "2.41.1",
-        "@lwc/features": "2.41.1",
-        "@lwc/synthetic-shadow": "2.41.1",
-        "@lwc/wire-service": "2.41.1"
+        "@lwc/compiler": "2.41.2",
+        "@lwc/engine-dom": "2.41.2",
+        "@lwc/engine-server": "2.41.2",
+        "@lwc/features": "2.41.2",
+        "@lwc/synthetic-shadow": "2.41.2",
+        "@lwc/wire-service": "2.41.2"
     },
     "nx": {
         "targets": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@lwc/playground",
-    "version": "2.41.1",
+    "version": "2.41.2",
     "type": "module",
     "description": "Playground project to experiment with LWC.",
     "scripts": {
@@ -9,9 +9,9 @@
         "build": "NODE_ENV=production rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.41.1",
+        "@lwc/rollup-plugin": "2.41.2",
         "@rollup/plugin-replace": "^5.0.2",
-        "lwc": "2.41.1",
+        "lwc": "2.41.2",
         "rollup": "^3.18.0",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.2"


### PR DESCRIPTION
## Details
Includes a patch fix for ordering of content during rendering of `lwc:if` blocks.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12246411
