### PR TITLE
fix(benchmarks): fix best import error

### DIFF
--- a/packages/@lwc/engine-server/src/utils/validate-style-text-contents.ts
+++ b/packages/@lwc/engine-server/src/utils/validate-style-text-contents.ts
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { parseFragment, DocumentFragment } from 'parse5';
+import * as parse5 from 'parse5';
+import type { DocumentFragment } from 'parse5';
 
 function isSingleStyleNodeContainingSingleTextNode(node: DocumentFragment) {
     if (node.childNodes.length !== 1) {
@@ -32,7 +33,7 @@ function isSingleStyleNodeContainingSingleTextNode(node: DocumentFragment) {
 // See: https://github.com/salesforce/lwc/issues/3439
 export function validateStyleTextContents(contents: string): void {
     // If parse5 parses this as more than one `<style>` tag, then it is unsafe to be rendered as-is
-    const fragment = parseFragment(`<style>${contents}</style>`);
+    const fragment = parse5.parseFragment(`<style>${contents}</style>`);
 
     if (!isSingleStyleNodeContainingSingleTextNode(fragment)) {
         throw new Error(


### PR DESCRIPTION
## Details

Something about Best's build process [does not like](https://github.com/salesforce/lwc/actions/runs/4661685489/jobs/8317449243#step:6:25) how we import from `parse5`, introduced in #3442 :

```
Error: 'parseFragment' is not exported by ../../../node_modules/parse5/lib/index.js
```

Using `import *` works fine though.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
