### PR TITLE
fix(hydration): log errors/warnings only in dev mode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -69,7 +69,7 @@ export function hydrateRoot(vm: VM) {
     runConnectedCallback(vm);
     hydrateVM(vm);
 
-    if (hasMismatch) {
+    if (hasMismatch && process.env.NODE_ENV !== 'production') {
         logError('Hydration completed with errors.', vm);
     }
 }
@@ -159,9 +159,11 @@ function getValidationPredicate(
     if (isArray(optOutStaticProp) && arrayEvery<string>(optOutStaticProp, isString)) {
         return (attrName: string) => !ArrayIncludes.call(optOutStaticProp, attrName);
     }
-    logWarn(
-        'Validation opt out must be `true` or an array of attributes that should not be validated.'
-    );
+    if (process.env.NODE_ENV !== 'production') {
+        logWarn(
+            'Validation opt out must be `true` or an array of attributes that should not be validated.'
+        );
+    }
     return (_attrName: string) => true;
 }
 
@@ -697,16 +699,18 @@ function areCompatibleNodes(client: Node, ssr: Node, vnode: VNode, renderer: Ren
 
     clientAttrsNames.forEach((attrName) => {
         if (getAttribute(client, attrName) !== getAttribute(ssr, attrName)) {
-            logError(
-                `Mismatch hydrating element <${getProperty(
-                    client,
-                    'tagName'
-                ).toLowerCase()}>: attribute "${attrName}" has different values, expected "${getAttribute(
-                    client,
-                    attrName
-                )}" but found "${getAttribute(ssr, attrName)}"`,
-                vnode.owner
-            );
+            if (process.env.NODE_ENV !== 'production') {
+                logError(
+                    `Mismatch hydrating element <${getProperty(
+                        client,
+                        'tagName'
+                    ).toLowerCase()}>: attribute "${attrName}" has different values, expected "${getAttribute(
+                        client,
+                        attrName
+                    )}" but found "${getAttribute(ssr, attrName)}"`,
+                    vnode.owner
+                );
+            }
             isCompatibleElements = false;
         }
     });

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -81,14 +81,13 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
                 .flat()
                 .map((err) => (err instanceof Error ? err.message : err));
             if (process.env.NODE_ENV === 'production') {
-                expect(observedErrors.length).toEqual(1);
+                expect(observedErrors).toEqual([]);
             } else {
-                expect(observedErrors.length).toEqual(2);
-                expect(observedErrors).toContain(
-                    '[LWC error]: Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.\n'
-                );
+                expect(observedErrors).toEqual([
+                    '[LWC error]: Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.\n',
+                    '[LWC error]: Hydration completed with errors.\n',
+                ]);
             }
-            expect(observedErrors).toContain('[LWC error]: Hydration completed with errors.\n');
         });
         it(`should occur when element exists before customElements.define and not throw errors if it's consistent`, () => {
             const elm = document.createElement('test-custom-element-preexisting-consistent');


### PR DESCRIPTION
## Details

Wraps all error/warn logs in `hydration.ts` in a `process.env.NODE_ENV !== 'production'` check. Prompted by https://github.com/salesforce/lwc/issues/2939#issuecomment-1560209569

Note we don't really have a test for this yet, because we only run the hydration tests in dev mode (#3253).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
