### PR TITLE
fix: metrics enum should not be const

### DIFF
--- a/packages/@lwc/errors/src/compiler/instrumentation.ts
+++ b/packages/@lwc/errors/src/compiler/instrumentation.ts
@@ -10,7 +10,7 @@ import { ErrorConfig } from './errors';
 /**
  * Pattern modeled after @lwc/engine-core's reporting.ts system
  */
-export const enum CompilerMetrics {
+export enum CompilerMetrics {
     LWCDynamicDirective = 'lwc-dynamic-directive',
     LWCRenderModeDirective = 'lwc-render-mode-directive',
     LWCSpreadDirective = 'lwc-spread-directive',


### PR DESCRIPTION
## Details
Removes `const` so this enum is not erased during compilation.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
