### PR TITLE
chore: temporarily remove ui-b2b-components from downstream

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -15,7 +15,6 @@ branches:
         - Trailhead-Platform/ui-trailhead-core-components
         - automation-platform/ui-interaction-explorer-components
         - communities/shared-experience-components
-        - communities/ui-b2b-components
         - communities/ui-feeds-components
         - communities/ui-lightning-community
         - communities/webruntime


### PR DESCRIPTION
Temporarily remove ui-b2b-components from downstream due to an unreliable build