### PR TITLE
test: fix aria tests in Firefox Nightly

### DIFF
--- a/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
@@ -134,10 +134,13 @@ describe('global html properties', () => {
         // Return the expected property value when no setter has been called
         const getDefaultPropertyValue = () => {
             switch (propName) {
+                case 'role':
                 case 'spellcheck':
                 case 'tabIndex':
                     // For spellcheck, Firefox returns false, Chrome/Safari returns true
                     // For tabIndex, IE11 returns 0 and the others return -1
+                    // For role, Firefox returns empty string, Chrome/Safari return null
+                    // https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
                     return document.createElement('div')[propName];
                 case 'draggable':
                 case 'hidden':
@@ -148,8 +151,6 @@ describe('global html properties', () => {
                 case 'id':
                 case 'lang':
                     return '';
-                case 'role':
-                    return null;
                 case 'title':
                     return '';
                 default:

--- a/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
@@ -134,13 +134,10 @@ describe('global html properties', () => {
         // Return the expected property value when no setter has been called
         const getDefaultPropertyValue = () => {
             switch (propName) {
-                case 'role':
                 case 'spellcheck':
                 case 'tabIndex':
                     // For spellcheck, Firefox returns false, Chrome/Safari returns true
                     // For tabIndex, IE11 returns 0 and the others return -1
-                    // For role, Firefox returns empty string, Chrome/Safari return null
-                    // https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
                     return document.createElement('div')[propName];
                 case 'draggable':
                 case 'hidden':
@@ -151,6 +148,12 @@ describe('global html properties', () => {
                 case 'id':
                 case 'lang':
                     return '';
+                case 'role':
+                    // For role, Firefox returns empty string when supported. Chrome/Safari return null
+                    // https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
+                    return 'role' in HTMLElement.prototype
+                        ? document.createElement('div').role
+                        : null;
                 case 'title':
                     return '';
                 default:

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -14,16 +14,10 @@ function testAriaProperty(property, attribute) {
             reportingControl.detachDispatcher();
         });
 
-        const standardAriaPropToDefaultValue = Object.fromEntries(
-            Object.keys(ariaPropertiesMapping)
-                .filter((prop) => !nonStandardAriaProperties.includes(prop))
-                .map((prop) => {
-                    const div = document.createElement('div');
-                    // Usually null, but undefined in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
-                    const defaultValue = div[prop];
-                    return [prop, defaultValue];
-                })
-        );
+        function getDefaultValue(prop) {
+            const div = document.createElement('div');
+            return div[prop];
+        }
 
         function expectWarningIfNonStandard(callback) {
             // eslint-disable-next-line jest/valid-expect
@@ -78,12 +72,11 @@ function testAriaProperty(property, attribute) {
 
         it(`should return default value if the value is not set`, () => {
             const el = document.createElement('div');
+            // Our polyfill always returns null, Firefox may return undefined
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
+            const expectedDefaultValue = isNative ? getDefaultValue(property) : null;
             expectWarningIfNonStandard(() => {
-                expect(el[property]).toBe(
-                    property in standardAriaPropToDefaultValue
-                        ? standardAriaPropToDefaultValue[property]
-                        : null
-                );
+                expect(el[property]).toBe(expectedDefaultValue);
             });
             expectGetterReportIfNonStandard();
         });

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -134,13 +134,19 @@ function testAriaProperty(property, attribute) {
             if (settingValueRemoves(undefined)) {
                 // Native Webkit/Chromium – setting undefined is treated the same as null
                 falsyValuesThatRemove.push(undefined);
+            } else {
+                falsyValuesThatDoNotRemove.push(undefined);
             }
             if (settingValueRemoves(null)) {
                 // As of this writing, Firefox is inconsistent with Chromium/WebKit and treats setting undefined/null
                 // as setting a string value: https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
                 falsyValuesThatRemove.push(null);
+            } else {
+                falsyValuesThatDoNotRemove.push(null);
             }
         } else {
+            // Our polyfill - null removes
+            falsyValuesThatRemove.push(null);
             // Our polyfill – setting undefined is not treated like null
             falsyValuesThatDoNotRemove.push(undefined);
         }


### PR DESCRIPTION
## Details

Firefox 119 ([scheduled](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no) to be released on October 24th) will potentially contain [a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1853209) that will break a bunch of our ARIA reflection tests. Rather than wait to be broken, let's proactively make these tests resilient to Firefox 119.

Note that I didn't bother to add Firefox Nightly to our test matrix, because I don't think it's worth it to run in CI every time. So you'll have to believe me that these new tests pass. 🙃 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
