### PR TITLE
feat(reporting): report disconnected connectedCallback

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -12,6 +12,7 @@ export const enum ReportingEventId {
     NonStandardAriaReflection = 'NonStandardAriaReflection',
     TemplateMutation = 'TemplateMutation',
     StylesheetMutation = 'StylesheetMutation',
+    ConnectedCallbackWhileDisconnected = 'ConnectedCallbackWhileDisconnected',
 }
 
 export interface BasePayload {
@@ -41,12 +42,15 @@ export interface StylesheetMutationPayload extends BasePayload {
     propertyName: string;
 }
 
+export interface ConnectedCallbackWhileDisconnectedPayload extends BasePayload {}
+
 export type ReportingPayloadMapping = {
     [ReportingEventId.CrossRootAriaInSyntheticShadow]: CrossRootAriaInSyntheticShadowPayload;
     [ReportingEventId.CompilerRuntimeVersionMismatch]: CompilerRuntimeVersionMismatchPayload;
     [ReportingEventId.NonStandardAriaReflection]: NonStandardAriaReflectionPayload;
     [ReportingEventId.TemplateMutation]: TemplateMutationPayload;
     [ReportingEventId.StylesheetMutation]: StylesheetMutationPayload;
+    [ReportingEventId.ConnectedCallbackWhileDisconnected]: ConnectedCallbackWhileDisconnectedPayload;
 };
 
 export type ReportingDispatcher<T extends ReportingEventId = ReportingEventId> = (
@@ -126,4 +130,11 @@ export function report<T extends ReportingEventId>(
     if (enabled) {
         currentDispatcher(reportingEventId, payload);
     }
+}
+
+/**
+ * Return true if reporting is enabled
+ */
+export function isReportingEnabled() {
+    return enabled;
 }

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -57,6 +57,7 @@ import {
     VStaticPart,
 } from './vnodes';
 import { StylesheetFactory, TemplateStylesheetFactories } from './stylesheet';
+import { isReportingEnabled, report, ReportingEventId } from './reporting';
 
 type ShadowRootMode = 'open' | 'closed';
 
@@ -667,6 +668,28 @@ export function runConnectedCallback(vm: VM) {
         invokeComponentCallback(vm, connectedCallback);
 
         logOperationEnd(OperationId.ConnectedCallback, vm);
+    }
+    // This test only makes sense in the browser, with synthetic lifecycle, and when reporting is enabled or
+    // we're in dev mode. This is to detect a particular issue with synthetic lifecycle.
+    if (
+        process.env.IS_BROWSER &&
+        !lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE &&
+        (process.env.NODE_ENV !== 'production' || isReportingEnabled())
+    ) {
+        if (!vm.renderer.isConnected(vm.elm)) {
+            if (process.env.NODE_ENV !== 'production') {
+                logWarnOnce(
+                    `Element <${vm.tagName}> ` +
+                        `fired a \`connectedCallback\` and rendered, but was not connected to the DOM. ` +
+                        `Please ensure all components are actually connected to the DOM, e.g. using ` +
+                        `\`document.body.appendChild(element)\`. This will not be supported in future versions of ` +
+                        `LWC and could cause breakages to your component.`
+                );
+            }
+            report(ReportingEventId.ConnectedCallbackWhileDisconnected, {
+                tagName: vm.tagName,
+            });
+        }
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -683,7 +683,7 @@ export function runConnectedCallback(vm: VM) {
                         `fired a \`connectedCallback\` and rendered, but was not connected to the DOM. ` +
                         `Please ensure all components are actually connected to the DOM, e.g. using ` +
                         `\`document.body.appendChild(element)\`. This will not be supported in future versions of ` +
-                        `LWC and could cause breakages to your component.`
+                        `LWC and could cause component errors. For details, see: https://sfdc.co/synthetic-lifecycle`
                 );
             }
             report(ReportingEventId.ConnectedCallbackWhileDisconnected, {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -39,8 +39,8 @@ if (typeof ElementInternals !== 'undefined' && !process.env.SYNTHETIC_SHADOW_ENA
     const createControlElm = () => {
         const form = document.createElement('form');
         const control = createElement('x-form-associated', { is: FormAssociated });
-        form.appendChild(control);
         document.body.appendChild(form);
+        form.appendChild(control);
         return control;
     };
 

--- a/packages/@lwc/integration-karma/test/component/LightningElement.isConnected/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.isConnected/index.spec.js
@@ -38,7 +38,15 @@ describe('Basic DOM manipulation cases', () => {
     });
     it('should return false for host connected to detached fargment', () => {
         const frag = document.createDocumentFragment();
-        frag.appendChild(elm);
+        const doAppend = () => frag.appendChild(elm);
+        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            doAppend();
+        } else {
+            // Expected warning, since we are working with disconnected nodes
+            expect(doAppend).toLogWarningDev(
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+            );
+        }
         expect(context.isConnected).toBe(false);
     });
 });

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -18,10 +18,14 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         });
 
         function expectLogs(regexes) {
-            const args = logger.calls.allArgs();
-            expect(args.length).toBe(regexes.length);
-            for (let i = 0; i < args.length; i++) {
-                expect(args[i][0]).toMatch(regexes[i]);
+            if (process.env.NODE_ENV === 'production') {
+                expect(logger).not.toHaveBeenCalled();
+            } else {
+                const args = logger.calls.allArgs();
+                expect(args.length).toBe(regexes.length);
+                for (let i = 0; i < args.length; i++) {
+                    expect(args[i][0]).toMatch(regexes[i]);
+                }
             }
         }
 

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -1,0 +1,64 @@
+import { __unstable__ReportingControl as reportingControl, createElement } from 'lwc';
+import Component from 'x/component';
+import Parent from 'x/parent';
+
+describe('ConnectedCallbackWhileDisconnected reporting', () => {
+    let logger;
+    let dispatcher;
+
+    beforeEach(() => {
+        dispatcher = jasmine.createSpy();
+        reportingControl.attachDispatcher(dispatcher);
+        logger = spyOn(console, 'warn');
+    });
+
+    afterEach(() => {
+        reportingControl.detachDispatcher();
+    });
+
+    function expectLogs(regexes) {
+        const args = logger.calls.allArgs();
+        expect(args.length).toBe(regexes.length);
+        for (let i = 0; i < args.length; i++) {
+            expect(args[i][0]).toMatch(regexes[i]);
+        }
+    }
+
+    it('disconnected DOM', async () => {
+        const div = document.createElement('div');
+
+        const elm = createElement('x-component', { is: Component });
+
+        div.appendChild(elm);
+        await Promise.resolve();
+        div.removeChild(elm);
+        await Promise.resolve();
+
+        expectLogs([
+            /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+        ]);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-component' }],
+        ]);
+    });
+
+    it('disconnected DOM - parent and child', async () => {
+        const div = document.createElement('div');
+
+        const elm = createElement('x-parent', { is: Parent });
+
+        div.appendChild(elm);
+        await Promise.resolve();
+        div.removeChild(elm);
+        await Promise.resolve();
+
+        expectLogs([
+            /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+            /Element <x-child> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+        ]);
+        expect(dispatcher.calls.allArgs()).toEqual([
+            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
+            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
+        ]);
+    });
+});

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -2,63 +2,65 @@ import { __unstable__ReportingControl as reportingControl, createElement } from 
 import Component from 'x/component';
 import Parent from 'x/parent';
 
-describe('ConnectedCallbackWhileDisconnected reporting', () => {
-    let logger;
-    let dispatcher;
+if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+    describe('ConnectedCallbackWhileDisconnected reporting', () => {
+        let logger;
+        let dispatcher;
 
-    beforeEach(() => {
-        dispatcher = jasmine.createSpy();
-        reportingControl.attachDispatcher(dispatcher);
-        logger = spyOn(console, 'warn');
-    });
+        beforeEach(() => {
+            dispatcher = jasmine.createSpy();
+            reportingControl.attachDispatcher(dispatcher);
+            logger = spyOn(console, 'warn');
+        });
 
-    afterEach(() => {
-        reportingControl.detachDispatcher();
-    });
+        afterEach(() => {
+            reportingControl.detachDispatcher();
+        });
 
-    function expectLogs(regexes) {
-        const args = logger.calls.allArgs();
-        expect(args.length).toBe(regexes.length);
-        for (let i = 0; i < args.length; i++) {
-            expect(args[i][0]).toMatch(regexes[i]);
+        function expectLogs(regexes) {
+            const args = logger.calls.allArgs();
+            expect(args.length).toBe(regexes.length);
+            for (let i = 0; i < args.length; i++) {
+                expect(args[i][0]).toMatch(regexes[i]);
+            }
         }
-    }
 
-    it('disconnected DOM', async () => {
-        const div = document.createElement('div');
+        it('disconnected DOM', async () => {
+            const div = document.createElement('div');
 
-        const elm = createElement('x-component', { is: Component });
+            const elm = createElement('x-component', { is: Component });
 
-        div.appendChild(elm);
-        await Promise.resolve();
-        div.removeChild(elm);
-        await Promise.resolve();
+            div.appendChild(elm);
+            await Promise.resolve();
+            div.removeChild(elm);
+            await Promise.resolve();
 
-        expectLogs([
-            /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
-        ]);
-        expect(dispatcher.calls.allArgs()).toEqual([
-            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-component' }],
-        ]);
+            expectLogs([
+                /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+            ]);
+            expect(dispatcher.calls.allArgs()).toEqual([
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-component' }],
+            ]);
+        });
+
+        it('disconnected DOM - parent and child', async () => {
+            const div = document.createElement('div');
+
+            const elm = createElement('x-parent', { is: Parent });
+
+            div.appendChild(elm);
+            await Promise.resolve();
+            div.removeChild(elm);
+            await Promise.resolve();
+
+            expectLogs([
+                /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+                /Element <x-child> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+            ]);
+            expect(dispatcher.calls.allArgs()).toEqual([
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
+            ]);
+        });
     });
-
-    it('disconnected DOM - parent and child', async () => {
-        const div = document.createElement('div');
-
-        const elm = createElement('x-parent', { is: Parent });
-
-        div.appendChild(elm);
-        await Promise.resolve();
-        div.removeChild(elm);
-        await Promise.resolve();
-
-        expectLogs([
-            /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
-            /Element <x-child> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
-        ]);
-        expect(dispatcher.calls.allArgs()).toEqual([
-            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
-            ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
-        ]);
-    });
-});
+}

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -29,15 +29,11 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             }
         }
 
-        it('disconnected DOM', async () => {
+        it('disconnected DOM', () => {
             const div = document.createElement('div');
-
             const elm = createElement('x-component', { is: Component });
 
             div.appendChild(elm);
-            await Promise.resolve();
-            div.removeChild(elm);
-            await Promise.resolve();
 
             expectLogs([
                 /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
@@ -47,15 +43,11 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             ]);
         });
 
-        it('disconnected DOM - parent and child', async () => {
+        it('disconnected DOM - parent and child', () => {
             const div = document.createElement('div');
-
             const elm = createElement('x-parent', { is: Parent });
 
             div.appendChild(elm);
-            await Promise.resolve();
-            div.removeChild(elm);
-            await Promise.resolve();
 
             expectLogs([
                 /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/parent/parent.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -2,6 +2,20 @@ import { createElement } from 'lwc';
 import Parent from 'x/parent';
 
 describe('vdom removes component while it is already disconnected', () => {
+    let spy;
+
+    beforeEach(() => {
+        spy = spyOn(console, 'warn');
+    });
+
+    afterEach(() => {
+        // expected since the engine calls appendChild to a disconnected DOM node
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.calls.mostRecent().args[0]).toMatch(
+            /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+        );
+    });
+
     it('repro "must have been connected" error W-14037619', async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -9,14 +9,14 @@ describe('vdom removes component while it is already disconnected', () => {
     });
 
     afterEach(() => {
-        if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            expect(spy).not.toHaveBeenCalled();
+        } else {
             // expected since the engine calls appendChild to a disconnected DOM node
             expect(spy).toHaveBeenCalledTimes(1);
             expect(spy.calls.mostRecent().args[0]).toMatch(
                 /fired a `connectedCallback` and rendered, but was not connected to the DOM/
             );
-        } else {
-            expect(spy).not.toHaveBeenCalled();
         }
     });
 

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -15,6 +15,8 @@ describe('vdom removes component while it is already disconnected', () => {
             expect(spy.calls.mostRecent().args[0]).toMatch(
                 /fired a `connectedCallback` and rendered, but was not connected to the DOM/
             );
+        } else {
+            expect(spy).not.toHaveBeenCalled();
         }
     });
 

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -9,11 +9,13 @@ describe('vdom removes component while it is already disconnected', () => {
     });
 
     afterEach(() => {
-        // expected since the engine calls appendChild to a disconnected DOM node
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy.calls.mostRecent().args[0]).toMatch(
-            /fired a `connectedCallback` and rendered, but was not connected to the DOM/
-        );
+        if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            // expected since the engine calls appendChild to a disconnected DOM node
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy.calls.mostRecent().args[0]).toMatch(
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+            );
+        }
     });
 
     it('repro "must have been connected" error W-14037619', async () => {

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -9,7 +9,10 @@ describe('vdom removes component while it is already disconnected', () => {
     });
 
     afterEach(() => {
-        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+        if (
+            window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE ||
+            process.env.NODE_ENV === 'production'
+        ) {
             expect(spy).not.toHaveBeenCalled();
         } else {
             // expected since the engine calls appendChild to a disconnected DOM node

--- a/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -138,7 +138,17 @@ describe('[W-9846457] event access when using native shadow dom', () => {
         const native = document.createElement('div');
 
         native.attachShadow({ mode: 'open' });
-        native.shadowRoot.appendChild(synthetic);
+
+        const doAppend = () => native.shadowRoot.appendChild(synthetic);
+        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            doAppend();
+        } else {
+            // Expected warning, since we are working with disconnected nodes
+            expect(doAppend).toLogWarningDev(
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+            );
+        }
+
         document.body.appendChild(native);
 
         synthetic.addEventListener('test', (event) => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
@@ -36,7 +36,17 @@ describe('Node.getRootNode', () => {
     it('root element in a disconnected DOM tree', () => {
         const elm = createElement('x-slotted', { is: Slotted });
         const frag = document.createDocumentFragment();
-        frag.appendChild(elm);
+        const doAppend = () => frag.appendChild(elm);
+
+        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            doAppend();
+        } else {
+            // Expected warning, since we are working with disconnected nodes
+            expect(doAppend).toLogWarningDev([
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+            ]);
+        }
 
         expect(elm.getRootNode()).toBe(frag);
         expect(elm.getRootNode(composedTrueConfig)).toBe(frag);

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
@@ -11,7 +11,16 @@ describe('Node.isConnected', () => {
     it('should return false if the component is in a DocumentFragment until its connected to the document', () => {
         const elm = createElement('x-test', { is: Test });
         const frag = document.createDocumentFragment();
-        frag.appendChild(elm);
+        const doAppend = () => frag.appendChild(elm);
+
+        if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+            doAppend();
+        } else {
+            // Expected warning, since we are working with disconnected nodes
+            expect(doAppend).toLogWarningDev(
+                /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+            );
+        }
 
         expect(elm.shadowRoot.isConnected).toBe(false);
 

--- a/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -32,7 +32,23 @@ function createDisconnectedTestElement() {
     const fragment = document.createDocumentFragment();
     const elm = createElement('x-container', { is: Container });
     elm.setAttribute('data-id', 'x-container');
-    fragment.appendChild(elm);
+
+    const doAppend = () => fragment.appendChild(elm);
+
+    if (window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+        doAppend();
+    } else {
+        // Expected warning, since we are working with disconnected nodes
+        expect(doAppend).toLogWarningDev(
+            Array(4)
+                .fill()
+                .map(
+                    () =>
+                        /fired a `connectedCallback` and rendered, but was not connected to the DOM/
+                )
+        );
+    }
+
     const nodes = extractDataIds(elm);
     // Manually added because document fragments can't have attributes.
     nodes.fragment = fragment;


### PR DESCRIPTION

## Details


Fixes #3764

This is a less ambitious version of https://github.com/salesforce/lwc/pull/3815. Rather than trying to report _all_ differences between synthetic and native lifecycle, we only report a `connectedCallback` firing when the element is disconnected from the DOM.

This has a few advantages:

1. It's much easier to detect
2. It's the most common cause of a true functional breakage we've seen with native vs synthetic lifecycle
3. It's something the component author can actually fix themselves (usually)

The risk of this PR is that a component author will be confused if they see the warning and don't understand how to resolve it. Even at the risk of such false positives, though, this PR is probably still worth it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-14220905
