### PR TITLE
fix: convert camel cased names to kebab case in registerComponent selector

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/actual.js
@@ -1,0 +1,3 @@
+import { LightningElement } from "lwc";
+export default class extends LightningElement {
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/config.json
@@ -1,0 +1,4 @@
+{
+    "namespace": "x",
+    "name": "camelCase"
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/camel-to-kebab-component-name/expected.js
@@ -1,0 +1,8 @@
+import _tmpl from "./test.html";
+import { registerComponent as _registerComponent, LightningElement } from "lwc";
+export default _registerComponent(class extends LightningElement {
+  /*LWC compiler vX.X.X*/
+}, {
+  tmpl: _tmpl,
+  sel: "x-camel-case"
+});

--- a/packages/@lwc/babel-plugin-component/src/component.ts
+++ b/packages/@lwc/babel-plugin-component/src/component.ts
@@ -45,7 +45,8 @@ function needsComponentRegistration(path: DeclarationPath) {
 
 function getComponentRegisteredName(t: BabelTypes, state: LwcBabelPluginPass) {
     const { namespace, name } = state.opts;
-    const componentName = namespace && name ? `${namespace}-${name}` : '';
+    const kebabCasedName = name?.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+    const componentName = namespace && kebabCasedName ? `${namespace}-${kebabCasedName}` : '';
     return t.stringLiteral(componentName);
 }
 


### PR DESCRIPTION
## Details
This PR fixes an issue where the `sel` in `registerComponent` does not convert a camel-cased name to kebab case.

This is needed for dynamic components so that the tag will contain the properly formatted name, ex:

A component with name `fancyButton` will be rendered as `x-fancybutton` rather than `x-fancy-button`.

## Does this pull request to introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

This only affects dynamic components, which is still in pilot.

## Does this pull request introduce an observable change?
* ⚠️ Yes, it does include an observable change.

The tag name for a dynamic component will now be properly converted to kebab case.  Dynamic components is still in pilot so this should be a safe change to make.
