### PR TITLE
chore: add injection points for devtools instrumentation

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -54,6 +54,7 @@ import { HTMLElementConstructor } from './base-bridge-element';
 import { updateComponentValue } from './update-component-value';
 import { markLockerLiveObject } from './membrane';
 import { TemplateStylesheetFactories } from './stylesheet';
+import { instrumentInstance } from './runtime-instrumentation';
 
 /**
  * This operation is called with a descriptor of an standard html property
@@ -205,6 +206,9 @@ export const LightningElement: LightningElementConstructor = function (
         // `class Foo extends LightningElement {}; new Foo()`
         throw new TypeError('Illegal constructor');
     }
+
+    // This is a no-op unless Lightning DevTools are enabled.
+    instrumentInstance(this, vmBeingConstructed);
 
     const vm = vmBeingConstructed;
     const { def, elm } = vm;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -33,6 +33,7 @@ import {
 } from '../shared/circular-module-dependencies';
 
 import { logError } from '../shared/logger';
+import { instrumentDef } from './runtime-instrumentation';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
 import { Template } from './template';
@@ -190,6 +191,9 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         errorCallback,
         render,
     };
+
+    // This is a no-op unless Lightning DevTools are enabled.
+    instrumentDef(def);
 
     if (process.env.NODE_ENV !== 'production') {
         freeze(Ctor.prototype);

--- a/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
+++ b/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
@@ -1,0 +1,11 @@
+type InstrumentedWindow = (Window & typeof globalThis) & {
+    __lwc_instrument_cmp_def?: (def: any) => void;
+    __lwc_instrument_cmp_instance?: (instance: any, vm: any) => void;
+};
+
+const win = typeof window !== 'undefined' ? (window as InstrumentedWindow) : null;
+
+function noop() {}
+
+export const instrumentDef = win?.__lwc_instrument_cmp_def ?? noop;
+export const instrumentInstance = win?.__lwc_instrument_cmp_instance ?? noop;

--- a/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
+++ b/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import { noop } from '@lwc/shared';
 import { globalThis } from '@lwc/shared';
 

--- a/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
+++ b/packages/@lwc/engine-core/src/framework/runtime-instrumentation.ts
@@ -1,11 +1,5 @@
-type InstrumentedWindow = (Window & typeof globalThis) & {
-    __lwc_instrument_cmp_def?: (def: any) => void;
-    __lwc_instrument_cmp_instance?: (instance: any, vm: any) => void;
-};
+import { noop } from '@lwc/shared';
+import { globalThis } from '@lwc/shared';
 
-const win = typeof window !== 'undefined' ? (window as InstrumentedWindow) : null;
-
-function noop() {}
-
-export const instrumentDef = win?.__lwc_instrument_cmp_def ?? noop;
-export const instrumentInstance = win?.__lwc_instrument_cmp_instance ?? noop;
+export const instrumentDef = globalThis.__lwc_instrument_cmp_def ?? noop;
+export const instrumentInstance = globalThis.__lwc_instrument_cmp_instance ?? noop;


### PR DESCRIPTION
## Details

This allows for future browser extensions to track & instrument component definitions & instances. If the browser extension is loaded on the page, a global function (provided by the extension) is invoked whenever a component definition is created or a component is instantiated. If the browser extension is not loaded, the function calls are no-ops and would be optimized away by the JavaScript engine (no perf impact).

I'd like to get this in the current code line, so that development of the browser extension can be done without modifying network calls to inject the instrumentation.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

The change here is negligible. Technically, if someone could modify the global scope prior to execution of component code, they could do things that they couldn't do before. However, this isn't a concern where LWS is enabled, and is generally how these things work (see Vue DevTools's [use of a global hook](https://github.com/vuejs/devtools/blob/main/packages/shell-chrome/src/detector.js#L39)).