### PR TITLE
fix: add default exports to `lwc` @W-13710298

### DIFF
--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -21,7 +21,9 @@ const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
 
 describe('default exports are not forgotten', () => {
     const allFiles = fs.readdirSync(PACKAGE_ROOT);
-    const packages = allFiles.filter((f) => f.endsWith('.js')).map((f) => f.slice(0, -3));
+    const packages = allFiles
+        .filter((f) => f.endsWith('.js') && f !== 'index.js')
+        .map((f) => f.slice(0, -3));
     test.each(packages)('@lwc/%s', async (pkg) => {
         const realModule = await import(`@lwc/${pkg}`);
         // When jest properly supports ESM, this will be a lot simpler

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -20,8 +20,9 @@ const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
 };
 
 /**
- * Packages with no exports (e.g. polyfill packages) have a "default" export of {default: {}}. The
- * placeholder object is an empty object whose prototype is an empty object with null prototype.
+ * Jest uses CommonJS, which means that packages with no explicit export statements actually export
+ * the default `module.exports` empty object. That export is an empty object with the prototype set
+ * to an empty object with null prototype.
  */
 const hasExplicitDefaultExport = (mod: object) => {
     // No default export = self explanatory

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -33,7 +33,3 @@ describe('default exports are not forgotten', () => {
         }
     });
 });
-
-test('test', () => {
-    expect(true).toBeTruthy();
-});

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const PACKAGE_ROOT = path.join(__dirname, '..');
+
+const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
+    const filename = path.join(PACKAGE_ROOT, pkgName + ext);
+    const contents = fs.readFileSync(filename, 'utf8');
+    const exportDefaultFromPackage = new RegExp(
+        `^export \\{ default \\} from '@lwc/${pkgName}';$`,
+        'm'
+    );
+    expect(contents).toMatch(exportDefaultFromPackage);
+};
+
+describe('default exports are not forgotten', () => {
+    const allFiles = fs.readdirSync(PACKAGE_ROOT);
+    const packages = allFiles.filter((f) => f.endsWith('.js')).map((f) => f.slice(0, -3));
+    test.each(packages)('@lwc/%s', async (pkg) => {
+        const realModule = await import(`@lwc/${pkg}`);
+        // When jest properly supports ESM, this will be a lot simpler
+        // const aliasedModule = await import(`lwc/${pkg}`);
+        // expect(aliasedModule.default).toBe(realModule.default);
+        if (realModule.default) {
+            expectExportDefaultFromPackageInFile(pkg, '.d.ts');
+            expectExportDefaultFromPackageInFile(pkg, '.js');
+        }
+    });
+});
+
+test('test', () => {
+    expect(true).toBeTruthy();
+});

--- a/packages/lwc/__tests__/package-exports.spec.ts
+++ b/packages/lwc/__tests__/package-exports.spec.ts
@@ -7,7 +7,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-describe('package exports', () => {
+describe('packaged dependencies are re-exported', () => {
     const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
     test.each(Object.keys(pkg.dependencies))(`%s is exported`, (name) => {
         const relative = name.replace('@lwc', '.');

--- a/packages/lwc/__tests__/package-exports.spec.ts
+++ b/packages/lwc/__tests__/package-exports.spec.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('package exports', () => {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
+    test.each(Object.keys(pkg.dependencies))(`%s is exported`, (name) => {
+        const relative = name.replace('@lwc', '.');
+        expect(pkg.exports[relative]).toBe(`${relative}.js`);
+    });
+});

--- a/packages/lwc/babel-plugin-component.d.ts
+++ b/packages/lwc/babel-plugin-component.d.ts
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export type * from '@lwc/babel-plugin-component';
+export { default } from '@lwc/babel-plugin-component';

--- a/packages/lwc/babel-plugin-component.js
+++ b/packages/lwc/babel-plugin-component.js
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export * from '@lwc/babel-plugin-component';
+export { default } from '@lwc/babel-plugin-component';

--- a/packages/lwc/features.d.ts
+++ b/packages/lwc/features.d.ts
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export type * from '@lwc/features';
+export { default } from '@lwc/features';

--- a/packages/lwc/features.js
+++ b/packages/lwc/features.js
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export * from '@lwc/features';
+export { default } from '@lwc/features';

--- a/packages/lwc/jest.config.cjs
+++ b/packages/lwc/jest.config.cjs
@@ -5,6 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /* eslint-env node */
+
+/**
+ * This is a .cjs file because this package is an ESM package, but jest needs CJS to work.
+ * If this file is ever changed to a .js file, add an exclusion to the package.json "files" list,
+ * so that this is not shipped as part of the package.
+ */
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const BASE_CONFIG = require('../../scripts/jest/base.config');
 

--- a/packages/lwc/jest.config.cjs
+++ b/packages/lwc/jest.config.cjs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+/* eslint-env node */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const BASE_CONFIG = require('../../scripts/jest/base.config');
+
+module.exports = {
+    ...BASE_CONFIG,
+    displayName: 'lwc',
+};

--- a/packages/lwc/jest.config.cjs
+++ b/packages/lwc/jest.config.cjs
@@ -18,4 +18,5 @@ const BASE_CONFIG = require('../../scripts/jest/base.config');
 module.exports = {
     ...BASE_CONFIG,
     displayName: 'lwc',
+    testEnvironment: 'jsdom',
 };

--- a/packages/lwc/rollup-plugin.d.ts
+++ b/packages/lwc/rollup-plugin.d.ts
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export type * from '@lwc/rollup-plugin';
+export { default } from '@lwc/rollup-plugin';

--- a/packages/lwc/rollup-plugin.js
+++ b/packages/lwc/rollup-plugin.js
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export * from '@lwc/rollup-plugin';
+export { default } from '@lwc/rollup-plugin';

--- a/packages/lwc/template-compiler.d.ts
+++ b/packages/lwc/template-compiler.d.ts
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export type * from '@lwc/template-compiler';
+export { default } from '@lwc/template-compiler';

--- a/packages/lwc/template-compiler.js
+++ b/packages/lwc/template-compiler.js
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 export * from '@lwc/template-compiler';
+export { default } from '@lwc/template-compiler';

--- a/packages/lwc/tsconfig.json
+++ b/packages/lwc/tsconfig.json
@@ -1,5 +1,7 @@
 {
+    "extends": "../../tsconfig.json",
+
     "compilerOptions": {
-        "lib": ["dom"]
+        "lib": ["dom", "es2021"]
     }
 }

--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -23,6 +23,7 @@ module.exports = {
         '<rootDir>/packages/@lwc/synthetic-shadow',
         '<rootDir>/packages/@lwc/template-compiler',
         '<rootDir>/packages/@lwc/wire-service',
+        '<rootDir>/packages/lwc',
     ],
     coverageThreshold: {
         global: {


### PR DESCRIPTION
## Details

Some of our packages have default exports, but `export * from 'some-package'` does not include the default export. In order to use a default export from an `lwc` re-export, the default export must be handled explicitly.

```ts
import LwcRollupPlugin from '@lwc/rollup-plugin' // has always worked
import LwcRollupPlugin from 'lwc/rollup-plugin' // didn't work, now it does
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-13710298
