### PR TITLE
test(integration-karma): add tests for updating class attribute

### DIFF
--- a/packages/@lwc/integration-karma/test/template/attribute-class/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/index.spec.js
@@ -77,4 +77,44 @@ describe('dynamic class attribute', () => {
             expect(target.className).toBe('bar baz');
         });
     });
+
+    describe('updating with null/undefined/empty string', () => {
+        function testRenderClassAttribute(type, value, expectedValue) {
+            it(`renders the class attribute for ${type}`, () => {
+                const elm = createElement('x-dynamic', { is: Dynamic });
+                elm.dynamicClass = value;
+                document.body.appendChild(elm);
+
+                expect(elm.shadowRoot.querySelector('div').getAttribute('class')).toBe(
+                    expectedValue
+                );
+            });
+        }
+
+        testRenderClassAttribute('null', null, null);
+        testRenderClassAttribute('undefined', undefined, null);
+        testRenderClassAttribute('empty string', '', null);
+        testRenderClassAttribute('class string', 'my-class', 'my-class');
+
+        function testUpdateClassAttribute(type, value, expectedValue) {
+            it(`updates the class attribute for ${type}`, async () => {
+                const elm = createElement('x-dynamic', { is: Dynamic });
+                elm.dynamicClass = 'my-class';
+                document.body.appendChild(elm);
+
+                expect(elm.shadowRoot.querySelector('div').getAttribute('class')).toBe('my-class');
+
+                elm.dynamicClass = value;
+                await Promise.resolve();
+                expect(elm.shadowRoot.querySelector('div').getAttribute('class')).toBe(
+                    expectedValue
+                );
+            });
+        }
+
+        testUpdateClassAttribute('null', null, '');
+        testUpdateClassAttribute('undefined', undefined, '');
+        testUpdateClassAttribute('empty string', '', '');
+        testUpdateClassAttribute('class string', 'my-class', 'my-class');
+    });
 });


### PR DESCRIPTION
## Details

While working on patch flags, I realized we were missing some tests for updating dynamic `class` attributes with null/undefined/empty string. This borrows some of the same tests from `integration-karma/test/template/attribute-style/index.spec.js` to accomplish this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
