### PR TITLE
fix minor typo: `providBookWithId` method name in wire-service docs

### DIFF
--- a/packages/@lwc/wire-service/README.md
+++ b/packages/@lwc/wire-service/README.md
@@ -50,7 +50,7 @@ export class getBook {
         }
     }
 
-    providBookWithId(id) {
+    provideBookWithId(id) {
         if (this.connected && this.bookId !== undefined) {
             const book = bookEndpoint.getById(id);
 


### PR DESCRIPTION
## Details

fix `providBookWithId` method name in wire-service docs. Example code does not currently work with incorrectly spelt method name.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

## GUS work item
N/A

