### PR TITLE
test: add treeshakable test back in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,9 @@ jobs:
           name: Check package.json integrity
           command: node ./scripts/tasks/check-and-rewrite-package-json.js --test
       - run:
+          name: Verify @lwc/shared is tree-shakable
+          command: node ./scripts/tasks/verify-treeshakable.js ./packages/@lwc/shared/dist/index.js
+      - run:
           name: Check formatting
           command: yarn prettier --check '{packages,scripts}/**/*.{js,ts,json,md}'
       - run:


### PR DESCRIPTION
## Details

I accidentally removed this test: https://github.com/salesforce/lwc/pull/3456/files#r1195609517

This PR adds it back in as a CI test.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
