### PR TITLE
chore(nucleus): remove o11y-sample-app

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -27,7 +27,6 @@ branches:
         - salesforce-experience-platform-emu/luvio
         - salesforce-experience-platform-emu/lwr
         - salesforce/lwr-lightning-platform
-        - salesforce/o11y-sample-app
         - salesforcedevs/doc-framework-monorepo
   release:
     pull-request:


### PR DESCRIPTION
It's breaking for unrelated reasons since #3520 