### PR TITLE
feat: log shadow mode through engine reporting API

### DIFF
--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -6,6 +6,8 @@
  */
 import { noop } from '@lwc/shared';
 
+import { ShadowMode } from './vm';
+
 export const enum ReportingEventId {
     CrossRootAriaInSyntheticShadow = 'CrossRootAriaInSyntheticShadow',
     CompilerRuntimeVersionMismatch = 'CompilerRuntimeVersionMismatch',
@@ -13,6 +15,7 @@ export const enum ReportingEventId {
     TemplateMutation = 'TemplateMutation',
     StylesheetMutation = 'StylesheetMutation',
     ConnectedCallbackWhileDisconnected = 'ConnectedCallbackWhileDisconnected',
+    ShadowModeUsage = 'ShadowModeUsage',
 }
 
 export interface BasePayload {
@@ -44,6 +47,10 @@ export interface StylesheetMutationPayload extends BasePayload {
 
 export interface ConnectedCallbackWhileDisconnectedPayload extends BasePayload {}
 
+export interface ShadowModeUsagePayload extends BasePayload {
+    mode: ShadowMode;
+}
+
 export type ReportingPayloadMapping = {
     [ReportingEventId.CrossRootAriaInSyntheticShadow]: CrossRootAriaInSyntheticShadowPayload;
     [ReportingEventId.CompilerRuntimeVersionMismatch]: CompilerRuntimeVersionMismatchPayload;
@@ -51,6 +58,7 @@ export type ReportingPayloadMapping = {
     [ReportingEventId.TemplateMutation]: TemplateMutationPayload;
     [ReportingEventId.StylesheetMutation]: StylesheetMutationPayload;
     [ReportingEventId.ConnectedCallbackWhileDisconnected]: ConnectedCallbackWhileDisconnectedPayload;
+    [ReportingEventId.ShadowModeUsage]: ShadowModeUsagePayload;
 };
 
 export type ReportingDispatcher<T extends ReportingEventId = ReportingEventId> = (

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -376,7 +376,8 @@ export function createVM<HostNode, HostElement>(
     vm.shadowMode = computeShadowMode(def, vm.owner, renderer);
     vm.tro = getTemplateReactiveObserver(vm);
 
-    if (isReportingEnabled()) {
+    // We don't need to report the shadow mode if we're rendering in light DOM
+    if (isReportingEnabled() && vm.renderMode === RenderMode.Shadow) {
         report(ReportingEventId.ShadowModeUsage, {
             tagName: vm.tagName,
             mode: vm.shadowMode,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -376,6 +376,13 @@ export function createVM<HostNode, HostElement>(
     vm.shadowMode = computeShadowMode(def, vm.owner, renderer);
     vm.tro = getTemplateReactiveObserver(vm);
 
+    if (isReportingEnabled()) {
+        report(ReportingEventId.ShadowModeUsage, {
+            tagName: vm.tagName,
+            mode: vm.shadowMode,
+        });
+    }
+
     if (process.env.NODE_ENV !== 'production') {
         vm.toString = (): string => {
             return `[object:vm ${def.name} (${vm.idx})]`;

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -345,6 +345,23 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         jasmine.addMatchers(customMatchers);
     });
 
+    /**
+     *
+     * @param {jasmine.Spy} dispatcher
+     * @param {String[]} runtimeEvents List of runtime events to filter by. If no list is provided, all events will be dispatched.
+     */
+    function attachReportingControlDispatcher(dispatcher, runtimeEvents) {
+        lwc.__unstable__ReportingControl.attachDispatcher((eventName, payload) => {
+            if (!runtimeEvents || runtimeEvents.includes(eventName)) {
+                dispatcher(eventName, payload);
+            }
+        });
+    }
+
+    function detachReportingControlDispatcher() {
+        lwc.__unstable__ReportingControl.detachDispatcher();
+    }
+
     function extractDataIds(root) {
         var nodes = {};
 
@@ -566,5 +583,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         nonStandardAriaProperties: nonStandardAriaProperties,
         nonPolyfilledAriaProperties: nonPolyfilledAriaProperties,
         getPropertyDescriptor: getPropertyDescriptor,
+        attachReportingControlDispatcher: attachReportingControlDispatcher,
+        detachReportingControlDispatcher: detachReportingControlDispatcher,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -42,7 +42,9 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 elm.getProp(prop);
                             }).not.toLogWarningDev();
 
-                            expect(dispatcher).not.toHaveBeenCalled();
+                            expect(dispatcher).not.toHaveBeenCalledWith(
+                                'NonStandardAriaReflection'
+                            );
                         });
 
                         it('LightningElement - outside component', () => {
@@ -52,7 +54,9 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 return unused; // remove lint warning
                             }).not.toLogWarningDev();
 
-                            expect(dispatcher).not.toHaveBeenCalled();
+                            expect(dispatcher).not.toHaveBeenCalledWith(
+                                'NonStandardAriaReflection'
+                            );
                         });
 
                         it('regular Element inside LightningElement', () => {
@@ -61,8 +65,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 elm.getPropOnElement(prop);
                             }).toLogWarningDev(inComponentWarning);
 
-                            expect(dispatcher).toHaveBeenCalledTimes(2);
-                            expect(dispatcher.calls.allArgs()).toEqual([
+                            [
                                 [
                                     'NonStandardAriaReflection',
                                     {
@@ -81,7 +84,9 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                         setValueType: undefined,
                                     },
                                 ],
-                            ]);
+                            ].forEach((dispatch) => {
+                                expect(dispatcher.calls.allArgs()).toContain(dispatch);
+                            });
                         });
 
                         it('regular Element outside LightningElement', () => {
@@ -93,8 +98,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 return unused; // remove lint warning
                             }).toLogWarningDev(outsideComponentWarning);
 
-                            expect(dispatcher).toHaveBeenCalledTimes(2);
-                            expect(dispatcher.calls.allArgs()).toEqual([
+                            [
                                 [
                                     'NonStandardAriaReflection',
                                     {
@@ -113,7 +117,9 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                         setValueType: undefined,
                                     },
                                 ],
-                            ]);
+                            ].forEach((dispatch) => {
+                                expect(dispatcher.calls.allArgs()).toContain(dispatch);
+                            });
                         });
                     });
                 });

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -1,5 +1,9 @@
-import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
-import { nonStandardAriaProperties } from 'test-utils';
+import { createElement } from 'lwc';
+import {
+    attachReportingControlDispatcher,
+    detachReportingControlDispatcher,
+    nonStandardAriaProperties,
+} from 'test-utils';
 import Light from 'x/light';
 import Shadow from 'x/shadow';
 
@@ -10,11 +14,11 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
 
         beforeEach(() => {
             dispatcher = jasmine.createSpy();
-            reportingControl.attachDispatcher(dispatcher);
+            attachReportingControlDispatcher(dispatcher, ['NonStandardAriaReflection']);
         });
 
         afterEach(() => {
-            reportingControl.detachDispatcher();
+            detachReportingControlDispatcher();
         });
 
         nonStandardAriaProperties.forEach((prop) => {
@@ -42,9 +46,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 elm.getProp(prop);
                             }).not.toLogWarningDev();
 
-                            expect(dispatcher).not.toHaveBeenCalledWith(
-                                'NonStandardAriaReflection'
-                            );
+                            expect(dispatcher).not.toHaveBeenCalled();
                         });
 
                         it('LightningElement - outside component', () => {
@@ -54,9 +56,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 return unused; // remove lint warning
                             }).not.toLogWarningDev();
 
-                            expect(dispatcher).not.toHaveBeenCalledWith(
-                                'NonStandardAriaReflection'
-                            );
+                            expect(dispatcher).not.toHaveBeenCalled();
                         });
 
                         it('regular Element inside LightningElement', () => {
@@ -65,7 +65,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 elm.getPropOnElement(prop);
                             }).toLogWarningDev(inComponentWarning);
 
-                            [
+                            expect(dispatcher.calls.allArgs()).toEqual([
                                 [
                                     'NonStandardAriaReflection',
                                     {
@@ -84,9 +84,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                         setValueType: undefined,
                                     },
                                 ],
-                            ].forEach((dispatch) => {
-                                expect(dispatcher.calls.allArgs()).toContain(dispatch);
-                            });
+                            ]);
                         });
 
                         it('regular Element outside LightningElement', () => {
@@ -98,7 +96,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                 return unused; // remove lint warning
                             }).toLogWarningDev(outsideComponentWarning);
 
-                            [
+                            expect(dispatcher.calls.allArgs()).toEqual([
                                 [
                                     'NonStandardAriaReflection',
                                     {
@@ -117,9 +115,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                                         setValueType: undefined,
                                     },
                                 ],
-                            ].forEach((dispatch) => {
-                                expect(dispatcher.calls.allArgs()).toContain(dispatch);
-                            });
+                            ]);
                         });
                     });
                 });

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -251,17 +251,23 @@ if (!process.env.NATIVE_SHADOW) {
                 elm2.linkUsingBoth({ idPrefix: 'prefix-2' }); // ids must be globally unique
             }).toLogWarningDev(expectedMessageForCrossRoot);
 
-            // dispatcher is still called twice for CrossRootAriaInSyntheticShadow
-            expect(
-                dispatcher.calls
-                    .allArgs()
-                    .filter(
-                        (dispatch) =>
-                            dispatch[0] === 'CrossRootAriaInSyntheticShadow' &&
-                            dispatch[1].tagName === 'x-aria-source' &&
-                            dispatch[1].attributeName === 'aria-labelledby'
-                    )
-            ).toHaveSize(2);
+            // dispatcher is still called twice
+            expect(dispatcher.calls.allArgs()).toEqual([
+                [
+                    'CrossRootAriaInSyntheticShadow',
+                    {
+                        tagName: 'x-aria-source',
+                        attributeName: 'aria-labelledby',
+                    },
+                ],
+                [
+                    'CrossRootAriaInSyntheticShadow',
+                    {
+                        tagName: 'x-aria-source',
+                        attributeName: 'aria-labelledby',
+                    },
+                ],
+            ]);
         });
 
         [false, true].forEach((reverseOrder) => {

--- a/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
@@ -228,7 +228,7 @@ describe('freezeTemplate', () => {
             expect(descriptor.enumerable).toEqual(true);
             expect(descriptor.configurable).toEqual(true);
         }
-        expect(dispatcher).not.toHaveBeenCalled();
+        expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
     });
 
     describe('ENABLE_FROZEN_TEMPLATE set to true', () => {
@@ -249,7 +249,8 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(Object.isFrozen(template.stylesheets)).toEqual(true);
-            expect(dispatcher).not.toHaveBeenCalled();
+            expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
+            expect(dispatcher).not.toHaveBeenCalledWith('TemplateMutation');
         });
 
         it('freezes a template with no stylesheets', () => {
@@ -258,7 +259,7 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(template.stylesheets).toEqual(undefined);
-            expect(dispatcher).not.toHaveBeenCalled();
+            expect(dispatcher).not.toHaveBeenCalledWith('TemplateMutation');
         });
 
         it('deep-freezes the stylesheets', () => {
@@ -275,7 +276,7 @@ describe('freezeTemplate', () => {
             expect(Object.isFrozen(stylesheets[0])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1][0])).toEqual(true);
-            expect(dispatcher).not.toHaveBeenCalled();
+            expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/freezeTemplate/index.spec.js
@@ -1,20 +1,17 @@
-import {
-    registerTemplate,
-    freezeTemplate,
-    setFeatureFlagForTest,
-    __unstable__ReportingControl as reportingControl,
-} from 'lwc';
+import { registerTemplate, freezeTemplate, setFeatureFlagForTest } from 'lwc';
+
+import { attachReportingControlDispatcher, detachReportingControlDispatcher } from 'test-utils';
 
 describe('freezeTemplate', () => {
     let dispatcher;
 
     beforeEach(() => {
         dispatcher = jasmine.createSpy();
-        reportingControl.attachDispatcher(dispatcher);
+        attachReportingControlDispatcher(dispatcher, ['StylesheetMutation', 'TemplateMutation']);
     });
 
     afterEach(() => {
-        reportingControl.detachDispatcher();
+        detachReportingControlDispatcher();
     });
 
     it('should warn when setting tmpl.stylesheetToken', () => {
@@ -228,7 +225,7 @@ describe('freezeTemplate', () => {
             expect(descriptor.enumerable).toEqual(true);
             expect(descriptor.configurable).toEqual(true);
         }
-        expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
+        expect(dispatcher).not.toHaveBeenCalled();
     });
 
     describe('ENABLE_FROZEN_TEMPLATE set to true', () => {
@@ -249,8 +246,7 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(Object.isFrozen(template.stylesheets)).toEqual(true);
-            expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
-            expect(dispatcher).not.toHaveBeenCalledWith('TemplateMutation');
+            expect(dispatcher).not.toHaveBeenCalled();
         });
 
         it('freezes a template with no stylesheets', () => {
@@ -259,7 +255,7 @@ describe('freezeTemplate', () => {
 
             expect(Object.isFrozen(template)).toEqual(true);
             expect(template.stylesheets).toEqual(undefined);
-            expect(dispatcher).not.toHaveBeenCalledWith('TemplateMutation');
+            expect(dispatcher).not.toHaveBeenCalled();
         });
 
         it('deep-freezes the stylesheets', () => {
@@ -276,7 +272,7 @@ describe('freezeTemplate', () => {
             expect(Object.isFrozen(stylesheets[0])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1])).toEqual(true);
             expect(Object.isFrozen(stylesheets[1][0])).toEqual(true);
-            expect(dispatcher).not.toHaveBeenCalledWith('StylesheetMutation');
+            expect(dispatcher).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -1,4 +1,6 @@
-import { __unstable__ReportingControl as reportingControl, createElement } from 'lwc';
+import { createElement } from 'lwc';
+import { attachReportingControlDispatcher, detachReportingControlDispatcher } from 'test-utils';
+
 import Component from 'x/component';
 import Parent from 'x/parent';
 
@@ -9,12 +11,12 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
 
         beforeEach(() => {
             dispatcher = jasmine.createSpy();
-            reportingControl.attachDispatcher(dispatcher);
+            attachReportingControlDispatcher(dispatcher, ['ConnectedCallbackWhileDisconnected']);
             logger = spyOn(console, 'warn');
         });
 
         afterEach(() => {
-            reportingControl.detachDispatcher();
+            detachReportingControlDispatcher();
         });
 
         function expectLogs(regexes) {
@@ -38,9 +40,8 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             expectLogs([
                 /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
             ]);
-            expect(dispatcher.calls.allArgs()).toContain([
-                'ConnectedCallbackWhileDisconnected',
-                { tagName: 'x-component' },
+            expect(dispatcher.calls.allArgs()).toEqual([
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-component' }],
             ]);
         });
 
@@ -54,14 +55,9 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
                 /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
                 /Element <x-child> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
             ]);
-            expect(dispatcher.calls.allArgs()).toContain([
-                'ConnectedCallbackWhileDisconnected',
-                { tagName: 'x-parent' },
-            ]);
-
-            expect(dispatcher.calls.allArgs()).toContain([
-                'ConnectedCallbackWhileDisconnected',
-                { tagName: 'x-child' },
+            expect(dispatcher.calls.allArgs()).toEqual([
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
             ]);
         });
     });

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -38,8 +38,9 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             expectLogs([
                 /Element <x-component> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
             ]);
-            expect(dispatcher.calls.allArgs()).toEqual([
-                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-component' }],
+            expect(dispatcher.calls.allArgs()).toContain([
+                'ConnectedCallbackWhileDisconnected',
+                { tagName: 'x-component' },
             ]);
         });
 
@@ -53,9 +54,14 @@ if (!window.lwcRuntimeFlags.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
                 /Element <x-parent> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
                 /Element <x-child> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
             ]);
-            expect(dispatcher.calls.allArgs()).toEqual([
-                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
-                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
+            expect(dispatcher.calls.allArgs()).toContain([
+                'ConnectedCallbackWhileDisconnected',
+                { tagName: 'x-parent' },
+            ]);
+
+            expect(dispatcher.calls.allArgs()).toContain([
+                'ConnectedCallbackWhileDisconnected',
+                { tagName: 'x-child' },
             ]);
         });
     });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
@@ -1,4 +1,5 @@
-import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
+import { createElement } from 'lwc';
+import { attachReportingControlDispatcher, detachReportingControlDispatcher } from 'test-utils';
 
 import Component from 'x/component';
 import Parent from 'x/parent';
@@ -14,11 +15,11 @@ describe('', () => {
 
     beforeEach(() => {
         dispatcher = jasmine.createSpy();
-        reportingControl.attachDispatcher(dispatcher);
+        attachReportingControlDispatcher(dispatcher, ['ShadowModeUsage']);
     });
 
     afterEach(() => {
-        reportingControl.detachDispatcher();
+        detachReportingControlDispatcher();
     });
 
     it('should report the shadow mode for the rendered component', () => {

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
@@ -1,0 +1,55 @@
+import { createElement, __unstable__ReportingControl as reportingControl } from 'lwc';
+
+import Component from 'x/component';
+import Parent from 'x/parent';
+
+// Should be kept in sync with the enum in vm.ts
+const ShadowMode = {
+    Native: 0,
+    Synthetic: 1,
+};
+
+describe('', () => {
+    let dispatcher;
+
+    beforeEach(() => {
+        dispatcher = jasmine.createSpy();
+        reportingControl.attachDispatcher(dispatcher);
+    });
+
+    afterEach(() => {
+        reportingControl.detachDispatcher();
+    });
+
+    it('should report the shadow mode for the rendered component', () => {
+        const element = createElement('x-component', { is: Component });
+        document.body.appendChild(element);
+
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-component',
+            mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
+        });
+    });
+
+    it('should report the shadow mode for all rendered components', () => {
+        const element = createElement('x-parent', { is: Parent });
+        document.body.appendChild(element);
+
+        expect(dispatcher).toHaveBeenCalledTimes(3);
+        // x-parent depends on environment
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-parent',
+            mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
+        });
+        // x-native should be set to native always
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-native',
+            mode: ShadowMode.Native,
+        });
+        // x-component depends on environment
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-component',
+            mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/index.spec.js
@@ -3,6 +3,7 @@ import { attachReportingControlDispatcher, detachReportingControlDispatcher } fr
 
 import Component from 'x/component';
 import Parent from 'x/parent';
+import Light from 'x/light';
 
 // Should be kept in sync with the enum in vm.ts
 const ShadowMode = {
@@ -10,7 +11,7 @@ const ShadowMode = {
     Synthetic: 1,
 };
 
-describe('', () => {
+describe('ShadowModeUsage', () => {
     let dispatcher;
 
     beforeEach(() => {
@@ -52,5 +53,37 @@ describe('', () => {
             tagName: 'x-component',
             mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
         });
+    });
+
+    it('should report the shadow mode for components when created using CustomElementConstructor', () => {
+        const ParentCustomElement = Parent.CustomElementConstructor;
+        customElements.define('x-parent-custom-element', ParentCustomElement);
+
+        const element = document.createElement('x-parent-custom-element');
+        document.body.appendChild(element);
+
+        expect(dispatcher).toHaveBeenCalledTimes(3);
+        // x-parent depends on environment
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'X-PARENT-CUSTOM-ELEMENT',
+            mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
+        });
+        // x-native should be set to native always
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-native',
+            mode: ShadowMode.Native,
+        });
+        // x-component depends on environment
+        expect(dispatcher).toHaveBeenCalledWith('ShadowModeUsage', {
+            tagName: 'x-component',
+            mode: process.env.NATIVE_SHADOW ? ShadowMode.Native : ShadowMode.Synthetic,
+        });
+    });
+
+    it('should report no shadow mode for light DOM components', () => {
+        const element = createElement('x-light', { is: Light });
+        document.body.appendChild(element);
+
+        expect(dispatcher).toHaveBeenCalledTimes(0);
     });
 });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <div>default component</div>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/light/light.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <p>Hello, Light DOM</p>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/light/light.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/light/light.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Light extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/native/native.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/native/native.html
@@ -1,0 +1,3 @@
+<template>
+    <div>shadowSupportMode = 'native'</div>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/native/native.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/native/native.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'native';
+}

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/parent/parent.html
@@ -1,0 +1,4 @@
+<template>
+    <x-native></x-native>
+    <x-component></x-component>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/reporting/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -2,8 +2,11 @@ import {
     ariaPropertiesMapping,
     nonStandardAriaProperties,
     nonPolyfilledAriaProperties,
+    attachReportingControlDispatcher,
+    detachReportingControlDispatcher,
 } from 'test-utils';
-import { __unstable__ReportingControl as reportingControl, createElement } from 'lwc';
+import { createElement } from 'lwc';
+
 import Component from 'x/component';
 
 function testAriaProperty(property, attribute) {
@@ -12,11 +15,11 @@ function testAriaProperty(property, attribute) {
 
         beforeEach(() => {
             dispatcher = jasmine.createSpy();
-            reportingControl.attachDispatcher(dispatcher);
+            attachReportingControlDispatcher(dispatcher, ['NonStandardAriaReflection']);
         });
 
         afterEach(() => {
-            reportingControl.detachDispatcher();
+            detachReportingControlDispatcher();
         });
 
         function getDefaultValue(prop) {
@@ -37,33 +40,37 @@ function testAriaProperty(property, attribute) {
 
         function expectGetterReportIfNonStandard() {
             if (nonStandardAriaProperties.includes(property)) {
-                expect(dispatcher.calls.allArgs()).toContain([
-                    'NonStandardAriaReflection',
-                    {
-                        tagName: undefined,
-                        propertyName: property,
-                        isSetter: false,
-                        setValueType: undefined,
-                    },
+                expect(dispatcher.calls.allArgs()).toEqual([
+                    [
+                        'NonStandardAriaReflection',
+                        {
+                            tagName: undefined,
+                            propertyName: property,
+                            isSetter: false,
+                            setValueType: undefined,
+                        },
+                    ],
                 ]);
             } else {
-                expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
+                expect(dispatcher).not.toHaveBeenCalled();
             }
         }
 
         function expectSetterReportIfNonStandard(setValueType) {
             if (nonStandardAriaProperties.includes(property)) {
-                expect(dispatcher.calls.allArgs()).toContain([
-                    'NonStandardAriaReflection',
-                    {
-                        tagName: undefined,
-                        propertyName: property,
-                        isSetter: true,
-                        setValueType,
-                    },
+                expect(dispatcher.calls.allArgs()).toEqual([
+                    [
+                        'NonStandardAriaReflection',
+                        {
+                            tagName: undefined,
+                            propertyName: property,
+                            isSetter: true,
+                            setValueType,
+                        },
+                    ],
                 ]);
             } else {
-                expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
+                expect(dispatcher).not.toHaveBeenCalled();
             }
         }
 
@@ -206,11 +213,11 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
 
         beforeEach(() => {
             dispatcher = jasmine.createSpy();
-            reportingControl.attachDispatcher(dispatcher);
+            attachReportingControlDispatcher(dispatcher, ['NonStandardAriaReflection']);
         });
 
         afterEach(() => {
-            reportingControl.detachDispatcher();
+            detachReportingControlDispatcher();
         });
 
         nonStandardAriaProperties.forEach((prop) => {
@@ -222,7 +229,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                     expect(() => {
                         elm.getProp(prop);
                     }).not.toLogWarningDev();
-                    expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
+                    expect(dispatcher).not.toHaveBeenCalled();
                 });
 
                 it('BaseBridgeElement (external)', () => {
@@ -232,7 +239,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                     expect(() => {
                         elm[prop] = 'foo';
                     }).not.toLogWarningDev();
-                    expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
+                    expect(dispatcher).not.toHaveBeenCalled();
                 });
             });
         });

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -37,37 +37,33 @@ function testAriaProperty(property, attribute) {
 
         function expectGetterReportIfNonStandard() {
             if (nonStandardAriaProperties.includes(property)) {
-                expect(dispatcher.calls.allArgs()).toEqual([
-                    [
-                        'NonStandardAriaReflection',
-                        {
-                            tagName: undefined,
-                            propertyName: property,
-                            isSetter: false,
-                            setValueType: undefined,
-                        },
-                    ],
+                expect(dispatcher.calls.allArgs()).toContain([
+                    'NonStandardAriaReflection',
+                    {
+                        tagName: undefined,
+                        propertyName: property,
+                        isSetter: false,
+                        setValueType: undefined,
+                    },
                 ]);
             } else {
-                expect(dispatcher).not.toHaveBeenCalled();
+                expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
             }
         }
 
         function expectSetterReportIfNonStandard(setValueType) {
             if (nonStandardAriaProperties.includes(property)) {
-                expect(dispatcher.calls.allArgs()).toEqual([
-                    [
-                        'NonStandardAriaReflection',
-                        {
-                            tagName: undefined,
-                            propertyName: property,
-                            isSetter: true,
-                            setValueType,
-                        },
-                    ],
+                expect(dispatcher.calls.allArgs()).toContain([
+                    'NonStandardAriaReflection',
+                    {
+                        tagName: undefined,
+                        propertyName: property,
+                        isSetter: true,
+                        setValueType,
+                    },
                 ]);
             } else {
-                expect(dispatcher).not.toHaveBeenCalled();
+                expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
             }
         }
 
@@ -226,7 +222,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                     expect(() => {
                         elm.getProp(prop);
                     }).not.toLogWarningDev();
-                    expect(dispatcher).not.toHaveBeenCalled();
+                    expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
                 });
 
                 it('BaseBridgeElement (external)', () => {
@@ -236,7 +232,7 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                     expect(() => {
                         elm[prop] = 'foo';
                     }).not.toLogWarningDev();
-                    expect(dispatcher).not.toHaveBeenCalled();
+                    expect(dispatcher).not.toHaveBeenCalledWith('NonStandardAriaReflection');
                 });
             });
         });

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -69,7 +69,7 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalled();
+                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
             } else {
                 expect(dispatcher.calls.allArgs()).toContain([
                     'CompilerRuntimeVersionMismatch',
@@ -106,7 +106,7 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalled();
+                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
             } else {
                 expect(dispatcher.calls.allArgs()).toContain([
                     'CompilerRuntimeVersionMismatch',
@@ -142,7 +142,7 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalled();
+                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
             } else {
                 expect(dispatcher.calls.allArgs()).toContain([
                     'CompilerRuntimeVersionMismatch',

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -71,14 +71,12 @@ describe('compiler version mismatch', () => {
             if (process.env.NODE_ENV === 'production') {
                 expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toEqual([
-                    [
-                        'CompilerRuntimeVersionMismatch',
-                        {
-                            runtimeVersion: process.env.LWC_VERSION,
-                            compilerVersion: '123.456.789',
-                        },
-                    ],
+                expect(dispatcher.calls.allArgs()).toContain([
+                    'CompilerRuntimeVersionMismatch',
+                    {
+                        runtimeVersion: process.env.LWC_VERSION,
+                        compilerVersion: '123.456.789',
+                    },
                 ]);
             }
         });
@@ -110,14 +108,12 @@ describe('compiler version mismatch', () => {
             if (process.env.NODE_ENV === 'production') {
                 expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toEqual([
-                    [
-                        'CompilerRuntimeVersionMismatch',
-                        {
-                            runtimeVersion: process.env.LWC_VERSION,
-                            compilerVersion: '123.456.789',
-                        },
-                    ],
+                expect(dispatcher.calls.allArgs()).toContain([
+                    'CompilerRuntimeVersionMismatch',
+                    {
+                        runtimeVersion: process.env.LWC_VERSION,
+                        compilerVersion: '123.456.789',
+                    },
                 ]);
             }
         });
@@ -148,14 +144,12 @@ describe('compiler version mismatch', () => {
             if (process.env.NODE_ENV === 'production') {
                 expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toEqual([
-                    [
-                        'CompilerRuntimeVersionMismatch',
-                        {
-                            runtimeVersion: process.env.LWC_VERSION,
-                            compilerVersion: '123.456.789',
-                        },
-                    ],
+                expect(dispatcher.calls.allArgs()).toContain([
+                    'CompilerRuntimeVersionMismatch',
+                    {
+                        runtimeVersion: process.env.LWC_VERSION,
+                        compilerVersion: '123.456.789',
+                    },
                 ]);
             }
         });

--- a/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/version-mismatch/index.spec.js
@@ -1,10 +1,6 @@
-import {
-    createElement,
-    LightningElement,
-    registerTemplate,
-    registerComponent,
-    __unstable__ReportingControl as reportingControl,
-} from 'lwc';
+import { createElement, LightningElement, registerTemplate, registerComponent } from 'lwc';
+import { attachReportingControlDispatcher, detachReportingControlDispatcher } from 'test-utils';
+
 import Component from 'x/component';
 import ComponentWithProp from 'x/componentWithProp';
 import ComponentWithTemplateAndStylesheet from 'x/componentWithTemplateAndStylesheet';
@@ -48,11 +44,11 @@ describe('compiler version mismatch', () => {
         beforeEach(() => {
             window.__lwcResetWarnedOnVersionMismatch();
             dispatcher = jasmine.createSpy();
-            reportingControl.attachDispatcher(dispatcher);
+            attachReportingControlDispatcher(dispatcher, 'CompilerRuntimeVersionMismatch');
         });
 
         afterEach(() => {
-            reportingControl.detachDispatcher();
+            detachReportingControlDispatcher();
         });
 
         it('template', () => {
@@ -69,14 +65,16 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
+                expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toContain([
-                    'CompilerRuntimeVersionMismatch',
-                    {
-                        runtimeVersion: process.env.LWC_VERSION,
-                        compilerVersion: '123.456.789',
-                    },
+                expect(dispatcher.calls.allArgs()).toEqual([
+                    [
+                        'CompilerRuntimeVersionMismatch',
+                        {
+                            runtimeVersion: process.env.LWC_VERSION,
+                            compilerVersion: '123.456.789',
+                        },
+                    ],
                 ]);
             }
         });
@@ -106,14 +104,16 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
+                expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toContain([
-                    'CompilerRuntimeVersionMismatch',
-                    {
-                        runtimeVersion: process.env.LWC_VERSION,
-                        compilerVersion: '123.456.789',
-                    },
+                expect(dispatcher.calls.allArgs()).toEqual([
+                    [
+                        'CompilerRuntimeVersionMismatch',
+                        {
+                            runtimeVersion: process.env.LWC_VERSION,
+                            compilerVersion: '123.456.789',
+                        },
+                    ],
                 ]);
             }
         });
@@ -142,14 +142,16 @@ describe('compiler version mismatch', () => {
                 )
             );
             if (process.env.NODE_ENV === 'production') {
-                expect(dispatcher).not.toHaveBeenCalledWith('CompilerRuntimeVersionMismatch');
+                expect(dispatcher).not.toHaveBeenCalled();
             } else {
-                expect(dispatcher.calls.allArgs()).toContain([
-                    'CompilerRuntimeVersionMismatch',
-                    {
-                        runtimeVersion: process.env.LWC_VERSION,
-                        compilerVersion: '123.456.789',
-                    },
+                expect(dispatcher.calls.allArgs()).toEqual([
+                    [
+                        'CompilerRuntimeVersionMismatch',
+                        {
+                            runtimeVersion: process.env.LWC_VERSION,
+                            compilerVersion: '123.456.789',
+                        },
+                    ],
                 ]);
             }
         });


### PR DESCRIPTION
## Details
Adds telemetry for shadow mode usage (synthetic vs native). Due to the volume of logs this is going to generate (easily TBs), we'll want to report this as a metric rather than as logs. We will do this in the consuming app container. (e.g. `if (reportName === 'ShadowModeUsage') { ... }`).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
