### PR TITLE
fix(engine-core): remove attribute locking

### DIFF
--- a/packages/@lwc/engine-core/src/framework/attributes.ts
+++ b/packages/@lwc/engine-core/src/framework/attributes.ts
@@ -17,20 +17,3 @@ export const defaultDefHTMLPropertyNames = [
     'tabIndex',
     'title',
 ];
-
-let controlledElement: Element | null = null;
-let controlledAttributeName: string | void;
-
-export function isAttributeLocked(elm: Element, attrName: string): boolean {
-    return elm !== controlledElement || attrName !== controlledAttributeName;
-}
-
-export function lockAttribute(_elm: Element, _key: string) {
-    controlledElement = null;
-    controlledAttributeName = undefined;
-}
-
-export function unlockAttribute(elm: Element, key: string) {
-    controlledElement = elm;
-    controlledAttributeName = key;
-}

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -27,7 +27,6 @@ import { getAssociatedVM } from './vm';
 import { getReadOnlyProxy } from './membrane';
 import { HTMLElementConstructor } from './html-element';
 import { HTMLElementOriginalDescriptors } from './html-properties';
-import { isAttributeLocked } from './attributes';
 
 // A bridge descriptor is a descriptor whose job is just to get the component instance
 // from the element instance, and get the value or set a new value on the component.
@@ -99,14 +98,6 @@ function createAttributeChangedCallback(
                 // @ts-ignore type-mismatch
                 superAttributeChangedCallback.apply(this, arguments);
             }
-            return;
-        }
-        if (!isAttributeLocked(this, attrName)) {
-            // Ignore changes triggered by the engine itself during:
-            // * diffing when public props are attempting to reflect to the DOM
-            // * component via `this.setAttribute()`, should never update the prop
-            // Both cases, the setAttribute call is always wrapped by the unlocking of the
-            // attribute to be changed
             return;
         }
         // Reflect attribute change to the corresponding property when changed from outside.

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -49,7 +49,6 @@ import {
     patchLightningElementPrototypeWithRestrictions,
     patchCustomElementWithRestrictions,
 } from './restrictions';
-import { unlockAttribute, lockAttribute } from './attributes';
 import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
 import { HTMLElementConstructor } from './base-bridge-element';
 import { updateComponentValue } from './update-component-value';
@@ -376,9 +375,7 @@ LightningElement.prototype = {
             elm,
             renderer: { removeAttribute },
         } = vm;
-        unlockAttribute(elm, name);
         removeAttribute(elm, name);
-        lockAttribute(elm, name);
     },
 
     removeAttributeNS(namespace: string | null, name: string): void {
@@ -386,9 +383,7 @@ LightningElement.prototype = {
             elm,
             renderer: { removeAttribute },
         } = getAssociatedVM(this);
-        unlockAttribute(elm, name);
         removeAttribute(elm, name, namespace);
-        lockAttribute(elm, name);
     },
 
     getAttribute(name: string): string | null {
@@ -422,9 +417,7 @@ LightningElement.prototype = {
             }
         }
 
-        unlockAttribute(elm, name);
         setAttribute(elm, name, value);
-        lockAttribute(elm, name);
     },
 
     setAttributeNS(namespace: string | null, name: string, value: string): void {
@@ -444,9 +437,7 @@ LightningElement.prototype = {
             }
         }
 
-        unlockAttribute(elm, name);
         setAttribute(elm, name, value, namespace);
-        lockAttribute(elm, name);
     },
 
     getBoundingClientRect(): ClientRect {

--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -7,7 +7,6 @@
 import { isNull, isUndefined, StringCharCodeAt, XML_NAMESPACE, XLINK_NAMESPACE } from '@lwc/shared';
 import { RendererAPI } from '../renderer';
 
-import { unlockAttribute, lockAttribute } from '../attributes';
 import { EmptyObject } from '../utils';
 import { VBaseElement } from '../vnodes';
 
@@ -35,7 +34,6 @@ export function patchAttributes(
         const old = oldAttrs[key];
 
         if (old !== cur) {
-            unlockAttribute(elm!, key);
             if (StringCharCodeAt.call(key, 3) === ColonCharCode) {
                 // Assume xml namespace
                 setAttribute(elm, key, cur as string, XML_NAMESPACE);
@@ -47,7 +45,6 @@ export function patchAttributes(
             } else {
                 setAttribute(elm, key, cur as string);
             }
-            lockAttribute(elm!, key);
         }
     }
 }


### PR DESCRIPTION
## Details

The goal of "attribute locking" is to avoid reflecting `setAttribute` to a property setter when manipulated by the framework.

I tested, though, and this only occurs for `CustomElementConstructor`, e.g. when [reflecting a set attribute to an `@api` prop](https://stackblitz.com/edit/salesforce-lwc-zk6nww?file=src/main.js).

This case is not actually tested in any of our tests, nor in any of our downstream tests. And AFAICT, with the introduction of `lwc:external`, it's not even possible for this case to arise, because we sniff to set a property rather than an attribute:

https://github.com/salesforce/lwc/blob/acc19c692f57ed8405a10a09b77f174ea015e440/packages/%40lwc/engine-core/src/framework/modules/attr-unless-prop.ts#L44-L46

So it seems to me that this code can just be removed.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

I can't think of a case where you could even observe this today.

<!-- If yes, please describe the anticipated observable changes. -->
