### PR TITLE
chore: relax the logged message when attempting to set unknown feature flag

### DIFF
--- a/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
+++ b/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
@@ -11,20 +11,20 @@ describe('setFeatureFlag', () => {
     ['development', 'production'].forEach((env) => {
         describe(`${env} mode`, () => {
             let originalNodeEnv: any;
-            let warn: jest.SpyInstance;
+            let info: jest.SpyInstance;
             let error: jest.SpyInstance;
 
             beforeEach(() => {
                 originalNodeEnv = process.env.NODE_ENV;
                 process.env.NODE_ENV = env;
-                warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+                info = jest.spyOn(console, 'info').mockImplementation(() => {});
                 error = jest.spyOn(console, 'error').mockImplementation(() => {});
             });
 
             afterEach(() => {
                 process.env.NODE_ENV = originalNodeEnv;
                 lwcRuntimeFlags.DUMMY_TEST_FLAG = undefined; // reset
-                warn.mockReset();
+                info.mockReset();
                 error.mockReset();
             });
 
@@ -49,10 +49,8 @@ describe('setFeatureFlag', () => {
             it('logs and does nothing when the flag is unknown', () => {
                 // @ts-ignore
                 setFeatureFlag('DOES_NOT_EXIST', true);
-                expect(warn).toHaveBeenCalledWith(
-                    expect.stringMatching(
-                        /Failed to set the value "true" for the runtime feature flag "DOES_NOT_EXIST" because it is undefined\./
-                    )
+                expect(info).toHaveBeenCalledWith(
+                    expect.stringMatching(/Attempt to set a value on an unknown feature flag/)
                 );
 
                 // value is not changed

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { create, keys, defineProperty, isUndefined, isBoolean, globalThis } from '@lwc/shared';
+import { create, defineProperty, isUndefined, isBoolean, globalThis } from '@lwc/shared';
 import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 const features: FeatureFlagMap = {
@@ -42,12 +42,9 @@ export function setFeatureFlag(name: FeatureFlagName, value: FeatureFlagValue): 
         }
     }
     if (isUndefined(features[name])) {
-        const availableFlags = keys(features)
-            .map((name) => `"${name}"`)
-            .join(', ');
         // eslint-disable-next-line no-console
-        console.warn(
-            `Failed to set the value "${value}" for the runtime feature flag "${name}" because it is undefined. Available flags: ${availableFlags}.`
+        console.info(
+            `Attempt to set a value on an unknown feature flag "${name}" resulted in a NOOP.`
         );
         return;
     }

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -7,6 +7,8 @@
 import { create, defineProperty, isUndefined, isBoolean, globalThis } from '@lwc/shared';
 import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
+// When deprecating a feature flag, ensure that it is also no longer set in the application. For
+// example, in core, the flag should be removed from LwcPermAndPrefUtilImpl.java
 const features: FeatureFlagMap = {
     DUMMY_TEST_FLAG: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,


### PR DESCRIPTION
## Details

This warning message keeps getting raised when users run into unrelated issues and start grasping at straws. 

## Does this pull request introduce a breaking change?

No

## Does this pull request introduce an observable change?

No

## GUS work item

W-13775648

