### PR TITLE
feat: adding native shadow mode support

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -123,7 +123,8 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         if (
             !isUndefined(ctorShadowSupportMode) &&
             ctorShadowSupportMode !== ShadowSupportMode.Any &&
-            ctorShadowSupportMode !== ShadowSupportMode.Default
+            ctorShadowSupportMode !== ShadowSupportMode.Default &&
+            ctorShadowSupportMode !== ShadowSupportMode.Native
         ) {
             logError(
                 `Invalid value for static property shadowSupportMode: '${ctorShadowSupportMode}'`

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -83,6 +83,7 @@ export const enum ShadowMode {
 export const enum ShadowSupportMode {
     Any = 'any',
     Default = 'reset',
+    Native = 'native',
 }
 
 export const enum LwcDomMode {
@@ -473,8 +474,14 @@ function computeShadowMode(def: ComponentDef, owner: VM | null, renderer: Render
             // ShadowMode.Native implies "not synthetic shadow" which is consistent with how
             // everything defaults to native when the synthetic shadow polyfill is unavailable.
             shadowMode = ShadowMode.Native;
-        } else if (lwcRuntimeFlags.ENABLE_MIXED_SHADOW_MODE) {
-            if (def.shadowSupportMode === ShadowSupportMode.Any) {
+        } else if (
+            lwcRuntimeFlags.ENABLE_MIXED_SHADOW_MODE ||
+            def.shadowSupportMode === ShadowSupportMode.Native
+        ) {
+            if (
+                def.shadowSupportMode === ShadowSupportMode.Any ||
+                def.shadowSupportMode === ShadowSupportMode.Native
+            ) {
                 shadowMode = ShadowMode.Native;
             } else {
                 const shadowAncestor = getNearestShadowAncestor(owner);

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -3,6 +3,7 @@ import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-
 
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
+import NativeOnly from 'x/native';
 
 describe('shadowSupportMode static property', () => {
     it('should log error for invalid values', () => {
@@ -38,5 +39,22 @@ describe('ENABLE_MIXED_SHADOW_MODE', () => {
 
     afterEach(() => {
         setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
+    });
+});
+
+describe('ENABLE_NATIVE_SHADOW_MODE', () => {
+    it('should be configured as "native" (sanity)', () => {
+        expect(NativeOnly.shadowSupportMode === 'native').toBeTrue();
+    });
+
+    it('should render native shadow root', () => {
+        const elm = createElement('x-native-only', { is: NativeOnly });
+        if (process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+            expect(isNativeShadowRootInstance(elm.shadowRoot)).toBeTrue();
+        } else {
+            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toThrow(
+                'Native shadow is not supported on this enviroment'
+            );
+        }
     });
 });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/native/native.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/native/native.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'native';
+}


### PR DESCRIPTION
## Details

Introduces renderMode = native for semantic rendering of native only components

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.



## Does this pull request introduce an observable change?


* ✅ No, it does not introduce an observable change.

## GUS work item
W-14092474

