### PR TITLE
fix(engine-core): do not warn on missing slot names

### DIFF
--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
-    ArrayIndexOf,
     ArrayUnshift,
     assert,
     create,
@@ -18,7 +17,6 @@ import {
     toString,
 } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import api, { RenderAPI } from './api';
 import {
@@ -30,7 +28,7 @@ import {
     TemplateCache,
     VM,
 } from './vm';
-import { assertNotProd, EmptyArray } from './utils';
+import { assertNotProd } from './utils';
 import { defaultEmptyTemplate, isTemplateRegistered } from './secure-template';
 import {
     createStylesheet,
@@ -68,11 +66,10 @@ export function setVMBeingRendered(vm: VM | null) {
     vmBeingRendered = vm;
 }
 
-function validateSlots(vm: VM, html: Template) {
+function validateSlots(vm: VM) {
     assertNotProd(); // this method should never leak to prod
 
     const { cmpSlots } = vm;
-    const { slots = EmptyArray } = html;
 
     for (const slotName in cmpSlots.slotAssignments) {
         // eslint-disable-next-line @lwc/lwc-internal/no-production-assert
@@ -82,15 +79,6 @@ function validateSlots(vm: VM, html: Template) {
                 cmpSlots.slotAssignments[slotName]
             )} for slot "${slotName}" in ${vm}.`
         );
-
-        if (slotName !== '' && ArrayIndexOf.call(slots, slotName) === -1) {
-            // TODO [#1297]: this should never really happen because the compiler should always validate
-            // eslint-disable-next-line @lwc/lwc-internal/no-production-assert
-            logError(
-                `Ignoring unknown provided slot name "${slotName}" in ${vm}. Check for a typo on the slot attribute.`,
-                vm
-            );
-        }
     }
 }
 
@@ -264,7 +252,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
 
                 if (process.env.NODE_ENV !== 'production') {
                     // validating slots in every rendering since the allocated content might change over time
-                    validateSlots(vm, html);
+                    validateSlots(vm);
                     // add the VM to the list of host VMs that can be re-rendered if html is swapped
                     setActiveVM(vm);
                 }

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
@@ -130,13 +130,7 @@ describe('slotted content using lwc:dynamic', () => {
         if (process.env.NATIVE_SHADOW) {
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBe(null);
         } else {
-            if (process.env.NODE_ENV === 'production') {
-                expect(consoleSpy.calls.error.length).toEqual(0);
-            } else {
-                expect(consoleSpy.calls.error[0][0].message).toContain(
-                    'Ignoring unknown provided slot name "bar"'
-                );
-            }
+            expect(consoleSpy.calls.error.length).toEqual(0);
         }
 
         // Swap construstor and check if nodes have been reallocated.
@@ -153,13 +147,7 @@ describe('slotted content using lwc:dynamic', () => {
                     null
                 );
             } else {
-                if (process.env.NODE_ENV === 'production') {
-                    expect(consoleSpy.calls.error.length).toEqual(0);
-                } else {
-                    expect(consoleSpy.calls.error[1][0].message).toContain(
-                        'Ignoring unknown provided slot name "foo"'
-                    );
-                }
+                expect(consoleSpy.calls.error.length).toEqual(0);
             }
         });
     });

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
@@ -128,10 +128,10 @@ describe('slotted content using lwc:dynamic', () => {
         expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBeDefined();
 
         if (process.env.NATIVE_SHADOW) {
+            // `slot-bar` is not rendered in synthetic shadow
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBe(null);
-        } else {
-            expect(consoleSpy.calls.error.length).toEqual(0);
         }
+        expect(consoleSpy.calls.error.length).toEqual(0);
 
         // Swap construstor and check if nodes have been reallocated.
         elm.ctor = ContainerBar;
@@ -143,12 +143,12 @@ describe('slotted content using lwc:dynamic', () => {
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBeDefined();
 
             if (process.env.NATIVE_SHADOW) {
+                // `slot-foo` is not rendered in synthetic shadow
                 expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBe(
                     null
                 );
-            } else {
-                expect(consoleSpy.calls.error.length).toEqual(0);
             }
+            expect(consoleSpy.calls.error.length).toEqual(0);
         });
     });
 });
@@ -256,10 +256,10 @@ describe('slotted content', () => {
         expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBeDefined();
 
         if (process.env.NATIVE_SHADOW) {
+            // `slot-bar` is not rendered in synthetic shadow
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBe(null);
-        } else {
-            expect(consoleSpy.calls.error.length).toEqual(0);
         }
+        expect(consoleSpy.calls.error.length).toEqual(0);
 
         // Swap constructor and check if nodes have been reallocated.
         elm.ctor = ContainerBar;
@@ -271,12 +271,12 @@ describe('slotted content', () => {
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBeDefined();
 
             if (process.env.NATIVE_SHADOW) {
+                // `slot-foo` is not rendered in synthetic shadow
                 expect(elm.shadowRoot.querySelector('[data-id="slot-foo"]').assignedSlot).toBe(
                     null
                 );
-            } else {
-                expect(consoleSpy.calls.error.length).toEqual(0);
             }
+            expect(consoleSpy.calls.error.length).toEqual(0);
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/dynamic-imports/index.spec.js
@@ -258,13 +258,7 @@ describe('slotted content', () => {
         if (process.env.NATIVE_SHADOW) {
             expect(elm.shadowRoot.querySelector('[data-id="slot-bar"]').assignedSlot).toBe(null);
         } else {
-            if (process.env.NODE_ENV === 'production') {
-                expect(consoleSpy.calls.error.length).toEqual(0);
-            } else {
-                expect(consoleSpy.calls.error[0][0].message).toContain(
-                    'Ignoring unknown provided slot name "bar"'
-                );
-            }
+            expect(consoleSpy.calls.error.length).toEqual(0);
         }
 
         // Swap constructor and check if nodes have been reallocated.
@@ -281,13 +275,7 @@ describe('slotted content', () => {
                     null
                 );
             } else {
-                if (process.env.NODE_ENV === 'production') {
-                    expect(consoleSpy.calls.error.length).toEqual(0);
-                } else {
-                    expect(consoleSpy.calls.error[1][0].message).toContain(
-                        'Ignoring unknown provided slot name "foo"'
-                    );
-                }
+                expect(consoleSpy.calls.error.length).toEqual(0);
             }
         });
     });

--- a/packages/@lwc/integration-karma/test/rendering/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/index.spec.js
@@ -1,9 +1,11 @@
 import { createElement } from 'lwc';
-
+import { spyConsole } from 'test-utils';
 import RenderCountParent from 'x/renderCountParent';
 import FallbackContentReuseParent from 'x/fallbackContentReuseParent';
 import RegressionContainer from 'x/regressionContainer';
 import FallbackContentReuseDynamicKeyParent from 'x/fallbackContentReuseDynamicKeyParent';
+import UnknownSlotShadow from 'x/unknownSlotShadow';
+import UnknownSlotLight from 'x/unknownSlotLight';
 
 // TODO [#1617]: Engine currently has trouble with slotting and invocation of the renderedCallback.
 xit('should not render if the slotted content changes', () => {
@@ -76,5 +78,46 @@ it('should not throw error when updating slotted content triggers next tick re-r
 
             done();
         });
+    });
+});
+
+describe('does not log an error/warning on unknown slot name', () => {
+    let consoleSpy;
+    beforeEach(() => {
+        consoleSpy = spyConsole();
+    });
+    afterEach(() => {
+        consoleSpy.reset();
+    });
+
+    it('shadow dom', async () => {
+        const elm = createElement('x-unknown-slot-shadow', { is: UnknownSlotShadow });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        // nothing slotted into the child
+        expect(
+            elm.shadowRoot
+                .querySelector('x-unknown-slot-shadow-child')
+                .shadowRoot.querySelector('slot')
+                .assignedNodes().length
+        ).toEqual(0);
+
+        expect(consoleSpy.calls.error.length).toEqual(0);
+        expect(consoleSpy.calls.warn.length).toEqual(0);
+    });
+
+    it('light dom', async () => {
+        const elm = createElement('x-unknown-slot-light', { is: UnknownSlotLight });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        // nothing slotted into the child
+        expect(elm.querySelector('x-unknown-slot-light-child').children.length).toEqual(0);
+
+        expect(consoleSpy.calls.error.length).toEqual(0);
+        expect(consoleSpy.calls.warn.length).toEqual(0);
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLight/unknownSlotLight.html
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLight/unknownSlotLight.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <x-unknown-slot-light-child>
+        <div slot="doesnotexist"></div>
+    </x-unknown-slot-light-child>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLight/unknownSlotLight.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLight/unknownSlotLight.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLightChild/unknownSlotLightChild.html
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLightChild/unknownSlotLightChild.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <slot></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLightChild/unknownSlotLightChild.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotLightChild/unknownSlotLightChild.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadow/unknownSlotShadow.html
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadow/unknownSlotShadow.html
@@ -1,0 +1,5 @@
+<template>
+    <x-unknown-slot-shadow-child>
+        <div slot="doesnotexist"></div>
+    </x-unknown-slot-shadow-child>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadow/unknownSlotShadow.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadow/unknownSlotShadow.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadowChild/unknownSlotShadowChild.html
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadowChild/unknownSlotShadowChild.html
@@ -1,0 +1,3 @@
+<template>
+    <slot></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadowChild/unknownSlotShadowChild.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/x/unknownSlotShadowChild/unknownSlotShadowChild.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Fixes #3403

Removes all warnings for when a slot name doesn't exist, in both synthetic shadow and light DOM.

I considered _adding_ a warning to native shadow, but I'm not sure this is something we can easily override, nor does it seem particularly valuable to me.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
 W-12703461
