### PR TITLE
chore: remove all Circle CI env vars

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ env:
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   SAUCE_TUNNEL_ID: github-action-tunnel-karma-${{github.run_id}}
   PUPPETEER_SKIP_DOWNLOAD: "true" # only needed for @best/runner-local, unused here
+  GITHUB_RUN_ID: ${{github.run_id}}
 
 jobs:
   run-integration-tests:

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -20,6 +20,7 @@ env:
   SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   PUPPETEER_SKIP_DOWNLOAD: "true" # only needed for @best/runner-local, unused here
+  GITHUB_RUN_ID: ${{github.run_id}}
   COVERAGE: "1"
 
 jobs:

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -28,8 +28,6 @@ function getSauceSection({ suiteName, tags, customData }) {
 
     const buildId = GITHUB_RUN_ID || Date.now();
 
-    console.log({ buildId });
-
     const testName = [suiteName, ...tags].join(' - ');
     const build = [suiteName, buildId, ...tags].join(' - ');
 

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -8,10 +8,7 @@
 'use strict';
 
 const {
-    CIRCLE_BRANCH,
-    CIRCLE_BUILD_NUM,
-    CIRCLE_BUILD_URL,
-    CIRCLE_SHA1,
+    GITHUB_RUN_ID,
     IS_CI,
     SAUCE_ACCESS_KEY,
     SAUCE_TUNNEL_ID,
@@ -29,7 +26,9 @@ function getSauceSection({ suiteName, tags, customData }) {
         throw new TypeError('Missing SAUCE_ACCESS_KEY environment variable');
     }
 
-    const buildId = CIRCLE_BUILD_NUM || Date.now();
+    const buildId = GITHUB_RUN_ID || Date.now();
+
+    console.log({ buildId });
 
     const testName = [suiteName, ...tags].join(' - ');
     const build = [suiteName, buildId, ...tags].join(' - ');
@@ -47,11 +46,6 @@ function getSauceSection({ suiteName, tags, customData }) {
             ...customData,
 
             ci: IS_CI,
-
-            build: CIRCLE_BUILD_NUM,
-            commit: CIRCLE_SHA1,
-            branch: CIRCLE_BRANCH,
-            buildUrl: CIRCLE_BUILD_URL,
         },
 
         startConnect: false,

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -42,8 +42,8 @@ function getSauceSection({ suiteName, tags, customData }) {
 
         customData: {
             ...customData,
-
             ci: IS_CI,
+            buildId,
         },
 
         startConnect: false,

--- a/packages/@lwc/integration-karma/scripts/shared/options.js
+++ b/packages/@lwc/integration-karma/scripts/shared/options.js
@@ -55,8 +55,5 @@ module.exports = {
 
     // CI
     IS_CI: Boolean(process.env.CI),
-    CIRCLE_BUILD_NUM: process.env.CIRCLE_BUILD_NUM,
-    CIRCLE_SHA1: process.env.CIRCLE_SHA1,
-    CIRCLE_BRANCH: process.env.CIRCLE_BRANCH,
-    CIRCLE_BUILD_URL: process.env.CIRCLE_BUILD_URL,
+    GITHUB_RUN_ID: process.env.GITHUB_RUN_ID,
 };

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -64,8 +64,6 @@ if (!accessKey) {
 const tunnelId = process.env.SAUCE_TUNNEL_ID;
 const buildId = process.env.GITHUB_RUN_ID || Date.now();
 
-console.log({ buildId });
-
 const name = ['integration-test', mode].join(' - ');
 const build = ['integration-test', buildId, mode].join(' - ');
 const tags = [mode];

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -62,7 +62,9 @@ if (!accessKey) {
 }
 
 const tunnelId = process.env.SAUCE_TUNNEL_ID;
-const buildId = process.env.CIRCLE_BUILD_NUM || Date.now();
+const buildId = process.env.GITHUB_RUN_ID || Date.now();
+
+console.log({ buildId });
 
 const name = ['integration-test', mode].join(' - ');
 const build = ['integration-test', buildId, mode].join(' - ');
@@ -70,11 +72,7 @@ const tags = [mode];
 
 const customData = {
     ci: !!process.env.CI,
-    build: process.env.CIRCLE_BUILD_NUM,
-
-    commit: process.env.CIRCLE_SHA1,
-    branch: process.env.CIRCLE_BRANCH,
-    buildUrl: process.env.CIRCLE_BUILD_URL,
+    buildId,
 };
 
 function getCapabilities() {


### PR DESCRIPTION
## Details

Guess we were still using some Circle CI env vars. These should have been removed in #3783.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
