### PR TITLE
chore: fix broken test due to Firefox update

### DIFF
--- a/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/decorators/api/index.spec.js
@@ -196,7 +196,7 @@ describe('non-LightningElement `this` when calling accessor', () => {
     });
 
     const expectedErrorMessage =
-        /(undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)'|Cannot read properties of undefined)/;
+        /(undefined has no properties|undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)'|Cannot read properties of undefined)/;
 
     const scenarios = [
         { type: 'getterSetter', prop: 'getterSetterProp' },


### PR DESCRIPTION
## Details

Firefox tests are newly failing due to:

```
Firefox 121.0 (Windows 10) component decorators api non-LightningElement `this` when calling accessor getterSetter setter - external FAILED
	Expected function to throw TypeError with a message matching /(undefined is not an object|Right side of assignment cannot be destructured|vm is undefined|undefined is not a VM|Cannot destructure property '(getHook|setHook)'|Cannot read properties of undefined)/, but it threw TypeError with message 'undefined has no properties'.
```

This fixes that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
