### PR TITLE
fix: isObject doesn't actually narrow down to just an object

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -547,8 +547,8 @@ function computeShadowMode(
     return shadowMode;
 }
 
-function assertIsVM(obj: any): asserts obj is VM {
-    if (isNull(obj) || !isObject(obj) || !('renderRoot' in obj)) {
+function assertIsVM(obj: unknown): asserts obj is VM {
+    if (!isObject(obj) || isNull(obj) || !('renderRoot' in obj)) {
         throw new TypeError(`${obj} is not a VM.`);
     }
 }

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+
 const {
     assign,
     create,
@@ -56,7 +57,7 @@ const {
 // Exposing this helper function is the closest we can get to preserving the usage patterns
 // of Array.prototype methods used elsewhere in the codebase.
 function arrayEvery<T>(
-    arr: any[],
+    arr: unknown[],
     predicate: (value: any, index: number, array: typeof arr) => value is T
 ): arr is T[] {
     return ArrayEvery.call(arr, predicate);
@@ -119,40 +120,40 @@ export {
     StringFromCharCode,
 };
 
-export function isUndefined(obj: any): obj is undefined {
+export function isUndefined(obj: unknown): obj is undefined {
     return obj === undefined;
 }
 
-export function isNull(obj: any): obj is null {
+export function isNull(obj: unknown): obj is null {
     return obj === null;
 }
 
-export function isTrue(obj: any): obj is true {
+export function isTrue(obj: unknown): obj is true {
     return obj === true;
 }
 
-export function isFalse(obj: any): obj is false {
+export function isFalse(obj: unknown): obj is false {
     return obj === false;
 }
 
-export function isBoolean(obj: any): obj is boolean {
+export function isBoolean(obj: unknown): obj is boolean {
     return typeof obj === 'boolean';
 }
 
 // Replacing `Function` with a narrower type that works for all our use cases is tricky...
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function isFunction(obj: any): obj is Function {
+export function isFunction(obj: unknown): obj is Function {
     return typeof obj === 'function';
 }
-export function isObject(obj: any): obj is object {
+export function isObject(obj: unknown): obj is object {
     return typeof obj === 'object';
 }
 
-export function isString(obj: any): obj is string {
+export function isString(obj: unknown): obj is string {
     return typeof obj === 'string';
 }
 
-export function isNumber(obj: any): obj is number {
+export function isNumber(obj: unknown): obj is number {
     return typeof obj === 'number';
 }
 
@@ -161,8 +162,8 @@ export function noop(): void {
 }
 
 const OtS = {}.toString;
-export function toString(obj: any): string {
-    if (obj && obj.toString) {
+export function toString(obj: unknown): string {
+    if (obj?.toString) {
         // Arrays might hold objects with "null" prototype So using
         // Array.prototype.toString directly will cause an error Iterate through
         // all the items and handle individually.
@@ -171,13 +172,14 @@ export function toString(obj: any): string {
         }
         return obj.toString();
     } else if (typeof obj === 'object') {
+        // Oops! This catches null and returns "[object Null]"
         return OtS.call(obj);
     } else {
-        return obj + '';
+        return String(obj);
     }
 }
 
-export function getPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined {
+export function getPropertyDescriptor(o: unknown, p: PropertyKey): PropertyDescriptor | undefined {
     do {
         const d = getOwnPropertyDescriptor(o, p);
         if (!isUndefined(d)) {

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -145,7 +145,7 @@ export function isBoolean(obj: unknown): obj is boolean {
 export function isFunction(obj: unknown): obj is Function {
     return typeof obj === 'function';
 }
-export function isObject(obj: unknown): obj is object {
+export function isObject(obj: unknown): obj is object | null {
     return typeof obj === 'object';
 }
 

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -168,11 +168,21 @@ export function toString(obj: unknown): string {
         // Array.prototype.toString directly will cause an error Iterate through
         // all the items and handle individually.
         if (isArray(obj)) {
+            // This behavior is slightly different from Array#toString:
+            // 1. Array#toString calls `this.join`, rather than Array#join
+            // Ex: arr = []; arr.join = () => 1; arr.toString() === 1; toString(arr) === ''
+            // 2. Array#toString delegates to Object#toString if `this.join` is not a function
+            // Ex: arr = []; arr.join = 'no'; arr.toString() === '[object Array]; toString(arr) = ''
+            // 3. Array#toString converts null/undefined to ''
+            // Ex: arr = [null, undefined]; arr.toString() === ','; toString(arr) === '[object Null],undefined'
+            // 4. Array#toString converts recursive references to arrays to ''
+            // Ex: arr = [1]; arr.push(arr, 2); arr.toString() === '1,,2'; toString(arr) throws
+            // Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
             return ArrayJoin.call(ArrayMap.call(obj, toString), ',');
         }
         return obj.toString();
     } else if (typeof obj === 'object') {
-        // Oops! This catches null and returns "[object Null]"
+        // This catches null and returns "[object Null]". Weird, but kept for backwards compatibility.
         return OtS.call(obj);
     } else {
         return String(obj);


### PR DESCRIPTION
## Details

Currently, `isObject` claims that it narrows a type to simply `object`, but it only checks `typeof obj === 'object'` and does not check for `null`. The following code passes type validation, but fails at runtime.

```ts
const obj: object | null = null
if (isObject(obj)) obj.toString()
```

The options to fix this are either to preserve the type guard and change the runtime behavior, or change the type guard and preserve the runtime behavior. Tests in our repo pass either way, but I opted for the former because preserving runtime behavior seems less likely to subtly break downstream users.

I also changed `any` to `unknown` where it is safe to do so, because that's Best Practices™ ✨.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* 🚨 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
