### PR TITLE
test: test `this` check on accessor in `@api`

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -515,6 +515,17 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaAttributes.push(ariaPropertiesMapping[ariaProperties[i]]);
     }
 
+    // Keep traversing up the prototype chain until a property descriptor is found
+    function getPropertyDescriptor(object, prop) {
+        do {
+            var descriptor = Object.getOwnPropertyDescriptor(object, prop);
+            if (descriptor) {
+                return descriptor;
+            }
+            object = Object.getPrototypeOf(object);
+        } while (object);
+    }
+
     return {
         clearRegister: clearRegister,
         extractDataIds: extractDataIds,
@@ -532,5 +543,6 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         ariaProperties: ariaProperties,
         ariaAttributes: ariaAttributes,
         nonStandardAriaProperties: nonStandardAriaProperties,
+        getPropertyDescriptor: getPropertyDescriptor,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -1,5 +1,7 @@
 import { createElement, LightningElement, api } from 'lwc';
+import { getPropertyDescriptor } from 'test-utils';
 
+import GetterSetterAndProp from 'x/getterSetterAndProp';
 import Properties from 'x/properties';
 import Mutate from 'x/mutate';
 import GetterSetter from 'x/getterSetter';
@@ -128,6 +130,65 @@ describe('restrictions', () => {
         }).toThrowErrorDev(
             'Invalid @api showFeatures field. Found a duplicate method with the same name.'
         );
+    });
+});
+
+describe('non-LightningElement `this` when calling accessor', () => {
+    let elm;
+
+    beforeEach(() => {
+        elm = createElement('x-getter-setter-and-prop', { is: GetterSetterAndProp });
+        document.body.appendChild(elm);
+    });
+
+    const expectedErrorMessage =
+        /(undefined is not a VM|Cannot destructure property '(getHook|setHook)' of 'vm' as it is undefined|Cannot read properties of undefined)/;
+
+    const scenarios = [
+        { type: 'getterSetter', prop: 'getterSetterProp' },
+        { type: 'classProp', prop: 'classProp' },
+    ];
+
+    scenarios.forEach(({ type, prop }) => {
+        describe(type, () => {
+            it('getter - external', () => {
+                const { get } = getPropertyDescriptor(elm, prop);
+                expect(() => {
+                    get.call({});
+                }).toThrowError(TypeError, expectedErrorMessage);
+            });
+
+            it('setter - external', () => {
+                const { set } = getPropertyDescriptor(elm, prop);
+                expect(() => {
+                    set.call({}, 'foo');
+                }).toThrowError(TypeError, expectedErrorMessage);
+            });
+
+            it('getter - internal', () => {
+                const callback = () => {
+                    elm.callGetterInternallyWithWrongThis(prop);
+                };
+                // TODO [#3245]: this should not differ between prod mode and dev mode, class property and getter/setter
+                if (type === 'classProp') {
+                    expect(callback).toThrowError(TypeError, expectedErrorMessage);
+                } else {
+                    expect(callback).toThrowErrorDev(TypeError, expectedErrorMessage);
+                }
+            });
+
+            it('setter - internal', () => {
+                const callback = () => {
+                    elm.callSetterInternallyWithWrongThis(prop, 'foo');
+                };
+                // TODO [#3245]: this should not differ between prod mode and dev mode, class property and getter/setter
+                if (type === 'classProp') {
+                    expect(callback).toThrowError(TypeError, expectedErrorMessage);
+                } else {
+                    expect(callback).toThrowErrorDev(TypeError, expectedErrorMessage);
+                }
+            });
+        });
     });
 });
 

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -142,7 +142,7 @@ describe('non-LightningElement `this` when calling accessor', () => {
     });
 
     const expectedErrorMessage =
-        /(undefined is not a VM|Cannot destructure property '(getHook|setHook)' of 'vm' as it is undefined|Cannot read properties of undefined)/;
+        /(undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)' of 'vm' as it is undefined|Cannot read properties of undefined)/;
 
     const scenarios = [
         { type: 'getterSetter', prop: 'getterSetterProp' },

--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -142,7 +142,7 @@ describe('non-LightningElement `this` when calling accessor', () => {
     });
 
     const expectedErrorMessage =
-        /(undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)' of 'vm' as it is undefined|Cannot read properties of undefined)/;
+        /(undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)'|Cannot read properties of undefined)/;
 
     const scenarios = [
         { type: 'getterSetter', prop: 'getterSetterProp' },

--- a/packages/@lwc/integration-karma/test/component/decorators/api/x/getterSetterAndProp/getterSetterAndProp.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/x/getterSetterAndProp/getterSetterAndProp.js
@@ -1,0 +1,29 @@
+import { LightningElement, api } from 'lwc';
+import { getPropertyDescriptor } from 'test-utils';
+
+export default class GetterSetter extends LightningElement {
+    _getterSetterProp;
+
+    @api
+    get getterSetterProp() {
+        return this._getterSetterProp;
+    }
+    set getterSetterProp(value) {
+        this._getterSetterProp = value;
+    }
+
+    @api
+    classProp;
+
+    @api
+    callGetterInternallyWithWrongThis(prop) {
+        const { get } = getPropertyDescriptor(this, prop);
+        get.call({});
+    }
+
+    @api
+    callSetterInternallyWithWrongThis(prop, val) {
+        const { set } = getPropertyDescriptor(this, prop);
+        set.call({}, val);
+    }
+}


### PR DESCRIPTION
## Details

(Related to #3245)

We have a bunch of code that checks the accessors on `@api`s and tries to throw an error if the `this` is incorrect. However, we have no tests for it. This PR adds tests.

Unfortunately, our current behavior is inconsistent between prod mode and dev mode, and between different types of accessors, but I think it's better to have tests for the existing behavior than no tests at all.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
