### PR TITLE
feat: add generic types for wires

### DIFF
--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -203,7 +203,7 @@ declare module 'lwc' {
 
     type LegacyWireAdapterConstructor<Config = any, Value = any> = (config?: Config) => Value;
     type WireConfigValue<Config extends object = Record<string, any>> = {
-        [K in keyof Config]: Config[K];
+        [K in keyof Config]: Config[K] | string;
     };
     type ContextValue<Context extends object = Record<string, any>> = Partial<
         Record<keyof Context, any>

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -191,10 +191,16 @@ declare module 'lwc' {
 
     /**
      * Decorator factory to wire a property or method to a wire adapter data source
+     * Use generic types to allow type checking for wire adapters
+     * Default all the generic types to any to maintain backward compatibility
      * @param adapter the adapter used to provision data
      * @param config configuration object for the adapter
      */
-    export function wire<Config extends object = any, Value = any, Context extends object = any>(
+    export function wire<
+        Config extends Record<string, any> = any,
+        Value = any,
+        Context extends Record<string, any> = any
+    >(
         adapter:
             | WireAdapterConstructor<Config, Value, Context>
             | LegacyWireAdapterConstructor<Config, Value>,
@@ -203,11 +209,10 @@ declare module 'lwc' {
 
     type LegacyWireAdapterConstructor<Config = any, Value = any> = (config?: Config) => Value;
     type WireConfigValue<Config extends object = Record<string, any>> = {
+        // wire reactive variables are strings prefixed with '$' so the config value can just be string
         [K in keyof Config]: Config[K] | string;
     };
-    type ContextValue<Context extends object = Record<string, any>> = Partial<
-        Record<keyof Context, any>
-    >;
+    type ContextValue<Context extends object = Record<string, any>> = Context;
 
     interface WireAdapter<Config extends object = any, Context extends object = any> {
         update(config: WireConfigValue<Config>, context?: ContextValue<Context>): void;

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -189,6 +189,7 @@ declare module 'lwc' {
      */
     export const track: PropertyDecorator;
 
+    type StringKeyedRecord = Record<string, any>;
     /**
      * Decorator factory to wire a property or method to a wire adapter data source
      * Use generic types to allow type checking for wire adapters
@@ -205,9 +206,9 @@ declare module 'lwc' {
      * @param config configuration object for the adapter
      */
     export function wire<
-        Config extends Record<string, any> = any,
+        Config extends StringKeyedRecord = any,
         Value = any,
-        Context extends Record<string, any> = any
+        Context extends StringKeyedRecord = any
     >(
         adapter:
             | WireAdapterConstructor<Config, Value, Context>
@@ -216,13 +217,16 @@ declare module 'lwc' {
     ): PropertyDecorator;
 
     type LegacyWireAdapterConstructor<Config = any, Value = any> = (config?: Config) => Value;
-    type WireConfigValue<Config extends object = Record<string, any>> = {
+    type WireConfigValue<Config extends StringKeyedRecord = StringKeyedRecord> = {
         // wire reactive variables are strings prefixed with '$' so the config value can just be string
         [K in keyof Config]: Config[K] | string;
     };
-    type ContextValue<Context extends object = Record<string, any>> = Context;
+    type ContextValue<Context extends StringKeyedRecord = StringKeyedRecord> = Context;
 
-    interface WireAdapter<Config extends object = any, Context extends object = any> {
+    interface WireAdapter<
+        Config extends StringKeyedRecord = any,
+        Context extends StringKeyedRecord = any
+    > {
         update(config: WireConfigValue<Config>, context?: ContextValue<Context>): void;
         connect(): void;
         disconnect(): void;
@@ -231,32 +235,32 @@ declare module 'lwc' {
     type WireDataCallback<Value = any> = (value: Value) => void;
     type WireAdapterSchemaValue = 'optional' | 'required';
 
-    interface ContextConsumer<Context extends object = any> {
+    interface ContextConsumer<Context extends StringKeyedRecord = any> {
         provide(newContext: ContextValue<Context>): void;
     }
 
-    interface ContextProviderOptions<Context extends object = any> {
+    interface ContextProviderOptions<Context extends StringKeyedRecord = any> {
         consumerConnectedCallback: (consumer: ContextConsumer<Context>) => void;
         consumerDisconnectedCallback?: (consumer: ContextConsumer<Context>) => void;
     }
 
     interface WireAdapterConstructor<
-        Config extends object = any,
+        Config extends StringKeyedRecord = any,
         Value = any,
-        Context extends object = any
+        Context extends StringKeyedRecord = any
     > {
         new (callback: WireDataCallback<Value>): WireAdapter<Config, Context>;
         configSchema?: Record<keyof Config, WireAdapterSchemaValue>;
         contextSchema?: Record<keyof Context, WireAdapterSchemaValue>;
     }
 
-    type Contextualizer<Context extends object = any> = (
+    type Contextualizer<Context extends StringKeyedRecord = any> = (
         elm: EventTarget,
         options: ContextProviderOptions<Context>
     ) => void;
     export function createContextProvider<
-        Config extends object = any,
+        Config extends StringKeyedRecord = any,
         Value = any,
-        Context extends object = any
+        Context extends StringKeyedRecord = any
     >(config: WireAdapterConstructor<Config, Value, Context>): Contextualizer<Context>;
 }

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -193,6 +193,14 @@ declare module 'lwc' {
      * Decorator factory to wire a property or method to a wire adapter data source
      * Use generic types to allow type checking for wire adapters
      * Default all the generic types to any to maintain backward compatibility
+     *
+     * For example, a wire adapter 'getRecord' can have the following type definition
+     *
+     * export const getRecord: WireAdapterConstructor<GetRecordConfig, RecordRepresentation>;
+     *
+     * in which 'GetRecordConfig' is the adapter config object type and 'RecordRepresentation'
+     * is the returned value.
+     *
      * @param adapter the adapter used to provision data
      * @param config configuration object for the adapter
      */


### PR DESCRIPTION
## Details
Add generic types for wires so that wire adapter authors can specify the types of a wire adapter and this can enable type checking for wire adapters. Setting all the default types to `any` so that it should be backward compatible. 

For example, a wire adapter author can have the following
```
export const getRecord: WireAdapterConstructor<GetRecordConfig, GetRecordPayload>;
```
so that users of `getRecord` can have type checking for the config object type `GetRecordConfig` and potentially the payload object `GetRecordPayload`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
