### PR TITLE
perf(synthetic-shadow): micro-optimize MutationObserver

### DIFF
--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-mutation-observer-ss/ss-mutation-observer-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-mutation-observer-ss/ss-mutation-observer-10k.benchmark.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import '@lwc/synthetic-shadow';
+import { createElement } from '@lwc/engine-dom';
+
+import TableComponent from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tableComponent/tableComponent.js';
+import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+benchmark(`dom/synthetic-shadow/mutation-observer/10k`, () => {
+    let tableElement;
+    let tableRows;
+    let store;
+
+    before(async () => {
+        tableElement = createElement('benchmark-table-component', { is: TableComponent });
+        store = new Store();
+        store.run();
+        tableElement.rows = store.data;
+        await insertComponent(tableElement);
+        tableRows = [...tableElement.shadowRoot.querySelectorAll('benchmark-table-component-row')];
+    });
+
+    run(async () => {
+        // observe at multiple levels, including where we shouldn't be allowed to see inside the shadow root
+        for (const rowElement of tableRows) {
+            new MutationObserver(() => {}).observe(tableElement, {
+                attributes: true,
+                characterData: true,
+                childList: true,
+                subtree: true,
+            });
+            new MutationObserver(() => {}).observe(rowElement, {
+                attributes: true,
+                characterData: true,
+                childList: true,
+                subtree: true,
+            });
+            new MutationObserver(() => {}).observe(rowElement.shadowRoot, {
+                attributes: true,
+                characterData: true,
+                childList: true,
+                subtree: true,
+            });
+        }
+
+        // trigger mutations - mutations, deletions, insertions
+        for (const rowElement of tableRows) {
+            for (const child of rowElement.shadowRoot.children) {
+                child.nodeValue += ' update';
+            }
+            rowElement.shadowRoot.lastChild.remove();
+            rowElement.shadowRoot.appendChild(document.createElement('div'));
+        }
+    });
+
+    after(() => {
+        destroyComponent(tableElement);
+    });
+});


### PR DESCRIPTION
## Details

A small micro-optimization for our `MutationObserver` polyfill.

Also adds a benchmark, which is improved by 2%-6%:

![Screenshot 2023-09-21 at 4 27 13 PM](https://github.com/salesforce/lwc/assets/283842/80fa7400-08af-4763-9e55-bee08004dac4)


I have other ideas for improvements, but I'm keeping this PR simple to make it easier to review.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
