### PR TITLE
ci: add instructions on github workflows to cache/restore ./.npx-cache dir

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,14 @@ jobs:
           node-version: "18.18.0"
           cache: 'yarn'
 
+      - name: Cache nx
+        uses: actions/cache@v3.3.2
+        with:
+          path: ./.nx-cache
+          key: ${{ runner.os }}-nx
+          restore-key: |
+            ${{ runner.os }}-nx
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,14 @@ jobs:
           node-version: "18.18.0"
           cache: 'yarn'
 
+      - name: Cache nx
+        uses: actions/cache@v3.3.2
+        with:
+          path: ./.nx-cache
+          key: ${{ runner.os }}-nx
+          restore-key: |
+            ${{ runner.os }}-nx
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -41,6 +41,14 @@ jobs:
           node-version: "18.18.0"
           cache: 'yarn'
 
+      - name: Cache nx
+        uses: actions/cache@v3.3.2
+        with:
+          path: ./.nx-cache
+          key: ${{ runner.os }}-nx
+          restore-key: |
+            ${{ runner.os }}-nx
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,6 +40,14 @@ jobs:
           chrome-version: 1194751
         id: setup-chrome
 
+      - name: Cache nx
+        uses: actions/cache@v3.3.2
+        with:
+          path: ./.nx-cache
+          key: ${{ runner.os }}-nx
+          restore-key: |
+            ${{ runner.os }}-nx
+      
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
## Details

https://github.com/salesforce/lwc/issues/3841

obs: nx handles cache hits automatically.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
N/A