### PR TITLE
chore: warn on shadowSupportMode 'any'

### DIFF
--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -132,10 +132,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         }
 
         // TODO [#3971]: Completely remove shadowSupportMode "any"
-        if (
-            !isUndefined(ctorShadowSupportMode) &&
-            ctorShadowSupportMode === ShadowSupportMode.Any
-        ) {
+        if (ctorShadowSupportMode === ShadowSupportMode.Any) {
             logWarn(
                 `Invalid value 'any' for static property shadowSupportMode. 'any' is deprecated and will be removed in a future release--use 'native' instead.`
             );

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -32,7 +32,7 @@ import {
     resolveCircularModuleDependency,
 } from '../shared/circular-module-dependencies';
 
-import { logError } from '../shared/logger';
+import { logError, logWarn } from '../shared/logger';
 import { instrumentDef } from './runtime-instrumentation';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
@@ -122,11 +122,21 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
 
         if (
             !isUndefined(ctorShadowSupportMode) &&
+            ctorShadowSupportMode !== ShadowSupportMode.Any &&
             ctorShadowSupportMode !== ShadowSupportMode.Default &&
             ctorShadowSupportMode !== ShadowSupportMode.Native
         ) {
             logError(
                 `Invalid value for static property shadowSupportMode: '${ctorShadowSupportMode}'`
+            );
+        }
+
+        if (
+            !isUndefined(ctorShadowSupportMode) &&
+            ctorShadowSupportMode === ShadowSupportMode.Any
+        ) {
+            logWarn(
+                `Invalid value 'any' for static property shadowSupportMode. 'any' is deprecated and will be removed in a future release--use 'native' instead.`
             );
         }
 

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -131,6 +131,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
             );
         }
 
+        // TODO [#3971]: Completely remove shadowSupportMode "any"
         if (
             !isUndefined(ctorShadowSupportMode) &&
             ctorShadowSupportMode === ShadowSupportMode.Any

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -94,6 +94,7 @@ export const enum ShadowMode {
 }
 
 export const enum ShadowSupportMode {
+    Any = 'any',
     Default = 'reset',
     Native = 'native',
 }

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -2,6 +2,7 @@ import { createElement } from 'lwc';
 import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
 import Any from 'x/any';
+import Any2 from 'x/any2';
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
 import NativeOnly from 'x/native';
@@ -21,14 +22,13 @@ describe('shadowSupportMode static property', () => {
 
     // TODO [#3971]: Completely remove shadowSupportMode "any"
     it('should warn for deprecated value "any"', () => {
-        let elm;
-
         // eslint-disable-next-line jest/valid-expect
         expect(() => {
-            elm = createElement('x-any', { is: Any });
+            createElement('x-any', { is: Any });
         }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
 
         if (process.env.SYNTHETIC_SHADOW_ENABLED && process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+            const elm = createElement('x-any2', { is: Any2 });
             expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
         }
     });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -28,7 +28,7 @@ describe('shadowSupportMode static property', () => {
             elm = createElement('x-any', { is: Any });
         }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
 
-        if (process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+        if (process.env.SYNTHETIC_SHADOW_ENABLED && process.env.NATIVE_SHADOW_ROOT_DEFINED) {
             expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
         }
     });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -19,18 +19,11 @@ describe('shadowSupportMode static property', () => {
         }).not.toLogErrorDev();
     });
 
-    it('should not log error for deprecated value "any"', () => {
+    // TODO [#3971]: Completely remove shadowSupportMode "any"
+    it('should warn for deprecated value "any"', () => {
         expect(() => {
             createElement('x-any', { is: Any });
-        }).not.toLogErrorDev(/Invalid value for static property shadowSupportMode/);
-    });
-
-    it('should log warning for deprecated value "any"', () => {
-        expect(() => {
-            createElement('x-any', { is: Any });
-        }).toLogWarningDev(
-            /Invalid value 'any' for static property shadowSupportMode\. 'any' is deprecated and will be removed in a future release--use 'native' instead\./
-        );
+        }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
     });
 });
 

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -21,9 +21,16 @@ describe('shadowSupportMode static property', () => {
 
     // TODO [#3971]: Completely remove shadowSupportMode "any"
     it('should warn for deprecated value "any"', () => {
+        let elm;
+
+        // eslint-disable-next-line jest/valid-expect
         expect(() => {
-            createElement('x-any', { is: Any });
+            elm = createElement('x-any', { is: Any });
         }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
+
+        if (process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+            expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
+        }
     });
 });
 

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -31,7 +31,7 @@ describe('shadowSupportMode static property', () => {
             let elm;
             expect(() => {
                 elm = createElement('x-any2', { is: Any2 });
-            }).toLogWarningDev();
+            }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
             expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
         }
     });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 import { isNativeShadowRootInstance, isSyntheticShadowRootInstance } from 'test-utils';
 
+import Any from 'x/any';
 import Invalid from 'x/invalid';
 import Valid from 'x/valid';
 import NativeOnly from 'x/native';
@@ -16,6 +17,20 @@ describe('shadowSupportMode static property', () => {
         expect(() => {
             createElement('x-valid', { is: Valid });
         }).not.toThrowError();
+    });
+
+    it('should not log error for deprecated value "any"', () => {
+        expect(() => {
+            createElement('x-any', { is: Any });
+        }).not.toLogErrorDev(/Invalid value for static property shadowSupportMode/);
+    });
+
+    it('should log warning for deprecated value "any"', () => {
+        expect(() => {
+            createElement('x-any', { is: Any });
+        }).toLogWarningDev(
+            /Invalid value 'any' for static property shadowSupportMode\. 'any' is deprecated and will be removed in a future release--use 'native' instead\./
+        );
     });
 });
 

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -27,7 +27,7 @@ describe('shadowSupportMode static property', () => {
             createElement('x-any', { is: Any });
         }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
 
-        if (process.env.SYNTHETIC_SHADOW_ENABLED && process.env.NATIVE_SHADOW_ROOT_DEFINED) {
+        if (process.env.SYNTHETIC_SHADOW_ENABLED && !process.env.MIXED_SHADOW) {
             let elm;
             expect(() => {
                 elm = createElement('x-any2', { is: Any2 });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -28,7 +28,10 @@ describe('shadowSupportMode static property', () => {
         }).toLogWarningDev(/Invalid value 'any' for static property shadowSupportMode/);
 
         if (process.env.SYNTHETIC_SHADOW_ENABLED && process.env.NATIVE_SHADOW_ROOT_DEFINED) {
-            const elm = createElement('x-any2', { is: Any2 });
+            let elm;
+            expect(() => {
+                elm = createElement('x-any2', { is: Any2 });
+            }).toLogWarningDev();
             expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
         }
     });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/index.spec.js
@@ -16,7 +16,7 @@ describe('shadowSupportMode static property', () => {
     it('should not throw for valid values', () => {
         expect(() => {
             createElement('x-valid', { is: Valid });
-        }).not.toThrowError();
+        }).not.toLogErrorDev();
     });
 
     it('should not log error for deprecated value "any"', () => {

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/any/any.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/any/any.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/any2/any2.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/LightningElement.shadowSupportMode/x/any2/any2.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'any';
+}


### PR DESCRIPTION
## Details

This avoids making the removal of `shadowSupportMode="any"` a breaking change.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-14974451