### PR TITLE
fix(engine-dom): fix constructable stylesheets in Safari

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,5 +31,6 @@
     "namedInputs": {
         "sharedGlobals": ["{workspaceRoot}/scripts/rollup/rollup.config.js"],
         "default": ["{projectRoot}/**/*", "sharedGlobals"]
-    }
+    },
+    "$schema": "./node_modules/nx/schemas/nx-schema.json"
 }

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { isUndefined, getOwnPropertyDescriptor, isArray, isFunction, isTrue } from '@lwc/shared';
+import { isUndefined, isArray, isFunction } from '@lwc/shared';
 
 //
 // Feature detection
@@ -15,13 +15,7 @@ import { isUndefined, getOwnPropertyDescriptor, isArray, isFunction, isTrue } fr
 // https://github.com/microsoft/fast/blob/d49d1ec/packages/web-components/fast-element/src/dom.ts#L51-L53
 // See also: https://github.com/whatwg/webidl/issues/1027#issuecomment-934510070
 const supportsConstructableStylesheets =
-    isFunction(CSSStyleSheet.prototype.replaceSync) &&
-    isArray(document.adoptedStyleSheets) &&
-    // The original adoptedStylesheet proposal used a frozen array. A follow-up proposal made the array mutable.
-    // Chromium 99+ and Firefox 101+ support mutable arrays. We check if the array is mutable, to ensure backward compat.
-    // (If the length is writable, then the array is mutable.) See: https://chromestatus.com/feature/5638996492288000
-    // TODO [#2828]: Re-evaluate this in the future once we drop support for older browser versions.
-    isTrue(getOwnPropertyDescriptor(document.adoptedStyleSheets, 'length')!.writable);
+    isFunction(CSSStyleSheet.prototype.replaceSync) && isArray(document.adoptedStyleSheets);
 
 //
 // Style sheet cache

--- a/packages/@lwc/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
@@ -8,11 +8,12 @@ if (process.env.NATIVE_SHADOW) {
             const element = createElement('x-multi', { is: Multi });
 
             const getNumStyleSheets = () => {
+                let count = 0;
                 if (element.shadowRoot.adoptedStyleSheets) {
-                    return element.shadowRoot.adoptedStyleSheets.length;
-                } else {
-                    return element.shadowRoot.querySelectorAll('style').length;
+                    count += element.shadowRoot.adoptedStyleSheets.length;
                 }
+                count += element.shadowRoot.querySelectorAll('style').length;
+                return count;
             };
 
             document.body.appendChild(element);

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -12,7 +12,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "./dist"
+                    "{projectRoot}/dist"
                 ]
             }
         }

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -35,7 +35,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "./dist"
+                    "{projectRoot}/dist"
                 ],
                 "//": "The build output depends on these env variables. See: https://nx.dev/concepts/how-caching-works#runtime-hash-inputs",
                 "inputs": [

--- a/playground/package.json
+++ b/playground/package.json
@@ -20,7 +20,7 @@
         "targets": {
             "build": {
                 "outputs": [
-                    "./dist"
+                    "{projectRoot}/dist"
                 ]
             }
         }


### PR DESCRIPTION
## Details

Fixes #2828 by dropping support for old Chrome. Adds support for constructable stylesheets in Safari 16.6.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
