### PR TITLE
chore(nucleus): add test workflow for milestone- branches

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -42,6 +42,7 @@ branches:
   milestone-.*: # used for prerelease testing
     pull-request:
       <<: *branch-definition
+      workflow: build-and-test
 steps:
   node-conformance:
     run:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -39,6 +39,9 @@ branches:
   winter24:
     pull-request:
       <<: *branch-definition
+  milestone-.*: # used for prerelease testing
+    pull-request:
+      <<: *branch-definition
 steps:
   node-conformance:
     run:

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -42,7 +42,7 @@ branches:
   milestone-.*: # used for prerelease testing
     pull-request:
       <<: *branch-definition
-      workflow: build-and-test
+      workflow: build-and-test # the default workflow is release, and we just want build+tests
 steps:
   node-conformance:
     run:


### PR DESCRIPTION
## Details

The `milestone-*` branches should run Nucleus tests when PRs are opened on them.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
