### PR TITLE
feat(engine): tagName property

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -175,6 +175,7 @@ type HTMLElementTheGoodParts = Pick<Object, 'toString'> &
         | 'setAttributeNS'
         | 'spellcheck'
         | 'tabIndex'
+        | 'tagName'
         | 'title'
     >;
 
@@ -644,6 +645,11 @@ LightningElement.prototype = {
             warnIfInvokedDuringConstruction(vm, 'ownerDocument');
         }
         return renderer.ownerDocument(vm.elm);
+    },
+
+    get tagName() {
+        const { elm, renderer } = getAssociatedVM(this);
+        return renderer.getTagName(elm);
     },
 
     render(): Template {

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -58,6 +58,7 @@ export interface RendererAPI {
     getFirstElementChild: (element: E) => E | null;
     getLastChild: (element: E) => N | null;
     getLastElementChild: (element: E) => E | null;
+    getTagName: (element: E) => string;
     isConnected: (node: N) => boolean;
     insertStylesheet: (content: string, target?: ShadowRoot) => void;
     assertInstanceOfHTMLElement: (elm: any, msg: string) => void;

--- a/packages/@lwc/engine-dom/src/renderer/index.ts
+++ b/packages/@lwc/engine-dom/src/renderer/index.ts
@@ -189,6 +189,10 @@ function ownerDocument(element: Element): Document {
     return element.ownerDocument;
 }
 
+function getTagName(elm: Element): string {
+    return elm.tagName;
+}
+
 export { registerContextConsumer, registerContextProvider } from './context';
 
 export {
@@ -223,6 +227,7 @@ export {
     getFirstElementChild,
     getLastChild,
     getLastElementChild,
+    getTagName,
     isConnected,
     assertInstanceOfHTMLElement,
     ownerDocument,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/expected.html
@@ -1,0 +1,7 @@
+<x-tag-name>
+  <template shadowroot="open">
+    <span>
+      X-TAG-NAME
+    </span>
+  </template>
+</x-tag-name>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/index.js
@@ -1,0 +1,2 @@
+export const tagName = 'x-tag-name';
+export { default } from 'x/tag-name';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/modules/x/tag-name/tag-name.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/modules/x/tag-name/tag-name.html
@@ -1,0 +1,3 @@
+<template>
+    <span>{test}</span>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/modules/x/tag-name/tag-name.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/tag-name/modules/x/tag-name/tag-name.js
@@ -1,12 +1,11 @@
-import { LightningElement, api } from 'lwc';
+import { LightningElement } from 'lwc';
 
-export default class Test extends LightningElement {
+export default class TagName extends LightningElement {
     constructor() {
         super();
         this._tagName = this.tagName;
     }
 
-    @api
     get test() {
         return this._tagName;
     }

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -379,7 +379,7 @@ const getLastElementChild = unsupportedMethod('getLastElementChild') as (
 ) => HostElement | null;
 
 function getTagName(elm: HostElement): string {
-    // tagName is lowercased on the server
+    // tagName is lowercased on the server, but to align with DOM APIs, we always return uppercase
     return elm.tagName.toUpperCase();
 }
 

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -378,6 +378,11 @@ const getLastElementChild = unsupportedMethod('getLastElementChild') as (
     element: HostElement
 ) => HostElement | null;
 
+function getTagName(elm: HostElement): string {
+    // tagName is lowercased on the server
+    return elm.tagName.toUpperCase();
+}
+
 /* noop */
 const assertInstanceOfHTMLElement = noop as (elm: any, msg: string) => void;
 
@@ -448,6 +453,7 @@ export const renderer = {
     getFirstElementChild,
     getLastChild,
     getLastElementChild,
+    getTagName,
     isConnected,
     insertStylesheet,
     assertInstanceOfHTMLElement,

--- a/packages/@lwc/integration-karma/test/component/LightningElement.tagName/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.tagName/index.spec.js
@@ -1,9 +1,14 @@
 import { createElement } from 'lwc';
 
+import Override from 'x/override';
 import Test from 'x/test';
 
-it('should not throw when accessing the property', () => {
-    expect(() => {
-        createElement('x-test', { is: Test });
-    }).not.toThrowError();
+it('should return the tag name', () => {
+    const elm = createElement('x-test', { is: Test });
+    expect(elm.test).toEqual('X-TEST');
+});
+
+it('should be overrideable', () => {
+    const elm = createElement('x-override', { is: Override });
+    expect(elm.tagName).toEqual('x-foo');
 });

--- a/packages/@lwc/integration-karma/test/component/LightningElement.tagName/x/override/override.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.tagName/x/override/override.js
@@ -1,0 +1,8 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Override extends LightningElement {
+    @api
+    get tagName() {
+        return 'x-foo';
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/properties/index.spec.js
@@ -41,6 +41,7 @@ const expectedEnumerableProps = [
     'shadowRoot',
     'spellcheck',
     'tabIndex',
+    'tagName',
     'template',
     'title',
     'toString',


### PR DESCRIPTION
## Details

Fixes #3633

## Does this pull request introduce a breaking change?

No

`tagName` can still be defined by the component.

## Does this pull request introduce an observable change?

Yes

`tagName` is no longer `undefined`.

## GUS work item

W-13784946