### PR TITLE
chore(nucleus): remove broken downstreams

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -14,9 +14,7 @@ branches:
         - Trailhead-Platform/ui-trailhead-core-components
         - automation-platform/ui-interaction-explorer-components
         - communities/shared-experience-components
-        - communities/ui-feeds-components
         - communities/ui-lightning-community
-        - communities/webruntime
         - lwc/lwc-platform
         - nrkruk/lwc-dev-core
         - ris-gpta/core_via_components
@@ -24,7 +22,6 @@ branches:
         - salesforce-experience-platform-emu/luvio
         - salesforce-experience-platform-emu/lwr
         - salesforce/lwr-lightning-platform
-        - salesforcedevs/doc-framework-monorepo
   release:
     pull-request:
       <<: *branch-definition


### PR DESCRIPTION
## Details


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
