### PR TITLE
chore: use inclusive language for feature flags

### DIFF
--- a/packages/@lwc/features/src/__tests__/features.spec.ts
+++ b/packages/@lwc/features/src/__tests__/features.spec.ts
@@ -9,7 +9,7 @@ import features from '../index';
 
 describe('features', () => {
     it('known flags in the features map are null', () => {
-        expect(features.DUMMY_TEST_FLAG).toBeNull();
+        expect(features.PLACEHOLDER_TEST_FLAG).toBeNull();
         for (const value of Object.values(features)) {
             expect(value).toBeNull();
         }

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -9,7 +9,7 @@ import { lwcRuntimeFlags } from '../index';
 
 describe('lwcRuntimeFlags', () => {
     it('known flags default to undefined', () => {
-        expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toBeUndefined();
+        expect(lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG).toBeUndefined();
     });
 
     it('unknown flags default to undefined', () => {

--- a/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
+++ b/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
@@ -23,17 +23,17 @@ describe('setFeatureFlag', () => {
 
             afterEach(() => {
                 process.env.NODE_ENV = originalNodeEnv;
-                lwcRuntimeFlags.DUMMY_TEST_FLAG = undefined; // reset
+                lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG = undefined; // reset
                 info.mockReset();
                 error.mockReset();
             });
 
             it('throws/logs and does nothing when set to a non-boolean', () => {
                 const expectedError =
-                    'Failed to set the value "foo" for the runtime feature flag "DUMMY_TEST_FLAG". Runtime feature flags can only be set to a boolean value.';
+                    'Failed to set the value "foo" for the runtime feature flag "PLACEHOLDER_TEST_FLAG". Runtime feature flags can only be set to a boolean value.';
                 const callback = () => {
                     // @ts-ignore
-                    setFeatureFlag('DUMMY_TEST_FLAG', 'foo');
+                    setFeatureFlag('PLACEHOLDER_TEST_FLAG', 'foo');
                 };
                 if (env === 'production') {
                     callback();
@@ -43,7 +43,7 @@ describe('setFeatureFlag', () => {
                 }
 
                 // value is not changed
-                expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toBeUndefined();
+                expect(lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG).toBeUndefined();
             });
 
             it('logs and does nothing when the flag is unknown', () => {
@@ -59,17 +59,17 @@ describe('setFeatureFlag', () => {
             });
 
             it('disallows setting a flag more than once', () => {
-                setFeatureFlag('DUMMY_TEST_FLAG', true);
-                expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(true);
-                setFeatureFlag('DUMMY_TEST_FLAG', false);
+                setFeatureFlag('PLACEHOLDER_TEST_FLAG', true);
+                expect(lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG).toEqual(true);
+                setFeatureFlag('PLACEHOLDER_TEST_FLAG', false);
                 if (env === 'production') {
                     expect(error).toHaveBeenCalledWith(
-                        'Failed to set the value "false" for the runtime feature flag "DUMMY_TEST_FLAG". "DUMMY_TEST_FLAG" has already been set with the value "true".'
+                        'Failed to set the value "false" for the runtime feature flag "PLACEHOLDER_TEST_FLAG". "PLACEHOLDER_TEST_FLAG" has already been set with the value "true".'
                     );
-                    expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(true);
+                    expect(lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG).toEqual(true);
                 } else {
                     expect(error).not.toHaveBeenCalled();
-                    expect(lwcRuntimeFlags.DUMMY_TEST_FLAG).toEqual(false);
+                    expect(lwcRuntimeFlags.PLACEHOLDER_TEST_FLAG).toEqual(false);
                 }
             });
         });

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -10,7 +10,7 @@ import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 // When deprecating a feature flag, ensure that it is also no longer set in the application. For
 // example, in core, the flag should be removed from LwcPermAndPrefUtilImpl.java
 const features: FeatureFlagMap = {
-    DUMMY_TEST_FLAG: null,
+    PLACEHOLDER_TEST_FLAG: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
     ENABLE_MIXED_SHADOW_MODE: null,
     ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: null,

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -19,7 +19,7 @@ export interface FeatureFlagMap {
     /**
      * This is only used to test that feature flags are actually working
      */
-    DUMMY_TEST_FLAG: FeatureFlagValue;
+    PLACEHOLDER_TEST_FLAG: FeatureFlagValue;
 
     /**
      * LWC engine flag to enable mixed shadow mode. Setting this flag to `true` enables usage of


### PR DESCRIPTION
## Details
This PR replaces the `DUMMY_TEST_FLAG` with `PLACEHOLDER_TEST_FLAG` to provide more inclusive language in our feature flags.

## Does this pull request introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.

## GUS work item
W-14136687
