### PR TITLE
fix(engine-core):  Change all console.errors to console.warns 

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -23,7 +23,7 @@ import {
     toString,
 } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 
 import { invokeEventListener } from './invoker';
 import { getVMBeingRendered, setVMBeingRendered } from './template';
@@ -129,7 +129,7 @@ function h(sel: string, data: VElementData, children: VNodes = EmptyArray): VEle
             `vnode.data.styleDecls and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
-            logError(
+            logWarn(
                 `Invalid 'style' attribute passed to <${sel}> is ignored. This attribute must be a string value.`,
                 vmBeingRendered
             );
@@ -175,7 +175,7 @@ function ti(value: any): number {
     if (process.env.NODE_ENV !== 'production') {
         const vmBeingRendered = getVMBeingRendered();
         if (shouldNormalize) {
-            logError(
+            logWarn(
                 `Invalid tabindex value \`${toString(
                     value
                 )}\` in template for ${vmBeingRendered}. This attribute must be set to 0 or -1.`,
@@ -215,7 +215,7 @@ function s(
                 // Check if slot types of parent and child are matching
                 if (assignedNodeIsScopedSlot !== isScopedSlotElement) {
                     if (process.env.NODE_ENV !== 'production') {
-                        logError(
+                        logWarn(
                             `Mismatched slot types for ${
                                 slotName === '' ? '(default)' : slotName
                             } slot. Both parent and child component must use standard type or scoped type for a given slot.`,
@@ -291,7 +291,7 @@ function c(
             `vnode.data.styleDecls and vnode.data.style ambiguous declaration.`
         );
         if (data.style && !isString(data.style)) {
-            logError(
+            logWarn(
                 `Invalid 'style' attribute passed to <${sel}> is ignored. This attribute must be a string value.`,
                 vmBeingRendered
             );
@@ -346,7 +346,7 @@ function i(
     const vmBeingRendered = getVMBeingRendered();
     if (isUndefined(iterable) || iterable === null) {
         if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `Invalid template iteration for value "${toString(
                     iterable
                 )}" in ${vmBeingRendered}. It must be an Array or an iterable Object.`,
@@ -418,7 +418,7 @@ function i(
     }
     if (process.env.NODE_ENV !== 'production') {
         if (!isUndefined(iterationError)) {
-            logError(iterationError, vmBeingRendered!);
+            logWarn(iterationError, vmBeingRendered!);
         }
     }
     return list;
@@ -497,7 +497,7 @@ function k(compilerKey: number, obj: any): string | void {
             return compilerKey + ':' + obj;
         case 'object':
             if (process.env.NODE_ENV !== 'production') {
-                logError(
+                logWarn(
                     `Invalid key value "${obj}" in ${getVMBeingRendered()}. Key must be a string or number.`
                 );
             }
@@ -509,7 +509,7 @@ function gid(id: string | undefined | null): string | null | undefined {
     const vmBeingRendered = getVMBeingRendered()!;
     if (isUndefined(id) || id === '') {
         if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `Invalid id value "${id}". The id attribute must contain a non-empty string.`,
                 vmBeingRendered
             );
@@ -533,7 +533,7 @@ function fid(url: string | undefined | null): string | null | undefined {
     if (isUndefined(url) || url === '') {
         if (process.env.NODE_ENV !== 'production') {
             if (isUndefined(url)) {
-                logError(
+                logWarn(
                     `Undefined url value for "href" or "xlink:href" attribute. Expected a non-empty string.`,
                     vmBeingRendered
                 );

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -21,7 +21,7 @@ import {
     htmlPropertyToAttribute,
 } from '@lwc/shared';
 import { applyAriaReflection } from '@lwc/aria-reflection';
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getAssociatedVM } from './vm';
 import { getReadOnlyProxy } from './membrane';
 import { HTMLElementConstructor } from './html-element';
@@ -154,7 +154,7 @@ export function HTMLBridgeElementFactory(
     descriptors.attachInternals = {
         get() {
             if (process.env.NODE_ENV !== 'production') {
-                logError(
+                logWarn(
                     'attachInternals cannot be accessed outside of a component. Use this.attachInternals instead.'
                 );
             }

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -29,7 +29,7 @@ import {
 } from '@lwc/shared';
 import { applyAriaReflection } from '@lwc/aria-reflection';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 
 import { HTMLElementOriginalDescriptors } from './html-properties';
@@ -85,7 +85,7 @@ function createBridgeToElementDescriptor(
             const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
-                    logError(
+                    logWarn(
                         `The value of property \`${propName}\` can't be read from the constructor because the owner component hasn't set the value yet. Instead, use the constructor to set a default value for the property.`,
                         vm
                     );
@@ -100,24 +100,24 @@ function createBridgeToElementDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 if (isInvokingRender) {
-                    logError(
+                    logWarn(
                         `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${propName}`
                     );
                 }
                 if (isUpdatingTemplate) {
-                    logError(
+                    logWarn(
                         `When updating the template of ${vmBeingRendered}, one of the accessors used by the template has side effects on the state of ${vm}.${propName}`
                     );
                 }
                 if (isBeingConstructed(vm)) {
-                    logError(
+                    logWarn(
                         `Failed to construct '${getComponentTag(
                             vm
                         )}': The result must not have attributes.`
                     );
                 }
                 if (isObject(newValue) && !isNull(newValue)) {
-                    logError(
+                    logWarn(
                         `Invalid value "${newValue}" for "${propName}" of ${vm}. Value cannot be an object, must be a primitive value.`
                     );
                 }
@@ -288,7 +288,7 @@ function doAttachShadow(vm: VM): ShadowRoot {
 
 function warnIfInvokedDuringConstruction(vm: VM, methodOrPropName: string) {
     if (isBeingConstructed(vm)) {
-        logError(
+        logWarn(
             `this.${methodOrPropName} should not be called during the construction of the custom element for ${getComponentTag(
                 vm
             )} because the element is not yet in the DOM or has no children yet.`
@@ -325,17 +325,17 @@ LightningElement.prototype = {
         if (process.env.NODE_ENV !== 'production') {
             const vmBeingRendered = getVMBeingRendered();
             if (isInvokingRender) {
-                logError(
+                logWarn(
                     `${vmBeingRendered}.render() method has side effects on the state of ${vm} by adding an event listener for "${type}".`
                 );
             }
             if (isUpdatingTemplate) {
-                logError(
+                logWarn(
                     `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm} by adding an event listener for "${type}".`
                 );
             }
             if (!isFunction(listener)) {
-                logError(
+                logWarn(
                     `Invalid second argument for this.addEventListener() in ${vm} for event "${type}". Expected an EventListener but received ${listener}.`
                 );
             }
@@ -418,7 +418,7 @@ LightningElement.prototype = {
 
         if (process.env.NODE_ENV !== 'production') {
             if (isBeingConstructed(vm)) {
-                logError(
+                logWarn(
                     `Failed to construct '${getComponentTag(
                         vm
                     )}': The result must not have attributes.`
@@ -438,7 +438,7 @@ LightningElement.prototype = {
 
         if (process.env.NODE_ENV !== 'production') {
             if (isBeingConstructed(vm)) {
-                logError(
+                logWarn(
                     `Failed to construct '${getComponentTag(
                         vm
                     )}': The result must not have attributes.`
@@ -502,7 +502,7 @@ LightningElement.prototype = {
 
         if (process.env.NODE_ENV !== 'production') {
             if (isBeingConstructed(vm)) {
-                logError(
+                logWarn(
                     `Failed to construct ${vm}: The result must not have attributes. Adding or tampering with classname in constructor is not allowed in a web component, use connectedCallback() instead.`
                 );
             }
@@ -516,7 +516,7 @@ LightningElement.prototype = {
 
         if (process.env.NODE_ENV !== 'production') {
             if (vm.renderMode === RenderMode.Light) {
-                logError(
+                logWarn(
                     '`this.template` returns null for light DOM components. Since there is no shadow, the rendered content can be accessed via `this` itself. e.g. instead of `this.template.querySelector`, use `this.querySelector`.'
                 );
             }
@@ -530,7 +530,7 @@ LightningElement.prototype = {
 
         if (isUpdatingTemplate) {
             if (process.env.NODE_ENV !== 'production') {
-                logError(
+                logWarn(
                     `this.refs should not be called while ${getComponentTag(
                         vm
                     )} is rendering. Use this.refs only when the DOM is stable, e.g. in renderedCallback().`
@@ -558,7 +558,7 @@ LightningElement.prototype = {
             isNull(cmpTemplate) &&
             !isBeingConstructed(vm)
         ) {
-            logError(
+            logWarn(
                 `this.refs is undefined for ${getComponentTag(
                     vm
                 )}. This is either because the attached template has no "lwc:ref" directive, or this.refs was ` +

--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -6,7 +6,7 @@
  */
 import { isNull, LWC_VERSION, LWC_VERSION_COMMENT_REGEX } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 
 import { Template } from './template';
 import { StylesheetFactory } from './stylesheet';
@@ -44,7 +44,7 @@ export function checkVersionMismatch(
             warned = true; // only warn once to avoid flooding the console
             // stylesheets and templates do not have user-meaningful names, but components do
             const friendlyName = type === 'component' ? `${type} ${func.name}` : type;
-            logError(
+            logWarn(
                 `LWC WARNING: current engine is v${LWC_VERSION}, but ${friendlyName} was compiled with v${version}.\nPlease update your compiled code or LWC engine so that the versions match.\nNo further warnings will appear.`
             );
             report(ReportingEventId.CompilerRuntimeVersionMismatch, {

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, isFunction, isNull, toString } from '@lwc/shared';
-import { logError } from '../../shared/logger';
+import { logWarn } from '../../shared/logger';
 import { isInvokingRender, isBeingConstructed } from '../invoker';
 import { componentValueObserved, componentValueMutated } from '../mutation-tracker';
 import { LightningElement } from '../base-lightning-element';
@@ -31,7 +31,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             const vm = getAssociatedVM(this);
             if (isBeingConstructed(vm)) {
                 if (process.env.NODE_ENV !== 'production') {
-                    logError(
+                    logWarn(
                         `Can’t read the value of property \`${toString(
                             key
                         )}\` from the constructor because the owner component hasn’t set the value yet. Instead, use the constructor to set a default value for the property.`,
@@ -48,7 +48,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 if (isInvokingRender) {
-                    logError(
+                    logWarn(
                         `render() method has side effects on the state of property "${toString(
                             key
                         )}"`,
@@ -56,7 +56,7 @@ export function createPublicPropertyDescriptor(key: string): PropertyDescriptor 
                     );
                 }
                 if (isUpdatingTemplate) {
-                    logError(
+                    logWarn(
                         `Updating the template has side effects on the state of property "${toString(
                             key
                         )}"`,
@@ -97,7 +97,7 @@ export function createPublicAccessorDescriptor(
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 if (isInvokingRender) {
-                    logError(
+                    logWarn(
                         `render() method has side effects on the state of property "${toString(
                             key
                         )}"`,
@@ -105,7 +105,7 @@ export function createPublicAccessorDescriptor(
                     );
                 }
                 if (isUpdatingTemplate) {
-                    logError(
+                    logWarn(
                         `Updating the template has side effects on the state of property "${toString(
                             key
                         )}"`,
@@ -116,7 +116,7 @@ export function createPublicAccessorDescriptor(
             if (set) {
                 set.call(this, newValue);
             } else if (process.env.NODE_ENV !== 'production') {
-                logError(
+                logWarn(
                     `Invalid attempt to set a new value for property "${toString(
                         key
                     )}" that does not has a setter decorated with @api.`,

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -16,7 +16,7 @@ import {
 import { LightningElementConstructor } from '../base-lightning-element';
 
 import { assertNotProd, EmptyObject } from '../utils';
-import { logError } from '../../shared/logger';
+import { logWarn } from '../../shared/logger';
 import { createObservedFieldPropertyDescriptor } from '../observed-fields';
 import {
     WireAdapterConstructor,
@@ -86,7 +86,7 @@ function validateObservedField(
         const message = `Invalid observed ${fieldName} field. Found a duplicate ${type} with the same name.`;
 
         // TODO [#3408]: this should throw, not log
-        logError(message);
+        logWarn(message);
     }
 }
 
@@ -99,9 +99,7 @@ function validateFieldDecoratedWithTrack(
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
         // TODO [#3408]: this should throw, not log
-        logError(
-            `Invalid @track ${fieldName} field. Found a duplicate ${type} with the same name.`
-        );
+        logWarn(`Invalid @track ${fieldName} field. Found a duplicate ${type} with the same name.`);
     }
 }
 
@@ -114,7 +112,7 @@ function validateFieldDecoratedWithWire(
     if (!isUndefined(descriptor)) {
         const type = getClassDescriptorType(descriptor);
         // TODO [#3408]: this should throw, not log
-        logError(`Invalid @wire ${fieldName} field. Found a duplicate ${type} with the same name.`);
+        logWarn(`Invalid @wire ${fieldName} field. Found a duplicate ${type} with the same name.`);
     }
 }
 
@@ -126,7 +124,7 @@ function validateMethodDecoratedWithWire(
     assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
         // TODO [#3441]: This line of code does not seem possible to reach.
-        logError(
+        logWarn(
             `Invalid @wire ${methodName} field. The field should have a valid writable descriptor.`
         );
     }
@@ -143,7 +141,7 @@ function validateFieldDecoratedWithApi(
         const message = `Invalid @api ${fieldName} field. Found a duplicate ${type} with the same name.`;
 
         // TODO [#3408]: this should throw, not log
-        logError(message);
+        logWarn(message);
     }
 }
 
@@ -156,13 +154,13 @@ function validateAccessorDecoratedWithApi(
     if (isFunction(descriptor.set)) {
         if (!isFunction(descriptor.get)) {
             // TODO [#3441]: This line of code does not seem possible to reach.
-            logError(
+            logWarn(
                 `Missing getter for property ${fieldName} decorated with @api in ${Ctor}. You cannot have a setter without the corresponding getter.`
             );
         }
     } else if (!isFunction(descriptor.get)) {
         // TODO [#3441]: This line of code does not seem possible to reach.
-        logError(`Missing @api get ${fieldName} accessor.`);
+        logWarn(`Missing @api get ${fieldName} accessor.`);
     }
 }
 
@@ -174,7 +172,7 @@ function validateMethodDecoratedWithApi(
     assertNotProd(); // this method should never leak to prod
     if (isUndefined(descriptor) || !isFunction(descriptor.value) || isFalse(descriptor.writable)) {
         // TODO [#3441]: This line of code does not seem possible to reach.
-        logError(`Invalid @api ${methodName} method.`);
+        logWarn(`Invalid @api ${methodName} method.`);
     }
 }
 
@@ -255,7 +253,7 @@ export function registerDecorators(
                 if (process.env.NODE_ENV !== 'production') {
                     if (!adapter) {
                         // TODO [#3408]: this should throw, not log
-                        logError(
+                        logWarn(
                             `@wire on method "${fieldOrMethodName}": adapter id must be truthy.`
                         );
                     }
@@ -270,7 +268,7 @@ export function registerDecorators(
                 if (process.env.NODE_ENV !== 'production') {
                     if (!adapter) {
                         // TODO [#3408]: this should throw, not log
-                        logError(
+                        logWarn(
                             `@wire on field "${fieldOrMethodName}": adapter id must be truthy.`
                         );
                     }

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -12,7 +12,7 @@ import { getReactiveProxy } from '../membrane';
 import { LightningElement } from '../base-lightning-element';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 import { updateComponentValue } from '../update-component-value';
-import { logError } from '../../shared/logger';
+import { logWarn } from '../../shared/logger';
 
 /**
  * @track decorator function to mark field value as reactive in
@@ -48,14 +48,14 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
             if (process.env.NODE_ENV !== 'production') {
                 const vmBeingRendered = getVMBeingRendered();
                 if (isInvokingRender) {
-                    logError(
+                    logWarn(
                         `${vmBeingRendered}.render() method has side effects on the state of ${vm}.${toString(
                             key
                         )}`
                     );
                 }
                 if (isUpdatingTemplate) {
-                    logError(
+                    logWarn(
                         `Updating the template of ${vmBeingRendered} has side effects on the state of ${vm}.${toString(
                             key
                         )}`

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -32,7 +32,7 @@ import {
     resolveCircularModuleDependency,
 } from '../shared/circular-module-dependencies';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { instrumentDef } from './runtime-instrumentation';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
@@ -106,7 +106,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         if (!Ctor.constructor) {
             // This error seems impossible to hit, due to an earlier check in `isComponentConstructor()`.
             // But we keep it here just in case.
-            logError(
+            logWarn(
                 `Missing ${ctorName}.constructor, ${ctorName} should have a "constructor" property.`
             );
         }
@@ -116,7 +116,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
             ctorShadowSupportMode !== ShadowSupportMode.Any &&
             ctorShadowSupportMode !== ShadowSupportMode.Default
         ) {
-            logError(
+            logWarn(
                 `Invalid value for static property shadowSupportMode: '${ctorShadowSupportMode}'`
             );
         }
@@ -126,7 +126,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
             ctorRenderMode !== 'light' &&
             ctorRenderMode !== 'shadow'
         ) {
-            logError(
+            logWarn(
                 `Invalid value for static property renderMode: '${ctorRenderMode}'. renderMode must be either 'light' or 'shadow'.`
             );
         }

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -18,7 +18,7 @@ import {
     isString,
 } from '@lwc/shared';
 
-import { logError, logWarn } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 
 import { RendererAPI } from './renderer';
 import { cloneAndOmitKey, parseStyleText } from './utils';
@@ -70,7 +70,7 @@ export function hydrateRoot(vm: VM) {
     hydrateVM(vm);
 
     if (hasMismatch && process.env.NODE_ENV !== 'production') {
-        logError('Hydration completed with errors.', vm);
+        logWarn('Hydration completed with errors.', vm);
     }
 }
 
@@ -361,7 +361,7 @@ function hydrateChildren(
                 if (process.env.NODE_ENV !== 'production') {
                     if (!hasWarned) {
                         hasWarned = true;
-                        logError(
+                        logWarn(
                             `Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.`,
                             owner
                         );
@@ -377,7 +377,7 @@ function hydrateChildren(
         hasMismatch = true;
         if (process.env.NODE_ENV !== 'production') {
             if (!hasWarned) {
-                logError(
+                logWarn(
                     `Hydration mismatch: incorrect number of rendered nodes. Server rendered more nodes than the client.`,
                     owner
                 );
@@ -420,7 +420,7 @@ function hasCorrectNodeType<T extends Node>(
     const { getProperty } = renderer;
     if (getProperty(node, 'nodeType') !== nodeType) {
         if (process.env.NODE_ENV !== 'production') {
-            logError('Hydration mismatch: incorrect node type received', vnode.owner);
+            logWarn('Hydration mismatch: incorrect node type received', vnode.owner);
         }
         return false;
     }
@@ -437,7 +437,7 @@ function isMatchingElement(
     const { getProperty } = renderer;
     if (vnode.sel.toLowerCase() !== getProperty(elm, 'tagName').toLowerCase()) {
         if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `Hydration mismatch: expecting element with tag "${vnode.sel.toLowerCase()}" but found "${getProperty(
                     elm,
                     'tagName'
@@ -504,7 +504,7 @@ function validateAttrs(
         if (!attributeValuesAreEqual(attrValue, elmAttrValue)) {
             if (process.env.NODE_ENV !== 'production') {
                 const { getProperty } = renderer;
-                logError(
+                logWarn(
                     `Mismatch hydrating element <${getProperty(
                         elm,
                         'tagName'
@@ -593,7 +593,7 @@ function validateClassAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
 
     if (!nodesAreCompatible) {
         if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `Mismatch hydrating element <${getProperty(
                     elm,
                     'tagName'
@@ -649,7 +649,7 @@ function validateStyleAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
     if (!nodesAreCompatible) {
         if (process.env.NODE_ENV !== 'production') {
             const { getProperty } = renderer;
-            logError(
+            logWarn(
                 `Mismatch hydrating element <${getProperty(
                     elm,
                     'tagName'
@@ -687,7 +687,7 @@ function areCompatibleNodes(client: Node, ssr: Node, vnode: VNode, renderer: Ren
     let isCompatibleElements = true;
     if (getProperty(client, 'tagName') !== getProperty(ssr, 'tagName')) {
         if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `Hydration mismatch: expecting element with tag "${getProperty(
                     client,
                     'tagName'
@@ -704,7 +704,7 @@ function areCompatibleNodes(client: Node, ssr: Node, vnode: VNode, renderer: Ren
     clientAttrsNames.forEach((attrName) => {
         if (getAttribute(client, attrName) !== getAttribute(ssr, attrName)) {
             if (process.env.NODE_ENV !== 'production') {
-                logError(
+                logWarn(
                     `Mismatch hydrating element <${getProperty(
                         client,
                         'tagName'

--- a/packages/@lwc/engine-core/src/framework/readonly.ts
+++ b/packages/@lwc/engine-core/src/framework/readonly.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getReadOnlyProxy } from './membrane';
 
 /**
@@ -16,7 +16,7 @@ export function readonly(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {
         // TODO [#1292]: Remove the readonly decorator
         if (arguments.length !== 1) {
-            logError(
+            logWarn(
                 '@readonly cannot be used as a decorator just yet, use it as a function with one argument to produce a readonly version of the provided value.'
             );
         }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -21,7 +21,7 @@ import {
     SVG_NAMESPACE,
 } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import { LifecycleCallback, RendererAPI } from './renderer';
 import { EmptyArray } from './utils';
@@ -672,7 +672,7 @@ export function allocateChildren(vnode: VCustomElement, vm: VM) {
             renderMode !== RenderMode.Light &&
             ArraySome.call(children, (child) => !isNull(child) && isVScopedSlotFragment(child))
         ) {
-            logError(
+            logWarn(
                 `Invalid usage of 'lwc:slot-data' on ${getComponentTag(
                     vm
                 )} tag. Scoped slot content can only be passed to a light dom child.`

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -18,7 +18,7 @@ import {
     isNull,
 } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 
 import { LightningElement } from './base-lightning-element';
@@ -59,7 +59,7 @@ export function lockDomMutation() {
 }
 
 function logMissingPortalError(name: string, type: string) {
-    return logError(
+    return logWarn(
         `The \`${name}\` ${type} is available only on elements that use the \`lwc:dom="manual"\` directive.`
     );
 }
@@ -77,7 +77,7 @@ export function patchElementWithRestrictions(
                 return originalOuterHTMLDescriptor.get!.call(this);
             },
             set(this: Element, value: string) {
-                logError(`Invalid attempt to set outerHTML on Element.`);
+                logWarn(`Invalid attempt to set outerHTML on Element.`);
                 return originalOuterHTMLDescriptor.set!.call(this, value);
             },
         }),
@@ -171,7 +171,7 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
                 return originalInnerHTMLDescriptor.get!.call(this);
             },
             set(this: ShadowRoot, value: string) {
-                logError(`Invalid attempt to set innerHTML on ShadowRoot.`);
+                logWarn(`Invalid attempt to set innerHTML on ShadowRoot.`);
                 return originalInnerHTMLDescriptor.set!.call(this, value);
             },
         }),
@@ -180,7 +180,7 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
                 return originalTextContentDescriptor.get!.call(this);
             },
             set(this: ShadowRoot, value: string) {
-                logError(`Invalid attempt to set textContent on ShadowRoot.`);
+                logWarn(`Invalid attempt to set textContent on ShadowRoot.`);
                 return originalTextContentDescriptor.set!.call(this, value);
             },
         }),
@@ -193,7 +193,7 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
             ) {
                 // TODO [#1824]: Potentially relax this restriction
                 if (!isUndefined(options)) {
-                    logError(
+                    logWarn(
                         'The `addEventListener` method on ShadowRoot does not support any options.',
                         getAssociatedVMIfPresent(this)
                     );
@@ -223,7 +223,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
                 return originalInnerHTMLDescriptor.get!.call(this);
             },
             set(this: HTMLElement, value: string) {
-                logError(`Invalid attempt to set innerHTML on HTMLElement.`);
+                logWarn(`Invalid attempt to set innerHTML on HTMLElement.`);
                 return originalInnerHTMLDescriptor.set!.call(this, value);
             },
         }),
@@ -232,7 +232,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
                 return originalOuterHTMLDescriptor.get!.call(this);
             },
             set(this: HTMLElement, value: string) {
-                logError(`Invalid attempt to set outerHTML on HTMLElement.`);
+                logWarn(`Invalid attempt to set outerHTML on HTMLElement.`);
                 return originalOuterHTMLDescriptor.set!.call(this, value);
             },
         }),
@@ -241,7 +241,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
                 return originalTextContentDescriptor.get!.call(this);
             },
             set(this: HTMLElement, value: string) {
-                logError(`Invalid attempt to set textContent on HTMLElement.`);
+                logWarn(`Invalid attempt to set textContent on HTMLElement.`);
                 return originalTextContentDescriptor.set!.call(this, value);
             },
         }),
@@ -254,7 +254,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
             ) {
                 // TODO [#1824]: Potentially relax this restriction
                 if (!isUndefined(options)) {
-                    logError(
+                    logWarn(
                         'The `addEventListener` method in `LightningElement` does not support any options.',
                         getAssociatedVMIfPresent(this)
                     );
@@ -283,7 +283,7 @@ function getLightningElementPrototypeRestrictionsDescriptors(
                     const { type } = event;
 
                     if (!/^[a-z][a-z0-9_]*$/.test(type)) {
-                        logError(
+                        logWarn(
                             `Invalid event type "${type}" dispatched in element ${getComponentTag(
                                 vm
                             )}.` +

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -6,7 +6,7 @@
  */
 import { ArrayMap, ArrayPush, isArray, isNull, isUndefined, KEY__SCOPED_CSS } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 
 import api from './api';
 import { RenderMode, ShadowMode, VM } from './vm';
@@ -140,7 +140,7 @@ function evaluateStylesheetsContent(
                 !isScopedCss &&
                 vm.renderMode === RenderMode.Light
             ) {
-                logError(
+                logWarn(
                     'Unscoped CSS is not supported in Light DOM in this environment. Please use scoped CSS ' +
                         '(*.scoped.css) instead of unscoped CSS (*.css). See also: https://sfdc.co/scoped-styles-light-dom'
                 );

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -17,7 +17,7 @@ import {
     toString,
 } from '@lwc/shared';
 
-import { logError } from '../shared/logger';
+import { logWarn } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import api, { RenderAPI } from './api';
 import {
@@ -90,7 +90,7 @@ function validateLightDomTemplate(template: Template, vm: VM) {
     }
     if (vm.renderMode === RenderMode.Light) {
         if (template.renderMode !== 'light') {
-            logError(
+            logWarn(
                 `Light DOM components can't render shadow DOM templates. Add an 'lwc:render-mode="light"' directive to the root template tag of ${getComponentTag(
                     vm
                 )}.`
@@ -98,7 +98,7 @@ function validateLightDomTemplate(template: Template, vm: VM) {
         }
     } else {
         if (!isUndefined(template.renderMode)) {
-            logError(
+            logWarn(
                 `Shadow DOM components template can't render light DOM templates. Either remove the 'lwc:render-mode' directive from ${getComponentTag(
                     vm
                 )} or set it to 'lwc:render-mode="shadow"`
@@ -290,7 +290,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
 
     if (process.env.NODE_ENV !== 'production') {
         if (!isArray(vnodes)) {
-            logError(`Compiler should produce html functions that always return an array.`);
+            logWarn(`Compiler should produce html functions that always return an array.`);
         }
     }
     return vnodes;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -22,7 +22,7 @@ import {
 } from '@lwc/shared';
 
 import { addErrorComponentStack } from '../shared/error';
-import { logError, logWarnOnce } from '../shared/logger';
+import { logWarn, logWarnOnce } from '../shared/logger';
 
 import { HostNode, HostElement, RendererAPI } from './renderer';
 import { renderComponent, markComponentAsDirty, getTemplateReactiveObserver } from './component';
@@ -403,7 +403,7 @@ function computeStylesheets(vm: VM, ctor: LightningElementConstructor) {
         if (valid) {
             return flattenStylesheets(stylesheets);
         } else if (process.env.NODE_ENV !== 'production') {
-            logError(
+            logWarn(
                 `static stylesheets must be an array of CSS stylesheets. Found invalid stylesheets on <${vm.tagName}>`,
                 vm
             );


### PR DESCRIPTION
## Details
Github issue link [#3692](https://github.com/salesforce/lwc/issues/3692).
First try replacing all logError calls with logWarn.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
