### PR TITLE
test(integration-karma): test CustomElementConstructor attributes

### DIFF
--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -5,6 +5,8 @@ import LifecycleParent from 'x/lifecycleParent';
 import WithChildElms from 'x/withChildElms';
 import DefinedComponent from 'x/definedComponent';
 import UndefinedComponent from 'x/undefinedComponent';
+import AttrChanged from 'x/attrChanged';
+import ReflectCamel from 'x/reflectCamel';
 
 // We can't register standard custom elements if we run compat because of the transformation applied to the component
 // constructor.
@@ -121,8 +123,9 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
 
     describe('attribute reflection', () => {
         beforeAll(() => {
-            const ReflectCustomElement = ReflectElement.CustomElementConstructor;
-            customElements.define('test-reflect', ReflectCustomElement);
+            customElements.define('test-reflect', ReflectElement.CustomElementConstructor);
+            customElements.define('test-reflect-camel', ReflectCamel.CustomElementConstructor);
+            customElements.define('test-attr-changed', AttrChanged.CustomElementConstructor);
         });
 
         it('should reflect attribute to properties before the first render', () => {
@@ -159,6 +162,69 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
 
             expect(elm.title).toBe('foo');
             expect(elm.number).toBe(10);
+        });
+
+        it('reflects kebab-case attributes to camel-case props', () => {
+            const elm = document.createElement('test-reflect-camel');
+            document.body.appendChild(elm);
+
+            elm.setAttribute('my-prop', 'foo');
+
+            expect(elm.getAttribute('my-prop')).toBe('foo');
+            expect(elm.myProp).toBe('foo');
+        });
+
+        // TODO [#2972]: support attributeChangedCallback
+        it('never calls attributeChangedCallback', async () => {
+            const elm = document.createElement('test-attr-changed');
+            document.body.appendChild(elm);
+
+            elm.setAttribute('observed', 'foo');
+            elm.setAttribute('api', 'foo');
+            elm.setAttribute('track', 'foo');
+
+            await Promise.resolve(); // just in case attributeChangedCallback is called async
+
+            // attributeChangedCallback is not called for any of these
+            expect(elm.attributeChangedCallbackCalls).toEqual([]);
+        });
+
+        it('only reflects @api, not @track or observedAttributes', () => {
+            const elm = document.createElement('test-attr-changed');
+            document.body.appendChild(elm);
+
+            elm.setAttribute('observed', 'foo');
+            elm.setAttribute('api', 'foo');
+            elm.setAttribute('track', 'foo');
+
+            // attrs are all set
+            expect(elm.getAttribute('observed')).toBe('foo');
+            expect(elm.getAttribute('api')).toBe('foo');
+            expect(elm.getAttribute('track')).toBe('foo');
+
+            // for props, only @api props are set
+            expect(elm.observed).toBeUndefined();
+            expect(elm.api).toBe('foo');
+            expect(elm.track).toBeUndefined();
+        });
+
+        it('does not call setter more than once if unchanged', () => {
+            const elm = document.createElement('test-attr-changed');
+            document.body.appendChild(elm);
+
+            expect(elm.apiSetterCallCounts).toEqual(0);
+
+            elm.setAttribute('api', 'foo');
+            expect(elm.api).toBe('foo');
+            expect(elm.apiSetterCallCounts).toEqual(1);
+
+            elm.setAttribute('api', 'foo');
+            expect(elm.api).toBe('foo');
+            expect(elm.apiSetterCallCounts).toEqual(1);
+
+            elm.setAttribute('api', 'bar');
+            expect(elm.api).toBe('bar');
+            expect(elm.apiSetterCallCounts).toEqual(2);
         });
     });
 }

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/attrChanged/attrChanged.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/attrChanged/attrChanged.js
@@ -1,0 +1,24 @@
+import { LightningElement, track, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api attributeChangedCallbackCalls = [];
+    @api apiSetterCallCounts = 0;
+
+    _api;
+    @track track;
+
+    get api() {
+        return this._api;
+    }
+    @api
+    set api(val) {
+        this.apiSetterCallCounts++;
+        this._api = val;
+    }
+
+    attributeChangedCallback(attrName, oldValue, newValue) {
+        this.attributeChangedCallbackCalls.push([attrName, oldValue, newValue]);
+    }
+
+    static observedAttributes = ['observed'];
+}

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/reflectCamel/reflectCamel.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/x/reflectCamel/reflectCamel.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api myProp;
+}


### PR DESCRIPTION
## Details

Adds tests to assert the existing behavior described here: https://github.com/salesforce/lwc/issues/2972#issuecomment-1550367388

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
