### PR TITLE
fix: move parse5 to devDeps

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -47,12 +47,12 @@
         "acorn": "~8.10.0",
         "astring": "~1.8.6",
         "estree-walker": "~2.0.2",
-        "he": "~1.2.0",
-        "parse5": "~7.1.2"
+        "he": "~1.2.0"
     },
     "devDependencies": {
         "@types/estree": "1.0.2",
         "@types/he": "^1.2.1",
-        "@types/source-map": "0.5.7"
+        "@types/source-map": "0.5.7",
+        "parse5": "~7.1.2"
     }
 }


### PR DESCRIPTION
## Details
As part of [the upgrade to v7](https://github.com/salesforce/lwc/pull/3602), the parse5 dependency should be moved to `devDependencies` so that it is properly inlined into the dist/ bundles.

https://github.com/salesforce/lwc/blob/1c1687e0afaa715287b119064237803f9df1cf5d/scripts/rollup/rollup.config.js#L133-L138

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
