### PR TITLE
test(integration-karma): cache Rollup output in CI

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -79,6 +79,7 @@ function createPreprocessor(config, emitter, logger) {
                 .join('-');
             tmpFile = path.join(tmpdir, 'lwc-karma-' + checksum);
             if (existsSync(tmpFile)) {
+                console.log('using cached content for', input);
                 const cachedContent = readFileSync(tmpFile, 'utf-8');
                 done(null, cachedContent);
                 return;

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -66,7 +66,7 @@ function createPreprocessor(config, emitter, logger) {
         // Return cached content to speed up CI. In CI the content can never change, so no need to recompile
         let tmpFile;
         if (isCI) {
-            tmpFile = getTmpFile([JSON.stringify(lwcRollupPluginOptions), input, content]);
+            tmpFile = getTmpFile(lwcRollupPluginOptions, input, content);
             if (existsSync(tmpFile)) {
                 console.log('using cached content for', input);
                 const cachedContent = readFileSync(tmpFile, 'utf-8');

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -25,6 +25,8 @@ const {
     DISABLE_STATIC_CONTENT_OPTIMIZATION,
 } = require('../shared/options');
 const Watcher = require('./Watcher');
+const isCI = process.env.CI;
+const tmpdir = os.tmpdir();
 
 function createChecksum(content) {
     const hashFunc = createHash('md5');
@@ -37,9 +39,6 @@ function createPreprocessor(config, emitter, logger) {
 
     const log = logger.create('preprocessor-lwc');
     const watcher = new Watcher(config, emitter, log);
-
-    const isCI = process.env.CI;
-    const tmpdir = os.tmpdir();
 
     // Cache reused between each compilation to speed up the compilation time.
     let cache;

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -71,20 +71,18 @@ function createPreprocessor(config, emitter, logger) {
             apiVersion: API_VERSION,
         };
 
-        // return cached content to speed up CI
-        const tmpFile =
-            isCI &&
-            path.join(
-                tmpdir,
-                'lwc-karma-' +
-                    [JSON.stringify(lwcRollupPluginOptions), input, content]
-                        .map(createChecksum)
-                        .join('-')
-            );
-        if (isCI && existsSync(tmpFile)) {
-            const cachedContent = readFileSync(tmpFile, 'utf-8');
-            done(null, cachedContent);
-            return;
+        // Return cached content to speed up CI. In CI the content can never change, so no need to recompile
+        let tmpFile;
+        if (isCI) {
+            const checksum = [JSON.stringify(lwcRollupPluginOptions), input, content]
+                .map(createChecksum)
+                .join('-');
+            tmpFile = path.join(tmpdir, 'lwc-karma-' + checksum);
+            if (existsSync(tmpFile)) {
+                const cachedContent = readFileSync(tmpFile, 'utf-8');
+                done(null, cachedContent);
+                return;
+            }
         }
 
         try {

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/tmp-file.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/tmp-file.js
@@ -15,9 +15,12 @@ function createChecksum(content) {
     return hashFunc.digest('hex');
 }
 
-function getTmpFile(cacheKeys) {
-    const checksum = cacheKeys.map(createChecksum).join('-');
+function getTmpFile(...cacheKeys) {
+    const checksum = cacheKeys
+        .map((value) => (typeof value !== 'string' ? JSON.stringify(value) : value))
+        .map(createChecksum)
+        .join('-');
     return path.join(os.tmpdir(), 'lwc-karma-' + checksum);
 }
 
-exports.getTmpFile = getTmpFile();
+exports.getTmpFile = getTmpFile;

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/tmp-file.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/tmp-file.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+const { createHash } = require('node:crypto');
+const path = require('node:path');
+const os = require('node:os');
+
+function createChecksum(content) {
+    const hashFunc = createHash('md5');
+    hashFunc.update(content);
+    return hashFunc.digest('hex');
+}
+
+function getTmpFile(cacheKeys) {
+    const checksum = cacheKeys.map(createChecksum).join('-');
+    return path.join(os.tmpdir(), 'lwc-karma-' + checksum);
+}
+
+exports.getTmpFile = getTmpFile();

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
@@ -49,7 +49,7 @@ function createPreprocessor(config, emitter, logger) {
         // Return cached content to speed up CI. In CI the content can never change, so no need to recompile
         let tmpFile;
         if (isCI) {
-            tmpFile = getTmpFile([input, content]);
+            tmpFile = getTmpFile(input, content);
             if (existsSync(tmpFile)) {
                 console.log('using cached content for', input);
                 const cachedContent = readFileSync(tmpFile, 'utf-8');


### PR DESCRIPTION
## Details

This should speed up Karma tests in CI by caching the Rollup output between builds.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
