### PR TITLE
fix: remove string.prototype.matchAll polyfill

### DIFF
--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -45,8 +45,7 @@
         "@lwc/shared": "5.0.2",
         "postcss": "~8.4.31",
         "postcss-selector-parser": "~6.0.13",
-        "postcss-value-parser": "~4.2.0",
-        "string.prototype.matchall": "^4.0.10"
+        "postcss-value-parser": "~4.2.0"
     },
     "devDependencies": {
         "@types/string.prototype.matchall": "^4.0.3"

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import postcss, { Result } from 'postcss';
-import matchAll from 'string.prototype.matchall';
 import { KEY__SCOPED_CSS, LWC_VERSION_COMMENT } from '@lwc/shared';
 import { Config } from './index';
 import { isImportMessage } from './utils/message';
@@ -286,7 +285,7 @@ function tokenizeCss(data: string): Token[] {
     const regex = new RegExp(`[[-](${attributes.join('|')})]?`, 'g');
 
     let lastIndex = 0;
-    for (const match of matchAll(data, regex)) {
+    for (const match of data.matchAll(regex)) {
         const index = match.index!;
         const [matchString, substring] = match;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9809,7 +9809,7 @@ reduce-flatten@^2.0.0:
   resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
   integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
-regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1:
+regexp.prototype.flags@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
   integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
@@ -10665,21 +10665,6 @@ string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
-
-string.prototype.matchall@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz#a1553eb532221d4180c51581d6072cd65d1ee100"
-  integrity sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    get-intrinsic "^1.2.1"
-    has-symbols "^1.0.3"
-    internal-slot "^1.0.5"
-    regexp.prototype.flags "^1.5.0"
-    set-function-name "^2.0.0"
-    side-channel "^1.0.4"
 
 string.prototype.trim@^1.2.8:
   version "1.2.8"


### PR DESCRIPTION
## Details

`String.prototype.matchall` is available in [Node v12+](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll#browser_compatibility). It should be safe to remove this polyfill.

Technically this is a breaking change, but historically we have not made any guarantees about Node compatibility, nor do we test in any version of Node other than the latest LTS. I suspect Node v10 is already broken anyway, and in any case, nobody should be using it.

This does not merit a major version bump IMO.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* 🚨 Yes, it does introduce a breaking change.
See above.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
