### PR TITLE
fix: expose wire-service package

### DIFF
--- a/scripts/tasks/check-and-rewrite-package-json.js
+++ b/scripts/tasks/check-and-rewrite-package-json.js
@@ -29,9 +29,9 @@ const IGNORED_PACKAGES = [
 
 // This is the same list as in @lwc/rollup-plugin/src/index.ts
 const LWC_EXPOSED_MODULES = {
-    '@lwc/engine-dom': 'lwc',
-    '@lwc/synthetic-shadow': '@lwc/synthetic-shadow',
-    '@lwc/wire-service': '@lwc/wire-service',
+    '@lwc/engine-dom': ['lwc'],
+    '@lwc/synthetic-shadow': ['@lwc/synthetic-shadow'],
+    '@lwc/wire-service': ['@lwc/wire-service', 'wire-service'],
 };
 
 const directories = globSync('./packages/@lwc/*').filter(
@@ -92,19 +92,17 @@ for (const dir of directories) {
         peerDependencies,
     };
 
-    const exposedModule = LWC_EXPOSED_MODULES[name];
-    if (exposedModule) {
+    const exposedModules = LWC_EXPOSED_MODULES[name];
+    if (exposedModules) {
         // Special case - consumers can do `import { LightningElement } from 'lwc'` and have it resolve to
         // `@lwc/engine-dom`. As for @lwc/synthetic-shadow and @lwc/wire-service, we have historically included these in
         // the "default modules" defined in @lwc/rollup-plugin.
         expectedJson.lwc = {
-            modules: [
-                {
-                    name: exposedModule,
-                    path: 'dist/index.js',
-                },
-            ],
-            expose: [exposedModule],
+            modules: exposedModules.map((exposedModule) => ({
+                name: exposedModule,
+                path: 'dist/index.js',
+            })),
+            expose: exposedModules,
         };
     }
 


### PR DESCRIPTION
## Details

Testing to see if this fixes downstream `webruntime` test

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
