### PR TITLE
fix(engine-core): fix timing of ref resets

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -221,7 +221,7 @@ function hydrateStaticElement(elm: Node, vnode: VStatic, renderer: RendererAPI):
 
     vnode.elm = elm;
 
-    applyStaticParts(elm, vnode, renderer);
+    applyStaticParts(elm, vnode, renderer, true);
 
     return elm;
 }

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -31,6 +31,7 @@ import {
     LwcDomMode,
     VM,
     runRenderedCallback,
+    resetRefVNodes,
 } from './vm';
 import {
     VNodes,
@@ -79,6 +80,9 @@ export function hydrateRoot(vm: VM) {
 function hydrateVM(vm: VM) {
     const children = renderComponent(vm);
     vm.children = children;
+
+    // reset the refs; they will be set during `hydrateChildren`
+    resetRefVNodes(vm);
 
     const {
         renderRoot: parentNode,

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -72,8 +72,14 @@ function traverseAndSetElements(root: Element, parts: VStaticPart[], renderer: R
  * @param root - the root element
  * @param vnode - the parent VStatic
  * @param renderer - the renderer to use
+ * @param mount - true this is a first (mount) render as opposed to a subsequent (patch) render
  */
-export function applyStaticParts(root: Element, vnode: VStatic, renderer: RendererAPI): void {
+export function applyStaticParts(
+    root: Element,
+    vnode: VStatic,
+    renderer: RendererAPI,
+    mount: boolean
+): void {
     // On the server, we don't support ref (because it relies on renderedCallback), nor do we
     // support event listeners (no interactivity), so traversing parts makes no sense
     if (!process.env.IS_BROWSER) {
@@ -87,9 +93,11 @@ export function applyStaticParts(root: Element, vnode: VStatic, renderer: Render
     traverseAndSetElements(root, parts, renderer); // this adds `part.elm` to each `part`
 
     for (const part of parts) {
-        // Event listeners are only applied once when mounting, so they are allowed for static vnodes
-        applyEventListeners(part, renderer);
-        // Refs are allowed as well
+        if (mount) {
+            // Event listeners are only applied once when mounting, so they are allowed for static vnodes
+            applyEventListeners(part, renderer);
+        }
+        // Refs are allowed as well, and must be updated after every render
         applyRefs(part, owner);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -92,6 +92,7 @@ export function applyStaticParts(
 
     // This adds `part.elm` to each `part`. We have to do this on every mount/patch because the `parts`
     // array is recreated from scratch every time, so each `part.elm` is now undefined.
+    // TODO [#3800]: avoid calling traverseAndSetElements on every re-render
     traverseAndSetElements(root, parts, renderer);
 
     // Currently only event listeners and refs are supported for static vnodes

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -90,14 +90,17 @@ export function applyStaticParts(
         return;
     }
 
-    traverseAndSetElements(root, parts, renderer); // this adds `part.elm` to each `part`
+    // This adds `part.elm` to each `part`. We have to do this on every mount/patch because the `parts`
+    // array is recreated from scratch every time, so each `part.elm` is now undefined.
+    traverseAndSetElements(root, parts, renderer);
 
+    // Currently only event listeners and refs are supported for static vnodes
     for (const part of parts) {
         if (mount) {
-            // Event listeners are only applied once when mounting, so they are allowed for static vnodes
+            // Event listeners only need to be applied once when mounting
             applyEventListeners(part, renderer);
         }
-        // Refs are allowed as well, and must be updated after every render
+        // Refs must be updated after every render due to refVNodes getting reset before every render
         applyRefs(part, owner);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -124,7 +124,7 @@ function patch(n1: VNode, n2: VNode, parent: ParentNode, renderer: RendererAPI) 
             break;
 
         case VNodeType.Static:
-            n2.elm = (n1 as VStatic).elm;
+            patchStatic(n1 as VStatic, n2, renderer);
             break;
 
         case VNodeType.Fragment:
@@ -268,6 +268,13 @@ function mountElement(
     mountVNodes(vnode.children, elm, renderer, null);
 }
 
+function patchStatic(n1: VStatic, n2: VStatic, renderer: RendererAPI) {
+    const elm = (n2.elm = n1.elm!);
+
+    // The `refs` object is blown away in every re-render, so we always need to re-apply them
+    applyStaticParts(elm, n2, renderer, false);
+}
+
 function patchElement(n1: VElement, n2: VElement, renderer: RendererAPI) {
     const elm = (n2.elm = n1.elm!);
 
@@ -298,7 +305,7 @@ function mountStatic(
     }
 
     insertNode(elm, parent, anchor, renderer);
-    applyStaticParts(elm, vnode, renderer);
+    applyStaticParts(elm, vnode, renderer, true);
 }
 
 function mountCustomElement(

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -283,9 +283,6 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                     setActiveVM(vm);
                 }
 
-                // reset the refs; they will be set during the tmpl() instantiation
-                vm.refVNodes = html.hasRefs ? create(null) : null;
-
                 // right before producing the vnodes, we clear up all internal references
                 // to custom elements from the template.
                 vm.velements = [];

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -546,7 +546,10 @@ function rehydrate(vm: VM) {
 }
 
 function patchShadowRoot(vm: VM, newCh: VNodes) {
-    const { renderRoot, children: oldCh, renderer } = vm;
+    const { renderRoot, children: oldCh, renderer, cmpTemplate } = vm;
+
+    // reset the refs; they will be set during `patchChildren`
+    vm.refVNodes = !isNull(cmpTemplate) && cmpTemplate.hasRefs ? create(null) : null;
 
     // caching the new children collection
     vm.children = newCh;

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -546,10 +546,10 @@ function rehydrate(vm: VM) {
 }
 
 function patchShadowRoot(vm: VM, newCh: VNodes) {
-    const { renderRoot, children: oldCh, renderer, cmpTemplate } = vm;
+    const { renderRoot, children: oldCh, renderer } = vm;
 
     // reset the refs; they will be set during `patchChildren`
-    vm.refVNodes = !isNull(cmpTemplate) && cmpTemplate.hasRefs ? create(null) : null;
+    resetRefVNodes(vm);
 
     // caching the new children collection
     vm.children = newCh;
@@ -926,4 +926,9 @@ export function runFormStateRestoreCallback(elm: HTMLElement) {
     if (!isUndefined(formStateRestoreCallback)) {
         runFormAssociatedCustomElementCallback(vm, formStateRestoreCallback);
     }
+}
+
+export function resetRefVNodes(vm: VM) {
+    const { cmpTemplate } = vm;
+    vm.refVNodes = !isNull(cmpTemplate) && cmpTemplate.hasRefs ? create(null) : null;
 }

--- a/packages/@lwc/integration-karma/test/component/refs/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/refs/index.spec.js
@@ -27,6 +27,7 @@ import Slotter from 'x/slotter';
 import AccessDuringRender from 'x/accessDuringRender';
 import RerenderElement from 'x/rerenderElement';
 import RerenderComponent from 'x/rerenderComponent';
+import RerenderElementStaticRef from 'x/RerenderElementStaticRef';
 
 describe('refs', () => {
     describe('basic refs example', () => {
@@ -321,6 +322,7 @@ describe('refs', () => {
             expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('div'));
             for (let i = 0; i < 3; i++) {
                 elm.version = i;
+                expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('div'));
                 await Promise.resolve();
                 expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('div'));
             }
@@ -333,8 +335,30 @@ describe('refs', () => {
             expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('x-rerender-element'));
             for (let i = 0; i < 3; i++) {
                 elm.version = i;
+                expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('x-rerender-element'));
                 await Promise.resolve();
                 expect(elm.getRef('foo')).toBe(elm.shadowRoot.querySelector('x-rerender-element'));
+            }
+        });
+
+        it('element with a different static ref', async () => {
+            const elm = createElement('x-rerender-element-static-ref', {
+                is: RerenderElementStaticRef,
+            });
+            document.body.appendChild(elm);
+
+            await Promise.resolve();
+
+            const fooDiv = elm.getRef('foo');
+            expect(fooDiv).not.toBeUndefined();
+
+            expect(elm.getRef('foo')).toBe(fooDiv);
+            await Promise.resolve();
+            for (let i = 0; i < 3; i++) {
+                elm.version = i;
+                expect(elm.getRef('foo')).toBe(fooDiv);
+                await Promise.resolve();
+                expect(elm.getRef('foo')).toBe(fooDiv);
             }
         });
     });

--- a/packages/@lwc/integration-karma/test/component/refs/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/refs/index.spec.js
@@ -27,7 +27,7 @@ import Slotter from 'x/slotter';
 import AccessDuringRender from 'x/accessDuringRender';
 import RerenderElement from 'x/rerenderElement';
 import RerenderComponent from 'x/rerenderComponent';
-import RerenderElementStaticRef from 'x/RerenderElementStaticRef';
+import RerenderElementStaticRef from 'x/rerenderElementStaticRef';
 
 describe('refs', () => {
     describe('basic refs example', () => {

--- a/packages/@lwc/integration-karma/test/component/refs/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/refs/index.spec.js
@@ -352,7 +352,6 @@ describe('refs', () => {
             const fooDiv = elm.getRef('foo');
             expect(fooDiv).not.toBeUndefined();
 
-            expect(elm.getRef('foo')).toBe(fooDiv);
             await Promise.resolve();
             for (let i = 0; i < 3; i++) {
                 elm.version = i;

--- a/packages/@lwc/integration-karma/test/component/refs/x/rerenderElementStaticRef/rerenderElementStaticRef.html
+++ b/packages/@lwc/integration-karma/test/component/refs/x/rerenderElementStaticRef/rerenderElementStaticRef.html
@@ -1,0 +1,4 @@
+<template>
+    <div>{version}</div>
+    <div lwc:ref="foo"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/component/refs/x/rerenderElementStaticRef/rerenderElementStaticRef.js
+++ b/packages/@lwc/integration-karma/test/component/refs/x/rerenderElementStaticRef/rerenderElementStaticRef.js
@@ -1,0 +1,11 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    version = 0;
+
+    @api
+    getRef(name) {
+        return this.refs[name];
+    }
+}

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -11,6 +11,7 @@ import StaticUnsafeTopLevel from 'x/staticUnsafeTopLevel';
 import OnlyEventListener from 'x/onlyEventListener';
 import OnlyEventListenerChild from 'x/onlyEventListenerChild';
 import OnlyEventListenerGrandchild from 'x/onlyEventListenerGrandchild';
+import ListenerStaticWithUpdates from 'x/listenerStaticWithUpdates';
 
 if (!process.env.NATIVE_SHADOW) {
     describe('Mixed mode for static content', () => {
@@ -342,5 +343,32 @@ describe('static optimization with event listeners', () => {
                 expect(dispatcher.calls.count()).toBe(2);
             });
         });
+    });
+});
+
+describe('event listeners on static nodes when other nodes are updated', () => {
+    it('event listeners work after updates', async () => {
+        const elm = createElement('x-listener-static-with-updates', {
+            is: ListenerStaticWithUpdates,
+        });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        let expectedCount = 0;
+
+        expect(elm.fooEventCount).toBe(expectedCount);
+        elm.fireFooEvent();
+        expect(elm.fooEventCount).toBe(++expectedCount);
+
+        await Promise.resolve();
+        for (let i = 0; i < 3; i++) {
+            elm.version = i;
+            elm.fireFooEvent();
+            expect(elm.fooEventCount).toBe(++expectedCount);
+            await Promise.resolve();
+            elm.fireFooEvent();
+            expect(elm.fooEventCount).toBe(++expectedCount);
+        }
     });
 });

--- a/packages/@lwc/integration-karma/test/static-content/x/listenerStaticWithUpdates/listenerStaticWithUpdates.html
+++ b/packages/@lwc/integration-karma/test/static-content/x/listenerStaticWithUpdates/listenerStaticWithUpdates.html
@@ -1,0 +1,4 @@
+<template>
+    <div onfoo={handleFooEvent}></div>
+    <span>{version}</span>
+</template>

--- a/packages/@lwc/integration-karma/test/static-content/x/listenerStaticWithUpdates/listenerStaticWithUpdates.js
+++ b/packages/@lwc/integration-karma/test/static-content/x/listenerStaticWithUpdates/listenerStaticWithUpdates.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    fooEventCount = 0;
+
+    @api
+    version = 0;
+
+    handleFooEvent() {
+        this.fooEventCount++;
+    }
+
+    @api
+    fireFooEvent() {
+        this.template.querySelector('div').dispatchEvent(new CustomEvent('foo'));
+    }
+}


### PR DESCRIPTION
## Details

Fixes #3796

This is an alternative to #3797 – it's a fix-forward rather than a revert.

I also added in the same tests.

I guess I'm waiting to see if both PRs pass CI, and then we can decide if we want to fix-forward or revert.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
[W-14294276](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001cOeCwYAK/view)
