### PR TITLE
test: remove references to ENABLE_LIGHT_GET_ROOT_NODE_PATCH

### DIFF
--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
 import LightContainer from 'x/lightContainer';
@@ -71,18 +71,14 @@ describe('Light DOM + Synthetic Shadow DOM', () => {
             );
         });
 
-        describe('light -> shadow with ENABLE_LIGHT_GET_ROOT_NODE_PATCH', () => {
+        describe('light -> shadow getRootNode()', () => {
             let elm, nodes;
             beforeEach(() => {
-                setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', true);
                 elm = createElement('x-light-container', {
                     is: LightContainer,
                 });
                 document.body.appendChild(elm);
                 nodes = extractDataIds(elm);
-            });
-            afterEach(() => {
-                setFeatureFlagForTest('ENABLE_LIGHT_GET_ROOT_NODE_PATCH', false);
             });
             it('with getRootNode', () => {
                 expect(nodes.p.getRootNode()).toEqual(document);


### PR DESCRIPTION
## Details

There was one reference we missed in #3426 @abdulsattar. This removes it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

