### PR TITLE
feat: add flag to render legacy CSS scope tokens (backport)

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -148,7 +148,12 @@ describe('transformSync', () => {
         `;
         const { cssScopeTokens } = transformSync(template, 'foo.html', TRANSFORMATION_OPTIONS);
 
-        expect(cssScopeTokens).toEqual(['lwc-1hl7358i549', 'lwc-1hl7358i549-host']);
+        expect(cssScopeTokens!.sort()).toEqual([
+            'lwc-1hl7358i549',
+            'lwc-1hl7358i549-host',
+            'x-foo_foo',
+            'x-foo_foo-host',
+        ]);
     });
 
     describe('dynamic components', () => {

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -70,17 +70,23 @@ export default function templateTransform(
     // thrown above. As for "Log" and "Fatal", they are currently unused.
     const warnings = result.warnings.filter((_) => _.level === DiagnosticLevel.Warning);
 
-    const scopeToken = generateScopeToken(filename, namespace, name, apiVersion);
+    // TODO [#3733]: remove support for legacy scope tokens
+    const { scopeToken, legacyScopeToken } = generateScopeTokens(filename, namespace, name);
 
     // Rollup only cares about the mappings property on the map. Since producing a source map for
     // the template doesn't make sense, the transform returns an empty mappings.
     return {
-        code: serialize(result.code, filename, scopeToken),
+        code: serialize(result.code, filename, scopeToken, legacyScopeToken, apiVersion),
         map: { mappings: '' },
         warnings,
         cssScopeTokens: [
             scopeToken,
             `${scopeToken}-host`, // implicit scope token created by `makeHostToken()` in `@lwc/engine-core`
+            // The legacy tokens must be returned as well since we technically don't know what we're going to render
+            // This is not strictly required since this is only used for Jest serialization (as of this writing),
+            // and people are unlikely to set runtime flags in Jest, but it is technically correct to include this.
+            legacyScopeToken,
+            `${legacyScopeToken}-host`,
         ],
     };
 }
@@ -118,30 +124,37 @@ function escapeScopeToken(input: string) {
     return input.replace(/@/g, '___at___').replace(/#/g, '___hash___');
 }
 
-function generateScopeToken(
+function generateScopeTokens(
     filename: string,
     namespace: string | undefined,
-    name: string | undefined,
-    apiVersion: APIVersion
+    name: string | undefined
 ) {
     const uniqueToken = `${namespace}-${name}_${path.basename(filename, path.extname(filename))}`;
 
-    if (isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)) {
-        const hashCode = generateHashCode(uniqueToken);
+    // This scope token is all lowercase so that it works correctly in case-sensitive namespaces (e.g. SVG).
+    // It is deliberately designed to discourage people from relying on it by appearing somewhat random.
+    // (But not totally random, because it's nice to have stable scope tokens for our own tests.)
+    // Base-32 is chosen because it is not case-sensitive (0-v), and generates short strings with the given hash
+    // code implementation (10-11 characters).
+    const hashCode = generateHashCode(uniqueToken);
+    const scopeToken = `lwc-${hashCode.toString(32)}`;
 
-        // This scope token is all lowercase so that it works correctly in case-sensitive namespaces (e.g. SVG).
-        // It is deliberately designed to discourage people from relying on it by appearing somewhat random.
-        // (But not totally random, because it's nice to have stable scope tokens for our own tests.)
-        // Base-32 is chosen because it is not case-sensitive (0-v), and generates short strings with the given hash
-        // code implementation (10-11 characters).
-        return `lwc-${hashCode.toString(32)}`;
-    } else {
-        // This scope token is based on the namespace and name, and contains a mix of uppercase/lowercase chars
-        return escapeScopeToken(uniqueToken);
-    }
+    // This scope token is based on the namespace and name, and contains a mix of uppercase/lowercase chars
+    const legacyScopeToken = escapeScopeToken(uniqueToken);
+
+    return {
+        scopeToken,
+        legacyScopeToken,
+    };
 }
 
-function serialize(code: string, filename: string, scopeToken: string): string {
+function serialize(
+    code: string,
+    filename: string,
+    scopeToken: string,
+    legacyScopeToken: string,
+    apiVersion: APIVersion
+): string {
     const cssRelPath = `./${path.basename(filename, path.extname(filename))}.css`;
     const scopedCssRelPath = `./${path.basename(filename, path.extname(filename))}.scoped.css`;
 
@@ -157,7 +170,18 @@ function serialize(code: string, filename: string, scopeToken: string): string {
     buffer += 'if (_implicitScopedStylesheets) {\n';
     buffer += `  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);\n`;
     buffer += `}\n`;
-    buffer += `tmpl.stylesheetToken = "${scopeToken}";\n`;
+
+    if (isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)) {
+        // Include both the new and legacy tokens, so that the runtime can decide based on a flag whether
+        // we need to render the legacy one. This is designed for cases where the legacy one is required
+        // for backwards compat (e.g. global stylesheets that rely on the legacy format for a CSS selector).
+        buffer += `tmpl.stylesheetToken = "${scopeToken}";\n`;
+        buffer += `tmpl.legacyStylesheetToken = "${legacyScopeToken}";\n`;
+    } else {
+        // In old API versions, we can just keep doing what we always did
+        buffer += `tmpl.stylesheetToken = "${legacyScopeToken}";\n`;
+    }
+
     // Note that `renderMode` and `slots` are already rendered in @lwc/template-compiler and appear
     // as `code` above. At this point, no more expando props should be added to `tmpl`.
     buffer += 'freezeTemplate(tmpl);\n';

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -525,7 +525,8 @@ function validateClassAttr(vnode: VBaseElement, elm: Element, renderer: Renderer
     const { data, owner } = vnode;
     let { className, classMap } = data;
     const { getProperty, getClassList, getAttribute } = renderer;
-    const scopedToken = getScopeTokenClass(owner);
+    // we don't care about legacy for hydration. it's a new use case
+    const scopedToken = getScopeTokenClass(owner, /* legacy */ false);
     const stylesheetTokenHost = isVCustomElement(vnode) ? getStylesheetTokenHost(vnode) : null;
 
     // Classnames for scoped CSS are added directly to the DOM during rendering,

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -51,7 +51,8 @@ function createInlineStyleVNode(content: string): VNode {
     );
 }
 
-export function updateStylesheetToken(vm: VM, template: Template) {
+// TODO [#3733]: remove support for legacy scope tokens
+export function updateStylesheetToken(vm: VM, template: Template, legacy: boolean) {
     const {
         elm,
         context,
@@ -59,7 +60,8 @@ export function updateStylesheetToken(vm: VM, template: Template) {
         shadowMode,
         renderer: { getClassList, removeAttribute, setAttribute },
     } = vm;
-    const { stylesheets: newStylesheets, stylesheetToken: newStylesheetToken } = template;
+    const { stylesheets: newStylesheets } = template;
+    const newStylesheetToken = legacy ? template.legacyStylesheetToken : template.stylesheetToken;
     const { stylesheets: newVmStylesheets } = vm;
     const isSyntheticShadow =
         renderMode === RenderMode.Shadow && shadowMode === ShadowMode.Synthetic;
@@ -70,11 +72,18 @@ export function updateStylesheetToken(vm: VM, template: Template) {
     let newHasTokenInAttribute: boolean | undefined;
 
     // Reset the styling token applied to the host element.
-    const {
-        stylesheetToken: oldToken,
-        hasTokenInClass: oldHasTokenInClass,
-        hasTokenInAttribute: oldHasTokenInAttribute,
-    } = context;
+    let oldToken;
+    let oldHasTokenInClass;
+    let oldHasTokenInAttribute;
+    if (legacy) {
+        oldToken = context.legacyStylesheetToken;
+        oldHasTokenInClass = context.hasLegacyTokenInClass;
+        oldHasTokenInAttribute = context.hasLegacyTokenInAttribute;
+    } else {
+        oldToken = context.stylesheetToken;
+        oldHasTokenInClass = context.hasTokenInClass;
+        oldHasTokenInAttribute = context.hasTokenInAttribute;
+    }
     if (!isUndefined(oldToken)) {
         if (oldHasTokenInClass) {
             getClassList(elm).remove(makeHostToken(oldToken));
@@ -105,9 +114,15 @@ export function updateStylesheetToken(vm: VM, template: Template) {
     }
 
     // Update the styling tokens present on the context object.
-    context.stylesheetToken = newToken;
-    context.hasTokenInClass = newHasTokenInClass;
-    context.hasTokenInAttribute = newHasTokenInAttribute;
+    if (legacy) {
+        context.legacyStylesheetToken = newToken;
+        context.hasLegacyTokenInClass = newHasTokenInClass;
+        context.hasLegacyTokenInAttribute = newHasTokenInAttribute;
+    } else {
+        context.stylesheetToken = newToken;
+        context.hasTokenInClass = newHasTokenInClass;
+        context.hasTokenInAttribute = newHasTokenInAttribute;
+    }
 }
 
 function evaluateStylesheetsContent(
@@ -218,9 +233,14 @@ function getNearestShadowComponent(vm: VM): VM | null {
  * this returns the unique token for that scoped stylesheet. Otherwise
  * it returns null.
  */
-export function getScopeTokenClass(owner: VM): string | null {
+// TODO [#3733]: remove support for legacy scope tokens
+export function getScopeTokenClass(owner: VM, legacy: boolean): string | null {
     const { cmpTemplate, context } = owner;
-    return (context.hasScopedStyles && cmpTemplate?.stylesheetToken) || null;
+    return (
+        (context.hasScopedStyles &&
+            (legacy ? cmpTemplate?.legacyStylesheetToken : cmpTemplate?.stylesheetToken)) ||
+        null
+    );
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -97,6 +97,13 @@ export interface Context {
     hasTokenInClass: boolean | undefined;
     /** True if a stylesheetToken was added to the host attributes */
     hasTokenInAttribute: boolean | undefined;
+    /** The legacy string used for synthetic shadow DOM and light DOM style scoping. */
+    // TODO [#3733]: remove support for legacy scope tokens
+    legacyStylesheetToken: string | undefined;
+    /** True if a legacyStylesheetToken was added to the host class */
+    hasLegacyTokenInClass: boolean | undefined;
+    /** True if a legacyStylesheetToken was added to the host attributes */
+    hasLegacyTokenInAttribute: boolean | undefined;
     /** Whether or not light DOM scoped styles are present in the stylesheets. */
     hasScopedStyles: boolean | undefined;
     /** The VNodes injected in all the shadow trees to apply the associated component stylesheets. */
@@ -315,6 +322,9 @@ export function createVM<HostNode, HostElement>(
             stylesheetToken: undefined,
             hasTokenInClass: undefined,
             hasTokenInAttribute: undefined,
+            legacyStylesheetToken: undefined,
+            hasLegacyTokenInClass: undefined,
+            hasLegacyTokenInAttribute: undefined,
             hasScopedStyles: undefined,
             styleVNodes: null,
             tplCache: EmptyObject,

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -16,6 +16,7 @@ const features: FeatureFlagMap = {
     DISABLE_LIGHT_DOM_UNSCOPED_CSS: null,
     ENABLE_FROZEN_TEMPLATE: null,
     DISABLE_ARIA_REFLECTION_POLYFILL: null,
+    ENABLE_LEGACY_SCOPE_TOKENS: null,
 };
 
 // eslint-disable-next-line no-restricted-properties

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -66,6 +66,13 @@ export interface FeatureFlagMap {
      * and HTMLBridgeElement base classes, not on every Element.
      */
     DISABLE_ARIA_REFLECTION_POLYFILL: FeatureFlagValue;
+
+    /**
+     * If true, render legacy CSS scope tokens in addition to the modern CSS scope tokens. This is designed
+     * for cases where backwards compat is required (e.g. global stylesheets using these tokens in their selectors).
+     */
+    // TODO [#3733]: remove support for legacy scope tokens
+    ENABLE_LEGACY_SCOPE_TOKENS: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
@@ -1,0 +1,140 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import Light from 'x/light';
+import Shadow from 'x/shadow';
+
+describe('legacy scope tokens', () => {
+    [false, true].forEach((enableLegacyScopeTokens) => {
+        describe(`enableLegacyScopeTokens=${enableLegacyScopeTokens}`, () => {
+            beforeEach(() => {
+                setFeatureFlagForTest('ENABLE_LEGACY_SCOPE_TOKENS', enableLegacyScopeTokens);
+            });
+
+            afterEach(() => {
+                setFeatureFlagForTest('ENABLE_LEGACY_SCOPE_TOKENS', false);
+            });
+
+            function getAttributes(elm) {
+                return [...elm.attributes]
+                    .map((_) => _.name)
+                    .filter((_) => _ !== 'class')
+                    .sort();
+            }
+
+            function getClasses(elm) {
+                return (
+                    [...elm.classList]
+                        // these are classes we add ourselves for the test
+                        .filter((_) => !['static', 'dynamic', 'manual'].includes(_))
+                        .sort()
+                );
+            }
+
+            function expectTokens(modern, legacy) {
+                return [
+                    ...new Set(
+                        [
+                            process.env.API_VERSION <= 58 ? legacy : modern,
+                            enableLegacyScopeTokens && legacy,
+                        ].filter(Boolean)
+                    ),
+                ].sort();
+            }
+
+            function expectShadowAttrTokens(modern, legacy) {
+                if (process.env.NATIVE_SHADOW) {
+                    return []; // no scope attributes added in native shadow
+                }
+                return expectTokens(modern, legacy);
+            }
+
+            it('light dom', async () => {
+                const elm = createElement('x-light', { is: Light });
+                document.body.appendChild(elm);
+
+                const verify = () => {
+                    const staticDiv = elm.querySelector('.static');
+                    const dynamicDiv = elm.querySelector('.dynamic');
+
+                    expect(getClasses(elm)).toEqual(
+                        expectTokens('lwc-1kadf5igpar-host', 'x-light_light-host')
+                    );
+                    expect(getClasses(staticDiv)).toEqual(
+                        expectTokens('lwc-1kadf5igpar', 'x-light_light')
+                    );
+                    expect(getClasses(dynamicDiv)).toEqual(
+                        expectTokens('lwc-1kadf5igpar', 'x-light_light')
+                    );
+
+                    expect(getAttributes(elm)).toEqual([]);
+                    expect(getAttributes(staticDiv)).toEqual([]);
+                    expect(getAttributes(dynamicDiv)).toEqual([]);
+                };
+
+                await Promise.resolve();
+
+                verify();
+
+                // force re-render
+                elm.rerender = 1;
+                await Promise.resolve();
+
+                verify();
+            });
+
+            if (!process.env.NATIVE_SHADOW) {
+                it('shadow dom', async () => {
+                    const elm = createElement('x-shadow', { is: Shadow });
+                    document.body.appendChild(elm);
+
+                    const verify = () => {
+                        const staticDiv = elm.shadowRoot.querySelector('.static');
+                        const dynamicDiv = elm.shadowRoot.querySelector('.dynamic');
+                        const manualDiv = elm.shadowRoot.querySelector('.manual');
+                        const span = elm.shadowRoot.querySelector('span'); // inserted inside dom:manual
+
+                        expect(getClasses(elm)).toEqual(
+                            expectTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
+                        );
+                        expect(getClasses(staticDiv)).toEqual(
+                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getClasses(dynamicDiv)).toEqual(
+                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getClasses(manualDiv)).toEqual(
+                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getClasses(span)).toEqual([]);
+
+                        expect(getAttributes(elm)).toEqual(
+                            expectShadowAttrTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
+                        );
+                        expect(getAttributes(staticDiv)).toEqual(
+                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getAttributes(dynamicDiv)).toEqual(
+                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getClasses(manualDiv)).toEqual(
+                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                        expect(getAttributes(span)).toEqual(
+                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                        );
+                    };
+
+                    await Promise.resolve();
+
+                    verify();
+
+                    // force re-render
+                    elm.rerender = 1;
+                    await Promise.resolve();
+                    await Promise.resolve(); // second microtask is for MutationObserver callbacks (portal)
+
+                    verify();
+                });
+            }
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.css
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.css
@@ -1,0 +1,7 @@
+:host {
+    color: green
+}
+
+div {
+    background: brown;
+}

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <div class="dynamic" lwc:spread={props}></div>
+    <div class="static"></div>
+    <span>{rerender}</span>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+
+    props = {};
+
+    @api rerender = 0;
+}

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/light/light.scoped.css
@@ -1,0 +1,7 @@
+:host {
+    background: blue;
+}
+
+div {
+    color: yellow;
+}

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.css
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.css
@@ -1,0 +1,7 @@
+:host {
+    color: green
+}
+
+div {
+    background: brown;
+}

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.html
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.html
@@ -1,0 +1,6 @@
+<template>
+    <div class="dynamic" lwc:spread={props}></div>
+    <div class="static"></div>
+    <div class="manual" lwc:ref="manual" lwc:dom="manual"></div>
+    <span>{rerender}</span>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.js
@@ -1,0 +1,11 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    props = {};
+
+    renderedCallback() {
+        this.refs.manual.innerHTML = '<span></span>';
+    }
+
+    @api rerender = 0;
+}

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/x/shadow/shadow.scoped.css
@@ -1,0 +1,7 @@
+:host {
+    background: blue;
+}
+
+div {
+    color: yellow;
+}

--- a/packages/@lwc/shared/src/keys.ts
+++ b/packages/@lwc/shared/src/keys.ts
@@ -12,6 +12,9 @@ export const KEY__SHADOW_STATIC = '$shadowStaticNode$';
 export const KEY__SHADOW_STATIC_PRIVATE = '$shadowStaticNodeKey$';
 export const KEY__SHADOW_TOKEN = '$shadowToken$';
 export const KEY__SHADOW_TOKEN_PRIVATE = '$$ShadowTokenKey$$';
+// TODO [#3733]: remove support for legacy scope tokens
+export const KEY__LEGACY_SHADOW_TOKEN = '$legacyShadowToken$';
+export const KEY__LEGACY_SHADOW_TOKEN_PRIVATE = '$$LegacyShadowTokenKey$$';
 export const KEY__SYNTHETIC_MODE = '$$lwc-synthetic-mode';
 export const KEY__SCOPED_CSS = '$scoped$';
 export const KEY__NATIVE_GET_ELEMENT_BY_ID = '$nativeGetElementById$';

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/legacy-shadow-token.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/legacy-shadow-token.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// TODO [#3733]: remove this entire file when we can remove legacy scope tokens
+import {
+    defineProperty,
+    isUndefined,
+    KEY__LEGACY_SHADOW_TOKEN,
+    KEY__LEGACY_SHADOW_TOKEN_PRIVATE,
+} from '@lwc/shared';
+import { setAttribute, removeAttribute } from '../env/element';
+
+export function getLegacyShadowToken(node: Node): string | undefined {
+    return (node as any)[KEY__LEGACY_SHADOW_TOKEN];
+}
+export function setLegacyShadowToken(node: Node, shadowToken: string | undefined) {
+    (node as any)[KEY__LEGACY_SHADOW_TOKEN] = shadowToken;
+}
+
+/**
+ * Patching Element.prototype.$legacyShadowToken$ to mark elements a portal:
+ * Same as $shadowToken$ but for legacy CSS scope tokens.
+ **/
+defineProperty(Element.prototype, KEY__LEGACY_SHADOW_TOKEN, {
+    set(this: Element, shadowToken: string | undefined) {
+        const oldShadowToken = (this as any)[KEY__LEGACY_SHADOW_TOKEN_PRIVATE];
+        if (!isUndefined(oldShadowToken) && oldShadowToken !== shadowToken) {
+            removeAttribute.call(this, oldShadowToken);
+        }
+        if (!isUndefined(shadowToken)) {
+            setAttribute.call(this, shadowToken, '');
+        }
+        (this as any)[KEY__LEGACY_SHADOW_TOKEN_PRIVATE] = shadowToken;
+    },
+    get(this: Element): string | undefined {
+        return (this as any)[KEY__LEGACY_SHADOW_TOKEN_PRIVATE];
+    },
+    configurable: true,
+});

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -14,6 +14,7 @@ import {
     ShadowRootResolver,
 } from './shadow-root';
 import { setShadowToken, getShadowToken } from './shadow-token';
+import { setLegacyShadowToken, getLegacyShadowToken } from './legacy-shadow-token';
 
 const DomManualPrivateKey = '$$DomManualKey$$';
 
@@ -30,7 +31,13 @@ const portalObserverConfig: MutationObserverInit = {
     childList: true,
 };
 
-function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string | undefined) {
+// TODO [#3733]: remove support for legacy scope tokens
+function adoptChildNode(
+    node: Node,
+    fn: ShadowRootResolver,
+    shadowToken: string | undefined,
+    legacyShadowToken: string | undefined
+) {
     const previousNodeShadowResolver = getShadowRootResolver(node);
     if (previousNodeShadowResolver === fn) {
         return; // nothing to do here, it is already correctly patched
@@ -38,6 +45,9 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
     setShadowRootResolver(node, fn);
     if (node instanceof Element) {
         setShadowToken(node, shadowToken);
+        if (lwcRuntimeFlags.ENABLE_LEGACY_SCOPE_TOKENS) {
+            setLegacyShadowToken(node, legacyShadowToken);
+        }
 
         if (isSyntheticShadowHost(node)) {
             // Root LWC elements can't get content slotted into them, therefore we don't observe their children.
@@ -51,7 +61,7 @@ function adoptChildNode(node: Node, fn: ShadowRootResolver, shadowToken: string 
         // recursively patching all children as well
         const childNodes = childNodesGetter.call(node);
         for (let i = 0, len = childNodes.length; i < len; i += 1) {
-            adoptChildNode(childNodes[i], fn, shadowToken);
+            adoptChildNode(childNodes[i], fn, shadowToken, legacyShadowToken);
         }
     }
 }
@@ -73,6 +83,9 @@ function initPortalObserver() {
             // the target of the mutation should always have a ShadowRootResolver attached to it
             const fn = getShadowRootResolver(elm)!;
             const shadowToken = getShadowToken(elm);
+            const legacyShadowToken = lwcRuntimeFlags.ENABLE_LEGACY_SCOPE_TOKENS
+                ? getLegacyShadowToken(elm)
+                : undefined;
 
             // Process removals first to handle the case where an element is removed and reinserted
             for (let i = 0, len = removedNodes.length; i < len; i += 1) {
@@ -80,14 +93,14 @@ function initPortalObserver() {
                 if (
                     !(compareDocumentPosition.call(elm, node) & Node.DOCUMENT_POSITION_CONTAINED_BY)
                 ) {
-                    adoptChildNode(node, DocumentResolverFn, undefined);
+                    adoptChildNode(node, DocumentResolverFn, undefined, undefined);
                 }
             }
 
             for (let i = 0, len = addedNodes.length; i < len; i += 1) {
                 const node: Node = addedNodes[i];
                 if (compareDocumentPosition.call(elm, node) & Node.DOCUMENT_POSITION_CONTAINED_BY) {
-                    adoptChildNode(node, fn, shadowToken);
+                    adoptChildNode(node, fn, shadowToken, legacyShadowToken);
                 }
             }
         });


### PR DESCRIPTION
## Details

Same as #3734 but backporting to winter24.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-14181183
