### PR TITLE
fix(engine-core): execute scoped slot fragment in the slot owner's reactive observer

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -222,7 +222,12 @@ function s(
                     // undefined is for root components, but root components cannot accept slotted content
                     setVMBeingRendered(slotset.owner!);
                     try {
-                        ArrayPush.call(newChildren, vnode.factory(data.slotData, data.key));
+                        // The factory function is a template snippet from the slot set owner's template,
+                        // hence switch over to the slot set owner's template reactive observer
+                        const { tro } = slotset.owner!;
+                        tro.observe(() => {
+                            ArrayPush.call(newChildren, vnode.factory(data.slotData, data.key));
+                        });
                     } finally {
                         setVMBeingRendered(vmBeingRenderedInception);
                     }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
@@ -40,6 +40,8 @@ describe('reactivity in scoped slots', () => {
                 // reset timing buffer before next rerender
                 resetTimingBuffer();
                 elm.changeItemsRow();
+                // contents of items is being observed by x-child and not by x-parent.
+                // Adding a new row or changing an entire row will only trigger renderedCallback of x-child and not of the parent
             })
             .then(() => {
                 const spans = elm.shadowRoot.querySelectorAll('span');

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
@@ -33,7 +33,8 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('38 - Audio');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback', // value(items) in child's template was changed, so call child's renderedCallback
+                    'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
                 ]);
 
                 // reset timing buffer before next rerender
@@ -45,9 +46,7 @@ describe('reactivity in scoped slots', () => {
                 expect(spans).toHaveSize(2);
                 expect(spans[0].innerHTML).toBe('37 - Tape');
                 expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
-                ]);
+                expect(window.timingBuffer).toEqual(['child:renderedCallback']);
             });
     });
 
@@ -58,7 +57,6 @@ describe('reactivity in scoped slots', () => {
         resetTimingBuffer();
         const child = elm.shadowRoot.querySelector('x-list-child-tracked-data');
         child.changeItemsNestedKey();
-
         return Promise.resolve()
             .then(() => {
                 const spans = elm.shadowRoot.querySelectorAll('span');
@@ -66,7 +64,8 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('38 - Audio');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
                 ]);
 
                 // reset timing buffer before next rerender
@@ -79,7 +78,8 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('37 - Tape');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    // Since the parent observes changes to the contents of the individual rows and not the items itself the parent's renderedCallback isn't invoked
                 ]);
             });
     });
@@ -110,6 +110,8 @@ describe('reactivity in scoped slots', () => {
                         'child-38:connectedCallback', // Connect and render edited entry
                         'child-38:renderedCallback',
                         'child-39:disconnectedCallback', // Removed list entry is disconnected
+                        'childSlotTagWithKey:renderedCallback', // slot receiver has been rendered
+                        'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
                     ]
                 );
 
@@ -121,7 +123,11 @@ describe('reactivity in scoped slots', () => {
             .then(() => {
                 verifyContentAndCallbacks(
                     ['38 - Light', '40 - Video'],
-                    ['child-38:renderedCallback']
+                    [
+                        'child-38:renderedCallback',
+                        'childSlotTagWithKey:renderedCallback',
+                        'parent:renderedCallback',
+                    ]
                 );
 
                 // reset timing buffer before next rerender
@@ -137,6 +143,7 @@ describe('reactivity in scoped slots', () => {
                         'child-37:connectedCallback',
                         'child-37:renderedCallback',
                         'child-38:disconnectedCallback',
+                        'childSlotTagWithKey:renderedCallback',
                     ]
                 );
             });
@@ -158,7 +165,8 @@ describe('reactivity in scoped slots', () => {
                 expect(div).toHaveSize(1);
                 expect(div[0].innerHTML).toBe('2000 hits');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    'parent:renderedCallback', // label is part of parent's template, call its renderedCallback
                 ]);
             });
         });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/x/childSlotTagWithKey/childSlotTagWithKey.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/x/childSlotTagWithKey/childSlotTagWithKey.js
@@ -3,4 +3,8 @@ import { LightningElement, api } from 'lwc';
 export default class ChildSlotTagWithKey extends LightningElement {
     static renderMode = 'light';
     @api items;
+
+    renderedCallback() {
+        window.timingBuffer.push('childSlotTagWithKey:renderedCallback');
+    }
 }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
@@ -1,8 +1,7 @@
 import { createElement } from 'lwc';
 import Parent from 'x/parent';
 
-// eslint-disable-next-line
-fdescribe('Should clean up content between rehydration', () => {
+describe('Should clean up content between rehydration', () => {
     beforeEach(() => {
         resetTimingBuffer();
     });
@@ -15,14 +14,23 @@ fdescribe('Should clean up content between rehydration', () => {
         window.timingBuffer = [];
     }
 
-    it('Issue W-12965122 automation', () => {
+    function verifySlotContent(elm, expectedContent) {
+        expect(
+            [...elm.shadowRoot.querySelectorAll('x-slotted')].map((_) =>
+                _.shadowRoot.innerHTML.trim()
+            )
+        ).toEqual(expectedContent);
+    }
+
+    it('Issue W-12965122 automation: Elements are not leaked when parent binding and child binding is mutated', () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
-        elm.changeAttr();
+        elm.changeAttr(); // counter 0
         return Promise.resolve()
             .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Fiat']);
                 expect(window.timingBuffer).toEqual([
                     'slotted:renderedCallback',
                     'child:renderedCallback',
@@ -31,17 +39,19 @@ fdescribe('Should clean up content between rehydration', () => {
                 // reset timing buffer before next rerender
                 resetTimingBuffer();
                 elm.flag = false;
-                elm.changeAttr();
+                elm.changeAttr(); // counter 1
             })
             .then(() => {
+                verifySlotContent(elm, []);
                 // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
                 expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
                 // reset timing buffer before next rerender
                 resetTimingBuffer();
                 elm.flag = true;
-                elm.changeAttr();
+                elm.changeAttr(); // counter 2
             })
             .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent2 Fiat']);
                 // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
                 expect(window.timingBuffer).toEqual([
                     'slotted:renderedCallback',
@@ -51,9 +61,10 @@ fdescribe('Should clean up content between rehydration', () => {
                 // reset timing buffer before next rerender
                 resetTimingBuffer();
                 elm.flag = false;
-                elm.changeAttr();
+                elm.changeAttr(); // counter 3
             })
             .then(() => {
+                verifySlotContent(elm, []);
                 // Prior to the bug fix, there would be two additional 'slotted:renderedCallback' entry(the leaked elements grow)
                 expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
                 // reset timing buffer before next rerender
@@ -62,11 +73,118 @@ fdescribe('Should clean up content between rehydration', () => {
                 elm.changeAttr();
             })
             .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent4 Fiat']);
                 expect(window.timingBuffer).toEqual([
                     'slotted:renderedCallback',
                     'child:renderedCallback',
                     'parent:renderedCallback',
                 ]);
+            });
+    });
+
+    it("Should rerender when only child's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                // Only change child's tracked value
+                elm.shadowRoot.querySelector('x-child').changeLabel();
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent Peugeot']);
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr(); // counter 3
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Verify there are no dangling x-slotted
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+            });
+    });
+
+    it("Should rerender when child's value is mutated before parent's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                elm.flag = false;
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                elm.flag = true;
+            })
+            .then(() => {
+                resetTimingBuffer();
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+                elm.changeAttr(); // Counter 0
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+
+    it("Should rerender when child's value is mutated after then parent's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                elm.flag = false;
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                elm.flag = true;
+            })
+            .then(() => {
+                resetTimingBuffer();
+                elm.changeAttr(); // Counter 0
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+
+    it('Should not leak slotted content if its changed by child before cleanup', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                resetTimingBuffer();
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Mutate child's value before parent turns off the branch containing x-child
+                elm.flag = false; // turn off the branch
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
             });
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
@@ -1,0 +1,72 @@
+import { createElement } from 'lwc';
+import Parent from 'x/parent';
+
+// eslint-disable-next-line
+fdescribe('Should clean up content between rehydration', () => {
+    beforeEach(() => {
+        resetTimingBuffer();
+    });
+
+    afterEach(() => {
+        delete window.timingBuffer;
+    });
+
+    function resetTimingBuffer() {
+        window.timingBuffer = [];
+    }
+
+    it('Issue W-12965122 automation', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        elm.changeAttr();
+        return Promise.resolve()
+            .then(() => {
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr();
+            })
+            .then(() => {
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = true;
+                elm.changeAttr();
+            })
+            .then(() => {
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr();
+            })
+            .then(() => {
+                // Prior to the bug fix, there would be two additional 'slotted:renderedCallback' entry(the leaked elements grow)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = true;
+                elm.changeAttr();
+            })
+            .then(() => {
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+});

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.html
@@ -1,0 +1,9 @@
+<template lwc:render-mode="light">
+    <ul>
+        <template for:each={items} for:item="item">
+            <li key={item.id}>
+                <slot lwc:slot-bind={item}></slot>
+            </li>
+        </template>
+    </ul>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
@@ -1,9 +1,14 @@
-import { LightningElement, track } from 'lwc';
+import { LightningElement, api, track } from 'lwc';
 
 export default class Child extends LightningElement {
     static renderMode = 'light';
     @track
     items = [{ id: 1, name: 'Fiat' }];
+
+    @api
+    changeLabel() {
+        this.items[0].name = 'Peugeot';
+    }
 
     renderedCallback() {
         window.timingBuffer.push('child:renderedCallback');

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
@@ -1,0 +1,11 @@
+import { LightningElement, track } from 'lwc';
+
+export default class Child extends LightningElement {
+    static renderMode = 'light';
+    @track
+    items = [{ id: 1, name: 'Fiat' }];
+
+    renderedCallback() {
+        window.timingBuffer.push('child:renderedCallback');
+    }
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.html
@@ -1,0 +1,12 @@
+<template>
+    <template lwc:if={flag}>
+        <x-child>
+            <template lwc:slot-data="item">
+                <x-slotted attr={attr} label={item.name}></x-slotted>
+            </template>
+        </x-child>
+    </template>
+    <template lwc:else>
+        Statement2
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
@@ -2,6 +2,10 @@ import { LightningElement, api, track } from 'lwc';
 
 let counter = 0;
 export default class Parent extends LightningElement {
+    constructor() {
+        super();
+        counter = 0;
+    }
     @track
     attr = { label: 'Parent' };
     @api changeAttr() {

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
@@ -1,0 +1,15 @@
+import { LightningElement, api, track } from 'lwc';
+
+let counter = 0;
+export default class Parent extends LightningElement {
+    @track
+    attr = { label: 'Parent' };
+    @api changeAttr() {
+        this.attr = { label: 'Parent' + counter++ };
+    }
+    @api flag = false;
+
+    renderedCallback() {
+        window.timingBuffer.push('parent:renderedCallback');
+    }
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.html
@@ -1,0 +1,3 @@
+<template>
+    Slotted content: {attr.label} {label}
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Slotted extends LightningElement {
+    @api attr;
+    @api label;
+    renderedCallback() {
+        window.timingBuffer.push('slotted:renderedCallback');
+    }
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
@@ -6,8 +6,4 @@ export default class Slotted extends LightningElement {
     renderedCallback() {
         window.timingBuffer.push('slotted:renderedCallback');
     }
-
-    connectedCallback() {
-        //window.timingBuffer.push('slotted:connectedCallback');
-    }
 }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
@@ -6,4 +6,8 @@ export default class Slotted extends LightningElement {
     renderedCallback() {
         window.timingBuffer.push('slotted:renderedCallback');
     }
+
+    connectedCallback() {
+        //window.timingBuffer.push('slotted:connectedCallback');
+    }
 }


### PR DESCRIPTION
## Details
The PR fixes a bug where the scopes slot fragment was executing in the receiving component's template reactive observer(tro) and led to memory leaks.
 Executing the scoped slot fragment in the child component's tro would result in the child component being registered as the observer for values that are observed in the scoped slot fragment(which come from the parent's template). If the scoped slot fragment happens to have bindings from the parent's component class and the bindings change, then child component would be added to the rehydration queue thus causing a memory leak.

Example template for better understanding.
```xml
<!-- x-parent's template -->
<template>
   <x-child>
        <template lwc:slot-data={item}>
                <!-- note that attr comes from the parent's class -->
                <x-slotted label={item.label} attr={attr}></x-slotted>
        </template>
   </x-child>
<template>
```

Note: The above template is not the full repro, the PR has a test with a more detailed setup.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
The parent's renderedCallback is also invoked(in addition to the child's renderedCallback) if a value used in the parent's template is changed and the child is re-rendered. Previously, only the child's renderedCallback was invoked.

## GUS work item
W-12965122
