### PR TITLE
chore(nucleus): test non-required downstreams

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -8,6 +8,7 @@ branches:
       auto-start: true
       auto-start-from-forks: false
       merge-method: disabled # do not auto-merge; we'll do it ourselves
+      validate-optional-downstream-deps: true # temporarily test non-required downstreams
       required-downstream-deps:
         - LightningMobileRuntime/ui-lmr-components
         - MobilePlatform/lds-debug-app


### PR DESCRIPTION
## Details

Let's temporarily test non-required downstreams, just to see which ones are failing.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
