### PR TITLE
fix(integration-karma): only fail on console warn/error

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-setup.js
+++ b/packages/@lwc/integration-karma/helpers/test-setup.js
@@ -54,9 +54,9 @@ afterEach(function () {
 
 var consoleCallCount = 0;
 
-// Patch console.log, console.error, etc. so if it's called, we throw
+// Patch console.error/console.warn, etc. so if it's called, we throw
 function patchConsole() {
-    ['assert', 'error', 'info', 'log', 'warn'].forEach(function (method) {
+    ['error', 'warn'].forEach(function (method) {
         // eslint-disable-next-line no-console
         var originalMethod = console[method];
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Details

Unfortunately in #3489 I broke the Karma local tests (`yarn start`), because Karma itself calls `console.log`, resulting in:

```
  An error was thrown in afterAll
  Error: Expected console not to be called, but was called 2133 time(s)
      at throwIfConsoleCalled (/Users/nlawson/workspace/lwc/packages/@lwc/integration-karma/helpers/test-setup.js:72:15)
      at UserContext.<anonymous> (/Users/nlawson/workspace/lwc/packages/@lwc/integration-karma/helpers/test-setup.js:116:5)
      at <Jasmine>
```

This PR scopes it to just error/warn, which is mostly what we want to catch in LWC anyway. It's the simplest solution I could think of.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

