### PR TITLE
fix(perf-benchmarks): fix server/hydrate benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,8 +242,9 @@ jobs:
 
 
   test_unit:
-    executor: node
+    executor: node-browsers
     steps:
+      - browser-tools/install-browser-tools # required for selenium used by tachometer benchmark smoke tests
       - load_workspace
       - run:
           name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,9 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn test:ci
-
+      - run:
+          name: Run benchmark smoke tests
+          command: BENCHMARK_SMOKE_TEST=1 yarn test:performance
 
   test_karma:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,13 +242,18 @@ jobs:
 
 
   test_unit:
-    executor: node-browsers
+    executor: node
     steps:
-      - browser-tools/install-browser-tools # required for selenium used by tachometer benchmark smoke tests
       - load_workspace
       - run:
           name: Run unit tests
           command: yarn test:ci
+
+  test_benchmark_smoke:
+    executor: node-browsers
+    steps:
+      - browser-tools/install-browser-tools # required for selenium used by tachometer benchmark smoke tests
+      - load_workspace
       - run:
           name: Run benchmark smoke tests
           command: BENCHMARK_SMOKE_TEST=1 yarn test:performance
@@ -362,6 +367,12 @@ workflows:
             - test_unit
 
       - test_integration_compat:
+          filters:
+            <<: *ignore_forks
+          requires:
+            - test_unit
+
+      - test_benchmark_smoke:
           filters:
             <<: *ignore_forks
           requires:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@commitlint/cli": "^17.5.1",
         "@lwc/eslint-plugin-lwc-internal": "link:./scripts/eslint-plugin",
         "@lwc/jest-utils-lwc-internals": "link:./scripts/jest/utils",
+        "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-inject": "^5.0.3",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-replace": "^5.0.2",

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -41,13 +41,11 @@
             }
         }
     },
-    "dependencies": {
-        "parse5": "^6.0.1"
-    },
     "devDependencies": {
         "@lwc/engine-core": "2.45.2",
         "@lwc/rollup-plugin": "2.45.2",
         "@lwc/shared": "2.45.2",
-        "@rollup/plugin-virtual": "^3.0.1"
+        "@rollup/plugin-virtual": "^3.0.1",
+        "parse5": "^6.0.1"
     }
 }

--- a/packages/@lwc/perf-benchmarks/README.md
+++ b/packages/@lwc/perf-benchmarks/README.md
@@ -60,6 +60,12 @@ BENCHMARK_TIMEOUT=5
 
 See the [Tachometer documentation](https://github.com/Polymer/tachometer) for details on what these mean.
 
+You can run a smoke test (to confirm the benchmark tests are working) using:
+
+```shell
+BENCHMARK_SMOKE_TEST=1
+```
+
 If anything gets messed up when comparing to the other branch, add the `--force-clean-npm-install` flag when running `tach`.
 
 Also note that, due to how NX does caching, any environment variables you pass to `build:performance` should also

--- a/packages/@lwc/perf-benchmarks/best.config.js
+++ b/packages/@lwc/perf-benchmarks/best.config.js
@@ -22,9 +22,6 @@ module.exports = {
     plugins: [
         // Best is currently using an older version of Rollup, so we use an older @rollup/plugin-node-resolve
         '@lwc/rollup-plugin-node-resolve-legacy',
-        // CommonJS is currently required for transitive deps like parse5
-        // TODO [#3451]: when parse5 is upgraded to v7, we should be able to remove this
-        '@lwc/rollup-plugin-commonjs-legacy',
         [
             '@rollup/plugin-replace',
             {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -6,7 +6,7 @@
         "build": "rm -fr dist && rollup -c  ./rollup.config.mjs && node scripts/build.js && ./scripts/fix-deps.sh",
         "test": "yarn test:run && yarn test:format",
         "test:run": "for file in $(find dist -name '*.tachometer.json'); do tach --config $file --json-file $(echo $file | sed 's/.json/.results.json/'); done",
-        "test:format": "node ./scripts/format-results.mjs $(find dist -name '*.results.json')",
+        "test:format": "if [ -z $BENCHMARK_SMOKE_TEST ]; then node ./scripts/format-results.mjs $(find dist -name '*.results.json'); fi",
         "test:best": "best src",
         "test:best:ci": "best src --runner remote"
     },
@@ -27,7 +27,6 @@
         "@best/runner-headless": "^8.1.3",
         "@best/runner-remote": "^8.1.3",
         "@lwc/rollup-plugin-node-resolve-legacy": "npm:rollup-plugin-node-resolve@5.2.0",
-        "@lwc/rollup-plugin-commonjs-legacy": "npm:rollup-plugin-commonjs@10.1.0",
         "folder-hash": "4.0.4",
         "markdown-table": "^3.0.3",
         "tachometer": "0.5.10"
@@ -54,6 +53,9 @@
                     },
                     {
                         "env": "BENCHMARK_TIMEOUT"
+                    },
+                    {
+                        "env": "BENCHMARK_SMOKE_TEST"
                     }
                 ]
             },

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -185,7 +185,8 @@ module.exports = {
             resolveOnly: [
                 /^@lwc\//,
                 'observable-membrane',
-                // Special case - parse5 is bundled only in @lwc/engine-server currently
+                // Special case - parse5 is bundled only in @lwc/engine-server currently, to avoid
+                // issues with Best/Tachometer and with shipping breaking ESM to consumers
                 packageName === '@lwc/engine-server' && 'parse5',
             ].filter(Boolean),
         }),

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -186,7 +186,9 @@ module.exports = {
                 /^@lwc\//,
                 'observable-membrane',
                 // Special case - parse5 is bundled only in @lwc/engine-server currently, to avoid
-                // issues with Best/Tachometer and with shipping breaking ESM to consumers
+                // issues with Best/Tachometer.
+                // We can probably remove this special case when we upgrade parse5 to the ESM version, and bundle it
+                // into @lwc/template-compiler as well (to avoid shipping breaking ESM changes to consumers).
                 packageName === '@lwc/engine-server' && 'parse5',
             ].filter(Boolean),
         }),

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -15,6 +15,7 @@ const { rollup } = require('rollup');
 const replace = require('@rollup/plugin-replace');
 const typescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
 
 // The assumption is that the build script for each sub-package runs in that sub-package's directory
 const packageRoot = process.cwd();
@@ -179,7 +180,18 @@ module.exports = {
     plugins: [
         nodeResolve({
             // These are the devDeps that may be inlined into the dist/ bundles
-            resolveOnly: [/^@lwc\//, 'observable-membrane'],
+            // These include packages owned by us (LWC, observable-membrane), as well as parse5,
+            // which is bundled because it makes it simpler to distribute
+            resolveOnly: [
+                /^@lwc\//,
+                'observable-membrane',
+                // Special case - parse5 is bundled only in @lwc/engine-server currently
+                packageName === '@lwc/engine-server' && 'parse5',
+            ].filter(Boolean),
+        }),
+        // TODO [#3451]: remove this once we upgrade parse5 to its ESM version
+        commonjs({
+            include: [/\/parse5\//],
         }),
         ...sharedPlugins(),
         backwardsCompatDistPlugin(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -14075,3 +14075,5 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,20 +2052,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/jest-utils-lwc-internals@link:./scripts/jest/utils":
   version "0.0.0"
-
-"@lwc/rollup-plugin-commonjs-legacy@npm:rollup-plugin-commonjs@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz#417af3b54503878e084d127adf4d1caf8beb86fb"
-  integrity sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  dependencies:
-    estree-walker "^0.6.1"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
-    rollup-pluginutils "^2.8.1"
+  uid ""
 
 "@lwc/rollup-plugin-node-resolve-legacy@npm:rollup-plugin-node-resolve@5.2.0":
   version "5.2.0"
@@ -2316,6 +2307,18 @@
   dependencies:
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
+
+"@rollup/plugin-commonjs@^25.0.0":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.0.tgz#ef55d12415dfcfb77fd52650dc1448c8aae8ed5c"
+  integrity sha512-hoho2Kay9TZrLu0bnDsTTCaj4Npa+THk9snajP/XDNb9a9mmjTjh52EQM9sKl3HD1LsnihX7js+eA2sd2uKAhw==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    commondir "^1.0.1"
+    estree-walker "^2.0.2"
+    glob "^8.0.3"
+    is-reference "1.2.1"
+    magic-string "^0.27.0"
 
 "@rollup/plugin-inject@^5.0.3":
   version "5.0.3"
@@ -4911,6 +4914,11 @@ commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -8060,7 +8068,7 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-reference@^1.1.2:
+is-reference@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
   integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -9644,13 +9652,6 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.1.tgz#bccac4a8f7b93163a8d163b8ebf385b3c5f55bf9"
   integrity sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==
 
-magic-string@^0.25.2, magic-string@~0.25.1:
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
-  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
-  dependencies:
-    sourcemap-codec "^1.4.8"
-
 magic-string@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
@@ -9664,6 +9665,13 @@ magic-string@^0.30.0:
   integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
+
+magic-string@~0.25.1:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
## Details

FIxes #3498

Also adds a CI test so we can stop breaking our benchmarks all the time.

The solution I used was to bundle `parse5` into `@lwc/engine-server` since Tachometer can't handle CommonJS. We'll have to do this anyway once we fix #3451, since we can't ship ESM directly to consumers without breaking a bunch of people.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-13219245](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001RaHltYAF/view)
