### PR TITLE
fix: register custom element during hydration

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -314,7 +314,8 @@ function hydrateCustomElement(
     }
 
     const { sel, mode, ctor, owner } = vnode;
-    renderer.defineCustomElement(StringToLowerCase.call(elm.tagName));
+    const { defineCustomElement, getTagName } = renderer;
+    defineCustomElement(StringToLowerCase.call(getTagName(elm)));
 
     const vm = createVM(elm, ctor, renderer, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -313,6 +313,7 @@ function hydrateCustomElement(
     }
 
     const { sel, mode, ctor, owner } = vnode;
+    renderer.getOrCreateUpgradableConstructor(elm.tagName.toLowerCase());
 
     const vm = createVM(elm, ctor, renderer, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -313,7 +313,7 @@ function hydrateCustomElement(
     }
 
     const { sel, mode, ctor, owner } = vnode;
-    renderer.getOrCreateUpgradableConstructor(elm.tagName.toLowerCase());
+    renderer.getUpgradableConstructor(elm.tagName.toLowerCase());
 
     const vm = createVM(elm, ctor, renderer, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -16,6 +16,7 @@ import {
     ArrayIncludes,
     isTrue,
     isString,
+    StringToLowerCase,
 } from '@lwc/shared';
 
 import { logError, logWarn } from '../shared/logger';
@@ -313,7 +314,7 @@ function hydrateCustomElement(
     }
 
     const { sel, mode, ctor, owner } = vnode;
-    renderer.getUpgradableConstructor(elm.tagName.toLowerCase());
+    renderer.defineCustomElement(StringToLowerCase.call(elm.tagName));
 
     const vm = createVM(elm, ctor, renderer, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -72,6 +72,11 @@ export interface RendererAPI {
         formResetCallback?: LifecycleCallback,
         formStateRestoreCallback?: LifecycleCallback
     ) => E;
+    getOrCreateUpgradableConstructor: (
+        tagName: string,
+        connectedCallback?: LifecycleCallback,
+        disconnectedCallback?: LifecycleCallback
+    ) => Function;
     ownerDocument(elm: E): Document;
     registerContextConsumer: (
         element: E,

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -72,11 +72,11 @@ export interface RendererAPI {
         formResetCallback?: LifecycleCallback,
         formStateRestoreCallback?: LifecycleCallback
     ) => E;
-    getUpgradableConstructor: (
+    defineCustomElement: (
         tagName: string,
         connectedCallback?: LifecycleCallback,
         disconnectedCallback?: LifecycleCallback
-    ) => Function;
+    ) => void;
     ownerDocument(elm: E): Document;
     registerContextConsumer: (
         element: E,

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -72,7 +72,7 @@ export interface RendererAPI {
         formResetCallback?: LifecycleCallback,
         formStateRestoreCallback?: LifecycleCallback
     ) => E;
-    getOrCreateUpgradableConstructor: (
+    getUpgradableConstructor: (
         tagName: string,
         connectedCallback?: LifecycleCallback,
         disconnectedCallback?: LifecycleCallback

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -76,7 +76,8 @@ export function hydrateComponent(
     }
 
     try {
-        renderer.defineCustomElement(StringToLowerCase.call(element.tagName));
+        const { defineCustomElement, getTagName } = renderer;
+        defineCustomElement(StringToLowerCase.call(getTagName(element)));
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -76,6 +76,7 @@ export function hydrateComponent(
     }
 
     try {
+        renderer.getOrCreateUpgradableConstructor(element.tagName.toLowerCase());
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -12,7 +12,7 @@ import {
     connectRootElement,
     getAssociatedVMIfPresent,
 } from '@lwc/engine-core';
-import { isFunction, isNull, isObject } from '@lwc/shared';
+import { StringToLowerCase, isFunction, isNull, isObject } from '@lwc/shared';
 import { renderer } from '../renderer';
 
 function resetShadowRootAndLightDom(element: Element, Ctor: typeof LightningElement) {
@@ -76,7 +76,7 @@ export function hydrateComponent(
     }
 
     try {
-        renderer.getUpgradableConstructor(element.tagName.toLowerCase());
+        renderer.defineCustomElement(StringToLowerCase.call(element.tagName));
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -76,7 +76,7 @@ export function hydrateComponent(
     }
 
     try {
-        renderer.getOrCreateUpgradableConstructor(element.tagName.toLowerCase());
+        renderer.getUpgradableConstructor(element.tagName.toLowerCase());
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -113,7 +113,7 @@ const createUpgradableConstructor = (
     return UpgradableConstructor;
 };
 
-export function getOrCreateUpgradableConstructor(
+export function getUpgradableConstructor(
     tagName: string,
     connectedCallback?: LifecycleCallback,
     disconnectedCallback?: LifecycleCallback
@@ -146,7 +146,7 @@ export const createCustomElement = (
     formResetCallback?: LifecycleCallback,
     formStateRestoreCallback?: LifecycleCallback
 ) => {
-    const UpgradableConstructor = getOrCreateUpgradableConstructor(
+    const UpgradableConstructor = getUpgradableConstructor(
         tagName,
         connectedCallback,
         disconnectedCallback

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -113,17 +113,11 @@ const createUpgradableConstructor = (
     return UpgradableConstructor;
 };
 
-export const createCustomElement = (
+export function getOrCreateUpgradableConstructor(
     tagName: string,
-    upgradeCallback: LifecycleCallback,
     connectedCallback?: LifecycleCallback,
-    disconnectedCallback?: LifecycleCallback,
-    formAssociatedCallback?: LifecycleCallback,
-    formDisabledCallback?: LifecycleCallback,
-    formResetCallback?: LifecycleCallback,
-    formStateRestoreCallback?: LifecycleCallback
-) => {
-    // use global custom elements registry
+    disconnectedCallback?: LifecycleCallback
+) {
     let UpgradableConstructor = cachedConstructors.get(tagName);
 
     if (isUndefined(UpgradableConstructor)) {
@@ -139,6 +133,24 @@ export const createCustomElement = (
         customElements.define(tagName, UpgradableConstructor);
         cachedConstructors.set(tagName, UpgradableConstructor);
     }
+    return UpgradableConstructor;
+}
+
+export const createCustomElement = (
+    tagName: string,
+    upgradeCallback: LifecycleCallback,
+    connectedCallback?: LifecycleCallback,
+    disconnectedCallback?: LifecycleCallback,
+    formAssociatedCallback?: LifecycleCallback,
+    formDisabledCallback?: LifecycleCallback,
+    formResetCallback?: LifecycleCallback,
+    formStateRestoreCallback?: LifecycleCallback
+) => {
+    const UpgradableConstructor = getOrCreateUpgradableConstructor(
+        tagName,
+        connectedCallback,
+        disconnectedCallback
+    );
 
     formAssociatedCallbackToUse = formAssociatedCallback;
     formDisabledCallbackToUse = formDisabledCallback;

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -22,10 +22,7 @@ import type { RendererAPI } from '@lwc/engine-core';
 // are omitted here
 export type SandboxableRendererAPI = Omit<
     RendererAPI,
-    | 'createCustomElement'
-    | 'insertStylesheet'
-    | 'isSyntheticShadowDefined'
-    | 'getUpgradableConstructor'
+    'createCustomElement' | 'insertStylesheet' | 'isSyntheticShadowDefined' | 'defineCustomElement'
 >;
 
 export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : SandboxableRendererAPI;

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -25,7 +25,7 @@ export type SandboxableRendererAPI = Omit<
     | 'createCustomElement'
     | 'insertStylesheet'
     | 'isSyntheticShadowDefined'
-    | 'getOrCreateUpgradableConstructor'
+    | 'getUpgradableConstructor'
 >;
 
 export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : SandboxableRendererAPI;

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -22,7 +22,10 @@ import type { RendererAPI } from '@lwc/engine-core';
 // are omitted here
 export type SandboxableRendererAPI = Omit<
     RendererAPI,
-    'createCustomElement' | 'insertStylesheet' | 'isSyntheticShadowDefined'
+    | 'createCustomElement'
+    | 'insertStylesheet'
+    | 'isSyntheticShadowDefined'
+    | 'getOrCreateUpgradableConstructor'
 >;
 
 export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : SandboxableRendererAPI;

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -9,7 +9,7 @@ import { assign, hasOwnProperty, KEY__SHADOW_TOKEN } from '@lwc/shared';
 import { insertStylesheet } from './styles';
 import {
     createCustomElement,
-    getOrCreateUpgradableConstructor,
+    getUpgradableConstructor,
 } from './custom-elements/create-custom-element';
 import { rendererFactory } from './renderer-factory';
 
@@ -29,7 +29,7 @@ export const renderer: RendererAPI = assign(
         insertStylesheet,
         // relies on a shared global cache
         createCustomElement,
-        getOrCreateUpgradableConstructor,
+        getUpgradableConstructor,
         isSyntheticShadowDefined: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
     }
 );

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -29,7 +29,7 @@ export const renderer: RendererAPI = assign(
         insertStylesheet,
         // relies on a shared global cache
         createCustomElement,
-        getUpgradableConstructor,
+        defineCustomElement: getUpgradableConstructor,
         isSyntheticShadowDefined: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
     }
 );

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -7,7 +7,10 @@
 
 import { assign, hasOwnProperty, KEY__SHADOW_TOKEN } from '@lwc/shared';
 import { insertStylesheet } from './styles';
-import { createCustomElement } from './custom-elements/create-custom-element';
+import {
+    createCustomElement,
+    getOrCreateUpgradableConstructor,
+} from './custom-elements/create-custom-element';
 import { rendererFactory } from './renderer-factory';
 
 import type { RendererAPI } from '@lwc/engine-core';
@@ -26,6 +29,7 @@ export const renderer: RendererAPI = assign(
         insertStylesheet,
         // relies on a shared global cache
         createCustomElement,
+        getOrCreateUpgradableConstructor,
         isSyntheticShadowDefined: hasOwnProperty.call(Element.prototype, KEY__SHADOW_TOKEN),
     }
 );

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -351,7 +351,7 @@ function createUpgradableElementConstructor(tagName: string): CreateElementAndUp
     };
 }
 
-function getUpgradableConstructor(
+function getUpgradableElement(
     tagName: string,
     _connectedCallback?: LifecycleCallback,
     _disconnectedCallback?: LifecycleCallback
@@ -367,7 +367,7 @@ function getUpgradableConstructor(
 }
 
 function createCustomElement(tagName: string, upgradeCallback: LifecycleCallback): HostElement {
-    const UpgradableConstructor = getUpgradableConstructor(tagName);
+    const UpgradableConstructor = getUpgradableElement(tagName);
     return new (UpgradableConstructor as any)(upgradeCallback);
 }
 
@@ -471,5 +471,5 @@ export const renderer = {
     ownerDocument,
     registerContextConsumer,
     attachInternals,
-    getUpgradableConstructor,
+    defineCustomElement: getUpgradableElement,
 };

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -351,7 +351,11 @@ function createUpgradableElementConstructor(tagName: string): CreateElementAndUp
     };
 }
 
-function getUpgradableElement(tagName: string): CreateElementAndUpgrade {
+function getOrCreateUpgradableConstructor(
+    tagName: string,
+    _connectedCallback?: LifecycleCallback,
+    _disconnectedCallback?: LifecycleCallback
+): CreateElementAndUpgrade {
     let ctor = localRegistryRecord.get(tagName);
     if (!isUndefined(ctor)) {
         return ctor;
@@ -363,7 +367,7 @@ function getUpgradableElement(tagName: string): CreateElementAndUpgrade {
 }
 
 function createCustomElement(tagName: string, upgradeCallback: LifecycleCallback): HostElement {
-    const UpgradableConstructor = getUpgradableElement(tagName);
+    const UpgradableConstructor = getOrCreateUpgradableConstructor(tagName);
     return new (UpgradableConstructor as any)(upgradeCallback);
 }
 
@@ -467,4 +471,5 @@ export const renderer = {
     ownerDocument,
     registerContextConsumer,
     attachInternals,
+    getOrCreateUpgradableConstructor,
 };

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -351,7 +351,7 @@ function createUpgradableElementConstructor(tagName: string): CreateElementAndUp
     };
 }
 
-function getOrCreateUpgradableConstructor(
+function getUpgradableConstructor(
     tagName: string,
     _connectedCallback?: LifecycleCallback,
     _disconnectedCallback?: LifecycleCallback
@@ -367,7 +367,7 @@ function getOrCreateUpgradableConstructor(
 }
 
 function createCustomElement(tagName: string, upgradeCallback: LifecycleCallback): HostElement {
-    const UpgradableConstructor = getOrCreateUpgradableConstructor(tagName);
+    const UpgradableConstructor = getUpgradableConstructor(tagName);
     return new (UpgradableConstructor as any)(upgradeCallback);
 }
 
@@ -471,5 +471,5 @@ export const renderer = {
     ownerDocument,
     registerContextConsumer,
     attachInternals,
-    getOrCreateUpgradableConstructor,
+    getUpgradableConstructor,
 };

--- a/packages/@lwc/integration-karma/test-hydration/simple/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/simple/index.spec.js
@@ -14,6 +14,8 @@ export default {
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
         expect(p.textContent).toBe('hello!');
+        expect(customElements.get(target.tagName.toLowerCase())).not.toBeUndefined();
+        expect(customElements.get('x-child')).not.toBeUndefined();
 
         target.greeting = 'bye!';
 

--- a/packages/@lwc/integration-karma/test-hydration/simple/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/simple/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    <div>Child</div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/simple/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/simple/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/simple/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/simple/x/main/main.html
@@ -1,3 +1,4 @@
 <template>
     <p>{greeting}</p>
+    <x-child></x-child>
 </template>

--- a/packages/@lwc/integration-karma/test/hydration/index.spec.js
+++ b/packages/@lwc/integration-karma/test/hydration/index.spec.js
@@ -10,7 +10,7 @@ it('throws error when hydrating non DOM element', () => {
 });
 if (process.env.NATIVE_SHADOW) {
     it('should log an error when passing an invalid LightningElement constructor.', () => {
-        const anElement = document.createElement('div');
+        const anElement = document.createElement('x-div');
 
         expect(() => {
             try {


### PR DESCRIPTION
## Details
We just register an `UpgradableConstructor` (without an `upgradeCallback`). There's no support for FACE because we didn't have them earlier to this PR as well. Also, there's no support for native callback lifecycle because, again, we didn't have support for this prior to this PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
