### PR TITLE
fix: providBookWithId method name typo in wire-service docs

### DIFF
--- a/packages/@lwc/wire-service/README.md
+++ b/packages/@lwc/wire-service/README.md
@@ -50,7 +50,7 @@ export class getBook {
         }
     }
 
-    providBookWithId(id) {
+    provideBookWithId(id) {
         if (this.connected && this.bookId !== undefined) {
             const book = bookEndpoint.getById(id);
 


### PR DESCRIPTION
https://github.com/salesforce/lwc/pull/3469