### PR TITLE
chore: Update target to es2021

### DIFF
--- a/packages/@lwc/aria-reflection/tsconfig.json
+++ b/packages/@lwc/aria-reflection/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/babel-plugin-component/tsconfig.json
+++ b/packages/@lwc/babel-plugin-component/tsconfig.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../../tsconfig.json",
 
-    "compilerOptions": {
-        "lib": ["es2018"]
-    },
-
     "include": ["src/"]
 }

--- a/packages/@lwc/engine-core/tsconfig.json
+++ b/packages/@lwc/engine-core/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/engine-dom/tsconfig.json
+++ b/packages/@lwc/engine-dom/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/engine-server/tsconfig.json
+++ b/packages/@lwc/engine-server/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/features/tsconfig.json
+++ b/packages/@lwc/features/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/signals/tsconfig.json
+++ b/packages/@lwc/signals/tsconfig.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../../tsconfig.json",
 
-    "compilerOptions": {
-        "lib": ["es2018"]
-    },
-
     "include": ["src/"]
 }

--- a/packages/@lwc/synthetic-shadow/tsconfig.json
+++ b/packages/@lwc/synthetic-shadow/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/packages/@lwc/wire-service/tsconfig.json
+++ b/packages/@lwc/wire-service/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2021"]
     },
 
     "include": ["src/"]

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -58,7 +58,7 @@ function sharedPlugins() {
 
     return [
         typescript({
-            target: 'es2017',
+            target: 'es2021',
             tsconfig: path.join(packageRoot, 'tsconfig.json'),
             noEmitOnError: !watchMode, // in watch mode, do not exit with an error if typechecking fails
             ...(watchMode && {

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -58,7 +58,6 @@ function sharedPlugins() {
 
     return [
         typescript({
-            target: 'es2021',
             tsconfig: path.join(packageRoot, 'tsconfig.json'),
             noEmitOnError: !watchMode, // in watch mode, do not exit with an error if typechecking fails
             ...(watchMode && {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
 
+    "target": "es2021",
     "lib": ["es2021"],
 
     // Disable automatic inclusion of @types packages

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
 
-    "target": "es2018",
-    "lib": ["es2018"],
+    "target": "es2021",
+    "lib": ["es2021"],
 
     // Disable automatic inclusion of @types packages
     "types": ["node", "jest"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
 
-    "target": "es2021",
     "lib": ["es2021"],
 
     // Disable automatic inclusion of @types packages


### PR DESCRIPTION
## Details

Fixes #3366 

@jamestu, @jye-sf, @wjhsf, and I determined the ES version to upgrade using the [compat table](https://compat-table.github.io/compat-table/es2016plus/) while considering Safari v16 as the lowest common denominator. It shows that Safari does not seem to have complete support for `Function.prototype.toString` which is an ES2019 feature, but we found it to be working when testing it in Safari v17.3:

```js
> const sum = new Function('a', 'b', 'return a + b');
> sum.toString();
> "function anonymous(a, b) {
return a + b
}" = $1
```
<img width="1682" alt="Screenshot 2024-02-08 at 10 55 45" src="https://github.com/salesforce/lwc/assets/134009/3ca05c54-4860-4560-815d-8a6f51e5fa2d">

https://compat-table.github.io/compat-table/es2016plus/

To be safe, we might consider adding a lint rule to make sure we don't use this anywhere, but that wouldn't guarantee that our transpilation target wouldn't use it.

If lack of support for `Function.prototype.toString` turns out to be a blocker, we should be able to go from `es2017` to `es2018`, but anything more recent than that would require us to wait for Safari.

Thoughts?

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

