### PR TITLE
fix(engine-core): fix subclass not inheriting `@api` in dev mode

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -138,7 +138,8 @@ export function HTMLBridgeElementFactory(
     publicProperties: string[],
     methods: string[],
     observedFields: string[],
-    proto: LightningElement | null
+    proto: LightningElement | null,
+    hasCustomSuperClass: boolean
 ): HTMLElementConstructor {
     const HTMLBridgeElement = class extends SuperClass {};
     // generating the hash table for attributes to avoid duplicate fields and facilitate validation
@@ -150,7 +151,8 @@ export function HTMLBridgeElementFactory(
 
     // present a hint message so that developers are aware that they have not decorated property with @api
     if (process.env.NODE_ENV !== 'production') {
-        if (!isUndefined(proto) && !isNull(proto)) {
+        // TODO [#3761]: enable for components that don't extend from LightningElement
+        if (!isUndefined(proto) && !isNull(proto) && !hasCustomSuperClass) {
             const nonPublicPropertiesToWarnOn = new Set(
                 [
                     // getters, setters, and methods
@@ -253,7 +255,8 @@ export const BaseBridgeElement = HTMLBridgeElementFactory(
     getOwnPropertyNames(HTMLElementOriginalDescriptors),
     [],
     [],
-    null
+    null,
+    false
 );
 
 if (process.env.IS_BROWSER) {

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -158,14 +158,15 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         render,
     } = proto;
     const superProto = getCtorProto(Ctor);
-    const superDef =
-        superProto !== LightningElement ? getComponentInternalDef(superProto) : lightingElementDef;
+    const hasCustomSuperClass = superProto !== LightningElement;
+    const superDef = hasCustomSuperClass ? getComponentInternalDef(superProto) : lightingElementDef;
     const bridge = HTMLBridgeElementFactory(
         superDef.bridge,
         keys(apiFields),
         keys(apiMethods),
         keys(observedFields),
-        proto
+        proto,
+        hasCustomSuperClass
     );
     const props: PropertyDescriptorMap = assign(create(null), superDef.props, apiFields);
     const propsConfig = assign(create(null), superDef.propsConfig, apiFieldsConfig);

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
@@ -1,0 +1,73 @@
+import { createElement } from 'lwc';
+import SuperSuperClass from 'x/superSuperClass';
+import SuperClass from 'x/superClass';
+import SubClass from 'x/subClass';
+
+describe('api decorator with superclasses', () => {
+    let superSuperClass;
+    let superClass;
+    let subClass;
+
+    beforeEach(() => {
+        superSuperClass = createElement('x-super-super-class', { is: SuperSuperClass });
+        superClass = createElement('x-super-class', { is: SuperClass });
+        subClass = createElement('x-sub-class', { is: SubClass });
+
+        document.body.appendChild(superSuperClass);
+        document.body.appendChild(superClass);
+        document.body.appendChild(subClass);
+    });
+
+    const variants = ['omit', 'public', 'private'];
+
+    const capitalize = (str) => str.charAt(0).toUpperCase() + str.substring(1);
+
+    for (const superSuperClassVariant of variants) {
+        for (const superClassVariant of variants) {
+            for (const subClassVariant of variants) {
+                describe(`superSuperClassVariant=${superSuperClassVariant}, superClassVariant=${superClassVariant}, subClassVariant=${subClassVariant}`, () => {
+                    const methodName = `method${capitalize(superSuperClassVariant)}${capitalize(
+                        superClassVariant
+                    )}${capitalize(subClassVariant)}`;
+
+                    const testElement = (elm, expectThrow) => {
+                        if (expectThrow) {
+                            expect(elm[methodName]).toBeUndefined();
+                            expect(() => {
+                                elm[methodName]();
+                            }).toThrow();
+                        } else {
+                            elm[methodName]();
+                        }
+                    };
+
+                    it('call on subClass', () => {
+                        // TODO [#3762]: components should not "inherit" @api from their superclasses
+                        const expectThrow = ![
+                            subClassVariant,
+                            superClassVariant,
+                            superSuperClassVariant,
+                        ].includes('public');
+
+                        testElement(subClass, expectThrow);
+                    });
+
+                    it('call on superClass', () => {
+                        // TODO [#3762]: components should not "inherit" @api from their superclasses
+                        const expectThrow = ![superClassVariant, superSuperClassVariant].includes(
+                            'public'
+                        );
+
+                        testElement(superClass, expectThrow);
+                    });
+
+                    it('call on superSuperClass', () => {
+                        const expectThrow = superSuperClassVariant !== 'public';
+
+                        testElement(superSuperClass, expectThrow);
+                    });
+                });
+            }
+        }
+    }
+});

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
@@ -61,6 +61,8 @@ describe('api decorator with superclasses', () => {
                         ].includes('public');
                         // TODO [#3761]: components that don't extend LightningElement should warn for missing @api
                         // These cases are very inconsistent, but this is the current behavior
+                        // Basically, the warning accessor is only placed on the SuperSuperClass (because it
+                        // extends from LightningElement) and is invoked for each call to the private methods
                         const expectWarn =
                             subClassVariant !== 'public' &&
                             superClassVariant !== 'public' &&

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/index.spec.js
@@ -62,12 +62,9 @@ describe('api decorator with superclasses', () => {
                         // TODO [#3761]: components that don't extend LightningElement should warn for missing @api
                         // These cases are very inconsistent, but this is the current behavior
                         const expectWarn =
-                            (subClassVariant === 'omit' &&
-                                superSuperClassVariant === 'private' &&
-                                superClassVariant !== 'public') ||
-                            (subClassVariant === 'private' &&
-                                superClassVariant !== 'public' &&
-                                superSuperClassVariant === 'private');
+                            subClassVariant !== 'public' &&
+                            superClassVariant !== 'public' &&
+                            superSuperClassVariant === 'private';
 
                         testElement(subClass, expectUndefined, expectWarn);
                     });

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/subClass/subClass.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/subClass/subClass.js
@@ -1,0 +1,49 @@
+import { api } from 'lwc';
+
+import SuperClass from 'x/superClass';
+export default class extends SuperClass {
+    @api
+    methodOmitOmitPublic() {}
+
+    methodOmitOmitPrivate() {}
+
+    @api
+    methodOmitPublicPublic() {}
+
+    methodOmitPublicPrivate() {}
+
+    @api
+    methodOmitPrivatePublic() {}
+
+    methodOmitPrivatePrivate() {}
+
+    @api
+    methodPublicOmitPublic() {}
+
+    methodPublicOmitPrivate() {}
+
+    @api
+    methodPublicPublicPublic() {}
+
+    methodPublicPublicPrivate() {}
+
+    @api
+    methodPublicPrivatePublic() {}
+
+    methodPublicPrivatePrivate() {}
+
+    @api
+    methodPrivateOmitPublic() {}
+
+    methodPrivateOmitPrivate() {}
+
+    @api
+    methodPrivatePublicPublic() {}
+
+    methodPrivatePublicPrivate() {}
+
+    @api
+    methodPrivatePrivatePublic() {}
+
+    methodPrivatePrivatePrivate() {}
+}

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/superClass/superClass.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/superClass/superClass.js
@@ -1,0 +1,49 @@
+import { api } from 'lwc';
+
+import SuperSuperClass from 'x/superSuperClass';
+export default class extends SuperSuperClass {
+    @api
+    methodOmitPublicOmit() {}
+
+    @api
+    methodOmitPublicPublic() {}
+
+    @api
+    methodOmitPublicPrivate() {}
+
+    methodOmitPrivateOmit() {}
+
+    methodOmitPrivatePublic() {}
+
+    methodOmitPrivatePrivate() {}
+
+    @api
+    methodPublicPublicOmit() {}
+
+    @api
+    methodPublicPublicPublic() {}
+
+    @api
+    methodPublicPublicPrivate() {}
+
+    methodPublicPrivateOmit() {}
+
+    methodPublicPrivatePublic() {}
+
+    methodPublicPrivatePrivate() {}
+
+    @api
+    methodPrivatePublicOmit() {}
+
+    @api
+    methodPrivatePublicPublic() {}
+
+    @api
+    methodPrivatePublicPrivate() {}
+
+    methodPrivatePrivateOmit() {}
+
+    methodPrivatePrivatePublic() {}
+
+    methodPrivatePrivatePrivate() {}
+}

--- a/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/superSuperClass/superSuperClass.js
+++ b/packages/@lwc/integration-karma/test/component/api-with-superclasses/x/superSuperClass/superSuperClass.js
@@ -1,0 +1,49 @@
+import { api } from 'lwc';
+
+import { LightningElement } from 'lwc';
+export default class extends LightningElement {
+    @api
+    methodPublicOmitOmit() {}
+
+    @api
+    methodPublicOmitPublic() {}
+
+    @api
+    methodPublicOmitPrivate() {}
+
+    @api
+    methodPublicPublicOmit() {}
+
+    @api
+    methodPublicPublicPublic() {}
+
+    @api
+    methodPublicPublicPrivate() {}
+
+    @api
+    methodPublicPrivateOmit() {}
+
+    @api
+    methodPublicPrivatePublic() {}
+
+    @api
+    methodPublicPrivatePrivate() {}
+
+    methodPrivateOmitOmit() {}
+
+    methodPrivateOmitPublic() {}
+
+    methodPrivateOmitPrivate() {}
+
+    methodPrivatePublicOmit() {}
+
+    methodPrivatePublicPublic() {}
+
+    methodPrivatePublicPrivate() {}
+
+    methodPrivatePrivateOmit() {}
+
+    methodPrivatePrivatePublic() {}
+
+    methodPrivatePrivatePrivate() {}
+}


### PR DESCRIPTION
## Details

Fixes #3758

For now I am just disabling the helpful dev warnings if a component does not directly extend from `LightningElement`. I opened some other issues to track follow-up work:

- #3761
- #3762

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-14208047
