### PR TITLE
refactor: rename experimentalDynamicComponents to dynamicImportConfig

### DIFF
--- a/packages/@lwc/babel-plugin-component/README.md
+++ b/packages/@lwc/babel-plugin-component/README.md
@@ -45,7 +45,7 @@ const { code } = babel.transformSync(source, {
 -   `name` (type: `string`, optional) - name of the component, e.g. `foo` in `x/foo`.
 -   `namespace` (type: `string`, optional) - namepace of the component, e.g. `x` in `x/foo`.
 -   `isExplicitImport` (type: `boolean`, optional) - true if this is an explicit import.
--   `dynamicImports` (type: `object`, optional) - see below:
+-   `dynamicImportConfig` (type: `object`, optional) - see below:
     -   `loader` (type: `string`, optional) - loader to use at runtime.
     -   `strictSpecifier` (type: `boolean`, optional) - true if a strict specifier should be used.
 -   `instrumentation` (type: `InstrumentationObject`, optional) - instrumentation object to gather metrics and non-error logs for internal use. See the `@lwc/errors` package for details on the interface.

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/check-validation-for-strict/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/check-validation-for-strict/config.json
@@ -1,5 +1,5 @@
 {
-    "dynamicImports": {
+    "dynamicImportConfig": {
         "loader": null,
         "strictSpecifier": true
     }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/test-custom-loader-multiple-imports/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/test-custom-loader-multiple-imports/config.json
@@ -1,5 +1,5 @@
 {
-    "dynamicImports": {
+    "dynamicImportConfig": {
         "loader": "@custom/loader",
         "strictSpecifier": true
     }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/test-custom-loader/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/test-custom-loader/config.json
@@ -1,5 +1,5 @@
 {
-    "dynamicImports": {
+    "dynamicImportConfig": {
         "loader": "@custom/loader",
         "strictSpecifier": true
     }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/unchanged-dynamic-import-in-strict-mode/config.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/dynamic-imports/unchanged-dynamic-import-in-strict-mode/config.json
@@ -1,5 +1,5 @@
 {
-    "dynamicImports": {
+    "dynamicImportConfig": {
         "loader": null,
         "strictSpecifier": true
     }

--- a/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
@@ -30,7 +30,7 @@ function validateImport(sourcePath: NodePath<types.Node>, state: LwcBabelPluginP
 
 /*
  * Expected API for this plugin:
- * { dynamicImports: { loader: string, strictSpecifier: boolean } }
+ * { dynamicImportConfig: { loader: string, strictSpecifier: boolean } }
  */
 export default function (): Visitor<LwcBabelPluginPass> {
     function getLoaderRef(
@@ -45,24 +45,24 @@ export default function (): Visitor<LwcBabelPluginPass> {
     }
 
     function addDynamicImportDependency(dependency: string, state: LwcBabelPluginPass) {
-        // TODO [#3444]: state.dynamicImports seems unused and can probably be deleted
-        if (!state.dynamicImports) {
-            state.dynamicImports = [];
+        // TODO [#3444]: state.dynamicImportConfigs seems unused and can probably be deleted
+        if (!state.dynamicImportConfigs) {
+            state.dynamicImportConfigs = [];
         }
 
-        if (!state.dynamicImports.includes(dependency)) {
-            state.dynamicImports!.push(dependency);
+        if (!state.dynamicImportConfigs.includes(dependency)) {
+            state.dynamicImportConfigs!.push(dependency);
         }
     }
 
     return {
         Import(path, state) {
-            const { dynamicImports } = state.opts;
-            if (!dynamicImports) {
+            const { dynamicImportConfig } = state.opts;
+            if (!dynamicImportConfig) {
                 return;
             }
 
-            const { loader, strictSpecifier } = dynamicImports;
+            const { loader, strictSpecifier } = dynamicImportConfig;
             const sourcePath = getImportSource(path);
 
             if (strictSpecifier) {

--- a/packages/@lwc/babel-plugin-component/src/types.ts
+++ b/packages/@lwc/babel-plugin-component/src/types.ts
@@ -13,7 +13,7 @@ export type BabelTypes = typeof types;
 
 export interface LwcBabelPluginOptions {
     isExplicitImport?: boolean;
-    dynamicImports?: {
+    dynamicImportConfig?: {
         loader?: string;
         strictSpecifier?: boolean;
     };
@@ -24,6 +24,6 @@ export interface LwcBabelPluginOptions {
 
 export interface LwcBabelPluginPass extends PluginPass {
     opts: LwcBabelPluginOptions;
-    dynamicImports?: string[];
+    dynamicImportConfigs?: string[];
     loaderRef?: types.Identifier;
 }

--- a/packages/@lwc/compiler/README.md
+++ b/packages/@lwc/compiler/README.md
@@ -42,7 +42,7 @@ const { code } = transformSync(source, filename, options);
     -   `name` (type: `string`, required) - name of the component, e.g. `foo` in `x/foo`.
     -   `namespace` (type: `string`, required) - namespace of the component, e.g. `x` in `x/foo`.
     -   `stylesheetConfig` (type: `object`, default: `{}`) - The stylesheet compiler configuration to pass to the `@lwc/style-compiler`.
-    -   `experimentalDynamicComponent` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
+    -   `dynamicImportConfig` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
     -   `experimentalDynamicDirective` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable deprecated dynamic components.
     -   `enableDynamicComponents` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable dynamic components.
     -   `outputConfig` (type: `object`, optional) - see below:

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -68,9 +68,8 @@ export interface TransformOptions {
     name?: string;
     namespace?: string;
     stylesheetConfig?: StylesheetConfig;
-    // TODO [#3331]: deprecate / rename this compiler option in 246
     /* Config applied in usage of dynamic import statements in javascript */
-    experimentalDynamicComponent?: DynamicImportConfig;
+    dynamicImportConfig?: DynamicImportConfig;
     /* Flag to enable usage of dynamic component(lwc:dynamic) directive in HTML template */
     experimentalDynamicDirective?: boolean;
     /* Flag to enable usage of dynamic component(lwc:is) directive in HTML template */
@@ -99,7 +98,7 @@ type RequiredTransformOptions = Omit<
     | 'enableLightningWebSecurityTransforms'
     | 'enableDynamicComponents'
     | 'experimentalDynamicDirective'
-    | 'experimentalDynamicComponent'
+    | 'dynamicImportConfig'
     | 'instrumentation'
 >;
 export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTransformOptions> {
@@ -111,7 +110,7 @@ export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTr
     enableLightningWebSecurityTransforms?: boolean;
     enableDynamicComponents?: boolean;
     experimentalDynamicDirective?: boolean;
-    experimentalDynamicComponent?: DynamicImportConfig;
+    dynamicImportConfig?: DynamicImportConfig;
     instrumentation?: InstrumentationObject;
 }
 
@@ -185,9 +184,9 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         },
     };
 
-    const experimentalDynamicComponent: Required<DynamicImportConfig> = {
+    const dynamicImportConfig: Required<DynamicImportConfig> = {
         ...DEFAULT_DYNAMIC_IMPORT_CONFIG,
-        ...options.experimentalDynamicComponent,
+        ...options.dynamicImportConfig,
     };
 
     return {
@@ -195,6 +194,6 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         ...options,
         stylesheetConfig,
         outputConfig,
-        experimentalDynamicComponent,
+        dynamicImportConfig,
     };
 }

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -121,7 +121,7 @@ describe('instrumentation', () => {
         `;
         await transform(actual, 'foo.js', {
             ...TRANSFORMATION_OPTIONS,
-            experimentalDynamicComponent: {
+            dynamicImportConfig: {
                 loader: '@custom/loader',
                 strictSpecifier: true,
             },

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -23,7 +23,7 @@ export default function scriptTransform(
 ): TransformResult {
     const {
         isExplicitImport,
-        experimentalDynamicComponent: dynamicImports,
+        dynamicImportConfig,
         outputConfig: { sourcemap },
         enableLightningWebSecurityTransforms,
         namespace,
@@ -33,7 +33,7 @@ export default function scriptTransform(
 
     const lwcBabelPluginOptions: LwcBabelPluginOptions = {
         isExplicitImport,
-        dynamicImports,
+        dynamicImportConfig,
         namespace,
         name,
         instrumentation,

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -28,7 +28,7 @@ export default function templateTransform(
     options: NormalizedTransformOptions
 ): TransformResult {
     const {
-        experimentalDynamicComponent,
+        dynamicImportConfig,
         // TODO [#3370]: remove experimental template expression flag
         experimentalComplexExpressions,
         preserveHtmlComments,
@@ -39,8 +39,7 @@ export default function templateTransform(
         experimentalDynamicDirective: deprecatedDynamicDirective,
         instrumentation,
     } = options;
-    const experimentalDynamicDirective =
-        deprecatedDynamicDirective ?? Boolean(experimentalDynamicComponent);
+    const experimentalDynamicDirective = deprecatedDynamicDirective ?? Boolean(dynamicImportConfig);
 
     let result;
     try {

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -54,7 +54,7 @@ async function getCompiledModule(dirName) {
                         dir: dirName,
                     },
                 ],
-                experimentalDynamicComponent: {
+                dynamicImportConfig: {
                     loader: 'test-utils',
                     strict: true,
                 },

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -47,7 +47,7 @@ function createPreprocessor(config, emitter, logger) {
         const plugins = [
             lwcRollupPlugin({
                 sourcemap: true,
-                experimentalDynamicComponent: {
+                dynamicImportConfig: {
                     loader: 'test-utils',
                     strict: true,
                 },

--- a/packages/@lwc/rollup-plugin/README.md
+++ b/packages/@lwc/rollup-plugin/README.md
@@ -29,7 +29,7 @@ export default {
 -   `modules` (type: `ModuleRecord[]`, default: `[]`) - The [module resolution](https://lwc.dev/guide/es_modules#module-resolution) overrides passed to the `@lwc/module-resolver`.
 -   `stylesheetConfig` (type: `object`, default: `{}`) - The stylesheet compiler configuration to pass to the `@lwc/style-compiler`.
 -   `preserveHtmlComments` (type: `boolean`, default: `false`) - The configuration to pass to the `@lwc/template-compiler`.
--   `experimentalDynamicComponent` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
+-   `dynamicImportConfig` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
 -   `experimentalDynamicDirective` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable deprecated dynamic components.
 -   `enableDynamicComponents` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable dynamic components.
 -   `enableLwcSpread` (type: `boolean`, default: `false`) - The configuration to pass to the `@lwc/template-compiler`.

--- a/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
@@ -119,13 +119,13 @@ describe('templateConfig', () => {
 });
 
 describe('javaScriptConfig', () => {
-    it('should accept experimentalDynamicComponent config flag', async () => {
+    it('should accept dynamicImportConfig config flag', async () => {
         const CUSTOM_LOADER = '@salesforce/loader';
         const bundle = await rollup({
             input: path.resolve(__dirname, 'fixtures/dynamicImportConfig/dynamicImportConfig.js'),
             plugins: [
                 lwc({
-                    experimentalDynamicComponent: { loader: CUSTOM_LOADER, strictSpecifier: true },
+                    dynamicImportConfig: { loader: CUSTOM_LOADER, strictSpecifier: true },
                 }),
             ],
             external: [CUSTOM_LOADER],

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -30,7 +30,7 @@ export interface RollupLwcOptions {
     /** The configuration to pass to the `@lwc/template-compiler`. */
     preserveHtmlComments?: boolean;
     /** The configuration to pass to `@lwc/compiler`. */
-    experimentalDynamicComponent?: DynamicImportConfig;
+    dynamicImportConfig?: DynamicImportConfig;
     /** The configuration to pass to `@lwc/template-compiler`. */
     experimentalDynamicDirective?: boolean;
     /** The configuration to pass to `@lwc/template-compiler`. */
@@ -145,7 +145,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
         stylesheetConfig,
         sourcemap = false,
         preserveHtmlComments,
-        experimentalDynamicComponent,
+        dynamicImportConfig,
         experimentalDynamicDirective,
         enableDynamicComponents,
         // TODO [#3370]: remove experimental template expression flag
@@ -307,7 +307,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 namespace,
                 outputConfig: { sourcemap },
                 stylesheetConfig,
-                experimentalDynamicComponent,
+                dynamicImportConfig,
                 experimentalDynamicDirective,
                 enableDynamicComponents,
                 // TODO [#3370]: remove experimental template expression flag


### PR DESCRIPTION
## Details
Now that dynamic components are going GA, this PR renames the `experimentalDynamicComponents` compiler option to `dynamicImportConfig`.

The new name is to be more in line with the function of the compiler option (to provide configuration options for dynamic imports).

This PR will require coordinating a release with downstream projects that need the compiler options updated (W-13519768).

## Does this pull request introduce a breaking change?
* 🚨 Yes, it does introduce a breaking change.

Downstream teams that use the `experimentalDynamicComponents` compiler options will need to switch to `dynamicImportConfig`.

## Does this pull request introduce an observable change?
* ⚠️ Yes, it does include an observable change.

The `experiementalDynamicComponents` option will no longer be a valid compiler option.

## GUS work item
W-12607866
