### PR TITLE
fix(compiler): change CSS scope tokens every release

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -57,7 +57,7 @@ describe('transformSync', () => {
             name: 'foo',
         });
 
-        expect(code).toContain(`tmpl.stylesheetToken = "lwc-143n22jptum";`);
+        expect(code).toMatch(/tmpl\.stylesheetToken = "lwc-[a-z0-9]+";/);
     });
 
     it('should hoist static vnodes when enableStaticContentOptimization is set to true', () => {
@@ -148,7 +148,9 @@ describe('transformSync', () => {
         `;
         const { cssScopeTokens } = transformSync(template, 'foo.html', TRANSFORMATION_OPTIONS);
 
-        expect(cssScopeTokens).toEqual(['lwc-1hl7358i549', 'lwc-1hl7358i549-host']);
+        expect(cssScopeTokens).toHaveLength(2);
+        expect(cssScopeTokens![0]).toMatch(/^lwc-[a-z0-9]+$/);
+        expect(cssScopeTokens![1]).toMatch(/^lwc-[a-z0-9]+-host$/);
     });
 
     describe('dynamic components', () => {

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -127,9 +127,8 @@ function generateScopeToken(
     const uniqueToken = `${namespace}-${name}_${path.basename(filename, path.extname(filename))}`;
 
     if (isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)) {
-        // "Salt" the scope token using the LWC version, so that it changes with every release.
-        // This is to further discourage developers from relying on it.
-        const hashCode = generateHashCode(uniqueToken + (process.env.LWC_VERSION as string));
+        // "Salt" the scope token using the API version. This is to further discourage developers from relying on it.
+        const hashCode = generateHashCode(uniqueToken + apiVersion);
 
         // This scope token is all lowercase so that it works correctly in case-sensitive namespaces (e.g. SVG).
         // It is deliberately designed to discourage people from relying on it by appearing somewhat random.

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -127,7 +127,9 @@ function generateScopeToken(
     const uniqueToken = `${namespace}-${name}_${path.basename(filename, path.extname(filename))}`;
 
     if (isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)) {
-        const hashCode = generateHashCode(uniqueToken);
+        // "Salt" the scope token using the LWC version, so that it changes with every release.
+        // This is to further discourage developers from relying on it.
+        const hashCode = generateHashCode(uniqueToken + (process.env.LWC_VERSION as string));
 
         // This scope token is all lowercase so that it works correctly in case-sensitive namespaces (e.g. SVG).
         // It is deliberately designed to discourage people from relying on it by appearing somewhat random.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -80,6 +80,12 @@ function formatHTML(src: string): string {
         return '  '.repeat(depth);
     };
 
+    // Replace all CSS scope tokens (e.g. "lwc-abc123") to avoid it changing every release.
+    // The lookahead check (`\b(?![->])`) is to avoid matching tag names like `<lwc-foo-bar>`.
+    src = src
+        .replace(/\blwc-[a-z0-9]+-host\b(?![->])/g, '__lwc_scope_token_host__')
+        .replace(/\blwc-[a-z0-9]+\b(?![->])/g, '__lwc_scope_token__');
+
     while (pos < src.length) {
         // Consume element tags and comments.
         if (src.charAt(pos) === '<') {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/expected.html
@@ -1,9 +1,9 @@
-<x-attribute-dynamic-with-scoped-css class="lwc-47oqt8q93b2-host">
+<x-attribute-dynamic-with-scoped-css class="__lwc_scope_token_host__">
   <template shadowroot="open">
-    <style class="lwc-47oqt8q93b2" type="text/css">
-      div.lwc-47oqt8q93b2 {color: black;}div.kree.lwc-47oqt8q93b2 {color: blue;}
+    <style class="__lwc_scope_token__" type="text/css">
+      div.__lwc_scope_token__ {color: black;}div.kree.__lwc_scope_token__ {color: blue;}
     </style>
-    <div class="lwc-47oqt8q93b2 kree">
+    <div class="__lwc_scope_token__ kree">
       In the middle of my backswing?!
     </div>
   </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-scoped-styles/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/light-dom-scoped-styles/expected.html
@@ -1,11 +1,11 @@
-<x-basic class="lwc-1rssj1tib70-host">
-  <style class="lwc-1rssj1tib70" type="text/css">
+<x-basic class="__lwc_scope_token_host__">
+  <style class="__lwc_scope_token__" type="text/css">
     p {color: red;}
   </style>
-  <style class="lwc-1rssj1tib70" type="text/css">
-    p.lwc-1rssj1tib70 {background-color: blue;}.lwc-1rssj1tib70-host {display: block;border: 1px solid black;}
+  <style class="__lwc_scope_token__" type="text/css">
+    p.__lwc_scope_token__ {background-color: blue;}.__lwc_scope_token_host__ {display: block;border: 1px solid black;}
   </style>
-  <p class="lwc-1rssj1tib70">
+  <p class="__lwc_scope_token__">
     Hello
   </p>
 </x-basic>

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -526,47 +526,23 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         } while (object);
     }
 
-    function generateScopeToken(legacyToken) {
-        // Copied verbatim from @lwc/compiler/src/transformers/template.ts
-        function generateHashCode(str) {
-            const seed = 0;
-            let h1 = 0xdeadbeef ^ seed;
-            let h2 = 0x41c6ce57 ^ seed;
-            for (let i = 0, ch; i < str.length; i++) {
-                ch = str.charCodeAt(i);
-                h1 = Math.imul(h1 ^ ch, 2654435761);
-                h2 = Math.imul(h2 ^ ch, 1597334677);
-            }
-            h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
-            h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-            h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
-            h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-
-            return 4294967296 * (2097151 & h2) + (h1 >>> 0);
-        }
-
-        const hashCode = generateHashCode(legacyToken + process.env.LWC_VERSION);
-        return `lwc-${hashCode.toString(32)}`;
-    }
-
     return {
-        clearRegister,
-        extractDataIds,
-        extractShadowDataIds,
-        getHostChildNodes,
-        isNativeShadowRootInstance,
-        isSyntheticShadowRootInstance,
-        load,
-        registerForLoad,
-        getHooks,
-        setHooks,
-        spyConsole,
-        customElementConnectedErrorListener,
-        ariaPropertiesMapping,
-        ariaProperties,
-        ariaAttributes,
-        nonStandardAriaProperties,
-        getPropertyDescriptor,
-        generateScopeToken,
+        clearRegister: clearRegister,
+        extractDataIds: extractDataIds,
+        extractShadowDataIds: extractShadowDataIds,
+        getHostChildNodes: getHostChildNodes,
+        isNativeShadowRootInstance: isNativeShadowRootInstance,
+        isSyntheticShadowRootInstance: isSyntheticShadowRootInstance,
+        load: load,
+        registerForLoad: registerForLoad,
+        getHooks: getHooks,
+        setHooks: setHooks,
+        spyConsole: spyConsole,
+        customElementConnectedErrorListener: customElementConnectedErrorListener,
+        ariaPropertiesMapping: ariaPropertiesMapping,
+        ariaProperties: ariaProperties,
+        ariaAttributes: ariaAttributes,
+        nonStandardAriaProperties: nonStandardAriaProperties,
+        getPropertyDescriptor: getPropertyDescriptor,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -526,23 +526,47 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         } while (object);
     }
 
+    function generateScopeToken(legacyToken) {
+        // Copied verbatim from @lwc/compiler/src/transformers/template.ts
+        function generateHashCode(str) {
+            const seed = 0;
+            let h1 = 0xdeadbeef ^ seed;
+            let h2 = 0x41c6ce57 ^ seed;
+            for (let i = 0, ch; i < str.length; i++) {
+                ch = str.charCodeAt(i);
+                h1 = Math.imul(h1 ^ ch, 2654435761);
+                h2 = Math.imul(h2 ^ ch, 1597334677);
+            }
+            h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+            h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+            h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+            h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+            return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+        }
+
+        const hashCode = generateHashCode(legacyToken + process.env.LWC_VERSION);
+        return `lwc-${hashCode.toString(32)}`;
+    }
+
     return {
-        clearRegister: clearRegister,
-        extractDataIds: extractDataIds,
-        extractShadowDataIds: extractShadowDataIds,
-        getHostChildNodes: getHostChildNodes,
-        isNativeShadowRootInstance: isNativeShadowRootInstance,
-        isSyntheticShadowRootInstance: isSyntheticShadowRootInstance,
-        load: load,
-        registerForLoad: registerForLoad,
-        getHooks: getHooks,
-        setHooks: setHooks,
-        spyConsole: spyConsole,
-        customElementConnectedErrorListener: customElementConnectedErrorListener,
-        ariaPropertiesMapping: ariaPropertiesMapping,
-        ariaProperties: ariaProperties,
-        ariaAttributes: ariaAttributes,
-        nonStandardAriaProperties: nonStandardAriaProperties,
-        getPropertyDescriptor: getPropertyDescriptor,
+        clearRegister,
+        extractDataIds,
+        extractShadowDataIds,
+        getHostChildNodes,
+        isNativeShadowRootInstance,
+        isSyntheticShadowRootInstance,
+        load,
+        registerForLoad,
+        getHooks,
+        setHooks,
+        spyConsole,
+        customElementConnectedErrorListener,
+        ariaPropertiesMapping,
+        ariaProperties,
+        ariaAttributes,
+        nonStandardAriaProperties,
+        getPropertyDescriptor,
+        generateScopeToken,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { generateScopeToken } from 'test-utils';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
@@ -11,7 +12,9 @@ if (!process.env.NATIVE_SHADOW) {
 
             // shadow grandparent
             expect(elm.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58 ? 'x-container_container' : 'lwc-7c9hba002d8'
+                process.env.API_VERSION <= 58
+                    ? 'x-container_container'
+                    : generateScopeToken('x-container_container')
             );
             expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
                 'rgb(0, 128, 0)'
@@ -27,7 +30,9 @@ if (!process.env.NATIVE_SHADOW) {
             // shadow grandchild
             const grandchild = child.querySelector('x-grandchild');
             expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58 ? 'x-grandchild_grandchild' : 'lwc-42b236sbaik'
+                process.env.API_VERSION <= 58
+                    ? 'x-grandchild_grandchild'
+                    : generateScopeToken('x-grandchild_grandchild')
             );
             expect(
                 getComputedStyle(grandchild.shadowRoot.querySelector('h1')).outlineColor

--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -1,5 +1,4 @@
 import { createElement } from 'lwc';
-import { generateScopeToken } from 'test-utils';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
@@ -11,10 +10,8 @@ if (!process.env.NATIVE_SHADOW) {
             document.body.appendChild(elm);
 
             // shadow grandparent
-            expect(elm.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58
-                    ? 'x-container_container'
-                    : generateScopeToken('x-container_container')
+            expect(elm.shadowRoot.querySelector('h1').outerHTML).toMatch(
+                process.env.API_VERSION <= 58 ? /\bx-container_container\b/ : /\blwc-[a-z0-9]+\b/
             );
             expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
                 'rgb(0, 128, 0)'
@@ -29,10 +26,8 @@ if (!process.env.NATIVE_SHADOW) {
 
             // shadow grandchild
             const grandchild = child.querySelector('x-grandchild');
-            expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58
-                    ? 'x-grandchild_grandchild'
-                    : generateScopeToken('x-grandchild_grandchild')
+            expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toMatch(
+                process.env.API_VERSION <= 58 ? /\bx-grandchild_grandchild\b/ : /\blwc-[a-z0-9]+\b/
             );
             expect(
                 getComputedStyle(grandchild.shadowRoot.querySelector('h1')).outlineColor

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -1,5 +1,4 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
-import { generateScopeToken } from 'test-utils';
 import Container from 'x/container';
 import Escape from 'x/escape';
 import MultipleStyles from 'x/multipleStyles';
@@ -36,12 +35,14 @@ if (!process.env.NATIVE_SHADOW) {
                     .shadowRoot.querySelector('x-component')
                     .shadowRoot.querySelector('div');
 
-                const token =
-                    process.env.API_VERSION <= 58
-                        ? 'x-component_component'
-                        : generateScopeToken('x-component_component');
-                expect(syntheticMode.hasAttribute(token)).toBe(true);
-                expect(nativeMode.hasAttribute(token)).toBe(false);
+                const syntheticAttrs = [...syntheticMode.attributes].map((_) => _.name);
+                const nativeAttrs = [...nativeMode.attributes].map((_) => _.name);
+
+                expect(syntheticAttrs.length).toBe(1);
+                expect(syntheticAttrs[0]).toMatch(
+                    process.env.API_VERSION <= 58 ? /^x-component_component$/ : /^lwc-[a-z0-9]+$/
+                );
+                expect(nativeAttrs.length).toBe(0);
             });
         });
     });
@@ -80,12 +81,11 @@ describe('static content when stylesheets change', () => {
         return Promise.resolve()
             .then(() => {
                 const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
-                expect(classList).toEqual([
-                    'foo',
-                    process.env.API_VERSION <= 58
-                        ? 'x-multipleStyles_b'
-                        : generateScopeToken('x-multipleStyles_b'),
-                ]);
+                expect(classList.length).toBe(2);
+                expect(classList[0]).toBe('foo');
+                expect(classList[1]).toMatch(
+                    process.env.API_VERSION <= 58 ? /^x-multipleStyles_b$/ : /^lwc-[a-z0-9]+$/
+                );
 
                 expect(() => {
                     elm.updateTemplate({

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
+import { generateScopeToken } from 'test-utils';
 import Container from 'x/container';
 import Escape from 'x/escape';
 import MultipleStyles from 'x/multipleStyles';
@@ -36,7 +37,9 @@ if (!process.env.NATIVE_SHADOW) {
                     .shadowRoot.querySelector('div');
 
                 const token =
-                    process.env.API_VERSION <= 58 ? 'x-component_component' : 'lwc-6a8uqob2ku4';
+                    process.env.API_VERSION <= 58
+                        ? 'x-component_component'
+                        : generateScopeToken('x-component_component');
                 expect(syntheticMode.hasAttribute(token)).toBe(true);
                 expect(nativeMode.hasAttribute(token)).toBe(false);
             });
@@ -79,7 +82,9 @@ describe('static content when stylesheets change', () => {
                 const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
                 expect(classList).toEqual([
                     'foo',
-                    process.env.API_VERSION <= 58 ? 'x-multipleStyles_b' : 'lwc-6fpm08fjoch',
+                    process.env.API_VERSION <= 58
+                        ? 'x-multipleStyles_b'
+                        : generateScopeToken('x-multipleStyles_b'),
                 ]);
 
                 expect(() => {

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -10,6 +10,7 @@ import { isNumber } from './language';
 export const enum APIVersion {
     V58_244_SUMMER_23 = 58,
     V59_246_WINTER_24 = 59,
+    V60_248_SPRING_24 = 60,
 }
 
 // These must be updated when the enum is updated.
@@ -17,8 +18,12 @@ export const enum APIVersion {
 // passing the `verify-treeshakeable.js` test.
 
 export const LOWEST_API_VERSION = APIVersion.V58_244_SUMMER_23;
-export const HIGHEST_API_VERSION = APIVersion.V59_246_WINTER_24;
-const allVersions = [APIVersion.V58_244_SUMMER_23, APIVersion.V59_246_WINTER_24];
+export const HIGHEST_API_VERSION = APIVersion.V60_248_SPRING_24;
+const allVersions = [
+    APIVersion.V58_244_SUMMER_23,
+    APIVersion.V59_246_WINTER_24,
+    APIVersion.V60_248_SPRING_24,
+];
 const allVersionsSet = /*@__PURE__@*/ new Set(allVersions);
 
 export function getAPIVersionFromNumber(version: number | undefined): APIVersion {


### PR DESCRIPTION
## Details

With v3.0.0, we changed [CSS scope tokens](https://github.com/salesforce/lwc/releases/tag/v3.0.0#:~:text=CSS%20scope%20tokens%20have%20changed). These tokens need to be consistent to avoid issues with caching (i.e. for the same input to the compiler, you should get the same output).

However, we don't want to replace one tech debt with another. So this PR changes the CSS token based on the ~LWC release version~ _API version_.

For first-party components, this means the token changes every release. For third-party components, it changes when they bump their API version.

<details><summary>see outdated</summary>

~On the Lightning platform, this means that the token will change with every major release (and possibly with patch/e-releases).~

~Off-core, it means that the token will change every time the LWC npm dependencies are updated. Technically this is a breaking change on patch/minor releases, but given that we really don't want people to rely on these as a public API, I think this is reasonable.~

</details>

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

See above if you want to debate semantics.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

See above.

<!-- If yes, please describe the anticipated observable changes. -->
