### PR TITLE
fix: warn only once about deprecated compiler option `enableLwcSpread`

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -8,6 +8,12 @@ import { InstrumentationObject, CompilerValidationErrors, invariant } from '@lwc
 import { isUndefined, isBoolean, isObject, getAPIVersionFromNumber } from '@lwc/shared';
 import { CustomRendererConfig } from '@lwc/template-compiler';
 
+/**
+ * Flag indicating that a warning about still using the deprecated `enableLwcSpread`
+ * compiler option has already been logged to the `console`.
+ */
+let alreadyWarnedAboutLwcSpread = false;
+
 type RecursiveRequired<T> = {
     [P in keyof T]-?: RecursiveRequired<T[P]>;
 };
@@ -124,7 +130,9 @@ export function validateTransformOptions(options: TransformOptions): NormalizedT
 function validateOptions(options: TransformOptions) {
     invariant(!isUndefined(options), CompilerValidationErrors.MISSING_OPTIONS_OBJECT, [options]);
 
-    if (!isUndefined(options.enableLwcSpread)) {
+    if (!isUndefined(options.enableLwcSpread) && !alreadyWarnedAboutLwcSpread) {
+        alreadyWarnedAboutLwcSpread = true;
+
         // eslint-disable-next-line no-console
         console.warn(
             `"enableLwcSpread" property is deprecated. The value doesn't impact the compilation and can safely be removed.`


### PR DESCRIPTION
## Details

To prevent tons of warning log lines for downstream consumers, the warning about still using the deprecated LWC compiler option `enableLwcSpread` is now only logged once.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
