### PR TITLE
docs: remove references to create-lwc-app

### DIFF
--- a/packages/lwc/README.md
+++ b/packages/lwc/README.md
@@ -1,10 +1,10 @@
-Lightning Web Components (LWC) is an enterprise-grade web components foundation for building user interfaces. LWC provides a simple authoring format for UI Components. LWC compiles this authoring format into low-level Web Component APIs. The `lwc` package is the main entry point for dependencies.
+Lightning Web Components (LWC) is an enterprise-grade web components foundation for building user interfaces. LWC provides a simple authoring format for UI components, which is compiled into low-level Web Component APIs. The `lwc` package is the main entry point for dependencies.
 
 -   Develop components quickly and declaratively using HTML, JavaScript, and CSS.
 -   Develop accessible components so that everyone can understand and navigate your app.
--   Components are encapsulated in all browsers via the `@lwc/synthetic-shadow` package, which polyfills the Shadow DOM.
+-   Components are encapsulated in Shadow DOM, with the `@lwc/synthetic-shadow` package as an optional polyfill for older browsers.
 
-Developing a Lightning web component is this easy.
+Developing a Lightning web component is this easy:
 
 ```ascii
 counter
@@ -58,15 +58,9 @@ For IE 11, LWC uses compatibility mode. Code is transpiled down to ES5 and the r
 
 [lwc.dev](https://lwc.dev) has all the information you need to develop components using LWC, including [code recipes](https://recipes.lwc.dev/) and code playgrounds.
 
-Get started fast using the [`create-lwc-app`](https://www.npmjs.com/package/create-lwc-app) tool.
-
-```bash
-npx create-lwc-app my-app
-cd my-app
-npm run watch
-```
-
 For support, use the `lwc` tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/lwc) or the `lightning-web-components` tag on [Salesforce Stack Exchange](https://salesforce.stackexchange.com/questions/tagged/lightning-web-components).
+
+When filing a bug, it's useful to use [playground.lwc.dev](https://playground.lwc.dev/) to create a live reproduction of the issue.
 
 ## Release Notes
 


### PR DESCRIPTION
## Details

Removes references to `create-lwc-app` from the `lwc` package README.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
