### PR TITLE
chore: remove legacy dist files (BREAKING CHANGE)

### DIFF
--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -8,7 +8,6 @@
 /* eslint-env node */
 
 const { readFileSync } = require('node:fs');
-const { writeFile, mkdir } = require('node:fs/promises');
 const path = require('node:path');
 const MagicString = require('magic-string');
 const { rollup } = require('rollup');
@@ -119,52 +118,6 @@ function injectInlineRenderer() {
     };
 }
 
-// TODO [#3445]: this purely exists for backwards compatibility, to avoid breaking code like this:
-//
-//     require('@lwc/synthetic-shadow/dist/synthetic-shadow.js')
-//     require('@lwc/engine-server/dist/engine-server.js')
-//     require('@lwc/compiler/dist/commonjs/transformers/transformer')
-//
-// Feel free to delete this entire plugin once we can safely release this breaking change.
-function backwardsCompatDistPlugin() {
-    const packageNamesToExtraDistFiles = {
-        '@lwc/compiler': {
-            'index.cjs.js': 'dist/commonjs/transformers/transformer.js',
-        },
-        '@lwc/engine-dom': {
-            'index.js': 'dist/engine-dom.js',
-        },
-        '@lwc/engine-server': {
-            'index.js': 'dist/engine-server.js',
-        },
-        '@lwc/synthetic-shadow': {
-            'index.js': 'dist/synthetic-shadow.js',
-        },
-        '@lwc/wire-service': {
-            'index.js': 'dist/wire-service.js',
-        },
-    };
-
-    return {
-        id: 'backwards-compat-dist',
-        async writeBundle(options, bundle) {
-            const extraDistFiles = packageNamesToExtraDistFiles[packageName];
-            if (extraDistFiles) {
-                for (const [id, extraDistFile] of Object.entries(extraDistFiles)) {
-                    const descriptor = bundle[id];
-                    if (descriptor) {
-                        // Write additional dist/ file as a side effect
-                        const fullFilename = path.join(packageRoot, extraDistFile);
-                        await mkdir(path.dirname(fullFilename), { recursive: true });
-                        await writeFile(fullFilename, descriptor.code, 'utf-8');
-                    }
-                }
-            }
-            return null;
-        },
-    };
-}
-
 module.exports = {
     input: path.resolve(packageRoot, './src/index.ts'),
 
@@ -198,7 +151,6 @@ module.exports = {
             include: [/\/parse5\//],
         }),
         ...sharedPlugins(),
-        backwardsCompatDistPlugin(),
         injectInlineRenderer(),
     ],
 


### PR DESCRIPTION
## Details

Fixes #3445. Removes legacy `dist/` files from the npm package.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* 🚨 Yes, it does introduce a breaking change.

The following will no longer work:

```js
require('@lwc/compiler/dist/commonjs/transformers/transformer.js')
require('@lwc/engine-dom/dist/engine-dom.js')
require('@lwc/synthetic-shadow/dist/synthetic-shadow.js')
```

Instead of a deep `require()`, do this:

```js
require('@lwc/compiler')
require('@lwc/engine-dom')
require('@lwc/synthetic-shadow')
```

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

