### PR TITLE
chore(integration-karma): fix sourcemaps

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -150,3 +150,6 @@ jobs:
         with:
           name: coverage-report-combined
           path: ./packages/@lwc/integration-karma/coverage/combined
+
+      - name: Add markdown summary
+        run: awk '/<table/,/<\/table>/' ./combined/index.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -144,3 +144,9 @@ jobs:
           path: ./packages/@lwc/integration-karma/coverage
 
       - run: yarn coverage
+
+      - name: Upload combined coverage HTML
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report-combined-html
+          path: ./packages/@lwc/integration-karma/coverage/combined/index.html

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -145,8 +145,8 @@ jobs:
 
       - run: yarn coverage
 
-      - name: Upload combined coverage HTML
+      - name: Upload combined coverage
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-report-combined-html
-          path: ./packages/@lwc/integration-karma/coverage/combined/index.html
+          name: coverage-report-combined
+          path: ./packages/@lwc/integration-karma/coverage/combined

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -152,4 +152,4 @@ jobs:
           path: ./packages/@lwc/integration-karma/coverage/combined
 
       - name: Add markdown summary
-        run: awk '/<table/,/<\/table>/' ./combined/index.html >> $GITHUB_STEP_SUMMARY
+        run: awk '/<table/,/<\/table>/' ./coverage/combined/index.html >> $GITHUB_STEP_SUMMARY

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -49,6 +49,7 @@ function createPreprocessor(config, emitter, logger) {
 
         const plugins = [
             lwcRollupPlugin({
+                // Sourcemaps don't work with Istanbul coverage
                 sourcemap: !process.env.COVERAGE,
                 experimentalDynamicComponent: {
                     loader: 'test-utils',
@@ -87,6 +88,7 @@ function createPreprocessor(config, emitter, logger) {
 
             const { output } = await bundle.generate({
                 format: 'iife',
+                // Sourcemaps don't work with Istanbul coverage
                 sourcemap: process.env.COVERAGE ? false : 'inline',
 
                 // The engine and the test-utils is injected as UMD. This mapping defines how those modules can be

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -49,7 +49,7 @@ function createPreprocessor(config, emitter, logger) {
 
         const plugins = [
             lwcRollupPlugin({
-                sourcemap: true,
+                sourcemap: !process.env.COVERAGE,
                 experimentalDynamicComponent: {
                     loader: 'test-utils',
                     strict: true,
@@ -87,7 +87,7 @@ function createPreprocessor(config, emitter, logger) {
 
             const { output } = await bundle.generate({
                 format: 'iife',
-                sourcemap: 'inline',
+                sourcemap: process.env.COVERAGE ? false : 'inline',
 
                 // The engine and the test-utils is injected as UMD. This mapping defines how those modules can be
                 // referenced from the window object.
@@ -103,10 +103,12 @@ function createPreprocessor(config, emitter, logger) {
 
             const { code, map } = output[0];
 
-            // We need to assign the source to the original file so Karma can source map the error in the console. Add
-            // also adding the source map inline for browser debugging.
-            // eslint-disable-next-line require-atomic-updates
-            file.sourceMap = map;
+            if (map) {
+                // We need to assign the source to the original file so Karma can source map the error in the console. Add
+                // also adding the source map inline for browser debugging.
+                // eslint-disable-next-line require-atomic-updates
+                file.sourceMap = map;
+            }
 
             done(null, code);
         } catch (error) {

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
@@ -94,7 +94,7 @@ function createPreprocessor(config, emitter, logger) {
 
         let code = magicString.toString();
 
-        // Sourcemaps cause an error in the Istanbul coverage report
+        // Sourcemaps don't work with Istanbul coverage
         if (!process.env.COVERAGE) {
             // We need to assign the source to the original file so Karma can source map the error in the console.
             // also adding the source map inline for browser debugging.

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
@@ -11,9 +11,8 @@
  */
 'use strict';
 
-const path = require('path');
-const { rollup } = require('rollup');
-const replace = require('@rollup/plugin-replace');
+const MagicString = require('magic-string');
+const { init, parse } = require('es-module-lexer');
 const Watcher = require('./Watcher');
 
 function getIifeName(filename) {
@@ -32,91 +31,80 @@ function getIifeName(filename) {
 }
 
 function createPreprocessor(config, emitter, logger) {
-    const { basePath } = config;
-
     const log = logger.create('preprocessor-transform-framework');
     const watcher = new Watcher(config, emitter, log);
 
-    // Cache reused between each compilation to speed up the compilation time.
-    let cache;
-
-    return async (_content, file, done) => {
+    return async (content, file, done) => {
         const input = file.path;
+        const iifeName = getIifeName(input);
 
-        try {
-            const bundle = await rollup({
-                input,
-                cache,
-                plugins: [
-                    /**
-                     * This transformation replaces:
-                     *     process.env.NODE_ENV === 'test-karma-lwc'
-                     * with:
-                     *     true
-                     *
-                     * You might wonder why we replace the whole thing rather than just `process.env.NODE_ENV`. Well, because we need a way
-                     * to test `process.env.NODE_ENV === "production"` (prod mode) vs `process.env.NODE_ENV !== "production"` (dev mode).
-                     * If we replaced `process.env.NODE_ENV`, then that would be impossible.
-                     *
-                     * Then you might wonder why we call it "test-karma-lwc" rather than something simple like "test". Well, because
-                     * "test" was already squatted by Jest, and we actually use it for Jest-specific (not Karma-specific) behavior:
-                     * - https://jestjs.io/docs/environment-variables#node_env
-                     * - https://github.com/search?q=repo%3Asalesforce%2Flwc%20node_env%20%3D%3D%3D%20%27test%27&type=code
-                     *
-                     * Then you might wonder why we don't invent our own thing like `process.env.IS_KARMA`. Well, because we're testing
-                     * the artifacts we ship in the npm package, and we can't expect our consumers to replace the string
-                     * `process.env.IS_KARMA`, although we do expect them to replace `process.env.NODE_ENV` (usually with "production").
-                     *
-                     * Then you might wonder why we don't just use a runtime check like `typeof __karma__ !== 'undefined'`. And the reason
-                     * for that is that we want Karma-specific code to be tree-shaken in prod mode. (Assuming our consumers are replacing
-                     * `process.env.NODE_ENV` with "production".)
-                     *
-                     * So then you might wonder why we test against the same artifacts we ship, rather than testing against Karma-specific
-                     * artifacts. And that's totally reasonable, but then it introduces the risk that we're not testing our "real"
-                     * artifacts.
-                     *
-                     * So that's why this is so weird and complicated. I'm sorry.
-                     */
-                    replace({
-                        preventAssignment: true,
-                        values: {
-                            [`process.env.NODE_ENV === 'test-karma-lwc'`]: 'true',
-                        },
-                        delimiters: ['', ''],
-                    }),
-                ],
-            });
+        watcher.watchSuite(input, []);
 
-            watcher.watchSuite(input, bundle.watchFiles);
+        // Strip sourcemap for now since we can't get index.js.map to actually work in either Karma or Istanbul
+        const magicString = new MagicString(content.replace(/\/\/# sourceMappingURL=\S+/, ''));
 
-            // eslint-disable-next-line require-atomic-updates
-            cache = bundle.cache;
+        /**
+         * This transformation replaces:
+         *     process.env.NODE_ENV === 'test-karma-lwc'
+         * with:
+         *     true
+         *
+         * You might wonder why we replace the whole thing rather than just `process.env.NODE_ENV`. Well, because we need a way
+         * to test `process.env.NODE_ENV === "production"` (prod mode) vs `process.env.NODE_ENV !== "production"` (dev mode).
+         * If we replaced `process.env.NODE_ENV`, then that would be impossible.
+         *
+         * Then you might wonder why we call it "test-karma-lwc" rather than something simple like "test". Well, because
+         * "test" was already squatted by Jest, and we actually use it for Jest-specific (not Karma-specific) behavior:
+         * - https://jestjs.io/docs/environment-variables#node_env
+         * - https://github.com/search?q=repo%3Asalesforce%2Flwc%20node_env%20%3D%3D%3D%20%27test%27&type=code
+         *
+         * Then you might wonder why we don't invent our own thing like `process.env.IS_KARMA`. Well, because we're testing
+         * the artifacts we ship in the npm package, and we can't expect our consumers to replace the string
+         * `process.env.IS_KARMA`, although we do expect them to replace `process.env.NODE_ENV` (usually with "production").
+         *
+         * Then you might wonder why we don't just use a runtime check like `typeof __karma__ !== 'undefined'`. And the reason
+         * for that is that we want Karma-specific code to be tree-shaken in prod mode. (Assuming our consumers are replacing
+         * `process.env.NODE_ENV` with "production".)
+         *
+         * So then you might wonder why we test against the same artifacts we ship, rather than testing against Karma-specific
+         * artifacts. And that's totally reasonable, but then it introduces the risk that we're not testing our "real"
+         * artifacts.
+         *
+         * So that's why this is so weird and complicated. I'm sorry.
+         */
+        const replacee = `process.env.NODE_ENV === 'test-karma-lwc'`;
+        // pad to keep things pretty in Istanbul coverage HTML
+        magicString.replaceAll(replacee, 'true'.padEnd(replacee.length, ' '));
 
-            const iifeName = getIifeName(input);
+        // Convert ESM to IIFE. Change `export { foo as bar }` to `return { bar: foo }`
+        magicString.replace(/\bexport \{/, 'return {');
 
-            const { output } = await bundle.generate({
-                format: 'iife',
-                name: iifeName,
-                // Source maps cause an error in coverage mode ("don't know how to turn this value into a node"), so skip it
-                sourcemap: process.env.COVERAGE ? false : 'inline',
-            });
+        await init;
+        const exportees = parse(content)[1].map((_) => ({ variable: _.ln, alias: _.n }));
 
-            const { code, map } = output[0];
-
-            if (map) {
-                // We need to assign the source to the original file so Karma can source map the error in the console.
-                // also adding the source map inline for browser debugging.
-                // eslint-disable-next-line require-atomic-updates
-                file.sourceMap = map;
+        for (const { variable, alias } of exportees) {
+            if (variable !== alias) {
+                magicString.replace(`${variable} as ${alias}`, `${alias}: ${variable}`);
             }
-
-            done(null, code);
-        } catch (error) {
-            const location = path.relative(basePath, file.path);
-            log.error('Error processing “%s”\n\n%s\n', location, error.stack || error.message);
-
-            done(error, null);
         }
+
+        // Wrap in an IIFE. Note we explicitly don't add newlines, since that would mess up Istanbul's coverage report
+        magicString.prepend(`${iifeName ? `var ${iifeName} = ` : ''}(function () {`);
+        magicString.append('})();');
+
+        let code = magicString.toString();
+
+        // Sourcemaps cause an error in the Istanbul coverage report
+        if (!process.env.COVERAGE) {
+            // We need to assign the source to the original file so Karma can source map the error in the console.
+            // also adding the source map inline for browser debugging.
+            const map = magicString.generateMap();
+            code += '\n//# sourceMappingURL=' + map.toUrl();
+            // eslint-disable-next-line require-atomic-updates
+            file.sourceMap = map;
+        }
+
+        done(null, code);
     };
 }
 


### PR DESCRIPTION
## Details

This fixes sourcemaps in the Karma tests. I confirmed that you can actually set breakpoints in `engine-dom` using `karma start`, and that the Istanbul coverage HTML reports actually work now:

![Screenshot 2023-11-17 at 3 39 45 PM](https://github.com/salesforce/lwc/assets/283842/55f1f3f2-9d06-42b2-9f82-90b99850488e)


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
