### PR TITLE
chore(babel-plugin-component): Access file name from state

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/conflicting-api-properties-with-getter-setter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/conflicting-api-properties-with-getter-setter/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 92,
         "length": 4
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/conflicting-api-properties-with-method/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/conflicting-api-properties-with-method/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 73,
         "length": 4
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/detecting-@api-on-both-getter-and-a-setter-should-produce-an-error/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/detecting-@api-on-both-getter-and-a-setter-should-produce-an-error/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 107,
         "length": 53
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 111,
         "length": 24
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/duplicate-api-properties/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/duplicate-api-properties/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 73,
         "length": 4
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-correct-error-if-property-name-is-maxlength/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-correct-error-if-property-name-is-maxlength/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 15
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-default-value-is-true/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-default-value-is-true/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 23
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-conflicts-with-disallowed-global-html-attribute-name/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-conflicts-with-disallowed-global-html-attribute-name/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 10
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-ambiguous/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-ambiguous/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 14
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-is/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-is/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 8
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-part/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-part/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 10
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-prefixed-with-data/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-prefixed-with-data/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 16
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-prefixed-with-on/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-prefixed-with-on/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 57,
         "length": 21
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-when-combined-with-@track/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-when-combined-with-@track/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 73,
         "length": 4
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-dereferenced/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-dereferenced/error.json
@@ -5,5 +5,6 @@
         "column": 0,
         "start": 29,
         "length": 20
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-used-as-a-member-expression/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-used-as-a-member-expression/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 30,
         "length": 15
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-used-on-a-class/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-a-decorator-is-used-on-a-class/error.json
@@ -5,5 +5,6 @@
         "column": 0,
         "start": 29,
         "length": 19
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-an-global-decorator-is-used-on-class-field/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-an-global-decorator-is-used-on-class-field/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 30,
         "length": 18
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-an-global-decorator-is-used-on-class-methods/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-if-an-global-decorator-is-used-on-class-methods/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 30,
         "length": 16
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-api-decorator-was-not-imported-from-lwc/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-api-decorator-was-not-imported-from-lwc/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 95,
         "length": 21
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-track-decorator-was-not-imported-from-lwc/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-track-decorator-was-not-imported-from-lwc/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 95,
         "length": 23
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-wire-decorator-was-not-imported-from-lwc/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/should-throw-when-wire-decorator-was-not-imported-from-lwc/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 127,
         "length": 31
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/throws-if-a-decorator-is-used-as-a-function/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/decorators/throws-if-a-decorator-is-used-as-a-function/error.json
@@ -5,5 +5,6 @@
         "column": 0,
         "start": 29,
         "length": 12
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/check-validation-for-strict/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/check-validation-for-strict/error.json
@@ -5,5 +5,6 @@
         "column": 25,
         "start": 76,
         "length": 2
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-class-method/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-class-method/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 71,
         "length": 6
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-getter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-getter/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 59,
         "length": 6
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-setter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/track-decorator/throws-if-track-decorator-is-applied-to-a-setter/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 71,
         "length": 6
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-an-imported-identifier-as-first-parameter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-an-imported-identifier-as-first-parameter/error.json
@@ -5,5 +5,6 @@
         "column": 8,
         "start": 88,
         "length": 2
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-an-object-as-second-parameter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-an-object-as-second-parameter/error.json
@@ -5,5 +5,6 @@
         "column": 16,
         "start": 111,
         "length": 7
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-wire-adapter-as-first-parameter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-wire-adapter-as-first-parameter/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 58,
         "length": 7
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-wire-adapter-to-be-imported/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-wire-adapter-to-be-imported/error.json
@@ -5,5 +5,6 @@
         "column": 8,
         "start": 116,
         "length": 7
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-nested-member-expression/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-nested-member-expression/error.json
@@ -5,5 +5,6 @@
         "column": 8,
         "start": 87,
         "length": 12
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-using-2-wired-decorators/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-using-2-wired-decorators/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 97,
         "length": 59
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-method-is-combined-with-@api/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-method-is-combined-with-@api/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 109,
         "length": 50
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-property-is-combined-with-@api/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-property-is-combined-with-@api/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 109,
         "length": 59
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-property-is-combined-with-@track/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/throws-when-wired-property-is-combined-with-@track/error.json
@@ -5,5 +5,6 @@
         "column": 2,
         "start": 113,
         "length": 59
-    }
+    },
+    "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -32,6 +32,7 @@ function normalizeError(err: any) {
             // Filter out the filename and the stacktrace, just include the error message
             message: err.message.match(/^.*?\.js: ([^\n]+)/)[1],
             loc: err.loc,
+            filename: err.filename,
         };
     } else {
         return {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -29,10 +29,10 @@ const BASE_CONFIG = {
 function normalizeError(err: any) {
     if (err.code === 'BABEL_TRANSFORM_ERROR') {
         return {
-            // Filter out the filename and the stacktrace, just include the error message
+            // Filter out the stacktrace, just include the error message
             message: err.message.match(/^.*?\.js: ([^\n]+)/)[1],
             loc: err.loc,
-            filename: err.filename,
+            filename: path.basename(err.filename),
         };
     } else {
         return {

--- a/packages/@lwc/babel-plugin-component/src/decorators/track/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/track/index.ts
@@ -7,8 +7,8 @@
 import { DecoratorErrors } from '@lwc/errors';
 import { LWC_COMPONENT_PROPERTIES, LWC_PACKAGE_EXPORTS } from '../../constants';
 import { generateError } from '../../utils';
+import { BabelTypes, LwcBabelPluginPass } from '../../types';
 import { DecoratorMeta } from '../index';
-import { BabelTypes } from '../../types';
 
 const { TRACK_DECORATOR } = LWC_PACKAGE_EXPORTS;
 
@@ -18,12 +18,16 @@ function isTrackDecorator(decorator: DecoratorMeta) {
     return decorator.name === TRACK_DECORATOR;
 }
 
-function validate(decorators: DecoratorMeta[]) {
+function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
     decorators.filter(isTrackDecorator).forEach(({ path }) => {
         if (!path.parentPath.isClassProperty()) {
-            throw generateError(path, {
-                errorInfo: DecoratorErrors.TRACK_ONLY_ALLOWED_ON_CLASS_PROPERTIES,
-            });
+            throw generateError(
+                path,
+                {
+                    errorInfo: DecoratorErrors.TRACK_ONLY_ALLOWED_ON_CLASS_PROPERTIES,
+                },
+                state
+            );
         }
     });
 }

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
@@ -9,44 +9,61 @@ import { NodePath } from '@babel/traverse';
 import { DecoratorErrors } from '@lwc/errors';
 import { LWC_PACKAGE_EXPORTS } from '../../constants';
 import { generateError } from '../../utils';
+import { LwcBabelPluginPass } from '../../types';
 import { DecoratorMeta } from '../index';
 import { isWireDecorator } from './shared';
 
 const { TRACK_DECORATOR, WIRE_DECORATOR, API_DECORATOR } = LWC_PACKAGE_EXPORTS;
 
-function validateWireParameters(path: NodePath) {
+function validateWireParameters(path: NodePath, state: LwcBabelPluginPass) {
     const [id, config] = path.get('expression.arguments') as [
         NodePath | undefined,
         NodePath<types.ObjectExpression> | undefined
     ];
 
     if (!id) {
-        throw generateError(path, {
-            errorInfo: DecoratorErrors.ADAPTER_SHOULD_BE_FIRST_PARAMETER,
-        });
+        throw generateError(
+            path,
+            {
+                errorInfo: DecoratorErrors.ADAPTER_SHOULD_BE_FIRST_PARAMETER,
+            },
+            state
+        );
     }
 
     const isIdentifier = id.isIdentifier();
     const isMemberExpression = id.isMemberExpression();
 
     if (!isIdentifier && !isMemberExpression) {
-        throw generateError(id, {
-            errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
-        });
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
+            },
+            state
+        );
     }
 
     if (id.isMemberExpression({ computed: true })) {
-        throw generateError(id, {
-            errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS,
-        });
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS,
+            },
+            state
+        );
     }
 
     // TODO [#3444]: improve member expression computed typechecking
     // @ts-ignore
     if (isMemberExpression && !id.get('object').isIdentifier()) {
-        throw generateError(id, {
-            errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_NESTED_MEMBER_EXRESSIONS,
-        });
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_NESTED_MEMBER_EXRESSIONS,
+            },
+            state
+        );
     }
 
     // TODO [#3444]: improve member expression computed typechecking
@@ -54,10 +71,14 @@ function validateWireParameters(path: NodePath) {
     // @ts-ignore
     const wireBinding = isMemberExpression ? id.node.object.name : id.node.name;
     if (!path.scope.getBinding(wireBinding)) {
-        throw generateError(id, {
-            errorInfo: DecoratorErrors.WIRE_ADAPTER_SHOULD_BE_IMPORTED,
-            messageArgs: [id.node.name],
-        });
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.WIRE_ADAPTER_SHOULD_BE_IMPORTED,
+                messageArgs: [id.node.name],
+            },
+            state
+        );
     }
 
     // ensure wire adapter is a first parameter
@@ -66,21 +87,30 @@ function validateWireParameters(path: NodePath) {
         !path.scope.getBinding(wireBinding)!.path.isImportSpecifier() &&
         !path.scope.getBinding(wireBinding)!.path.isImportDefaultSpecifier()
     ) {
-        throw generateError(id, {
-            errorInfo: DecoratorErrors.IMPORTED_FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
-        });
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.IMPORTED_FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
+            },
+            state
+        );
     }
 
     if (config && !config.isObjectExpression()) {
-        throw generateError(config, {
-            errorInfo: DecoratorErrors.CONFIG_OBJECT_SHOULD_BE_SECOND_PARAMETER,
-        });
+        throw generateError(
+            config,
+            {
+                errorInfo: DecoratorErrors.CONFIG_OBJECT_SHOULD_BE_SECOND_PARAMETER,
+            },
+            state
+        );
     }
 }
 
 function validateUsageWithOtherDecorators(
     path: NodePath<types.Decorator>,
-    decorators: DecoratorMeta[]
+    decorators: DecoratorMeta[],
+    state: LwcBabelPluginPass
 ) {
     decorators.forEach((decorator) => {
         if (
@@ -88,25 +118,33 @@ function validateUsageWithOtherDecorators(
             decorator.name === WIRE_DECORATOR &&
             decorator.path.parentPath.node === path.parentPath.node
         ) {
-            throw generateError(path, {
-                errorInfo: DecoratorErrors.ONE_WIRE_DECORATOR_ALLOWED,
-            });
+            throw generateError(
+                path,
+                {
+                    errorInfo: DecoratorErrors.ONE_WIRE_DECORATOR_ALLOWED,
+                },
+                state
+            );
         }
         if (
             (decorator.name === API_DECORATOR || decorator.name === TRACK_DECORATOR) &&
             decorator.path.parentPath.node === path.parentPath.node
         ) {
-            throw generateError(path, {
-                errorInfo: DecoratorErrors.CONFLICT_WITH_ANOTHER_DECORATOR,
-                messageArgs: [decorator.name],
-            });
+            throw generateError(
+                path,
+                {
+                    errorInfo: DecoratorErrors.CONFLICT_WITH_ANOTHER_DECORATOR,
+                    messageArgs: [decorator.name],
+                },
+                state
+            );
         }
     });
 }
 
-export default function validate(decorators: DecoratorMeta[]) {
+export default function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
     decorators.filter(isWireDecorator).forEach(({ path }) => {
-        validateUsageWithOtherDecorators(path, decorators);
-        validateWireParameters(path);
+        validateUsageWithOtherDecorators(path, decorators, state);
+        validateWireParameters(path, state);
     });
 }

--- a/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
@@ -15,12 +15,16 @@ function getImportSource(path: NodePath<types.Import>): NodePath<types.Node> {
     return path.parentPath.get('arguments.0') as NodePath<types.Node>;
 }
 
-function validateImport(sourcePath: NodePath<types.Node>) {
+function validateImport(sourcePath: NodePath<types.Node>, state: LwcBabelPluginPass) {
     if (!sourcePath.isStringLiteral()) {
-        throw generateError(sourcePath, {
-            errorInfo: LWCClassErrors.INVALID_DYNAMIC_IMPORT_SOURCE_STRICT,
-            messageArgs: [String(sourcePath)],
-        });
+        throw generateError(
+            sourcePath,
+            {
+                errorInfo: LWCClassErrors.INVALID_DYNAMIC_IMPORT_SOURCE_STRICT,
+                messageArgs: [String(sourcePath)],
+            },
+            state
+        );
     }
 }
 
@@ -62,7 +66,7 @@ export default function (): Visitor<LwcBabelPluginPass> {
             const sourcePath = getImportSource(path);
 
             if (strictSpecifier) {
-                validateImport(sourcePath);
+                validateImport(sourcePath, state);
             }
 
             if (loader) {

--- a/packages/@lwc/babel-plugin-component/src/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/index.ts
@@ -45,11 +45,11 @@ export default function LwcClassTransform(api: BabelAPI): PluginObj<LwcBabelPlug
             // The LWC babel plugin is incompatible with other plugins. To get around this, we run the LWC babel plugin
             // first by running all its traversals from this Program visitor.
             Program: {
-                enter(path) {
+                enter(path, state) {
                     const engineImportSpecifiers = getEngineImportSpecifiers(path);
 
                     // Validate the usage of LWC decorators.
-                    validateImportedLwcDecoratorUsage(engineImportSpecifiers);
+                    validateImportedLwcDecoratorUsage(engineImportSpecifiers, state);
 
                     // Add ?scoped=true to *.scoped.css imports
                     scopeCssImports(api, path);

--- a/packages/@lwc/babel-plugin-component/src/utils.ts
+++ b/packages/@lwc/babel-plugin-component/src/utils.ts
@@ -10,6 +10,7 @@ import { NodePath } from '@babel/traverse';
 import { generateErrorMessage } from '@lwc/errors';
 import { LWC_PACKAGE_ALIAS } from './constants';
 import { DecoratorErrorOptions, ImportSpecifier } from './decorators/types';
+import { LwcBabelPluginPass } from './types';
 
 function isClassMethod(
     classMethod: NodePath<types.Node>,
@@ -73,17 +74,6 @@ function getEngineImportSpecifiers(path: NodePath): ImportSpecifier[] {
     );
 }
 
-function normalizeFilename(source: NodePath<types.Node>) {
-    return (
-        // TODO [#3444]: use `this.filename` to get the filename
-        (source.hub &&
-            (source.hub as any).file &&
-            (source.hub as any).file.opts &&
-            (source.hub as any).file.opts.filename) ||
-        null
-    );
-}
-
 function normalizeLocation(source: NodePath<types.Node>) {
     const location = (source.node && (source.node.loc || (source.node as any)._loc)) || null;
     if (!location) {
@@ -110,12 +100,13 @@ function normalizeLocation(source: NodePath<types.Node>) {
 
 function generateError(
     source: NodePath<types.Node>,
-    { errorInfo, messageArgs }: DecoratorErrorOptions
+    { errorInfo, messageArgs }: DecoratorErrorOptions,
+    state: LwcBabelPluginPass
 ) {
     const message = generateErrorMessage(errorInfo, messageArgs);
     const error = source.buildCodeFrameError(message);
 
-    (error as any).filename = normalizeFilename(source);
+    (error as any).filename = state.filename;
     (error as any).loc = normalizeLocation(source);
     (error as any).lwcCode = errorInfo && errorInfo.code;
     return error;


### PR DESCRIPTION
## Details
This PR partially fixes https://github.com/salesforce/lwc/issues/3444. It passes state and access filename from the state.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->


