### PR TITLE
chore: update git2gus to 248 codeline for CLCO

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,5 +1,5 @@
 {
   "productTag": "a1aB0000000g309IAA",
-  "defaultBuild": "244",
+  "defaultBuild": "248",
   "hideWorkItemUrl": true
 }


### PR DESCRIPTION
## Details
Update git2gus for 248

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-13733617