### PR TITLE
chore: disable perf smoke tests until image with chrome 119 is published

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -52,4 +52,5 @@ jobs:
       - name: Run Jest tests
         run: yarn test:ci
       - name: Run benchmark smoke tests
+        if: ${{ false }} # Disabled until a runner-image with Chrome 119 is available
         run: BENCHMARK_SMOKE_TEST=1 yarn test:performance


### PR DESCRIPTION
## Details
Disable perf smoke test that runs as part of unit test suite. Note: This does not affect perf tests that are run on best.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
