### PR TITLE
fix(babel-plugin-component): ensure nx caches types

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -43,7 +43,8 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "./dist"
+                    "./dist",
+                    "./types"
                 ]
             }
         }


### PR DESCRIPTION
## Details

Forgot to tell NX to cache the `types` directory in `@babel/plugin-component`. Amazingly this has been broken since #3373 but was probably flappy because it depended on whether we loaded the cache or not.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
