### PR TITLE
chore: improve license header checks @W-14846456

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,16 +6,8 @@
         "sourceType": "module"
     },
 
-    "plugins": [
-        "jest",
-        "@lwc/lwc-internal",
-        "@typescript-eslint",
-        "import"
-    ],
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/eslint-recommended"
-    ],
+    "plugins": ["jest", "@lwc/lwc-internal", "@typescript-eslint", "import", "header"],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/eslint-recommended"],
 
     "env": {
         "es6": true
@@ -23,11 +15,7 @@
 
     "rules": {
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-            "error",
-            { "argsIgnorePattern": "^_" }
-        ],
-
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "block-scoped-var": "error",
         "no-alert": "error",
         "no-buffer-constructor": "error",
@@ -41,77 +29,120 @@
         "no-proto": "error",
         "no-prototype-builtins": "error",
         "no-new-require": "error",
-        "no-restricted-properties": ["error", {
-            "object": "arguments",
-            "property": "callee",
-            "message": "arguments.callee is deprecated"
-        }, {
-            "object": "global",
-            "property": "isFinite",
-            "message": "Please use Number.isFinite instead"
-        }, {
-            "object": "self",
-            "property": "isFinite",
-            "message": "Please use Number.isFinite instead"
-        }, {
-            "object": "window",
-            "property": "isFinite",
-            "message": "Please use Number.isFinite instead"
-        }, {
-            "object": "global",
-            "property": "isNaN",
-            "message": "Please use Number.isNaN instead"
-        }, {
-            "object": "self",
-            "property": "isNaN",
-            "message": "Please use Number.isNaN instead"
-        }, {
-            "object": "window",
-            "property": "isNaN",
-            "message": "Please use Number.isNaN instead"
-        }, {
-            "property": "__defineGetter__",
-            "message": "Please use Object.defineProperty instead."
-        }, {
-            "property": "__defineSetter__",
-            "message": "Please use Object.defineProperty instead."
-        }, {
-            "object": "Math",
-            "property": "pow",
-            "message": "Use the exponentiation operator (**) instead."
-        }, {
-            "object": "globalThis",
-            "property": "lwcRuntimeFlags",
-            "message": "Use the bare global lwcRuntimeFlags instead."
-        }],
+        "no-restricted-properties": [
+            "error",
+            {
+                "object": "arguments",
+                "property": "callee",
+                "message": "arguments.callee is deprecated"
+            },
+            {
+                "object": "global",
+                "property": "isFinite",
+                "message": "Please use Number.isFinite instead"
+            },
+            {
+                "object": "self",
+                "property": "isFinite",
+                "message": "Please use Number.isFinite instead"
+            },
+            {
+                "object": "window",
+                "property": "isFinite",
+                "message": "Please use Number.isFinite instead"
+            },
+            {
+                "object": "global",
+                "property": "isNaN",
+                "message": "Please use Number.isNaN instead"
+            },
+            {
+                "object": "self",
+                "property": "isNaN",
+                "message": "Please use Number.isNaN instead"
+            },
+            {
+                "object": "window",
+                "property": "isNaN",
+                "message": "Please use Number.isNaN instead"
+            },
+            {
+                "property": "__defineGetter__",
+                "message": "Please use Object.defineProperty instead."
+            },
+            {
+                "property": "__defineSetter__",
+                "message": "Please use Object.defineProperty instead."
+            },
+            {
+                "object": "Math",
+                "property": "pow",
+                "message": "Use the exponentiation operator (**) instead."
+            },
+            {
+                "object": "globalThis",
+                "property": "lwcRuntimeFlags",
+                "message": "Use the bare global lwcRuntimeFlags instead."
+            }
+        ],
         "no-self-compare": "error",
         "no-undef-init": "error",
         "no-useless-computed-key": "error",
         "no-useless-return": "error",
-        "prefer-const": ["error", {
-            "destructuring": "any",
-            "ignoreReadBeforeAssign": true
-        }],
+        "prefer-const": [
+            "error",
+            {
+                "destructuring": "any",
+                "ignoreReadBeforeAssign": true
+            }
+        ],
         "template-curly-spacing": "error",
         "yoda": "error",
 
         "@lwc/lwc-internal/no-invalid-todo": "error",
         "import/order": [
             "error",
-            { "groups": ["builtin", "external", "internal", "parent", "index", "sibling", "object", "type"] }
+            {
+                "groups": [
+                    "builtin",
+                    "external",
+                    "internal",
+                    "parent",
+                    "index",
+                    "sibling",
+                    "object",
+                    "type"
+                ]
+            }
         ],
-        "no-restricted-imports": ["error", {
-            "name": "@lwc/features",
-            "importNames": ["lwcRuntimeFlags", "runtimeFlags", "default"],
-            "message": "Do not directly import runtime flags from @lwc/features. Use the global lwcRuntimeFlags variable instead."
-        }]
+        "no-restricted-imports": [
+            "error",
+            {
+                "name": "@lwc/features",
+                "importNames": ["lwcRuntimeFlags", "runtimeFlags", "default"],
+                "message": "Do not directly import runtime flags from @lwc/features. Use the global lwcRuntimeFlags variable instead."
+            }
+        ],
+        "header/header": [
+            2,
+            "block",
+            [
+                "",
+                {
+                    "pattern": "^ \\* Copyright \\(c\\) \\d{4}, ([sS]alesforce.com, inc|Salesforce, Inc)\\.$",
+                    "template": " * Copyright (c) 2024, Salesforce, Inc."
+                },
+                " * All rights reserved.",
+                " * SPDX-License-Identifier: MIT",
+                " * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT",
+                " "
+            ]
+        ]
     },
 
     "overrides": [
         {
-            "files": [
-                "**/packages/lwc/**"
-            ],
+            "files": ["**/packages/lwc/**"],
             "rules": {
                 "no-restricted-imports": "off"
             }
@@ -129,11 +160,7 @@
             }
         },
         {
-            "files": [
-                "**/__tests__/**",
-                "**/__mocks__/**",
-                "**/@lwc/integration-karma/**"
-            ],
+            "files": ["**/__tests__/**", "**/__mocks__/**", "**/@lwc/integration-karma/**"],
 
             "env": {
                 "jest": true,
@@ -149,9 +176,7 @@
             }
         },
         {
-            "files": [
-                "**/@lwc/integration-tests/**"
-            ],
+            "files": ["**/@lwc/integration-tests/**"],
 
             "globals": {
                 "$": true,
@@ -159,11 +184,7 @@
             }
         },
         {
-            "files": [
-                "./*.js",
-                "**/scripts/**",
-                "**/jest.config.js"
-            ],
+            "files": ["./*.js", "**/scripts/**", "**/jest.config.js"],
 
             "env": {
                 "node": true,
@@ -175,15 +196,27 @@
             }
         },
         {
-            "files": [
-                "**/perf-benchmarks/**"
-            ],
+            "files": ["**/perf-benchmarks/**"],
 
             "globals": {
                 "after": true,
                 "before": true,
                 "benchmark": true,
                 "run": true
+            }
+        },
+        // NOTE: This should match the ignored patterns in /scripts/check-license-headers.js
+        {
+            "files": [
+                "**/playground/**",
+                "**/fixtures/**",
+                "packages/@lwc/integration-tests/src/**/!(*.spec.js)",
+                "packages/@lwc/integration-karma/test/**",
+                "packages/@lwc/integration-karma/test-hydration/**",
+                "packages/@lwc/engine-server/src/__tests__/modules/**"
+            ],
+            "rules": {
+                "header/header": "off"
             }
         }
     ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "build:performance": "yarn build:performance:components && yarn build:performance:benchmarks",
         "build:performance:components": "nx build @lwc/perf-benchmarks-components",
         "build:performance:benchmarks": "nx build @lwc/perf-benchmarks",
+        "check-license-headers": "node ./scripts/tasks/check-license-headers.js",
         "dev": "nx run-many --target=dev --all --parallel=999 --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests,lwc",
         "test": "jest --config ./scripts/jest/root.config.js",
         "test:debug": "node --inspect node_modules/.bin/jest --config ./scripts/jest/root.config.js --runInBand --watch",
@@ -70,7 +71,7 @@
     "lint-staged": {
         "**/*.{js,mjs,ts}": [
             "eslint",
-            "node ./scripts/tasks/check-license-headers"
+            "yarn check-license-headers"
         ],
         "{packages,scripts}/**/*.{js,mjs,ts,json,md}": "prettier --write",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js"

--- a/package.json
+++ b/package.json
@@ -69,10 +69,8 @@
         "typescript": "5.3.3"
     },
     "lint-staged": {
-        "**/*.{js,mjs,ts}": [
-            "eslint",
-            "yarn check-license-headers"
-        ],
+        "*": "yarn check-license-headers",
+        "**/*.{js,mjs,ts}": "eslint",
         "{packages,scripts}/**/*.{js,mjs,ts,json,md}": "prettier --write",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js"
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "bytes": "^3.1.2",
         "es-module-lexer": "^1.4.1",
         "eslint": "^8.56.0",
+        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.6.0",
         "glob": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
         "typescript": "5.3.3"
     },
     "lint-staged": {
-        "**/*.{js,mjs,ts}": "eslint",
+        "**/*.{js,mjs,ts}": [
+            "eslint",
+            "node ./scripts/tasks/check-license-headers"
+        ],
         "{packages,scripts}/**/*.{js,mjs,ts,json,md}": "prettier --write",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js"
     },

--- a/packages/@lwc/template-compiler/src/shared/utils.ts
+++ b/packages/@lwc/template-compiler/src/shared/utils.ts
@@ -1,11 +1,11 @@
-import { DASHED_TAGNAME_ELEMENT_SET } from './constants';
-
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { DASHED_TAGNAME_ELEMENT_SET } from './constants';
+
 export function toPropertyName(attr: string) {
     let prop = '';
     let shouldUpperCaseNext = false;

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -124,7 +124,8 @@ const INCLUDED_PATTERNS = [
     /\.[^/]+$/,
 ];
 
-const COPYRIGHT_HEADER_RE = /Copyright (\(c\))? [0-9]{4}, (s|S)alesforce.com, inc./;
+// In 2022, Salesforce changed from "salesforce.com, inc." to "Salesforce, Inc."
+const COPYRIGHT_HEADER_RE = /Copyright (\(c\))? 20[0-9]{2}, (s|S)alesforce(\.com)?, [iI]nc./;
 
 function needsCopyrightHeader(file) {
     const contents = getFileContents(file);

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -102,6 +102,7 @@ const GENERIC_IGNORED_PATTERNS = [
     '^MANIFEST\\.in$',
 ].map(createRegExp);
 
+// NOTE: Ignored JS files match the overrides for "header/header" in /.eslintrc
 const CUSTOM_IGNORED_PATTERNS = [
     // add anything repo specific here
     'playground/',

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -104,7 +104,6 @@ const GENERIC_IGNORED_PATTERNS = [
 
 const CUSTOM_IGNORED_PATTERNS = [
     // add anything repo specific here
-    'babel.config.js',
     'playground/',
     '/fixtures/',
     '/@lwc/integration-tests/src/(.(?!.*.spec.js$))*$',

--- a/scripts/tasks/check-license-headers.js
+++ b/scripts/tasks/check-license-headers.js
@@ -131,10 +131,8 @@ function needsCopyrightHeader(file) {
     return contents.trim().length > 0 && !COPYRIGHT_HEADER_RE.test(contents);
 }
 
-function check() {
-    const allFiles = execSync('git ls-files', { encoding: 'utf-8' }).trim().split('\n');
-
-    const invalidFiles = allFiles.filter(
+function check(files) {
+    const invalidFiles = files.filter(
         (file) =>
             INCLUDED_PATTERNS.some((pattern) => pattern.test(file)) &&
             !IGNORED_PATTERNS.some((pattern) => pattern.test(file)) &&
@@ -151,4 +149,9 @@ Please include the header or add an exception for the file in \`scripts/check-li
     }
 }
 
-check();
+// Check provided files, if any, otherwise check all files tracked by git
+check(
+    process.argv.length > 2
+        ? process.argv.slice(2)
+        : execSync('git ls-files', { encoding: 'utf-8' }).trim().split('\n')
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,9 +1265,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/jest-utils-lwc-internals@link:./scripts/jest/utils":
   version "0.0.0"
+  uid ""
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"
@@ -4934,6 +4936,11 @@ eslint-module-utils@^2.8.0:
   integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
   dependencies:
     debug "^3.2.7"
+
+eslint-plugin-header@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz#6ce512432d57675265fac47292b50d1eff11acd6"
+  integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
 
 eslint-plugin-import@^2.29.1:
   version "2.29.1"


### PR DESCRIPTION
## Details

In #3949 I changed the headers. That didn't fail until CI, even though it's a trivial check to run locally. So I updated lint-staged to run that check on commit. I also added a new eslint header rule that automatically adds the header, when missing, so that we have to think about it even less!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-14846456
