### PR TITLE
chore: remove unused devDependency

### DIFF
--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -46,8 +46,5 @@
         "postcss": "~8.4.31",
         "postcss-selector-parser": "~6.0.13",
         "postcss-value-parser": "~4.2.0"
-    },
-    "devDependencies": {
-        "@types/string.prototype.matchall": "^4.0.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,11 +2041,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/string.prototype.matchall@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@types/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz#19ab711a23a549fb7579947d70819a5cbb0fceaa"
-  integrity sha512-N7UZ2wK2QY7llJhkG8OsiSW1DgNJ2nkMGamrxHX2nD6V9BvtlKJ2jLxlb4KpzNGDceYLdYKTLRlrbQ359ZsM6g==
-
 "@types/table@^6.0.0":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@types/table/-/table-6.3.2.tgz#e18ad2594400d81c3da28c31b342eb5a0d87a8e7"


### PR DESCRIPTION
## Details

I missed this in https://github.com/salesforce/lwc/pull/3864. We're not using `string.prototype.matchall` anymore, so we don't need its `@types` package either.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
