### PR TITLE
refactor: avoid calling traverseAndSetElement on every rerender

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -52,7 +52,7 @@ import {
 
 import { patchProps } from './modules/props';
 import { applyEventListeners } from './modules/events';
-import { applyStaticParts } from './modules/static-parts';
+import { mountStaticParts } from './modules/static-parts';
 import { getScopeTokenClass, getStylesheetTokenHost } from './stylesheet';
 import { renderComponent } from './component';
 import { applyRefs } from './modules/refs';
@@ -228,7 +228,7 @@ function hydrateStaticElement(elm: Node, vnode: VStatic, renderer: RendererAPI):
 
     vnode.elm = elm;
 
-    applyStaticParts(elm, vnode, renderer, true);
+    mountStaticParts(elm, vnode, renderer);
 
     return elm;
 }

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -69,7 +69,7 @@ import { applyEventListeners } from './modules/events';
 import { applyStaticClassAttribute } from './modules/static-class-attr';
 import { applyStaticStyleAttribute } from './modules/static-style-attr';
 import { applyRefs } from './modules/refs';
-import { applyStaticParts, patchStaticParts } from './modules/static-parts';
+import { mountStaticParts, patchStaticParts } from './modules/static-parts';
 import { LightningElementConstructor } from './base-lightning-element';
 
 export function patchChildren(
@@ -265,12 +265,12 @@ function mountElement(
 }
 
 function patchStatic(n1: VStatic, n2: VStatic, renderer: RendererAPI) {
-    const elm = (n2.elm = n1.elm!);
+    n2.elm = n1.elm!;
 
     // slotAssignments can only apply to the top level element, never to a static part.
     patchSlotAssignment(n1, n2, renderer);
     // The `refs` object is blown away in every re-render, so we always need to re-apply them
-    patchStaticParts(n1, n2, elm, renderer);
+    patchStaticParts(n1, n2);
 }
 
 function patchElement(n1: VElement, n2: VElement, renderer: RendererAPI) {
@@ -305,7 +305,7 @@ function mountStatic(
     // slotAssignments can only apply to the top level element, never to a static part.
     patchSlotAssignment(null, vnode, renderer);
     insertNode(elm, parent, anchor, renderer);
-    applyStaticParts(elm, vnode, renderer, true);
+    mountStaticParts(elm, vnode, renderer);
 }
 
 function mountCustomElement(

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -69,7 +69,7 @@ import { applyEventListeners } from './modules/events';
 import { applyStaticClassAttribute } from './modules/static-class-attr';
 import { applyStaticStyleAttribute } from './modules/static-style-attr';
 import { applyRefs } from './modules/refs';
-import { applyStaticParts } from './modules/static-parts';
+import { applyStaticParts, patchStaticParts } from './modules/static-parts';
 import { LightningElementConstructor } from './base-lightning-element';
 
 export function patchChildren(
@@ -270,7 +270,7 @@ function patchStatic(n1: VStatic, n2: VStatic, renderer: RendererAPI) {
     // slotAssignments can only apply to the top level element, never to a static part.
     patchSlotAssignment(n1, n2, renderer);
     // The `refs` object is blown away in every re-render, so we always need to re-apply them
-    applyStaticParts(elm, n2, renderer, false);
+    patchStaticParts(n1, n2, elm, renderer);
 }
 
 function patchElement(n1: VElement, n2: VElement, renderer: RendererAPI) {


### PR DESCRIPTION
## Details

Fixes #3800

This PR fixes the issue of calling `traverseAndSetElement` on every render by only traversing the parts instead of the entire subtree of the static node.

I wrote a small perf benchmark to demonstrate the gains with deeply nested static parts, [here](https://github.com/salesforce/lwc/commit/cd318b9d196f9916832d4534d5569577364ba05b). 

<img width="2133" alt="Screenshot 2024-02-14 at 2 43 59 PM" src="https://github.com/salesforce/lwc/assets/8368171/95540590-3517-4ef8-81ca-66fceea251e6">


The benchmark shows a roughly 17% perf improvement in this scenario.

The benchmark is not included in this PR as it is specific to this fix and I plan to include more benchmarks as part of the work in #3624.

## Does this pull request introduce a breaking change?
* ✅ No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?
* ✅ No, it does not introduce an observable change.

## GUS work item
W-15044923
