### PR TITLE
refactor(engine-core): allow list `ElementInternals` APIs and update type definitions

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -344,9 +344,7 @@ function isAllowedElementInternalAccessor(propertyKey: string | symbol) {
         isAllowedAccessor =
             elementInternalsAccessorAllowList.has(propertyKey) || /^aria/.test(propertyKey);
         if (!isAllowedAccessor && process.env.NODE_ENV !== 'production') {
-            logWarn(
-                'Only access to ElementInternals properties defined in the HTML spec are accessible'
-            );
+            logWarn('Only properties defined in the ElementInternals HTML spec are available.');
         }
     }
 

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -20,6 +20,7 @@ import {
     freeze,
     hasOwnProperty,
     isFunction,
+    isString,
     isNull,
     isObject,
     isUndefined,
@@ -317,11 +318,7 @@ const formAssociatedProps = new Set([
 
 // Verify that access to a form-associated property of the ElementInternals proxy has formAssociated set in the LWC.
 function verifyPropForFormAssociation(propertyKey: string | symbol, isFormAssociated: boolean) {
-    if (
-        isString(propertyKey)
-        formAssociatedProps.has(propertyKey) &&
-        !isFormAssociated
-    ) {
+    if (isString(propertyKey) && formAssociatedProps.has(propertyKey) && !isFormAssociated) {
         //Note this error message mirrors Chrome and Firefox error messages, in Safari the error is slightly different.
         throw new DOMException(
             `Failed to execute '${propertyKey}' on 'ElementInternals': The target element is not a form-associated custom element.`
@@ -383,9 +380,7 @@ function createElementInternalsProxy(
                 // Verify that formAssociated is set for form associated properties
                 verifyPropForFormAssociation(propertyKey, isFormAssociated);
                 const propertyValue = Reflect.get(target, propertyKey);
-                return isFunction(propertyValue)
-                    ? propertyValue.bind(target)
-                    : propertyValue;
+                return isFunction(propertyValue) ? propertyValue.bind(target) : propertyValue;
             }
         },
     });

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -338,7 +338,7 @@ function isAllowedElementInternalAccessor(propertyKey: string | symbol) {
     let isAllowedAccessor = false;
     // As of this writing all ElementInternal property keys as described in the spec are implemented with strings
     // in Chrome, Firefox, and Safari
-    if (typeof propertyKey === 'string') {
+    if (isString(propertyKey)) {
         // Allow list is based on HTML spec:
         // https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface
         isAllowedAccessor =

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -383,7 +383,7 @@ function createElementInternalsProxy(
                 // Verify that formAssociated is set for form associated properties
                 verifyPropForFormAssociation(propertyKey, isFormAssociated);
                 const propertyValue = Reflect.get(target, propertyKey);
-                return typeof propertyValue === 'function'
+                return isFunction(propertyValue)
                     ? propertyValue.bind(target)
                     : propertyValue;
             }

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -318,7 +318,7 @@ const formAssociatedProps = new Set([
 // Verify that access to a form-associated property of the ElementInternals proxy has formAssociated set in the LWC.
 function verifyPropForFormAssociation(propertyKey: string | symbol, isFormAssociated: boolean) {
     if (
-        typeof propertyKey == 'string' &&
+        isString(propertyKey)
         formAssociatedProps.has(propertyKey) &&
         !isFormAssociated
     ) {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -27,12 +27,12 @@ if (process.env.NATIVE_SHADOW && typeof ElementInternals !== 'undefined') {
                 // Chrome/Firefox/Safari have different messages
                 expect(() =>
                     expect(() => (elm.internals.foo = 'bar')).toLogWarningDev(
-                        /Only access to ElementInternals properties defined in the HTML spec are accessible/
+                        /Only properties defined in the ElementInternals HTML spec are available./
                     )
                 ).toThrow();
                 // Not allowed getters
                 expect(() => elm.internals.foo).toLogWarningDev(
-                    /Only access to ElementInternals properties defined in the HTML spec are accessible/
+                    /Only properties defined in the ElementInternals HTML spec are available./
                 );
                 // Allowed getter
                 expect(() => elm.internals.ariaAtomic).not.toThrow();

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -24,11 +24,12 @@ if (process.env.NATIVE_SHADOW && typeof ElementInternals !== 'undefined') {
         it('only allow listed properties accessible', () => {
             if (process.env.NODE_ENV !== 'production') {
                 // Not allowed setter
+                // Chrome/Firefox/Safari have different messages
                 expect(() =>
                     expect(() => (elm.internals.foo = 'bar')).toLogWarningDev(
                         /Only access to ElementInternals properties defined in the HTML spec are accessible/
                     )
-                ).toThrowError(/'set' on proxy: trap returned falsish for property/);
+                ).toThrow();
                 // Not allowed getters
                 expect(() => elm.internals.foo).toLogWarningDev(
                     /Only access to ElementInternals properties defined in the HTML spec are accessible/
@@ -37,9 +38,8 @@ if (process.env.NATIVE_SHADOW && typeof ElementInternals !== 'undefined') {
                 expect(() => elm.internals.ariaAtomic).not.toThrow();
             } else {
                 // Not allowed setter
-                expect(() => (elm.internals.foo = 'bar')).toThrowError(
-                    /'set' on proxy: trap returned falsish for property/
-                );
+                // Chrome/Firefox/Safari have different messages
+                expect(() => (elm.internals.foo = 'bar')).toThrow();
                 // Not allowed getters
                 expect(elm.internals.foo).toBeUndefined();
                 // Allowed getter

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -38,6 +38,7 @@ declare module 'lwc' {
         querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
         getElementsByTagName(tagNameOrWildCard: string): HTMLCollectionOf<Element>;
         getElementsByClassName(names: string): HTMLCollectionOf<Element>;
+        attachInternals(): ElementInternals;
         readonly tagName: string;
         readonly classList: DOMTokenList;
 


### PR DESCRIPTION
## Details
Fixes #3782 

Updated `ElementInternals` proxy to an allow listed set of APIs.

## Does this pull request introduce a breaking change?

* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

* ✅ No, it does not introduce an observable change.

## GUS work item
W-14260034