### PR TITLE
fix(babel-plugin-component): improve error reporting

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -31,7 +31,7 @@ function normalizeError(err: any) {
             // Filter out the stacktrace, just include the error message
             message: err.message.match(/^.*?\.js: ([^\n]+)/)[1],
             loc: err.loc,
-            filename: path.basename(err.filename),
+            filename: err.filename ? path.basename(err.filename) : undefined,
         };
     } else {
         return {


### PR DESCRIPTION
## Details

If an error is thrown within the Babel plugin itself (e.g. caused by #3910), you get a very unhelpful error because `err.filename` is undefined below, and so it fails when you try to `path.basename` it.

The resulting error is still not very helpful (and we should address #3910 to resolve that), but this PR makes it so you at least don't get a totally unrelated error message.

I do not believe it's worth adding tests for this, because any error thrown by the plugin is a bug that should be fixed eventually, so any test we write will quickly become stale.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
