### PR TITLE
feat: add timsort 

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -44,7 +44,8 @@
     "dependencies": {
         "@lwc/aria-reflection": "3.5.0",
         "@lwc/features": "3.5.0",
-        "@lwc/shared": "3.5.0"
+        "@lwc/shared": "3.5.0",
+        "timsort": "0.3.0"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import timsort from 'timsort';
+
 import {
     ArrayPush,
     ArraySlice,
@@ -603,7 +605,7 @@ function flushRehydrationQueue() {
             `If rehydrateQueue was scheduled, it is because there must be at least one VM on this pending queue instead of ${rehydrateQueue}.`
         );
     }
-    const vms = rehydrateQueue.sort((a: VM, b: VM): number => a.idx - b.idx);
+    const vms = timsort.sort(rehydrateQueue, (a: VM, b: VM): number => a.idx - b.idx);
     rehydrateQueue = []; // reset to a new queue
     for (let i = 0, len = vms.length; i < len; i += 1) {
         const vm = vms[i];


### PR DESCRIPTION
## Details

I looked for places where `Array.prototype.sort` was used at runtime and then added this algorithm because it is the fastest sorting algorithm in js https://www.npmjs.com/package/timsort.

I'm not sure:
- does timsort algorithm make any difference where I added it? My computer can't run the benchmarks :(
- are there other places we could use it that would make a difference?
- how can we be sure that this algorithm works on all browsers?
- should it be added in the `shared` package ?


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
N/A