### PR TITLE
test: add expected log check

### DIFF
--- a/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/programmatic-stylesheets/index.spec.js
@@ -248,13 +248,17 @@ describe('programmatic stylesheets', () => {
         // TODO [#3447]: This test verifies existing behavior is maintained and should be removed
         // once the warnings are converted into errors.
         it('applies the styles if the arbitrary function returns a valid string', () => {
-            const elm = createElement('x-invalid3', {
-                is: Invalid3,
-            });
-            document.body.appendChild(elm);
+            expect(() => {
+                const elm = createElement('x-invalid3', {
+                    is: Invalid3,
+                });
+                document.body.appendChild(elm);
 
-            const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-            expect(style.color).toEqual('rgb(255, 0, 0)');
+                const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+                expect(style.color).toEqual('rgb(255, 0, 0)');
+            }).toLogWarningDev(
+                /\[LWC warn]: TypeError: Unexpected LWC stylesheet content found for component <x-invalid3>./
+            );
         });
     });
 });


### PR DESCRIPTION
## Details

Adds an `expect().toLogWarningDev` – otherwise this warning appears in the console when running tests:

    Error: [LWC warn]: TypeError: Unexpected LWC stylesheet content found for component <x-invalid3>.

Follow-up to #3443

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
