### PR TITLE
fix: pin chrome version to bypass shadowRoot issues with chrome 121

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
@@ -10,7 +10,8 @@ exports.STANDARD_SAUCE_BROWSERS = [
         label: 'sl_chrome_latest',
         browserName: 'chrome',
         // Hydration tests are broken on Chrome 121 due to changes with shadowRoot, but fixed on Chrome 122.
-        // Pinning Chrome version to unblock tests. Should be removed once Chrome 122 becomes latest.
+        // Pinning Chrome version to unblock tests.
+        // TODO [#3987]: Should be removed once Chrome 122 becomes latest.
         browserVersion: '120',
     },
     {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
@@ -9,7 +9,9 @@ exports.STANDARD_SAUCE_BROWSERS = [
     {
         label: 'sl_chrome_latest',
         browserName: 'chrome',
-        browserVersion: 'latest',
+        // Hydration tests are broken on Chrome 121 due to changes with shadowRoot, but fixed on Chrome 122.
+        // Pinning Chrome version to unblock tests. Should be removed once Chrome 122 becomes latest.
+        browserVersion: '120',
     },
     {
         label: 'sl_firefox_latest',

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -23,9 +23,7 @@ const browsers = [
     {
         commonName: 'chrome',
         browserName: 'chrome',
-        // Hydration tests are broken on Chrome 121 due to changes with shadowRoot, but fixed on Chrome 122.
-        // Pinning Chrome version to unblock tests. Should be removed once Chrome 122 becomes latest.
-        version: '120',
+        version: 'latest',
         // Note chrome fails for Linux and macOS
         platform: 'Windows 11',
     },

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -23,7 +23,9 @@ const browsers = [
     {
         commonName: 'chrome',
         browserName: 'chrome',
-        version: 'latest',
+        // Hydration tests are broken on Chrome 121 due to changes with shadowRoot, but fixed on Chrome 122.
+        // Pinning Chrome version to unblock tests. Should be removed once Chrome 122 becomes latest.
+        version: '120',
         // Note chrome fails for Linux and macOS
         platform: 'Windows 11',
     },


### PR DESCRIPTION
## Details


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
