### PR TITLE
chore(nx): fix NX dist caching

### DIFF
--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -40,7 +40,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -36,7 +36,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "dist"
+                    "./dist"
                 ]
             }
         }

--- a/scripts/tasks/check-and-rewrite-package-json.js
+++ b/scripts/tasks/check-and-rewrite-package-json.js
@@ -72,6 +72,7 @@ for (const dir of directories) {
         main: 'dist/index.cjs.js',
         module: 'dist/index.js',
         types: 'dist/index.d.ts',
+        // It's important _not_ to use `./dist` here (with the `./`), because npm does not understand that
         files: ['dist'],
         scripts: {
             build: 'rollup --config ../../../scripts/rollup/rollup.config.js',
@@ -80,7 +81,9 @@ for (const dir of directories) {
         nx: {
             targets: {
                 build: {
-                    outputs: ['dist'],
+                    // It's important to use the `./` here, otherwise NX does not restore the dist files
+                    // See https://github.com/salesforce/lwc/issues/3511
+                    outputs: ['./dist'],
                 },
             },
         },


### PR DESCRIPTION
## Details

Fixes #3511


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-13223900](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ReAQVYA3/view)
