### PR TITLE
chore: release v2.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc-monorepo",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "private": true,
     "description": "Lightning Web Components",
     "repository": {

--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/aria-reflection",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "ARIA element reflection polyfill for strings",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -34,7 +34,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lwc/shared": "2.44.0"
+        "@lwc/shared": "2.45.0"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.44.0",
+    "version": "2.45.0",
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "typings": "types/index.d.ts",
@@ -25,8 +25,8 @@
     ],
     "dependencies": {
         "@babel/helper-module-imports": "~7.21.4",
-        "@lwc/errors": "2.44.0",
-        "@lwc/shared": "2.44.0",
+        "@lwc/errors": "2.45.0",
+        "@lwc/shared": "2.45.0",
         "line-column": "~1.0.2"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/compiler",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "LWC compiler",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -25,11 +25,11 @@
         "@babel/core": "~7.21.4",
         "@babel/plugin-proposal-class-properties": "~7.18.6",
         "@babel/plugin-proposal-object-rest-spread": "~7.20.2",
-        "@lwc/babel-plugin-component": "2.44.0",
-        "@lwc/errors": "2.44.0",
-        "@lwc/shared": "2.44.0",
-        "@lwc/style-compiler": "2.44.0",
-        "@lwc/template-compiler": "2.44.0"
+        "@lwc/babel-plugin-component": "2.45.0",
+        "@lwc/errors": "2.45.0",
+        "@lwc/shared": "2.45.0",
+        "@lwc/style-compiler": "2.45.0",
+        "@lwc/template-compiler": "2.45.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-core",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Core LWC engine APIs.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,9 +24,9 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/aria-reflection": "2.44.0",
-        "@lwc/features": "2.44.0",
-        "@lwc/shared": "2.44.0"
+        "@lwc/aria-reflection": "2.45.0",
+        "@lwc/features": "2.45.0",
+        "@lwc/shared": "2.45.0"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-dom",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Renders LWC components in a DOM environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,9 +24,9 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/aria-reflection": "2.44.0",
-        "@lwc/engine-core": "2.44.0",
-        "@lwc/shared": "2.44.0",
+        "@lwc/aria-reflection": "2.45.0",
+        "@lwc/engine-core": "2.45.0",
+        "@lwc/shared": "2.45.0",
         "magic-string": "^0.30.0"
     },
     "lwc": {

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/engine-server",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Renders LWC components in a server environment.",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -30,9 +30,9 @@
         "parse5": "^6.0.1"
     },
     "devDependencies": {
-        "@lwc/engine-core": "2.44.0",
-        "@lwc/rollup-plugin": "2.44.0",
-        "@lwc/shared": "2.44.0",
+        "@lwc/engine-core": "2.45.0",
+        "@lwc/rollup-plugin": "2.45.0",
+        "@lwc/shared": "2.45.0",
         "@rollup/plugin-virtual": "^3.0.1"
     },
     "publishConfig": {

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/errors",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "LWC Error Utilities",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/features",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "LWC Features Flags",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,7 +24,7 @@
         "types/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.44.0"
+        "@lwc/shared": "2.45.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-karma",
     "private": true,
-    "version": "2.44.0",
+    "version": "2.45.0",
     "scripts": {
         "start": "karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
@@ -16,11 +16,11 @@
         "karma-jasmine": "must be kept at v4 because it is only compatible with jasmine-core@4, which we need for IE11"
     },
     "devDependencies": {
-        "@lwc/compiler": "2.44.0",
-        "@lwc/engine-dom": "2.44.0",
-        "@lwc/engine-server": "2.44.0",
-        "@lwc/rollup-plugin": "2.44.0",
-        "@lwc/synthetic-shadow": "2.44.0",
+        "@lwc/compiler": "2.45.0",
+        "@lwc/engine-dom": "2.45.0",
+        "@lwc/engine-server": "2.45.0",
+        "@lwc/rollup-plugin": "2.45.0",
+        "@lwc/synthetic-shadow": "2.45.0",
         "chokidar": "^3.5.3",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-tests",
     "private": true,
-    "version": "2.44.0",
+    "version": "2.45.0",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -23,7 +23,7 @@
         "webdriverio, @wdio/cli": "Currently can't upgrade @wdio namespaced dependencies to v8.0.0 because it dropped CommonJS support https://github.com/webdriverio/webdriverio/releases/tag/v8.0.0"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.44.0",
+        "@lwc/rollup-plugin": "2.45.0",
         "@wdio/cli": "^7.26.0",
         "@wdio/devtools-service": "^7.30.1",
         "@wdio/local-runner": "^7.26.0",
@@ -34,7 +34,7 @@
         "@wdio/static-server-service": "^7.26.0",
         "deepmerge": "^4.3.0",
         "dotenv": "^16.0.3",
-        "lwc": "2.44.0",
+        "lwc": "2.45.0",
         "minimist": "^1.2.8",
         "webdriverio": "^7.26.0"
     }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -10,7 +10,7 @@
     "bugs": {
         "url": "https://github.com/salesforce/lwc/issues"
     },
-    "version": "2.44.0",
+    "version": "2.45.0",
     "main": "dist/commonjs/index.js",
     "typings": "dist/types/index.d.ts",
     "scripts": {

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lwc/perf-benchmarks-components",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c ./rollup.config.mjs"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.44.0"
+        "@lwc/rollup-plugin": "2.45.0"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/perf-benchmarks",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c  ./rollup.config.mjs && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -17,10 +17,10 @@
         "Also note that we use legacy versions of rollup-plugin-node-resolve and rollup-plugin-commonjs because Best uses an old version of Rollup."
     ],
     "dependencies": {
-        "@lwc/engine-dom": "2.44.0",
-        "@lwc/engine-server": "2.44.0",
-        "@lwc/perf-benchmarks-components": "2.44.0",
-        "@lwc/synthetic-shadow": "2.44.0"
+        "@lwc/engine-dom": "2.45.0",
+        "@lwc/engine-server": "2.45.0",
+        "@lwc/perf-benchmarks-components": "2.45.0",
+        "@lwc/synthetic-shadow": "2.45.0"
     },
     "devDependencies": {
         "@best/cli": "^8.1.3",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/rollup-plugin",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Rollup plugin to compile LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,12 +22,12 @@
         "dist/"
     ],
     "devDependencies": {
-        "@lwc/compiler": "2.44.0",
-        "@lwc/engine-dom": "2.44.0",
-        "@lwc/errors": "2.44.0"
+        "@lwc/compiler": "2.45.0",
+        "@lwc/engine-dom": "2.45.0",
+        "@lwc/errors": "2.45.0"
     },
     "dependencies": {
-        "@lwc/module-resolver": "2.44.0",
+        "@lwc/module-resolver": "2.45.0",
         "@rollup/pluginutils": "~5.0.2"
     },
     "peerDependencies": {

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/shared",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Utilities and methods that are shared across packages",
     "homepage": "https://lwc.dev/",
     "repository": {

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/style-compiler",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -22,7 +22,7 @@
         "dist/"
     ],
     "dependencies": {
-        "@lwc/shared": "2.44.0",
+        "@lwc/shared": "2.45.0",
         "postcss": "~8.4.20",
         "postcss-selector-parser": "~6.0.11",
         "postcss-value-parser": "~4.2.0",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/synthetic-shadow",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Synthetic Shadow Root for LWC",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -36,8 +36,8 @@
         "access": "public"
     },
     "devDependencies": {
-        "@lwc/features": "2.44.0",
-        "@lwc/shared": "2.44.0"
+        "@lwc/features": "2.45.0",
+        "@lwc/shared": "2.45.0"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/template-compiler",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Template compiler package",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -30,8 +30,8 @@
         "@types/source-map": "0.5.7"
     },
     "dependencies": {
-        "@lwc/errors": "2.44.0",
-        "@lwc/shared": "2.44.0",
+        "@lwc/errors": "2.45.0",
+        "@lwc/shared": "2.45.0",
         "acorn": "~8.8.2",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/wire-service",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "@wire service",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -24,8 +24,8 @@
         "types/"
     ],
     "devDependencies": {
-        "@lwc/engine-core": "2.44.0",
-        "@lwc/shared": "2.44.0"
+        "@lwc/engine-core": "2.45.0",
+        "@lwc/shared": "2.45.0"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -41,12 +41,12 @@
         ]
     },
     "dependencies": {
-        "@lwc/compiler": "2.44.0",
-        "@lwc/engine-dom": "2.44.0",
-        "@lwc/engine-server": "2.44.0",
-        "@lwc/features": "2.44.0",
-        "@lwc/synthetic-shadow": "2.44.0",
-        "@lwc/wire-service": "2.44.0"
+        "@lwc/compiler": "2.45.0",
+        "@lwc/engine-dom": "2.45.0",
+        "@lwc/engine-server": "2.45.0",
+        "@lwc/features": "2.45.0",
+        "@lwc/synthetic-shadow": "2.45.0",
+        "@lwc/wire-service": "2.45.0"
     },
     "nx": {
         "targets": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@lwc/playground",
-    "version": "2.44.0",
+    "version": "2.45.0",
     "type": "module",
     "description": "Playground project to experiment with LWC.",
     "scripts": {
@@ -9,9 +9,9 @@
         "build": "NODE_ENV=production rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "2.44.0",
+        "@lwc/rollup-plugin": "2.45.0",
         "@rollup/plugin-replace": "^5.0.2",
-        "lwc": "2.44.0",
+        "lwc": "2.45.0",
         "rollup": "^3.20.2",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.2"


### PR DESCRIPTION
## Details

Minor version bump after the revert in #3472.

## Does this pull request introduce a breaking change?

* 🚨 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

This will require a follow-up PR internally to accommodate the API changes in this revert. See #3443 for what is being rolled back.

## GUS work item

