### PR TITLE
chore(ci): increase jasmine test timeout (backport)

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-setup.js
+++ b/packages/@lwc/integration-karma/helpers/test-setup.js
@@ -115,3 +115,6 @@ afterAll(function () {
 
     throwIfConsoleCalled();
 });
+
+// The default of 5000ms seems to get surpassed frequently in Safari in SauceLabs
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;


### PR DESCRIPTION
## Details

Backport of a test fix we did in a0bc2a6189c87708d209ae66ce1f36ee29e006e5

As it turns out, I guess Safari is really slow in SauceLabs

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
