### PR TITLE
chore: bump saucelabs tunnel version and pin platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ commands:
           name: Install and start sauce connect
           background: true
           command: |
-              curl https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz -o saucelabs.tar.gz
+              curl https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz -o saucelabs.tar.gz
               tar -xzf saucelabs.tar.gz
               cd sc-*
               bin/sc -u ${<< parameters.username >>} -k ${<< parameters.key >>} -i ${<< parameters.tunnel_id >>} -P 4445

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 orbs:
   browser-tools: circleci/browser-tools@1.4.4
+  saucectl: saucelabs/saucectl-run@2.0.0
 
 # Shared config
 ignore_forks: &ignore_forks
@@ -280,7 +281,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id	>>_test_karma
     steps:
       - load_workspace
-      - start_sauce_connect
+      - saucectl/saucectl-run
       - run_karma
       - run_karma:
           disable_synthetic: true
@@ -325,7 +326,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id >>_test_integration_prod
     steps:
       - load_workspace
-      - start_sauce_connect
+      - saucectl/saucectl-run
       - retry_command:
           command_name: Run integration test - Chrome - prod mode
           command: yarn sauce:prod --browsers chrome
@@ -337,7 +338,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id >>_test_integration_dev
     steps:
       - load_workspace
-      - start_sauce_connect
+      - saucectl/saucectl-run
       - retry_command:
           command_name: Run integration test - Chrome - dev mode
           command: yarn sauce:dev --browsers chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 orbs:
   browser-tools: circleci/browser-tools@1.4.4
-  saucectl: saucelabs/saucectl-run@2.0.0
 
 # Shared config
 ignore_forks: &ignore_forks
@@ -281,7 +280,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id	>>_test_karma
     steps:
       - load_workspace
-      - saucectl/saucectl-run
+      - start_sauce_connect
       - run_karma
       - run_karma:
           disable_synthetic: true
@@ -326,7 +325,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id >>_test_integration_prod
     steps:
       - load_workspace
-      - saucectl/saucectl-run
+      - start_sauce_connect
       - retry_command:
           command_name: Run integration test - Chrome - prod mode
           command: yarn sauce:prod --browsers chrome
@@ -338,7 +337,7 @@ jobs:
       SAUCE_TUNNEL_ID: lwc_<< pipeline.id >>_test_integration_dev
     steps:
       - load_workspace
-      - saucectl/saucectl-run
+      - start_sauce_connect
       - retry_command:
           command_name: Run integration test - Chrome - dev mode
           command: yarn sauce:dev --browsers chrome

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -16,27 +16,36 @@ require('dotenv').config({
 
 const baseConfig = require('./wdio.conf.js');
 
+// #TODO[3754]: Only Chrome on Windows platform currently works, all other browser tests fail.
+// Need to investigate why sauce labs fails for all other platforms.
 const browsers = [
     // Note that headless Chrome also needs to be updated in wdio.conf.js for non-SauceLabs runs
     {
         commonName: 'chrome',
         browserName: 'chrome',
         version: 'latest',
+        // Note chrome fails for Linux and macOS
+        platform: 'Windows 11',
     },
     {
         commonName: 'edge',
         browserName: 'MicrosoftEdge',
         version: 'latest',
+        platform: 'Windows 11',
     },
     {
         commonName: 'safari',
         browserName: 'safari',
         version: 'latest',
+        // Note safari fails for macOS
+        platform: 'macOS 13',
     },
     {
         commonName: 'firefox',
         browserName: 'firefox',
         version: 'latest',
+        // Note firefox is failing for both Linux and Windows 11
+        platform: 'Windows 11',
     },
 ];
 

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -16,7 +16,7 @@ require('dotenv').config({
 
 const baseConfig = require('./wdio.conf.js');
 
-// #TODO[3754]: Only Chrome on Windows platform currently works, all other browser tests fail.
+// #TODO[3754]: Only Chrome and Edge on Windows platform currently works, all other browser tests fail.
 // Need to investigate why sauce labs fails for all other platforms.
 const browsers = [
     // Note that headless Chrome also needs to be updated in wdio.conf.js for non-SauceLabs runs


### PR DESCRIPTION
## Details
Bump saucelabs tunnel version from 4.6.2 (deprecated) > 4.9.1.

Also pin the platform version per browser for saucelabs tests.

## Does this pull request introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.