### PR TITLE
feat(compiler): return cssScopeTokens

### DIFF
--- a/packages/@lwc/compiler/README.md
+++ b/packages/@lwc/compiler/README.md
@@ -63,6 +63,7 @@ const { code } = transformSync(source, filename, options);
 -   `code` (string) - the compiled source code.
 -   `map` (object) - the generated source map.
 -   `warnings` (array, optional) - the array of diagnostic warnings, if any.
+-   `cssScopeTokens` (array, optional) - String tokens used for style scoping in synthetic shadow DOM and `*.scoped.css` (as either attributes or classes), if any.
 
 ### `transform` (deprecated)
 

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -125,6 +125,17 @@ describe('transformSync', () => {
         expect(code).not.toMatch('renderer: renderer');
     });
 
+    it('should return scope tokens', () => {
+        const template = `
+            <template>
+                <div>Hello</div>
+            </template>
+        `;
+        const { cssScopeTokens } = transformSync(template, 'foo.html', TRANSFORMATION_OPTIONS);
+
+        expect(cssScopeTokens).toEqual(['x-foo_foo', 'x-foo_foo-host']);
+    });
+
     describe('dynamic components', () => {
         it('should allow dynamic components when enableDynamicComponents is set to true', () => {
             const template = `

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -23,6 +23,7 @@ export interface TransformResult {
     code: string;
     map: unknown;
     warnings?: CompilerDiagnostic[];
+    cssScopeTokens?: string[];
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -34,6 +34,7 @@ export type StylesheetFactory = (
 export type TemplateStylesheetFactories = Array<StylesheetFactory | TemplateStylesheetFactories>;
 
 function makeHostToken(token: string) {
+    // Note: if this ever changes, update the `cssScopeTokens` returned by `@lwc/compiler`
     return `${token}-host`;
 }
 


### PR DESCRIPTION
## Details

This adds an explicit `cssScopeTokens` return value for `transformSync` in `@lwc/compiler`. This would be a cleaner way for `lwc-test` to know which scope tokens are being generated by the template compiler.

E.g. if you look at https://github.com/salesforce/lwc-test/pull/184, you can see that I have to do [a regex-search](https://github.com/salesforce/lwc-test/pull/184/files#r1218686881) on the code returned by `@lwc/compiler` to detect and replace the scope tokens. This is ugly; we should just have the compiler return the scope tokens explicitly.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-12425100
