### PR TITLE
fix(synthetic-shadow): convert dev-only errors to logs

### DIFF
--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/index.spec.js
@@ -1,0 +1,34 @@
+import { createElement } from 'lwc';
+import Source from 'x/source';
+import Target from 'x/target';
+
+if (!process.env.NATIVE_SHADOW) {
+    describe('activeElement', () => {
+        it('can call shadowRoot.activeElement on transported node with no lwc:dom=manual', async () => {
+            const source = createElement('x-source', { is: Source });
+            const target = createElement('x-target', { is: Target });
+            document.body.appendChild(source);
+            document.body.appendChild(target);
+            await Promise.resolve();
+
+            const button = source.shadowRoot.querySelector('button');
+
+            // append directly to the element, not to some <div lwc:dom=manual> inside of it as recommended
+            target.appendChild(button);
+
+            // make active
+            button.focus();
+
+            let activeElement;
+
+            expect(() => {
+                activeElement = target.shadowRoot.activeElement;
+            }).toLogErrorDev(
+                /NodeOwnedBy\(\) should never be called with a node that is not a child node of/
+            );
+
+            // synthetic shadow gets this wrong when lwc:dom=manual is not used, so just assert that it exists
+            expect(activeElement).not.toBeNull();
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/source/source.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/source/source.html
@@ -1,0 +1,3 @@
+<template>
+    <button></button>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/source/source.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/source/source.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/target/target.html
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/target/target.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/target/target.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/x/target/target.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayReduce, ArrayPush, assert, isNull, isUndefined, ArrayFilter } from '@lwc/shared';
+import { ArrayReduce, ArrayPush, isNull, isUndefined, ArrayFilter } from '@lwc/shared';
 
 import { arrayFromCollection } from '../shared/utils';
 import { getNodeKey, getNodeNearestOwnerKey, isNodeShadowed } from '../shared/node-ownership';
@@ -38,18 +38,20 @@ function foldSlotElement(slot: HTMLElement) {
 
 function isNodeSlotted(host: Element, node: Node): boolean {
     if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            host instanceof HTMLElement,
-            `isNodeSlotted() should be called with a host as the first argument instead of ${host}`
-        );
-        assert.invariant(
-            node instanceof Node,
-            `isNodeSlotted() should be called with a node as the second argument instead of ${node}`
-        );
-        assert.invariant(
-            compareDocumentPosition.call(node, host) & DOCUMENT_POSITION_CONTAINS,
-            `isNodeSlotted() should never be called with a node that is not a child node of ${host}`
-        );
+        if (!(host instanceof HTMLElement)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeSlotted() should be called with a host as the first argument`);
+        }
+        if (!(node instanceof Node)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeSlotted() should be called with a node as the second argument`);
+        }
+        if (!(compareDocumentPosition.call(node, host) & DOCUMENT_POSITION_CONTAINS)) {
+            // eslint-disable-next-line no-console
+            console.error(
+                `isNodeSlotted() should never be called with a node that is not a child node of the given host`
+            );
+        }
     }
     const hostKey = getNodeKey(host);
     // this routine assumes that the node is coming from a different shadow (it is not owned by the host)
@@ -134,18 +136,20 @@ export function isSlotElement(node: Node): node is HTMLSlotElement {
 
 export function isNodeOwnedBy(owner: Element, node: Node): boolean {
     if (process.env.NODE_ENV !== 'production') {
-        assert.invariant(
-            owner instanceof HTMLElement,
-            `isNodeOwnedBy() should be called with an element as the first argument instead of ${owner}`
-        );
-        assert.invariant(
-            node instanceof Node,
-            `isNodeOwnedBy() should be called with a node as the second argument instead of ${node}`
-        );
-        assert.invariant(
-            compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS,
-            `isNodeOwnedBy() should never be called with a node that is not a child node of ${owner}`
-        );
+        if (!(owner instanceof HTMLElement)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeOwnedBy() should be called with an element as the first argument`);
+        }
+        if (!(node instanceof Node)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeOwnedBy() should be called with a node as the second argument`);
+        }
+        if (!(compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS)) {
+            // eslint-disable-next-line no-console
+            console.error(
+                `isNodeOwnedBy() should never be called with a node that is not a child node of of the given owner`
+            );
+        }
     }
     const ownerKey = getNodeNearestOwnerKey(node);
 


### PR DESCRIPTION
## Details

Partially addresses #3413

Makes some more dev-only errors into logs.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[TD-0142487](https://gus.lightning.force.com/lightning/r/a0nEE000000Dhf3YAC/view)
