### PR TITLE
fix(engine-core): clean up some untested dev-only errors

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { assert, isFunction, toString } from '@lwc/shared';
+import { assert, isFunction, isNull, toString } from '@lwc/shared';
 import { logError } from '../../shared/logger';
 import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
@@ -47,18 +47,22 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
-                assert.invariant(
-                    !isInvokingRender,
-                    `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
-                        key
-                    )}`
-                );
-                assert.invariant(
-                    !isUpdatingTemplate,
-                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
-                        key
-                    )}`
-                );
+                if (isInvokingRender) {
+                    logError(
+                        `render() method has side effects on the state of property "${toString(
+                            key
+                        )}"`,
+                        isNull(vmBeingRendered) ? vm : vmBeingRendered
+                    );
+                }
+                if (isUpdatingTemplate) {
+                    logError(
+                        `Updating the template has side effects on the state of property "${toString(
+                            key
+                        )}"`,
+                        isNull(vmBeingRendered) ? vm : vmBeingRendered
+                    );
+                }
             }
             vm.cmpProps[key] = newValue;
 
@@ -92,26 +96,31 @@ export function createPublicAccessorDescriptor(
             const vm = getAssociatedVM(this);
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
-                assert.invariant(
-                    !isInvokingRender,
-                    `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
-                        key
-                    )}`
-                );
-                assert.invariant(
-                    !isUpdatingTemplate,
-                    `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
-                        key
-                    )}`
-                );
+                if (isInvokingRender) {
+                    logError(
+                        `render() method has side effects on the state of property "${toString(
+                            key
+                        )}"`,
+                        isNull(vmBeingRendered) ? vm : vmBeingRendered
+                    );
+                }
+                if (isUpdatingTemplate) {
+                    logError(
+                        `Updating the template has side effects on the state of property "${toString(
+                            key
+                        )}"`,
+                        isNull(vmBeingRendered) ? vm : vmBeingRendered
+                    );
+                }
             }
             if (set) {
                 set.call(this, newValue);
             } else if (process.env.NODE_ENV !== 'production') {
-                assert.fail(
-                    `Invalid attempt to set a new value for property ${toString(
+                logError(
+                    `Invalid attempt to set a new value for property "${toString(
                         key
-                    )} of ${vm} that does not has a setter decorated with @api.`
+                    )}" that does not has a setter decorated with @api.`,
+                    vm
                 );
             }
         },

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -12,6 +12,7 @@ import Inheritance from 'x/inheritance';
 import NullInitialValue from 'x/nullInitialValue';
 
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
+import NoSetter from 'x/noSetter';
 
 describe('properties', () => {
     it('should expose class properties with the api decorator', () => {
@@ -381,5 +382,17 @@ describe('regression [W-9927596]', () => {
                 expect(elm.shadowRoot.querySelector('p').textContent).toBe('test');
             });
         });
+    });
+
+    it('logs an error when attempting to set property when there is no setter', () => {
+        const elm = createElement('x-no-setter', { is: NoSetter });
+
+        document.body.appendChild(elm);
+
+        expect(() => {
+            elm.foo = 'foo';
+        }).toLogErrorDev(
+            /Invalid attempt to set a new value for property "foo" that does not has a setter decorated with @api/
+        );
     });
 });

--- a/packages/@lwc/integration-karma/test/component/decorators/api/x/noSetter/noSetter.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/x/noSetter/noSetter.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class GetterSetter extends LightningElement {
+    _foo = 'foo';
+
+    @api
+    get foo() {
+        return this._foo;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/index.spec.js
@@ -1,0 +1,99 @@
+import { createElement } from 'lwc';
+import { spyConsole } from 'test-utils';
+
+import SideEffectDuringRender from 'x/sideEffectDuringRender';
+import SideEffectDuringTemplate from 'x/sideEffectDuringTemplate';
+import SideEffectDuringRenderExternal from 'x/sideEffectDuringRenderExternal';
+import SideEffectDuringTemplateExternal from 'x/sideEffectDuringTemplateExternal';
+
+describe('side effects', () => {
+    let consoleSpy;
+    beforeEach(() => {
+        consoleSpy = spyConsole();
+    });
+    afterEach(() => {
+        consoleSpy.reset();
+    });
+
+    it('logs error for side effect during render', async () => {
+        const elm = createElement('x-side-effect-during-render', { is: SideEffectDuringRender });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        if (process.env.NODE_ENV === 'production') {
+            expect(consoleSpy.calls.error.length).toEqual(0);
+        } else {
+            expect(consoleSpy.calls.error.length).toEqual(1);
+            expect(consoleSpy.calls.error[0][0].message).toContain(
+                'render() method has side effects on the state of property "foo"'
+            );
+        }
+    });
+
+    it('logs error for side effect during template updating', async () => {
+        const elm = createElement('x-side-effect-during-template', {
+            is: SideEffectDuringTemplate,
+        });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        if (process.env.NODE_ENV === 'production') {
+            expect(consoleSpy.calls.error.length).toEqual(0);
+        } else {
+            expect(consoleSpy.calls.error.length).toEqual(1);
+            expect(consoleSpy.calls.error[0][0].message).toContain(
+                'Updating the template has side effects on the state of property "foo"'
+            );
+        }
+    });
+
+    it('logs error for side effect on external component during render', async () => {
+        const elm = createElement('x-side-effect-during-render-external', {
+            is: SideEffectDuringRenderExternal,
+        });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        expect(consoleSpy.calls.error.length).toEqual(0);
+
+        elm.bar = 1; // force re-render
+
+        await Promise.resolve();
+
+        if (process.env.NODE_ENV === 'production') {
+            expect(consoleSpy.calls.error.length).toEqual(0);
+        } else {
+            expect(consoleSpy.calls.error.length).toEqual(1);
+            expect(consoleSpy.calls.error[0][0].message).toContain(
+                'render() method has side effects on the state of property "baz"'
+            );
+        }
+    });
+
+    it('logs error for side effect on external component during template updating', async () => {
+        const elm = createElement('x-side-effect-during-template-external', {
+            is: SideEffectDuringTemplateExternal,
+        });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        expect(consoleSpy.calls.error.length).toEqual(0);
+
+        elm.bar = 1; // force re-render
+
+        await Promise.resolve();
+
+        if (process.env.NODE_ENV === 'production') {
+            expect(consoleSpy.calls.error.length).toEqual(0);
+        } else {
+            expect(consoleSpy.calls.error.length).toEqual(1);
+            expect(consoleSpy.calls.error[0][0].message).toContain(
+                'Updating the template has side effects on the state of property "baz"'
+            );
+        }
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/childWithApiGetterSetter/childWithApiGetterSetter.html
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/childWithApiGetterSetter/childWithApiGetterSetter.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/childWithApiGetterSetter/childWithApiGetterSetter.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/childWithApiGetterSetter/childWithApiGetterSetter.js
@@ -1,0 +1,11 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    _baz = undefined;
+    @api get baz() {
+        return this._baz;
+    }
+    set baz(val) {
+        this._baz = val;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRender/sideEffectDuringRender.html
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRender/sideEffectDuringRender.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRender/sideEffectDuringRender.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRender/sideEffectDuringRender.js
@@ -1,0 +1,13 @@
+import { LightningElement, api } from 'lwc';
+
+import template from './sideEffectDuringRender.html';
+
+export default class extends LightningElement {
+    @api foo;
+
+    render() {
+        // side effect here
+        this.foo = 'foo';
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRenderExternal/sideEffectDuringRenderExternal.html
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRenderExternal/sideEffectDuringRenderExternal.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child-with-api-getter-setter class={bar}></x-child-with-api-getter-setter>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRenderExternal/sideEffectDuringRenderExternal.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringRenderExternal/sideEffectDuringRenderExternal.js
@@ -1,0 +1,17 @@
+import { LightningElement, api } from 'lwc';
+
+import template from './sideEffectDuringRenderExternal.html';
+
+export default class extends LightningElement {
+    @api bar = '';
+
+    render() {
+        // side effect here
+        const elm = this.template.querySelector('x-child-with-api-getter-setter');
+        if (elm) {
+            elm.baz = 'baz';
+        }
+
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplate/sideEffectDuringTemplate.html
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplate/sideEffectDuringTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <div class={myClass}></div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplate/sideEffectDuringTemplate.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplate/sideEffectDuringTemplate.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    _myClass = '';
+
+    @api foo;
+
+    set myClass(val) {
+        this._myClass = val;
+    }
+
+    get myClass() {
+        // side effect here
+        this.foo = 'foo';
+
+        return this._myClass;
+    }
+}

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplateExternal/sideEffectDuringTemplateExternal.html
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplateExternal/sideEffectDuringTemplateExternal.html
@@ -1,0 +1,4 @@
+<template>
+    <div class={myClass}></div>
+    <x-child-with-api-getter-setter class={bar}></x-child-with-api-getter-setter>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplateExternal/sideEffectDuringTemplateExternal.js
+++ b/packages/@lwc/integration-karma/test/rendering/side-effects/x/sideEffectDuringTemplateExternal/sideEffectDuringTemplateExternal.js
@@ -1,0 +1,22 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api foo;
+    @api bar = '';
+
+    _myClass = '';
+
+    set myClass(val) {
+        this._myClass = val;
+    }
+
+    get myClass() {
+        // side effect here
+        const elm = this.template.querySelector('x-child-with-api-getter-setter');
+        if (elm) {
+            elm.baz = 'baz';
+        }
+
+        return this._myClass;
+    }
+}


### PR DESCRIPTION
## Details

As it turns out, I missed some dev-only errors in the other 3 PRs:

- #3409 
- #3412 
- #3413 

The reason I missed them is that we didn't have any tests for them. 😅 So I added some tests, and then changed the errors to be `console.error`s instead.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->