### PR TITLE
chore(nucleus): set "latest" dist-tag when publishing

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -69,3 +69,7 @@ steps:
         # add NX cache
         - '.nx-cache'
     after: node-build
+  npm-publish-release:
+    params:
+      access: public
+      tag: latest # note: this should be summer22, winter23, etc. if this .nucleus.yaml file is in a non-master branch


### PR DESCRIPTION
## Details

This ensures that Nucleus applies the `latest` npm dist-tag when publishing to npm.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
