### PR TITLE
fix(engine-core): execute scoped slot fragment in the slot owner's reactive observer

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -222,7 +222,12 @@ function s(
                     // undefined is for root components, but root components cannot accept slotted content
                     setVMBeingRendered(slotset.owner!);
                     try {
-                        ArrayPush.call(newChildren, vnode.factory(data.slotData, data.key));
+                        // The factory function is a template snippet from the slot set owner's template,
+                        // hence switch over to the slot set owner's template reactive observer
+                        const { tro } = slotset.owner!;
+                        tro.observe(() => {
+                            ArrayPush.call(newChildren, vnode.factory(data.slotData, data.key));
+                        });
                     } finally {
                         setVMBeingRendered(vmBeingRenderedInception);
                     }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
@@ -33,21 +33,22 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('38 - Audio');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback', // value(items) in child's template was changed, so call child's renderedCallback
+                    'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
                 ]);
 
                 // reset timing buffer before next rerender
                 resetTimingBuffer();
                 elm.changeItemsRow();
+                // contents of items is being observed by x-child and not by x-parent.
+                // Adding a new row or changing an entire row will only trigger renderedCallback of x-child and not of the parent
             })
             .then(() => {
                 const spans = elm.shadowRoot.querySelectorAll('span');
                 expect(spans).toHaveSize(2);
                 expect(spans[0].innerHTML).toBe('37 - Tape');
                 expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
-                ]);
+                expect(window.timingBuffer).toEqual(['child:renderedCallback']);
             });
     });
 
@@ -58,7 +59,6 @@ describe('reactivity in scoped slots', () => {
         resetTimingBuffer();
         const child = elm.shadowRoot.querySelector('x-list-child-tracked-data');
         child.changeItemsNestedKey();
-
         return Promise.resolve()
             .then(() => {
                 const spans = elm.shadowRoot.querySelectorAll('span');
@@ -66,7 +66,8 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('38 - Audio');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
                 ]);
 
                 // reset timing buffer before next rerender
@@ -79,7 +80,8 @@ describe('reactivity in scoped slots', () => {
                 expect(spans[0].innerHTML).toBe('37 - Tape');
                 expect(spans[1].innerHTML).toBe('40 - Video');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    // Since the parent observes changes to the contents of the individual rows and not the items itself the parent's renderedCallback isn't invoked
                 ]);
             });
     });
@@ -110,6 +112,8 @@ describe('reactivity in scoped slots', () => {
                         'child-38:connectedCallback', // Connect and render edited entry
                         'child-38:renderedCallback',
                         'child-39:disconnectedCallback', // Removed list entry is disconnected
+                        'childSlotTagWithKey:renderedCallback', // slot receiver has been rendered
+                        'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
                     ]
                 );
 
@@ -121,7 +125,11 @@ describe('reactivity in scoped slots', () => {
             .then(() => {
                 verifyContentAndCallbacks(
                     ['38 - Light', '40 - Video'],
-                    ['child-38:renderedCallback']
+                    [
+                        'child-38:renderedCallback',
+                        'childSlotTagWithKey:renderedCallback',
+                        'parent:renderedCallback',
+                    ]
                 );
 
                 // reset timing buffer before next rerender
@@ -137,6 +145,7 @@ describe('reactivity in scoped slots', () => {
                         'child-37:connectedCallback',
                         'child-37:renderedCallback',
                         'child-38:disconnectedCallback',
+                        'childSlotTagWithKey:renderedCallback',
                     ]
                 );
             });
@@ -158,7 +167,8 @@ describe('reactivity in scoped slots', () => {
                 expect(div).toHaveSize(1);
                 expect(div[0].innerHTML).toBe('2000 hits');
                 expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // Only the child gets re-rendered
+                    'child:renderedCallback',
+                    'parent:renderedCallback', // label is part of parent's template, call its renderedCallback
                 ]);
             });
         });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/x/childSlotTagWithKey/childSlotTagWithKey.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/reactivity/x/childSlotTagWithKey/childSlotTagWithKey.js
@@ -3,4 +3,8 @@ import { LightningElement, api } from 'lwc';
 export default class ChildSlotTagWithKey extends LightningElement {
     static renderMode = 'light';
     @api items;
+
+    renderedCallback() {
+        window.timingBuffer.push('childSlotTagWithKey:renderedCallback');
+    }
 }

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
@@ -1,0 +1,190 @@
+import { createElement } from 'lwc';
+import Parent from 'x/parent';
+
+describe('Should clean up content between rehydration', () => {
+    beforeEach(() => {
+        resetTimingBuffer();
+    });
+
+    afterEach(() => {
+        delete window.timingBuffer;
+    });
+
+    function resetTimingBuffer() {
+        window.timingBuffer = [];
+    }
+
+    function verifySlotContent(elm, expectedContent) {
+        expect(
+            [...elm.shadowRoot.querySelectorAll('x-slotted')].map((_) =>
+                _.shadowRoot.innerHTML.trim()
+            )
+        ).toEqual(expectedContent);
+    }
+
+    it('Issue W-12965122 automation: Elements are not leaked when parent binding and child binding is mutated', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        elm.changeAttr(); // counter 0
+        return Promise.resolve()
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Fiat']);
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr(); // counter 1
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = true;
+                elm.changeAttr(); // counter 2
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent2 Fiat']);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr(); // counter 3
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Prior to the bug fix, there would be two additional 'slotted:renderedCallback' entry(the leaked elements grow)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                elm.flag = true;
+                elm.changeAttr();
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent4 Fiat']);
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+
+    it("Should rerender when only child's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                // reset timing buffer before next rerender
+                resetTimingBuffer();
+                // Only change child's tracked value
+                elm.shadowRoot.querySelector('x-child').changeLabel();
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent Peugeot']);
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+                resetTimingBuffer();
+                elm.flag = false;
+                elm.changeAttr(); // counter 3
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Verify there are no dangling x-slotted
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+            });
+    });
+
+    it("Should rerender when child's value is mutated before parent's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                elm.flag = false;
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                elm.flag = true;
+            })
+            .then(() => {
+                resetTimingBuffer();
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+                elm.changeAttr(); // Counter 0
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+
+    it("Should rerender when child's value is mutated after then parent's value is mutated", () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                elm.flag = false;
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                elm.flag = true;
+            })
+            .then(() => {
+                resetTimingBuffer();
+                elm.changeAttr(); // Counter 0
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+            })
+            .then(() => {
+                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual([
+                    'slotted:renderedCallback',
+                    'child:renderedCallback',
+                    'parent:renderedCallback',
+                ]);
+            });
+    });
+
+    it('Should not leak slotted content if its changed by child before cleanup', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+        resetTimingBuffer();
+        elm.flag = true;
+        return Promise.resolve()
+            .then(() => {
+                resetTimingBuffer();
+                elm.shadowRoot.querySelector('x-child').changeLabel(); // Mutate child's value before parent turns off the branch containing x-child
+                elm.flag = false; // turn off the branch
+            })
+            .then(() => {
+                verifySlotContent(elm, []);
+                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+            });
+    });
+});

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.html
@@ -1,0 +1,9 @@
+<template lwc:render-mode="light">
+    <ul>
+        <template for:each={items} for:item="item">
+            <li key={item.id}>
+                <slot lwc:slot-bind={item}></slot>
+            </li>
+        </template>
+    </ul>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/child/child.js
@@ -1,0 +1,16 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class Child extends LightningElement {
+    static renderMode = 'light';
+    @track
+    items = [{ id: 1, name: 'Fiat' }];
+
+    @api
+    changeLabel() {
+        this.items[0].name = 'Peugeot';
+    }
+
+    renderedCallback() {
+        window.timingBuffer.push('child:renderedCallback');
+    }
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.html
@@ -1,0 +1,12 @@
+<template>
+    <template lwc:if={flag}>
+        <x-child>
+            <template lwc:slot-data="item">
+                <x-slotted attr={attr} label={item.name}></x-slotted>
+            </template>
+        </x-child>
+    </template>
+    <template lwc:else>
+        Statement2
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/parent/parent.js
@@ -1,0 +1,19 @@
+import { LightningElement, api, track } from 'lwc';
+
+let counter = 0;
+export default class Parent extends LightningElement {
+    constructor() {
+        super();
+        counter = 0;
+    }
+    @track
+    attr = { label: 'Parent' };
+    @api changeAttr() {
+        this.attr = { label: 'Parent' + counter++ };
+    }
+    @api flag = false;
+
+    renderedCallback() {
+        window.timingBuffer.push('parent:renderedCallback');
+    }
+}

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.html
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.html
@@ -1,0 +1,3 @@
+<template>
+    Slotted content: {attr.label} {label}
+</template>

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/x/slotted/slotted.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Slotted extends LightningElement {
+    @api attr;
+    @api label;
+    renderedCallback() {
+        window.timingBuffer.push('slotted:renderedCallback');
+    }
+}


### PR DESCRIPTION
## Details

Backport of #3525 

(cherry picked from commit 7034cf8d520a5bbc75fa3a1bc901d4f8fe5e0777)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-13461672
