### PR TITLE
chore: use comment nodes for VFragment bookends

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -6,6 +6,7 @@
  */
 import {
     APIFeature,
+    APIVersion,
     ArrayPush,
     assert,
     create as ObjectCreate,
@@ -99,8 +100,12 @@ function st(fragment: Element, key: Key, parts?: VStaticPart[]): VStatic {
 
 // [fr]agment node
 function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
-    const leading = co('');
-    const trailing = co('');
+    const owner = getVMBeingRendered()!;
+    const useCommentNodes = owner.apiVersion >= APIVersion.V60_248_SPRING_24;
+
+    const leading = useCommentNodes ? co('') : t('');
+    const trailing = useCommentNodes ? co('') : t('');
+
     return {
         type: VNodeType.Fragment,
         sel: undefined,
@@ -108,7 +113,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
         elm: undefined,
         children: [leading, ...children, trailing],
         stable,
-        owner: getVMBeingRendered()!,
+        owner,
         leading,
         trailing,
     };

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -99,8 +99,8 @@ function st(fragment: Element, key: Key, parts?: VStaticPart[]): VStatic {
 
 // [fr]agment node
 function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
-    const leading = t('');
-    const trailing = t('');
+    const leading = co('');
+    const trailing = co('');
     return {
         type: VNodeType.Fragment,
         sel: undefined,

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -6,7 +6,6 @@
  */
 import {
     APIFeature,
-    APIVersion,
     ArrayPush,
     assert,
     create as ObjectCreate,
@@ -101,7 +100,10 @@ function st(fragment: Element, key: Key, parts?: VStaticPart[]): VStatic {
 // [fr]agment node
 function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
     const owner = getVMBeingRendered()!;
-    const useCommentNodes = owner.apiVersion >= APIVersion.V60_248_SPRING_24;
+    const useCommentNodes = isAPIFeatureEnabled(
+        APIFeature.USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+        owner.apiVersion
+    );
 
     const leading = useCommentNodes ? co('') : t('');
     const trailing = useCommentNodes ? co('') : t('');

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -17,6 +17,7 @@ import {
     isTrue,
     isString,
     StringToLowerCase,
+    APIVersion,
 } from '@lwc/shared';
 
 import { logError, logWarn } from '../shared/logger';
@@ -387,7 +388,10 @@ function hydrateChildren(
         }
     }
 
-    if (!expectAddlSiblings && nextNode) {
+    if (
+        (owner.apiVersion < APIVersion.V60_248_SPRING_24 ? true : !expectAddlSiblings) &&
+        nextNode
+    ) {
         hasMismatch = true;
         if (process.env.NODE_ENV !== 'production') {
             if (!hasWarned) {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -74,8 +74,8 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
     // which diffing strategy to use.
     stable: 0 | 1;
-    leading: VText;
-    trailing: VText;
+    leading: VComment;
+    trailing: VComment;
 }
 
 export interface VText extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -74,8 +74,10 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
     // which diffing strategy to use.
     stable: 0 | 1;
-    leading: VComment;
-    trailing: VComment;
+    // The leading and trailing nodes are text nodes <= v59 and comment nodes
+    // in v60+.
+    leading: VText | VComment;
+    trailing: VText | VComment;
 }
 
 export interface VText extends BaseVNode {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -74,8 +74,8 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
     // which diffing strategy to use.
     stable: 0 | 1;
-    // The leading and trailing nodes are text nodes <= v59 and comment nodes
-    // in v60+.
+    // The leading and trailing nodes are text nodes when APIFeature.USE_COMMENTS_FOR_FRAGMENT_BOOKENDS
+    // is disabled and comment nodes when it is enabled.
     leading: VText | VComment;
     trailing: VText | VComment;
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/basic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/basic/expected.html
@@ -2,11 +2,13 @@
   <template shadowroot="open">
     <x-basic-child>
       <div>
-        ‍‍
+        <!---->
+        <!---->
         <span>
           99 - ssr
         </span>
-        ‍‍
+        <!---->
+        <!---->
       </div>
     </x-basic-child>
   </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/for-each/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/for-each/expected.html
@@ -6,18 +6,22 @@
     <x-child-with-for-each>
       <ul>
         <li>
-          ‍‍
+          <!---->
+          <!---->
           <span>
             39 - Audio
           </span>
-          ‍‍
+          <!---->
+          <!---->
         </li>
         <li>
-          ‍‍
+          <!---->
+          <!---->
           <span>
             40 - Video
           </span>
-          ‍‍
+          <!---->
+          <!---->
         </li>
       </ul>
     </x-child-with-for-each>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/named-slot/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/named-slot/expected.html
@@ -2,14 +2,18 @@
   <template shadowroot="open">
     <x-child>
       <div>
-        ‍‍
+        <!---->
+        <!---->
         <span>
           99 - ssr
         </span>
-        ‍‍
+        <!---->
+        <!---->
       </div>
       <p>
-        ‍Default slot - default content‍
+        <!---->
+        Default slot - default content
+        <!---->
       </p>
     </x-child>
   </template>

--- a/packages/@lwc/integration-karma/helpers/test-hydrate.js
+++ b/packages/@lwc/integration-karma/helpers/test-hydrate.js
@@ -67,6 +67,8 @@ window.HydrateTest = (function (lwc, testUtils) {
                 Component,
                 hydrateComponent: lwc.hydrateComponent.bind(lwc),
                 consoleSpy,
+                container,
+                selector,
             });
         }
 

--- a/packages/@lwc/integration-karma/scripts/shared/options.js
+++ b/packages/@lwc/integration-karma/scripts/shared/options.js
@@ -7,6 +7,8 @@
 
 'use strict';
 
+const { HIGHEST_API_VERSION } = require('@lwc/shared');
+
 // Helpful error. Remove after a few months.
 if (process.env.NATIVE_SHADOW) {
     throw new Error('NATIVE_SHADOW is deprecated. Use DISABLE_SYNTHETIC instead!');
@@ -28,10 +30,9 @@ const DISABLE_STATIC_CONTENT_OPTIMIZATION = Boolean(
     process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION
 );
 const NODE_ENV_FOR_TEST = process.env.NODE_ENV_FOR_TEST;
-const LATEST_API_VERSION = 60;
 const API_VERSION = process.env.API_VERSION
     ? parseInt(process.env.API_VERSION, 10)
-    : LATEST_API_VERSION;
+    : HIGHEST_API_VERSION;
 
 module.exports = {
     // Test configuration
@@ -43,7 +44,6 @@ module.exports = {
     DISABLE_SYNTHETIC_SHADOW_SUPPORT_IN_COMPILER,
     DISABLE_STATIC_CONTENT_OPTIMIZATION,
     SYNTHETIC_SHADOW_ENABLED: !DISABLE_SYNTHETIC,
-    LATEST_API_VERSION,
     API_VERSION,
     GREP: process.env.GREP,
     COVERAGE: Boolean(process.env.COVERAGE),

--- a/packages/@lwc/integration-karma/scripts/shared/options.js
+++ b/packages/@lwc/integration-karma/scripts/shared/options.js
@@ -28,7 +28,10 @@ const DISABLE_STATIC_CONTENT_OPTIMIZATION = Boolean(
     process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION
 );
 const NODE_ENV_FOR_TEST = process.env.NODE_ENV_FOR_TEST;
-const API_VERSION = process.env.API_VERSION && parseInt(process.env.API_VERSION, 10);
+const LATEST_API_VERSION = 60;
+const API_VERSION = process.env.API_VERSION
+    ? parseInt(process.env.API_VERSION, 10)
+    : LATEST_API_VERSION;
 
 module.exports = {
     // Test configuration
@@ -40,6 +43,7 @@ module.exports = {
     DISABLE_SYNTHETIC_SHADOW_SUPPORT_IN_COMPILER,
     DISABLE_STATIC_CONTENT_OPTIMIZATION,
     SYNTHETIC_SHADOW_ENABLED: !DISABLE_SYNTHETIC,
+    LATEST_API_VERSION,
     API_VERSION,
     GREP: process.env.GREP,
     COVERAGE: Boolean(process.env.COVERAGE),

--- a/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/index.spec.js
@@ -1,0 +1,34 @@
+export default {
+    props: {},
+    snapshot(target) {
+        const first = target.shadowRoot.querySelector('.first');
+        const second = target.shadowRoot.querySelector('.second');
+
+        return {
+            first,
+            second,
+        };
+    },
+    advancedTest(target, { Component, hydrateComponent, consoleSpy, container, selector }) {
+        const snapshotBeforeHydration = this.snapshot(target);
+        hydrateComponent(target, Component, this.props);
+        const hydratedTarget = container.querySelector(selector);
+        const snapshotAfterHydration = this.snapshot(hydratedTarget);
+
+        for (const snapshotKey of Object.keys(snapshotBeforeHydration)) {
+            expect(snapshotBeforeHydration[snapshotKey])
+                .withContext(
+                    `${snapshotKey} should be the same DOM element both before and after hydration`
+                )
+                .toBe(snapshotAfterHydration[snapshotKey]);
+            expect(snapshotBeforeHydration[snapshotKey].childNodes)
+                .withContext(
+                    `${snapshotKey} should have the same number of child nodes before & after hydration`
+                )
+                .toHaveSize(snapshotAfterHydration[snapshotKey].childNodes.length);
+        }
+
+        expect(consoleSpy.calls.warn).toHaveSize(0);
+        expect(consoleSpy.calls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/x/main/main.html
@@ -1,0 +1,4 @@
+<template>
+    <p class="first">{zeroLengthText}‍{zeroLengthText}‍</p>
+    <p class="second">{zeroLengthText}{zeroLengthText}{zeroLengthText}{zeroLengthText}</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/adjacent-text-nodes/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    zeroLengthText = '';
+}

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/index.spec.js
@@ -1,0 +1,41 @@
+export default {
+    props: {},
+    snapshot(target) {
+        const cmpChild = target.querySelector('x-child');
+        const cmpChildDiv = target.querySelector('x-child div');
+        const [cmpScopedOuter, cmpScopedInner] = target.querySelectorAll('x-scoped');
+
+        return {
+            target,
+            cmpScopedOuter,
+            cmpScopedInner,
+            cmpChild,
+            cmpChildDiv,
+        };
+    },
+    advancedTest(target, { Component, hydrateComponent, consoleSpy, container, selector }) {
+        const snapshotBeforeHydration = this.snapshot(target);
+        hydrateComponent(target, Component, this.props);
+        const hydratedTarget = container.querySelector(selector);
+        const snapshotAfterHydration = this.snapshot(hydratedTarget);
+
+        for (const snapshotKey of Object.keys(snapshotBeforeHydration)) {
+            expect(snapshotBeforeHydration[snapshotKey])
+                .withContext(
+                    `${snapshotKey} should be the same DOM element both before and after hydration`
+                )
+                .toBe(snapshotAfterHydration[snapshotKey]);
+        }
+
+        for (const snapshotKey of ['target', 'cmpScopedOuter', 'cmpScopedInner']) {
+            expect(snapshotBeforeHydration[snapshotKey].childNodes)
+                .withContext(
+                    `${snapshotKey} should have the same number of child nodes before & after hydration`
+                )
+                .toHaveSize(snapshotAfterHydration[snapshotKey].childNodes.length);
+        }
+
+        expect(consoleSpy.calls.warn).toHaveSize(0);
+        expect(consoleSpy.calls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/child/child.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <div lwc:ref="childdiv">&lt;x-child /&gt;</div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/main/main.html
@@ -1,0 +1,14 @@
+<template lwc:render-mode="light">
+    <div>&lt;x-main&gt;</div>
+    <x-scoped instance="1">
+        <template lwc:slot-data="item1">
+            <x-scoped instance="2">
+                <template lwc:slot-data="item2">
+                    <span>main: {item1.msg} {item2.msg}</span>
+                    <x-child></x-child>
+                </template>
+            </x-scoped>
+        </template>
+    </x-scoped>
+    <div>&lt;/x-main&gt;</div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/main/main.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Main extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/scoped/scoped.html
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/scoped/scoped.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <div lwc:ref="div1">&lt;x-scoped&gt; ({instance})</div>
+    <slot lwc:slot-bind={scopedItem}></slot>
+    <div lwc:ref="div2">&lt;/x-scoped&gt; ({instance})</div>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/scoped/scoped.js
+++ b/packages/@lwc/integration-karma/test-hydration/light-dom/slots/nested-and-scoped/x/scoped/scoped.js
@@ -1,0 +1,12 @@
+import { LightningElement, api } from 'lwc';
+
+export default class scoped extends LightningElement {
+    static renderMode = 'light';
+    @api instance = 'unknown';
+
+    get scopedItem() {
+        return {
+            msg: `from-x-scoped-${this.instance}`,
+        };
+    }
+}

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -10,6 +10,8 @@ import ReflectCamel from 'x/reflectCamel';
 import WithChildElmsHasSlot from 'x/withChildElmsHasSlot';
 import WithChildElmsHasSlotLight from 'x/withChildElmsHasSlotLight';
 
+const vFragBookend = process.env.API_VERSION > 59 ? '<!---->' : '';
+
 it('should throw when trying to claim abstract LightningElement as custom element', () => {
     expect(() => LightningElement.CustomElementConstructor).toThrowError(
         TypeError,
@@ -127,7 +129,7 @@ describe('non-empty custom element', () => {
             expectWarnings([]);
         }
 
-        expect(elm.innerHTML).toBe('<!----><!---->');
+        expect(elm.innerHTML).toBe(`${vFragBookend}${vFragBookend}`);
     });
 
     it('should log error if slotted synthetic shadow dom custom element has children', () => {

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -127,7 +127,7 @@ describe('non-empty custom element', () => {
             expectWarnings([]);
         }
 
-        expect(elm.innerHTML).toBe('');
+        expect(elm.innerHTML).toBe('<!----><!---->');
     });
 
     it('should log error if slotted synthetic shadow dom custom element has children', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
@@ -8,13 +8,17 @@ describe('if-block', () => {
         elm.showStandard = true;
         document.body.appendChild(elm);
         const child = elm.shadowRoot.querySelector('x-mixed-slot-child');
-        expect(child.innerHTML).toBe('<span>Slotted content from parent</span>');
+        expect(child.innerHTML).toBe(
+            '<!----><!----><span>Slotted content from parent</span><!----><!---->'
+        );
 
         // Switch off the if branch and switch on the elseif branch
         elm.showStandard = false;
         elm.showVariant = true;
         return Promise.resolve().then(() => {
-            expect(child.innerHTML).toBe('<span>1 - slots and if block</span>');
+            expect(child.innerHTML).toBe(
+                '<!----><!----><!----><span>1 - slots and if block</span><!----><!----><!---->'
+            );
         });
     });
 
@@ -42,7 +46,7 @@ describe('if-block', () => {
                     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
                     expect(errorMsg).toMatch(/Mismatched slot types for \(default\) slot/);
                 }
-                expect(child.innerHTML).toBe('');
+                expect(child.innerHTML).toBe('<!----><!----><!----><!---->');
             });
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
@@ -2,6 +2,8 @@ import { createElement } from 'lwc';
 
 import MixedSlotParent from 'x/mixedSlotParent';
 
+const vFragBookend = process.env.API_VERSION > 59 ? '<!---->' : '';
+
 describe('if-block', () => {
     it('should work when parent and child have matching slot types', () => {
         const elm = createElement('x-parent', { is: MixedSlotParent });
@@ -9,7 +11,7 @@ describe('if-block', () => {
         document.body.appendChild(elm);
         const child = elm.shadowRoot.querySelector('x-mixed-slot-child');
         expect(child.innerHTML).toBe(
-            '<!----><!----><span>Slotted content from parent</span><!----><!---->'
+            `${vFragBookend}${vFragBookend}<span>Slotted content from parent</span>${vFragBookend}${vFragBookend}`
         );
 
         // Switch off the if branch and switch on the elseif branch
@@ -17,7 +19,7 @@ describe('if-block', () => {
         elm.showVariant = true;
         return Promise.resolve().then(() => {
             expect(child.innerHTML).toBe(
-                '<!----><!----><!----><span>1 - slots and if block</span><!----><!----><!---->'
+                `${vFragBookend}${vFragBookend}${vFragBookend}<span>1 - slots and if block</span>${vFragBookend}${vFragBookend}${vFragBookend}`
             );
         });
     });
@@ -46,7 +48,9 @@ describe('if-block', () => {
                     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
                     expect(errorMsg).toMatch(/Mismatched slot types for \(default\) slot/);
                 }
-                expect(child.innerHTML).toBe('<!----><!----><!----><!---->');
+                expect(child.innerHTML).toBe(
+                    `${vFragBookend}${vFragBookend}${vFragBookend}${vFragBookend}`
+                );
             });
     });
 });

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
@@ -46,13 +46,21 @@ describe('scoped slots', () => {
 
         const child = elm.shadowRoot.querySelector('x-child-with-named-slots');
         // Verify scoped slots
-        expect(child.querySelector('.slotname1').innerHTML).toBe('<p>2021 World Series</p>');
-        expect(child.querySelector('.slotname2').innerHTML).toBe('<p>Houston Astros</p>');
-        expect(child.querySelector('.defaultslot').innerHTML).toBe('<p>Atlanta Braves</p>');
+        expect(child.querySelector('.slotname1').innerHTML).toBe(
+            '<!----><!----><p>2021 World Series</p><!----><!---->'
+        );
+        expect(child.querySelector('.slotname2').innerHTML).toBe(
+            '<!----><!----><p>Houston Astros</p><!----><!---->'
+        );
+        expect(child.querySelector('.defaultslot').innerHTML).toBe(
+            '<!----><!----><p>Atlanta Braves</p><!----><!---->'
+        );
         // verify standard slot type
         // For standard slot content, "slot" attribute goes directly on the element unlike scoped
         //  slots where the attribute goes on the template tag
-        expect(child.querySelector('.slotname3').innerHTML).toBe('<p slot="slotname3">MLB</p>');
+        expect(child.querySelector('.slotname3').innerHTML).toBe(
+            '<!----><p slot="slotname3">MLB</p><!---->'
+        );
     });
 
     it('scoped slot content can be nested inside another', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
@@ -6,6 +6,8 @@ import ParentWNoSlotContent from 'x/parentWNoSlotContent';
 import ParentOfChildWithNamedSlots from 'x/parentOfChildWithNamedSlots';
 import NestedSlots from 'x/nestedSlots';
 
+const vFragBookend = process.env.API_VERSION > 59 ? '<!---->' : '';
+
 describe('scoped slots', () => {
     it('scoped slots work with default slots', () => {
         const elm = createElement('x-component', { is: BasicParent });
@@ -47,19 +49,19 @@ describe('scoped slots', () => {
         const child = elm.shadowRoot.querySelector('x-child-with-named-slots');
         // Verify scoped slots
         expect(child.querySelector('.slotname1').innerHTML).toBe(
-            '<!----><!----><p>2021 World Series</p><!----><!---->'
+            `${vFragBookend}${vFragBookend}<p>2021 World Series</p>${vFragBookend}${vFragBookend}`
         );
         expect(child.querySelector('.slotname2').innerHTML).toBe(
-            '<!----><!----><p>Houston Astros</p><!----><!---->'
+            `${vFragBookend}${vFragBookend}<p>Houston Astros</p>${vFragBookend}${vFragBookend}`
         );
         expect(child.querySelector('.defaultslot').innerHTML).toBe(
-            '<!----><!----><p>Atlanta Braves</p><!----><!---->'
+            `${vFragBookend}${vFragBookend}<p>Atlanta Braves</p>${vFragBookend}${vFragBookend}`
         );
         // verify standard slot type
         // For standard slot content, "slot" attribute goes directly on the element unlike scoped
         //  slots where the attribute goes on the template tag
         expect(child.querySelector('.slotname3').innerHTML).toBe(
-            '<!----><p slot="slotname3">MLB</p><!---->'
+            `${vFragBookend}<p slot="slotname3">MLB</p>${vFragBookend}`
         );
     });
 

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
@@ -3,6 +3,8 @@ import { createElement } from 'lwc';
 import ParentWithScopedSlotContent from 'x/parentWithScopedSlotContent';
 import ParentWithStandardSlotContent from 'x/parentWithStandardSlotContent';
 
+const vFragBookend = process.env.API_VERSION > 59 ? '<!---->' : '';
+
 describe('runtime validation of slot content and slot', () => {
     it('Ignores content when parent uses scoped slot and child has standard slot', () => {
         const elm = createElement('x-parent', { is: ParentWithScopedSlotContent });
@@ -12,7 +14,7 @@ describe('runtime validation of slot content and slot', () => {
         }).toLogErrorDev(/Mismatched slot types for \(default\) slot./gm);
         const child = elm.shadowRoot.querySelector('x-child-with-standard-slots');
         // The child's default content for that <slot> is ignored too
-        expect(child.innerHTML).toBe('<!----><!---->');
+        expect(child.innerHTML).toBe(`${vFragBookend}${vFragBookend}`);
     });
 
     it('Ignores content when parent uses standard slot and child has scoped slot', () => {
@@ -22,7 +24,7 @@ describe('runtime validation of slot content and slot', () => {
         }).toLogErrorDev(/Mismatched slot types for \(default\) slot./gm);
         const child = elm.shadowRoot.querySelector('x-child-with-scoped-slots');
         // The child's default content for that <slot> is ignored too
-        expect(child.innerHTML).toBe('<!----><!---->');
+        expect(child.innerHTML).toBe(`${vFragBookend}${vFragBookend}`);
     });
 
     it('Ignores content when parent uses scoped slot on child using shadow dom', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
@@ -12,7 +12,7 @@ describe('runtime validation of slot content and slot', () => {
         }).toLogErrorDev(/Mismatched slot types for \(default\) slot./gm);
         const child = elm.shadowRoot.querySelector('x-child-with-standard-slots');
         // The child's default content for that <slot> is ignored too
-        expect(child.innerHTML).toBe('');
+        expect(child.innerHTML).toBe('<!----><!---->');
     });
 
     it('Ignores content when parent uses standard slot and child has scoped slot', () => {
@@ -22,7 +22,7 @@ describe('runtime validation of slot content and slot', () => {
         }).toLogErrorDev(/Mismatched slot types for \(default\) slot./gm);
         const child = elm.shadowRoot.querySelector('x-child-with-scoped-slots');
         // The child's default content for that <slot> is ignored too
-        expect(child.innerHTML).toBe('');
+        expect(child.innerHTML).toBe('<!----><!---->');
     });
 
     it('Ignores content when parent uses scoped slot on child using shadow dom', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -9,6 +9,8 @@ import ConditionalSlot from 'x/conditionalSlot';
 import ConditionalSlotted from 'x/conditionalSlotted';
 import ForwardedSlotConsumer from 'x/forwardedSlotConsumer';
 
+const vFragBookend = process.env.API_VERSION > 59 ? '<!---->' : '';
+
 function createTestElement(tag, component) {
     const elm = createElement(tag, { is: component });
     elm.setAttribute('data-id', tag);
@@ -73,7 +75,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-shadow-consumer', ShadowConsumer);
 
         expect(nodes['x-shadow-consumer'].shadowRoot.innerHTML).toEqual(
-            '<x-light-container><!----><p data-id="container-upper-slot-default">Upper slot default</p><!----><!----><p data-id="shadow-consumer-text">Hello from Shadow DOM</p><!----><!----><p data-id="container-lower-slot-default">Lower slot default</p><!----></x-light-container>'
+            `<x-light-container>${vFragBookend}<p data-id="container-upper-slot-default">Upper slot default</p>${vFragBookend}${vFragBookend}<p data-id="shadow-consumer-text">Hello from Shadow DOM</p>${vFragBookend}${vFragBookend}<p data-id="container-lower-slot-default">Lower slot default</p>${vFragBookend}</x-light-container>`
         );
     });
 
@@ -90,7 +92,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-conditional-slotted', ConditionalSlotted);
         const elm = nodes['x-conditional-slotted'];
         expect(elm.innerHTML).toEqual(
-            '<x-conditional-slot data-id="conditional-slot"><!----><p data-id="slotted-text">Slotted content</p><!----><button data-id="button">Toggle</button></x-conditional-slot>'
+            `<x-conditional-slot data-id="conditional-slot">${vFragBookend}<p data-id="slotted-text">Slotted content</p>${vFragBookend}<button data-id="button">Toggle</button></x-conditional-slot>`
         );
         nodes.button.click();
         await Promise.resolve();
@@ -103,7 +105,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-forwarded-slot-consumer', ForwardedSlotConsumer);
         const elm = nodes['x-forwarded-slot-consumer'];
         expect(elm.innerHTML).toEqual(
-            '<x-forwarded-slot><x-light-container><!----><p slot="upper">Upper slot content forwarded</p><!----><!----><p>Default slot forwarded</p><!----><!----><p slot="lower">Lower slot content forwarded</p><!----></x-light-container></x-forwarded-slot>'
+            `<x-forwarded-slot><x-light-container>${vFragBookend}<p slot="upper">Upper slot content forwarded</p>${vFragBookend}${vFragBookend}<p>Default slot forwarded</p>${vFragBookend}${vFragBookend}<p slot="lower">Lower slot content forwarded</p>${vFragBookend}</x-light-container></x-forwarded-slot>`
         );
     });
     it('should render default content in forwarded slots', async () => {
@@ -113,7 +115,7 @@ describe('Slotting', () => {
 
         await Promise.resolve();
         expect(elm.innerHTML).toEqual(
-            '<x-forwarded-slot><x-light-container><!----><p data-id="container-upper-slot-default">Upper slot default</p><!----><!---->Default slot not yet forwarded<!----><!----><p data-id="container-lower-slot-default">Lower slot default</p><!----></x-light-container></x-forwarded-slot>'
+            `<x-forwarded-slot><x-light-container>${vFragBookend}<p data-id="container-upper-slot-default">Upper slot default</p>${vFragBookend}${vFragBookend}Default slot not yet forwarded${vFragBookend}${vFragBookend}<p data-id="container-lower-slot-default">Lower slot default</p>${vFragBookend}</x-light-container></x-forwarded-slot>`
         );
     });
 

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -73,7 +73,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-shadow-consumer', ShadowConsumer);
 
         expect(nodes['x-shadow-consumer'].shadowRoot.innerHTML).toEqual(
-            '<x-light-container><p data-id="container-upper-slot-default">Upper slot default</p><p data-id="shadow-consumer-text">Hello from Shadow DOM</p><p data-id="container-lower-slot-default">Lower slot default</p></x-light-container>'
+            '<x-light-container><!----><p data-id="container-upper-slot-default">Upper slot default</p><!----><!----><p data-id="shadow-consumer-text">Hello from Shadow DOM</p><!----><!----><p data-id="container-lower-slot-default">Lower slot default</p><!----></x-light-container>'
         );
     });
 
@@ -90,7 +90,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-conditional-slotted', ConditionalSlotted);
         const elm = nodes['x-conditional-slotted'];
         expect(elm.innerHTML).toEqual(
-            '<x-conditional-slot data-id="conditional-slot"><p data-id="slotted-text">Slotted content</p><button data-id="button">Toggle</button></x-conditional-slot>'
+            '<x-conditional-slot data-id="conditional-slot"><!----><p data-id="slotted-text">Slotted content</p><!----><button data-id="button">Toggle</button></x-conditional-slot>'
         );
         nodes.button.click();
         await Promise.resolve();
@@ -103,7 +103,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-forwarded-slot-consumer', ForwardedSlotConsumer);
         const elm = nodes['x-forwarded-slot-consumer'];
         expect(elm.innerHTML).toEqual(
-            '<x-forwarded-slot><x-light-container><p slot="upper">Upper slot content forwarded</p><p>Default slot forwarded</p><p slot="lower">Lower slot content forwarded</p></x-light-container></x-forwarded-slot>'
+            '<x-forwarded-slot><x-light-container><!----><p slot="upper">Upper slot content forwarded</p><!----><!----><p>Default slot forwarded</p><!----><!----><p slot="lower">Lower slot content forwarded</p><!----></x-light-container></x-forwarded-slot>'
         );
     });
     it('should render default content in forwarded slots', async () => {
@@ -113,7 +113,7 @@ describe('Slotting', () => {
 
         await Promise.resolve();
         expect(elm.innerHTML).toEqual(
-            '<x-forwarded-slot><x-light-container><p data-id="container-upper-slot-default">Upper slot default</p>Default slot not yet forwarded<p data-id="container-lower-slot-default">Lower slot default</p></x-light-container></x-forwarded-slot>'
+            '<x-forwarded-slot><x-light-container><!----><p data-id="container-upper-slot-default">Upper slot default</p><!----><!---->Default slot not yet forwarded<!----><!----><p data-id="container-lower-slot-default">Lower slot default</p><!----></x-light-container></x-forwarded-slot>'
         );
     });
 
@@ -122,13 +122,13 @@ describe('Slotting', () => {
         document.body.appendChild(elm);
         await Promise.resolve();
         const container = elm.querySelector('x-light-container');
-        const emptyTextNodes = [...container.childNodes].filter(
-            (_) => _.nodeType === Node.TEXT_NODE && _.data === ''
+        const commentNodes = [...container.childNodes].filter(
+            (_) => _.nodeType === Node.COMMENT_NODE
         );
         if (process.env.API_VERSION <= 59) {
-            expect(emptyTextNodes.length).toBe(0); // old implementation does not use fragments, just flattening
+            expect(commentNodes.length).toBe(0); // old implementation does not use fragments, just flattening
         } else {
-            expect(emptyTextNodes.length).toBe(6); // 3 slots, so 3*2=6 empty text nodes
+            expect(commentNodes.length).toBe(6); // 3 slots, so 3*2=6 comment nodes
         }
     });
 });

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -72,6 +72,12 @@ export const enum APIFeature {
      * This avoids unnecessary decorators on classes that cannot possibly be LightningElements.
      */
     SKIP_UNNECESSARY_REGISTER_DECORATORS,
+    /**
+     * If enabled, comment nodes will be added to the beginning and end of each VFragment node, used
+     * as anchors/bookends for efficient DOM operations. If disabled, empty text nodes will be used
+     * instead of comment nodes.
+     */
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
 }
 
 export function isAPIFeatureEnabled(
@@ -85,6 +91,7 @@ export function isAPIFeatureEnabled(
         case APIFeature.USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS:
         case APIFeature.DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION:
         case APIFeature.SKIP_UNNECESSARY_REGISTER_DECORATORS:
+        case APIFeature.USE_COMMENTS_FOR_FRAGMENT_BOOKENDS:
             return apiVersion >= APIVersion.V60_248_SPRING_24;
     }
 }


### PR DESCRIPTION
## Details

Prior to this PR, empty text nodes were placed at each end of a VFragment. This allows for efficient insertion and removal of elements relative to the fragment, which may have sibling nodes not belonging to the fragment. These text nodes are essential bookends for fragments like those found in scoped slots or `lwc:if`.

When rendered on the server, these empty text nodes are rendered using a zero-width space character. This ensures that a text node is actually present after HTML is parsed by the browser. For example,`<div /><div/>` will be parsed by the browser (post-SSR, pre-hydration) as two `<div>`s, even if an empty text node was present in between those `<div>`s in the VDOM.

This introduces two problems:
1.  **Zero-width space characters are layout-impacting.** During hydration, we have special logic looking for text nodes with a single zero-width space character, to be matched with empty text VNodes. However, as part of that special logic, we replace the zero-width space character with an empty string, in order to match future CSR VDOM expectations. Additionally, an empty text node is not layout-impacting, whereas a single zero-width space character is layout-impacting in `inline` or `inline-block` contexts.
2. **VFragments can be nested.** Because fragments are flattened into their containing element, this means there can be two or more text nodes adjacent to each other in the DOM, each one containing a zero-width space character. When this is rendered to HTML and subsequently parsed by the browser, the result is a single text node containing multiple zero-width space characters. Consequently, the number & placement of nodes/elements are inconsistent between SSR'd DOM and CSR VDOM, resulting in hydration failures.

The solution introduced here is to use comment nodes in place of empty text nodes. This clutters the Elements panel in the dev console somewhat, with seemingly extraneous comment nodes. However, this fix results in no performance degradation. HTML will be gzipped in transit, so the multiple comment nodes shouldn't impact network transit size. And we need not introduce special handling to the diffing algo that could easily result in a performance hit.


## Does this pull request introduce a breaking change?

* ⚠️ _Probably yes,_ it does include an observable change.

See description of the breaking change in #3649.

## Does this pull request introduce an observable change?

* ⚠️ Yes, it does include an observable change.

Comment nodes will be present in the DOM where they were not before. Additionally, this involves a compiler change that will require an LWC minor-version bump.

## GUS work item

W-14408593
