### PR TITLE
refactor: remove `shadowSupportMode = 'any'`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -122,7 +122,6 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
 
         if (
             !isUndefined(ctorShadowSupportMode) &&
-            ctorShadowSupportMode !== ShadowSupportMode.Any &&
             ctorShadowSupportMode !== ShadowSupportMode.Default &&
             ctorShadowSupportMode !== ShadowSupportMode.Native
         ) {

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -94,7 +94,6 @@ export const enum ShadowMode {
 }
 
 export const enum ShadowSupportMode {
-    Any = 'any',
     Default = 'reset',
     Native = 'native',
 }
@@ -519,10 +518,7 @@ function computeShadowMode(def: ComponentDef, owner: VM | null, renderer: Render
             lwcRuntimeFlags.ENABLE_MIXED_SHADOW_MODE ||
             def.shadowSupportMode === ShadowSupportMode.Native
         ) {
-            if (
-                def.shadowSupportMode === ShadowSupportMode.Any ||
-                def.shadowSupportMode === ShadowSupportMode.Native
-            ) {
+            if (def.shadowSupportMode === ShadowSupportMode.Native) {
                 shadowMode = ShadowMode.Native;
             } else {
                 const shadowAncestor = getNearestShadowAncestor(owner);

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -12,7 +12,6 @@ import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 const features: FeatureFlagMap = {
     PLACEHOLDER_TEST_FLAG: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
-    ENABLE_MIXED_SHADOW_MODE: null,
     DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: null,
     ENABLE_WIRE_SYNC_EMIT: null,
     DISABLE_LIGHT_DOM_UNSCOPED_CSS: null,

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -22,12 +22,6 @@ export interface FeatureFlagMap {
     PLACEHOLDER_TEST_FLAG: FeatureFlagValue;
 
     /**
-     * LWC engine flag to enable mixed shadow mode. Setting this flag to `true` enables usage of
-     * native shadow DOM even when the synthetic shadow polyfill is applied.
-     */
-    ENABLE_MIXED_SHADOW_MODE: FeatureFlagValue;
-
-    /**
      * LWC engine flag to force native shadow mode for mixed shadow mode testing.
      */
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: FeatureFlagValue;

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-styles/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 import Basic from 'x/basic';
 import Other from 'x/other';
@@ -8,14 +8,6 @@ import ShadowWithScoped from 'x/shadowWithScoped';
 import PseudoParent from 'x/pseudoParent';
 
 describe('Light DOM scoped CSS', () => {
-    beforeAll(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-    });
-
-    afterAll(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-    });
-
     it('should scope scoped CSS and allow unscoped CSS to leak out', () => {
         const basicElement = createElement('x-basic', { is: Basic });
         const otherElement = createElement('x-other', { is: Other });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -24,8 +24,8 @@ describe('ENABLE_MIXED_SHADOW_MODE', () => {
         setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
     });
 
-    it('should be configured as "any" (sanity)', () => {
-        expect(Valid.shadowSupportMode === 'any').toBeTrue();
+    it('should be configured as "native" (sanity)', () => {
+        expect(Valid.shadowSupportMode === 'native').toBeTrue();
     });
 
     it('should enable mixed shadow mode', () => {

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
 import Invalid from 'x/invalid';
@@ -16,29 +16,6 @@ describe('shadowSupportMode static property', () => {
         expect(() => {
             createElement('x-valid', { is: Valid });
         }).not.toThrowError();
-    });
-});
-
-describe('ENABLE_MIXED_SHADOW_MODE', () => {
-    beforeEach(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-    });
-
-    it('should be configured as "native" (sanity)', () => {
-        expect(Valid.shadowSupportMode === 'native').toBeTrue();
-    });
-
-    it('should enable mixed shadow mode', () => {
-        const elm = createElement('x-valid', { is: Valid });
-        if (process.env.NATIVE_SHADOW_ROOT_DEFINED) {
-            expect(isNativeShadowRootInstance(elm.shadowRoot)).toBeTrue();
-        } else {
-            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
-        }
-    });
-
-    afterEach(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
     });
 });
 

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/valid/valid.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/valid/valid.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/restrictions/x/component/component.js
@@ -1,8 +1,6 @@
 import { LightningElement, api } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
-
     @api
     setInnerHtmlOnShadowRoot() {
         this.template.innerHTML = '<div></div>';

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/scoped-ids/scoped-ids.spec.js
@@ -1,15 +1,7 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import Test from 'x/test';
 
 describe('scoped-ids', () => {
-    beforeAll(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-    });
-
-    afterAll(() => {
-        setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-    });
-
     it('should entrust id scoping to native shadow (static)', () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/scoped-ids/x/test/test.js
@@ -1,7 +1,7 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 
     get yamanashi() {
         return 'yamanashi';

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/slotting/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/slotting/x/child/child.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class Child extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds, isNativeShadowRootInstance } from 'test-utils';
 import ParentAnyChildAny from 'x/parentAnyChildAny';
 import ParentAnyChildReset from 'x/parentAnyChildReset';
@@ -17,13 +17,6 @@ import GrandparentResetParentResetChildReset from 'x/grandparentResetParentReset
 
 if (!process.env.NATIVE_SHADOW) {
     describe('synthetic behavior', () => {
-        beforeEach(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-        });
-        afterEach(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-        });
-
         const scenarios = [
             {
                 Component: ParentAnyChildAny,

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildAny/grandparentAnyParentAnyChildAny.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentAnyChildReset/grandparentAnyParentAnyChildReset.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildAny/grandparentAnyParentResetChildAny.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/grandparentAnyParentResetChildReset/grandparentAnyParentResetChildReset.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/leafAny/leafAny.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/leafAny/leafAny.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/parentAnyChildAny/parentAnyChildAny.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/parentAnyChildAny/parentAnyChildAny.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/parentAnyChildReset/parentAnyChildReset.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/x/parentAnyChildReset/parentAnyChildReset.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
 import ResetExtendsAny from 'x/resetExtendsAny';
@@ -14,17 +14,12 @@ function assertNativeShadowRootWhenPossible(elm) {
 }
 
 if (!process.env.NATIVE_SHADOW) {
-    describe('when root component shadowSupportMode="any"', () => {
+    describe('when root component shadowSupportMode="native"', () => {
         let elm;
 
         beforeEach(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
             elm = createElement('x-native-container', { is: NativeContainer });
             document.body.appendChild(elm);
-        });
-
-        afterAll(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
         });
 
         it('should attach a native shadow root when possible', () => {

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/x/native/native.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/x/native/native.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/x/nativeContainer/nativeContainer.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/x/nativeContainer/nativeContainer.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 import Container from 'x/container';
 import Escape from 'x/escape';
@@ -19,13 +19,6 @@ import PreserveComments from 'x/preserveComments';
 
 if (!process.env.NATIVE_SHADOW) {
     describe('Mixed mode for static content', () => {
-        beforeEach(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', true);
-        });
-        afterEach(() => {
-            setFeatureFlagForTest('ENABLE_MIXED_SHADOW_MODE', false);
-        });
-
         ['native', 'synthetic'].forEach((firstRenderMode) => {
             it(`should set the tokens for synthetic shadow when it renders first in ${firstRenderMode}`, () => {
                 const elm = createElement('x-container', { is: Container });

--- a/packages/@lwc/integration-karma/test/static-content/x/native/native.js
+++ b/packages/@lwc/integration-karma/test/static-content/x/native/native.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class Native extends LightningElement {
-    static shadowSupportMode = 'any';
+    static shadowSupportMode = 'native';
 }


### PR DESCRIPTION
## Details
This PR removes the `shadowSupportMode = 'any'` option.

## Does this pull request introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

`shadowSupportMode = 'any'` was gated behind a feature flag and should not break existing customers.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.

## GUS work item
W-14832125
