### PR TITLE
test(integration-karma): fail if console called unexpectedly

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-setup.js
+++ b/packages/@lwc/integration-karma/helpers/test-setup.js
@@ -52,6 +52,29 @@ afterEach(function () {
     window.__lwcResetAlreadyLoggedMessages();
 });
 
+var consoleCallCount = 0;
+
+// Patch console.log, console.error, etc. so if it's called, we throw
+function patchConsole() {
+    ['assert', 'error', 'info', 'log', 'warn'].forEach(function (method) {
+        // eslint-disable-next-line no-console
+        var originalMethod = console[method];
+        // eslint-disable-next-line no-console
+        console[method] = function () {
+            consoleCallCount++;
+            return originalMethod.apply(this, arguments);
+        };
+    });
+}
+
+function throwIfConsoleCalled() {
+    if (consoleCallCount) {
+        throw new Error(
+            `Expected console not to be called, but was called ${consoleCallCount} time(s)`
+        );
+    }
+}
+
 // Run some logic before all tests have run and after all tests have run to ensure that
 // no test dirtied the DOM with leftover elements
 var originalHeadChildren;
@@ -61,6 +84,7 @@ beforeAll(function () {
     originalHeadChildren = getHeadChildren();
     originalBodyChildren = getBodyChildren();
     originalAdoptedStyleSheets = getAdoptedStyleSheets();
+    patchConsole();
 });
 
 // Throwing an Error in afterAll will cause a non-zero exit code
@@ -88,4 +112,6 @@ afterAll(function () {
             );
         }
     });
+
+    throwIfConsoleCalled();
 });


### PR DESCRIPTION
## Details

We sometimes accidentally check in code that called console.warn/console.error/etc. without an `expect()`. It's easy to miss, because the only observable effect is that it logs to the console.

This fixes that, by making it a test failure if we call any console method unexpectedly. I tested manually and it fails with a `1` exit code.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
