### PR TITLE
feat(engine-dom): add DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR flag (backport)

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/lightning-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/lightning-element.ts
@@ -42,6 +42,9 @@ function getCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementCon
  */
 defineProperty(LightningElement, 'CustomElementConstructor', {
     get() {
+        if (lwcRuntimeFlags.DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR) {
+            throw new Error('CustomElementConstructor is not supported in this environment');
+        }
         return getCustomElementConstructor(this);
     },
 });

--- a/packages/@lwc/features/src/flags.ts
+++ b/packages/@lwc/features/src/flags.ts
@@ -16,6 +16,7 @@ const features: FeatureFlagMap = {
     DISABLE_LIGHT_DOM_UNSCOPED_CSS: null,
     ENABLE_FROZEN_TEMPLATE: null,
     DISABLE_ARIA_REFLECTION_POLYFILL: null,
+    DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR: null,
 };
 
 // eslint-disable-next-line no-restricted-properties

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -66,6 +66,11 @@ export interface FeatureFlagMap {
      * and HTMLBridgeElement base classes, not on every Element.
      */
     DISABLE_ARIA_REFLECTION_POLYFILL: FeatureFlagValue;
+
+    /**
+     * Flag to disable the CustomElementConstructor API.
+     */
+    DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -1,4 +1,4 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, setFeatureFlagForTest, buildCustomElementConstructor } from 'lwc';
 
 import ReflectElement from 'x/reflect';
 import LifecycleParent from 'x/lifecycleParent';
@@ -50,6 +50,34 @@ if (SUPPORTS_CUSTOM_ELEMENTS) {
 
         expect(elm.shadowRoot).not.toBe(null);
         expect(elm.shadowRoot.mode).toBe('open');
+    });
+
+    describe('DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR flag', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR', true);
+        });
+
+        afterEach(() => {
+            setFeatureFlagForTest('DISABLE_CUSTOM_ELEMENT_CONSTRUCTOR', false);
+        });
+
+        it('should throw an error on Ctor.CustomElementConstructor', () => {
+            class Test extends LightningElement {}
+            expect(() => {
+                return Test.CustomElementConstructor;
+            }).toThrowError(/CustomElementConstructor is not supported in this environment/);
+        });
+
+        it('should throw an error on buildCustomElementConstructor', () => {
+            class Test extends LightningElement {}
+            expect(() => {
+                expect(() => {
+                    return buildCustomElementConstructor(Test);
+                }).toThrowError(/CustomElementConstructor is not supported in this environment/);
+            }).toLogWarningDev(
+                /"buildCustomElementConstructor" function is deprecated and it will be removed/
+            );
+        });
     });
 
     describe('implicit hydration', () => {


### PR DESCRIPTION
## Details

Same as #3552 but 244 backport

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-13537585](https://gus.lightning.force.com/a07EE00001SypX4YAJ)
