### PR TITLE
feat(api-versioning): bump latest to 61

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -59,6 +59,8 @@ jobs:
       - run: ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE=1 DISABLE_SYNTHETIC=1 yarn sauce:ci
       - run: API_VERSION=58 yarn sauce:ci
       - run: API_VERSION=58 DISABLE_SYNTHETIC=1 yarn sauce:ci
+      - run: API_VERSION=59 yarn sauce:ci
+      - run: API_VERSION=59 DISABLE_SYNTHETIC=1 yarn sauce:ci
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
@@ -93,8 +95,8 @@ jobs:
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
           tunnelName: ${{ env.SAUCE_TUNNEL_ID }}
 
-      - run: API_VERSION=59 yarn sauce:ci
-      - run: API_VERSION=59 DISABLE_SYNTHETIC=1 yarn sauce:ci
+      - run: API_VERSION=60 yarn sauce:ci
+      - run: API_VERSION=60 DISABLE_SYNTHETIC=1 yarn sauce:ci
       - run: ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL=1 yarn sauce:ci
       - run: ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL=1 DISABLE_SYNTHETIC=1 yarn sauce:ci
       - run: DISABLE_SYNTHETIC_SHADOW_SUPPORT_IN_COMPILER=1 DISABLE_SYNTHETIC=1 yarn sauce:ci

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -11,6 +11,7 @@ export const enum APIVersion {
     V58_244_SUMMER_23 = 58,
     V59_246_WINTER_24 = 59,
     V60_248_SPRING_24 = 60,
+    V61_250_SUMMER_24 = 61,
 }
 
 // These must be updated when the enum is updated.
@@ -18,11 +19,12 @@ export const enum APIVersion {
 // passing the `verify-treeshakeable.js` test.
 
 export const LOWEST_API_VERSION = APIVersion.V58_244_SUMMER_23;
-export const HIGHEST_API_VERSION = APIVersion.V60_248_SPRING_24;
+export const HIGHEST_API_VERSION = APIVersion.V61_250_SUMMER_24;
 const allVersions = [
     APIVersion.V58_244_SUMMER_23,
     APIVersion.V59_246_WINTER_24,
     APIVersion.V60_248_SPRING_24,
+    APIVersion.V61_250_SUMMER_24,
 ];
 const allVersionsSet = /*@__PURE__@*/ new Set(allVersions);
 


### PR DESCRIPTION
## Details

This is a _non-breaking_ change to prepare for API version 61 (aka 250, aka Summer '24). All this does it bump the latest API version and add tests for the n-1 version.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
