### PR TITLE
chore: remove event name/type restriction

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -49,7 +49,6 @@ import {
 import { componentValueObserved } from './mutation-tracker';
 import {
     patchCustomElementWithRestrictions,
-    patchLightningElementPrototypeWithRestrictions,
     patchShadowRootWithRestrictions,
 } from './restrictions';
 import { getVMBeingRendered, isUpdatingTemplate, Template } from './template';
@@ -851,7 +850,3 @@ defineProperty(LightningElement, 'CustomElementConstructor', {
     },
     configurable: true,
 });
-
-if (process.env.NODE_ENV !== 'production') {
-    patchLightningElementPrototypeWithRestrictions(LightningElement.prototype);
-}

--- a/packages/@lwc/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.dispatchEvent/index.spec.js
@@ -42,35 +42,3 @@ it('should not throw when event is dispatched during construction', function () 
         createElement('x-test', { is: Test });
     }).not.toThrow();
 });
-
-function testInvalidEvent(reason, name) {
-    it(`should log an error if an event name ${reason}`, () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-
-        expect(() => {
-            elm.dispatch(new CustomEvent(name));
-        }).toLogErrorDev(new RegExp(`Invalid event type "${name}" dispatched in element <x-test>`));
-    });
-}
-
-function testValidEvent(reason, name) {
-    it(`should not log an error if an event name ${reason}`, () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-
-        expect(() => {
-            elm.dispatch(new CustomEvent(name));
-        }).not.toLogErrorDev();
-    });
-}
-
-testInvalidEvent('contains a hyphen', 'foo-bar');
-testInvalidEvent('contains an uppercase character', 'fooBar');
-testInvalidEvent('starts with a number', '1foo');
-testInvalidEvent('is a single number', '7');
-testInvalidEvent('is a single underscore', '_');
-testValidEvent('ends with an underscore', 'foo_');
-testValidEvent('ends with a number', 'foo1');
-testValidEvent('contains an underscore', 'foo_bar');
-testValidEvent('is a single letter', 'e');

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/index.spec.js
@@ -47,14 +47,6 @@ describe('restrictions', () => {
     });
 
     describe('LightningElement', () => {
-        it('dispatchEvent', () => {
-            expect(() => {
-                elm.dispatchEventWithInvalidName();
-            }).toLogErrorDev(
-                'Error: [LWC error]: Invalid event type "UPPERCASE-AND-HYPHENS" dispatched in element <x-component>. Event name must start with a lowercase letter and followed only lowercase letters, numbers, and underscores\n'
-            );
-        });
-
         it('get className', () => {
             expect(() => {
                 elm.getClassName();

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
@@ -24,11 +24,6 @@ export default class extends LightningElement {
     }
 
     @api
-    dispatchEventWithInvalidName() {
-        this.dispatchEvent(new CustomEvent('UPPERCASE-AND-HYPHENS'));
-    }
-
-    @api
     getClassName() {
         return this.className;
     }


### PR DESCRIPTION
## Details

This is not really a restriction as nothing is actually prevented. The intention was likely to help developers identify potential typos, or maybe to nudge them into using declarative event binding in their template. While it is preferred to use declarative event binding over imperative event binding, we don't prevent the former, so it doesn't make sense to log an error for it. It doesn't make sense to make this a warning for the same reason--this should have been implemented as a lint rule to begin with.


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

