### PR TITLE
chore(ci): pin chromedriver version

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install chromedriver
-        run: yarn install chromedriver@^119 # pin to same version as chrome above so Tachometer uses the same version
+        run: yarn add -W chromedriver@^119 # pin to same version as chrome above so Tachometer uses the same version
 
       - name: Check missing file headers
         run: node ./scripts/tasks/check-license-headers.js

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Install chromedriver
-        run: yarn add -W chromedriver@^119 # pin to same version as chrome above so Tachometer uses the same version
+      - name: Install chromedriver v119
+        run: yarn add -W chromedriver@^119 # pin to same version as Chrome above so Tachometer uses the same version
 
       - name: Check missing file headers
         run: node ./scripts/tasks/check-license-headers.js

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,8 +43,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
+      # See: https://github.com/google/tachometer#on-demand-dependencies
       - name: Install chromedriver v119
-        run: yarn add -W chromedriver@^119 # pin to same version as Chrome above so Tachometer uses the same version
+        run: yarn add -W chromedriver@^119
 
       - name: Check missing file headers
         run: node ./scripts/tasks/check-license-headers.js

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Install chromedriver
+        run: yarn install chromedriver@^119 # pin to same version as chrome above so Tachometer uses the same version
+
       - name: Check missing file headers
         run: node ./scripts/tasks/check-license-headers.js
       - name: Check package.json integrity


### PR DESCRIPTION

## Details

Fixes #3852

Pins chromedriver to the same version of Chrome we are currently using in the Tachometer benchmark smoke tests.


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
