### PR TITLE
test: syntax errors should not crash karma

### DIFF
--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -3,9 +3,9 @@
     "private": true,
     "version": "4.0.1",
     "scripts": {
-        "start": "karma start ./scripts/karma-configs/test/local.js",
+        "start": "KARMA_MODE=watch karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
-        "hydration:start": "karma start ./scripts/karma-configs/hydration/local.js",
+        "hydration:start": "KARMA_MODE=watch karma start ./scripts/karma-configs/hydration/local.js",
         "hydration:test": "karma start ./scripts/karma-configs/hydration/local.js --single-run --browsers ChromeHeadless",
         "hydration:sauce": "karma start ./scripts/karma-configs/hydration/sauce.js --single-run",
         "hydration:sauce:ci": "../../../scripts/ci/retry.sh karma start ./scripts/karma-configs/hydration/sauce.js --single-run",

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -28,7 +28,7 @@ function createPreprocessor(config, emitter, logger) {
     // Cache reused between each compilation to speed up the compilation time.
     let cache;
 
-    return async (_content, file, done) => {
+    return async (content, file, done) => {
         const input = file.path;
 
         const suiteDir = path.dirname(input);
@@ -108,7 +108,12 @@ function createPreprocessor(config, emitter, logger) {
             const location = path.relative(basePath, file.path);
             log.error('Error processing “%s”\n\n%s\n', location, error.stack || error.message);
 
-            done(error, null);
+            if (process.env.KARMA_MODE === 'watch') {
+                log.error('Ignoring error in watch mode');
+                done(null, content); // just pass the untransformed content in for now
+            } else {
+                done(error, null);
+            }
         }
     };
 }


### PR DESCRIPTION
## Details

This one has bugged me for a while.

If you run `yarn start` in the Karma tests, and your test file has a syntax error, then the whole Karma process (and the browser) crashes. This PR makes it so that the syntax error is temporarily ignored, but only when running in "watch" mode (i.e. `karma start` or `karma hydration:start`).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
