### PR TITLE
chore(eslint): add JSDOC plugin @W-13278716

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -301,8 +301,7 @@
             ],
             "rules": {
                 "jsdoc/require-jsdoc": "off",
-                // TODO [W-13278716]: All JSDOC should be valid
-                "jsdoc/require-param": "off",
+                // TODO [W-13278716]: All JSDOC should describe all params and returns
                 "jsdoc/require-param-description": "off",
                 "jsdoc/require-returns": "off"
             }

--- a/.eslintrc
+++ b/.eslintrc
@@ -304,8 +304,7 @@
                 // TODO [W-13278716]: All JSDOC should be valid
                 "jsdoc/require-param": "off",
                 "jsdoc/require-param-description": "off",
-                "jsdoc/require-returns": "off",
-                "jsdoc/require-yields": "off"
+                "jsdoc/require-returns": "off"
             }
         }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,12 @@
         "project": true
     },
 
-    "plugins": ["jest", "@lwc/lwc-internal", "@typescript-eslint", "import", "header"],
-    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended-type-checked"],
+    "plugins": ["jest", "@lwc/lwc-internal", "@typescript-eslint", "import", "header", "jsdoc"],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended-type-checked",
+        "plugin:jsdoc/recommended-typescript"
+    ],
 
     "env": {
         "es6": true
@@ -159,7 +163,9 @@
         "@typescript-eslint/no-unsafe-call": "off",
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-unsafe-argument": "off"
+        "@typescript-eslint/no-unsafe-argument": "off",
+
+        "jsdoc/require-jsdoc": ["warn", { "publicOnly": true }]
     },
 
     "overrides": [
@@ -262,6 +268,46 @@
             ],
             "rules": {
                 "header/header": "off"
+            }
+        },
+        {
+            // We don't control the 3rd party license, so don't complain about it
+            "files": ["packages/@lwc/synthetic-shadow/src/3rdparty/**"],
+            "rules": {
+                "jsdoc/check-values": "off"
+            }
+        },
+        {
+            "files": [
+                "packages/lwc/**",
+                // Private packages - documentation isn't required (but should still be good, if present)
+                "packages/@lwc/integration-karma/**",
+                "packages/@lwc/integration-tests/**",
+                "packages/@lwc/perf-benchmarks-components/**",
+                "packages/@lwc/perf-benchmarks/**",
+                // TODO [W-13278716]: All top-level exports should have JSDOC enforced
+                "packages/@lwc/babel-plugin-component/**",
+                "packages/@lwc/compiler/**",
+                "packages/@lwc/engine-core/**",
+                "packages/@lwc/engine-dom/**",
+                "packages/@lwc/engine-server/**",
+                "packages/@lwc/errors/**",
+                "packages/@lwc/features/**",
+                "packages/@lwc/module-resolver/**",
+                "packages/@lwc/rollup-plugin/**",
+                "packages/@lwc/shared/**",
+                "packages/@lwc/style-compiler/**",
+                "packages/@lwc/synthetic-shadow/**",
+                "packages/@lwc/template-compiler/**",
+                "packages/@lwc/wire-service/**"
+            ],
+            "rules": {
+                "jsdoc/require-jsdoc": "off",
+                // TODO [W-13278716]: All JSDOC should be valid
+                "jsdoc/require-param": "off",
+                "jsdoc/require-param-description": "off",
+                "jsdoc/require-returns": "off",
+                "jsdoc/require-yields": "off"
             }
         }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -219,9 +219,7 @@
 
             "env": {
                 "jest": true,
-                "es6": true,
-                "es2017": true,
-                "es2020": true
+                "es2021": true
             },
 
             "rules": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.6.3",
+        "eslint-plugin-jsdoc": "^48.1.0",
         "glob": "^10.3.10",
         "husky": "^8.0.2",
         "isbinaryfile": "^5.0.0",

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -34,12 +34,19 @@ function isLwcDecoratorName(name: string) {
     return DECORATOR_TRANSFORMS.some((transform) => transform.name === name);
 }
 
-/** Returns a list of all the references to an identifier */
+/**
+ * Returns a list of all the references to an identifier
+ * @param identifier
+ */
 function getReferences(identifier: NodePath<types.Identifier>) {
     return identifier.scope.getBinding(identifier.node.name)!.referencePaths;
 }
 
-/** Returns the type of decorator depdending on the property or method if get applied to */
+/**
+ * Returns the type of decorator depdending on the property or method if get applied to
+ * @param decoratorPath
+ * @param state
+ */
 function getDecoratedNodeType(
     decoratorPath: NodePath<types.Decorator>,
     state: LwcBabelPluginPass
@@ -125,7 +132,11 @@ function isImportedFromLwcSource(decoratorBinding: Binding) {
     );
 }
 
-/** Validate the usage of decorator by calling each validation function */
+/**
+ * Validate the usage of decorator by calling each validation function
+ * @param decorators
+ * @param state
+ */
 function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
     for (const { name, path } of decorators) {
         const binding = path.scope.getBinding(name);
@@ -136,7 +147,10 @@ function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
     DECORATOR_TRANSFORMS.forEach(({ validate }) => validate(decorators, state));
 }
 
-/** Remove import specifiers. It also removes the import statement if the specifier list becomes empty */
+/**
+ * Remove import specifiers. It also removes the import statement if the specifier list becomes empty
+ * @param engineImportSpecifiers
+ */
 function removeImportedDecoratorSpecifiers(
     engineImportSpecifiers: { name: any; path: NodePath<Node> }[]
 ) {

--- a/packages/@lwc/babel-plugin-component/src/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/index.ts
@@ -26,6 +26,7 @@ export type { LwcBabelPluginOptions } from './types';
  * The transform is done in 2 passes:
  *    - First, apply in a single AST traversal the decorators and the component transformation.
  *    - Then, in a second path transform class properties using the official babel plugin "babel-plugin-transform-class-properties".
+ * @param api
  */
 export default function LwcClassTransform(api: BabelAPI): PluginObj<LwcBabelPluginPass> {
     const { ExportDefaultDeclaration: transformCreateRegisterComponent } = component(api);

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -21,6 +21,9 @@ import { TransformResult } from './transformer';
  * Transforms a HTML template into module exporting a template function.
  * The transform also add a style import for the default stylesheet associated with
  * the template regardless if there is an actual style or not.
+ * @param src
+ * @param filename
+ * @param options
  */
 export default function templateTransform(
     src: string,

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -29,6 +29,9 @@ export interface TransformResult {
 /**
  * Transforms the passed code. Returning a Promise of an object with the generated code, source map
  * and gathered metadata.
+ * @param src
+ * @param filename
+ * @param options
  * @deprecated Use transformSync instead.
  */
 export function transform(
@@ -50,6 +53,9 @@ export function transform(
 /**
  * Transform the passed source code. Returning an object with the generated code, source map and
  * gathered metadata.
+ * @param src
+ * @param filename
+ * @param options
  */
 export function transformSync(
     src: string,

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -29,7 +29,6 @@ export interface TransformResult {
 /**
  * Transforms the passed code. Returning a Promise of an object with the generated code, source map
  * and gathered metadata.
- *
  * @deprecated Use transformSync instead.
  */
 export function transform(

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -469,6 +469,7 @@ function i(
 
 /**
  * [f]lattening
+ * @param items
  */
 function f(items: Readonly<Array<Readonly<Array<VNodes>> | VNodes>>): VNodes {
     if (process.env.NODE_ENV !== 'production') {
@@ -600,6 +601,10 @@ function fid(url: string | undefined | null): string | null | undefined {
  * [ddc] - create a (deprecated) dynamic component via `<x-foo lwc:dynamic={Ctor}>`
  *
  * TODO [#3331]: remove usage of lwc:dynamic in 246
+ * @param sel
+ * @param Ctor
+ * @param data
+ * @param children
  */
 function ddc(
     sel: string,
@@ -628,6 +633,9 @@ function ddc(
 
 /**
  * [dc] - create a dynamic component via `<lwc:component lwc:is={Ctor}>`
+ * @param Ctor
+ * @param data
+ * @param children
  */
 function dc(
     Ctor: LightningElementConstructor | null | undefined,
@@ -670,13 +678,13 @@ function dc(
  * to the engine that a particular collection of children must be diffed using the slow
  * algo based on keys due to the nature of the list. E.g.:
  *
- *   - slot element's children: the content of the slot has to be dynamic when in synthetic
- *                              shadow mode because the `vnode.children` might be the slotted
- *                              content vs default content, in which case the size and the
- *                              keys are not matching.
- *   - children that contain dynamic components
- *   - children that are produced by iteration
- *
+ * - slot element's children: the content of the slot has to be dynamic when in synthetic
+ * shadow mode because the `vnode.children` might be the slotted
+ * content vs default content, in which case the size and the
+ * keys are not matching.
+ * - children that contain dynamic components
+ * - children that are produced by iteration
+ * @param vnodes
  */
 function sc(vnodes: VNodes): VNodes {
     if (process.env.NODE_ENV !== 'production') {
@@ -704,6 +712,7 @@ export type SanitizeHtmlContentHook = (content: unknown) => string;
 
 /**
  * Sets the sanitizeHtmlContentHook.
+ * @param newHookImpl
  */
 export function setSanitizeHtmlContentHook(newHookImpl: SanitizeHtmlContentHook) {
     sanitizeHtmlContentHook = newHookImpl;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -64,6 +64,8 @@ import { applyShadowMigrateMode } from './shadow-migration-mode';
  * that a Custom Element can support (including AOM properties), which
  * determines what kind of capabilities the Base Lightning Element should support. When producing the new descriptors
  * for the Base Lightning Element, it also include the reactivity bit, so the standard property is reactive.
+ * @param propName
+ * @param descriptor
  */
 function createBridgeToElementDescriptor(
     propName: string,

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -204,7 +204,7 @@ export interface LightningElement extends HTMLElementTheGoodParts, AccessibleEle
 /**
  * This class is the base class for any LWC element.
  * Some elements directly extends this class, others implement it via inheritance.
- **/
+ */
 // @ts-ignore
 export const LightningElement: LightningElementConstructor = function (
     this: LightningElement

--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -27,6 +27,8 @@ if (process.env.NODE_ENV === 'test-karma-lwc') {
  * Validate a template, stylesheet, or component to make sure that its compiled version matches
  * the version used by the LWC engine at runtime. Note that this only works in dev mode because
  * it relies on code comments, which are stripped in production due to minification.
+ * @param func
+ * @param type
  */
 export function checkVersionMismatch(func: Template, type: 'template'): void;
 export function checkVersionMismatch(func: StylesheetFactory, type: 'stylesheet'): void;

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -37,6 +37,8 @@ const registeredComponentMap: Map<LightningElementConstructor, ComponentConstruc
 /**
  * INTERNAL: This function can only be invoked by compiled code. The compiler
  * will prevent this function from being imported by userland code.
+ * @param Ctor
+ * @param metadata
  */
 export function registerComponent(
     // We typically expect a LightningElementConstructor, but technically you can call this with anything

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -16,6 +16,9 @@ import { isUpdatingTemplate, getVMBeingRendered } from '../template';
  * The @api decorator marks public fields and public methods in
  * LWC Components. This function implements the internals of this
  * decorator.
+ * @param target
+ * @param propertyKey
+ * @param descriptor
  */
 export default function api(target: any, propertyKey: string, descriptor: PropertyDescriptor): void;
 export default function api() {

--- a/packages/@lwc/engine-core/src/framework/decorators/api.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/api.ts
@@ -13,7 +13,7 @@ import { getAssociatedVM } from '../vm';
 import { isUpdatingTemplate, getVMBeingRendered } from '../template';
 
 /**
- * @api decorator to mark public fields and public methods in
+ * The @api decorator marks public fields and public methods in
  * LWC Components. This function implements the internals of this
  * decorator.
  */

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -181,6 +181,8 @@ function validateMethodDecoratedWithApi(
 /**
  * INTERNAL: This function can only be invoked by compiled code. The compiler
  * will prevent this function from being imported by user-land code.
+ * @param Ctor
+ * @param meta
  */
 export function registerDecorators(
     Ctor: LightningElementConstructor,

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -15,7 +15,7 @@ import { updateComponentValue } from '../update-component-value';
 import { logError } from '../../shared/logger';
 
 /**
- * @track decorator function to mark field value as reactive in
+ * The @track decorator function marks field values as reactive in
  * LWC Components. This function can also be invoked directly
  * with any value to obtain the trackable version of the value.
  */

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -18,6 +18,9 @@ import { logError } from '../../shared/logger';
  * The @track decorator function marks field values as reactive in
  * LWC Components. This function can also be invoked directly
  * with any value to obtain the trackable version of the value.
+ * @param target
+ * @param propertyKey
+ * @param descriptor
  */
 export default function track(
     target: any,

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -15,6 +15,8 @@ import { updateComponentValue } from '../update-component-value';
  * The @wire decorator wires fields and methods to a wire adapter in
  * LWC Components. This function implements the internals of this
  * decorator.
+ * @param _adapter
+ * @param _config
  */
 export default function wire(
     _adapter: WireAdapterConstructor,

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -12,7 +12,7 @@ import { WireAdapterConstructor } from '../wiring';
 import { updateComponentValue } from '../update-component-value';
 
 /**
- * @wire decorator to wire fields and methods to a wire adapter in
+ * The @wire decorator wires fields and methods to a wire adapter in
  * LWC Components. This function implements the internals of this
  * decorator.
  */

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -263,6 +263,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
 /**
  * EXPERIMENTAL: This function allows for the identification of LWC constructors. This API is
  * subject to change or being removed.
+ * @param ctor
  */
 export function isComponentConstructor(ctor: unknown): ctor is LightningElementConstructor {
     if (!isFunction(ctor)) {
@@ -369,6 +370,7 @@ interface PublicComponentDef {
 /**
  * EXPERIMENTAL: This function allows for the collection of internal component metadata. This API is
  * subject to change or being removed.
+ * @param Ctor
  */
 export function getComponentDef(Ctor: any): PublicComponentDef {
     const def = getComponentInternalDef(Ctor);

--- a/packages/@lwc/engine-core/src/framework/get-component-constructor.ts
+++ b/packages/@lwc/engine-core/src/framework/get-component-constructor.ts
@@ -12,6 +12,7 @@ import { getAssociatedVMIfPresent } from './vm';
 /**
  * EXPERIMENTAL: This function provides access to the component constructor, given an HTMLElement.
  * This API is subject to change or being removed.
+ * @param elm
  */
 export function getComponentConstructor(elm: HTMLElement): typeof LightningElement | null {
     let ctor: typeof LightningElement | null = null;

--- a/packages/@lwc/engine-core/src/framework/membrane.ts
+++ b/packages/@lwc/engine-core/src/framework/membrane.ts
@@ -19,6 +19,7 @@ const reactiveMembrane = new ObservableMembrane({
  * EXPERIMENTAL: This function implements an unwrap mechanism that
  * works for observable membrane objects. This API is subject to
  * change or being removed.
+ * @param value
  */
 export function unwrap(value: any): any {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -71,7 +71,6 @@ function traverseAndSetElements(root: Element, parts: VStaticPart[], renderer: R
  * @param root - the root element
  * @param vnode - the parent VStatic
  * @param renderer - the renderer to use
- * @param mount - true this is a first (mount) render as opposed to a subsequent (patch) render
  */
 export function mountStaticParts(root: Element, vnode: VStatic, renderer: RendererAPI): void {
     // On the server, we don't support ref (because it relies on renderedCallback), nor do we

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -68,7 +68,6 @@ function traverseAndSetElements(root: Element, parts: VStaticPart[], renderer: R
 
 /**
  * Given an array of static parts, do all the mounting required for these parts.
- *
  * @param root - the root element
  * @param vnode - the parent VStatic
  * @param renderer - the renderer to use
@@ -100,7 +99,6 @@ export function mountStaticParts(root: Element, vnode: VStatic, renderer: Render
 
 /**
  * Mounts elements to the newly generated VStatic node
- *
  * @param n1 - the previous VStatic vnode
  * @param n2 - the current VStatic vnode
  */

--- a/packages/@lwc/engine-core/src/framework/readonly.ts
+++ b/packages/@lwc/engine-core/src/framework/readonly.ts
@@ -11,6 +11,7 @@ import { getReadOnlyProxy } from './membrane';
  * EXPERIMENTAL: This function allows you to create a reactive readonly
  * membrane around any object value. This API is subject to change or
  * being removed.
+ * @param obj
  */
 export function readonly(obj: any): any {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -726,6 +726,7 @@ export function allocateChildren(vnode: VCustomElement, vm: VM) {
  * With the delimiters removed, the contents are marked dynamic so they are diffed correctly.
  *
  * This function is used for slotted VFragments to avoid the text delimiters interfering with slotting functionality.
+ * @param children
  */
 function flattenFragmentsInChildren(children: VNodes): VNodes {
     const flattenedChildren: VNodes = [];

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -74,7 +74,7 @@ export type ReportingDispatcher<T extends ReportingEventId = ReportingEventId> =
     payload: ReportingPayloadMapping[T]
 ) => void;
 
-/** Callbacks to invoke when reporting is enabled **/
+/** Callbacks to invoke when reporting is enabled */
 type OnReportingEnabledCallback = () => void;
 const onReportingEnabledCallbacks: OnReportingEnabledCallback[] = [];
 
@@ -92,7 +92,6 @@ let enabled = false;
 export const reportingControl = {
     /**
      * Attach a new reporting control (aka dispatcher).
-     *
      * @param dispatcher - reporting control
      */
     attachDispatcher(dispatcher: ReportingDispatcher): void {

--- a/packages/@lwc/engine-core/src/framework/secure-template.ts
+++ b/packages/@lwc/engine-core/src/framework/secure-template.ts
@@ -21,6 +21,7 @@ export function isTemplateRegistered(tpl: Template): boolean {
 /**
  * INTERNAL: This function can only be invoked by compiled code. The compiler
  * will prevent this function from being imported by userland code.
+ * @param tpl
  */
 export function registerTemplate(tpl: Template): Template {
     if (process.env.NODE_ENV !== 'production') {
@@ -36,6 +37,10 @@ export function registerTemplate(tpl: Template): Template {
 /**
  * EXPERIMENTAL: This function acts like a hook for Lightning Locker Service and other similar
  * libraries to sanitize vulnerable attributes.
+ * @param tagName
+ * @param namespaceUri
+ * @param attrName
+ * @param attrValue
  */
 export function sanitizeAttribute(
     tagName: string,

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -233,6 +233,8 @@ function getNearestShadowComponent(vm: VM): VM | null {
  * If the component that is currently being rendered uses scoped styles,
  * this returns the unique token for that scoped stylesheet. Otherwise
  * it returns null.
+ * @param owner
+ * @param legacy
  */
 // TODO [#3733]: remove support for legacy scope tokens
 export function getScopeTokenClass(owner: VM, legacy: boolean): string | null {
@@ -249,6 +251,7 @@ export function getScopeTokenClass(owner: VM, legacy: boolean): string | null {
  * exists. Otherwise it returns null.
  *
  * A host style token is applied to the component if scoped styles are used.
+ * @param vnode
  */
 export function getStylesheetTokenHost(vnode: VCustomElement): string | null {
     const { template } = getComponentInternalDef(vnode.ctor);

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -28,8 +28,8 @@ export type StylesheetFactory = (
 
 /**
  * The list of stylesheets associated with a template. Each entry is either a StylesheetFactory or a
- * TemplateStylesheetFactory a given stylesheet depends on other external stylesheets (via the
- * @import CSS declaration).
+ * TemplateStylesheetFactory a given stylesheet depends on other external stylesheets (via
+ * the @import CSS declaration).
  */
 export type TemplateStylesheetFactories = Array<StylesheetFactory | TemplateStylesheetFactories>;
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -122,8 +122,10 @@ export interface Context {
     hasScopedStyles: boolean | undefined;
     /** The VNodes injected in all the shadow trees to apply the associated component stylesheets. */
     styleVNodes: VNode[] | null;
-    /** Object used by the template function to store information that can be reused between
-     *  different render cycle of the same template. */
+    /**
+     * Object used by the template function to store information that can be reused between
+     *  different render cycle of the same template.
+     */
     tplCache: TemplateCache;
     /** List of wire hooks that are invoked when the component gets connected. */
     wiredConnecting: Array<() => void>;
@@ -162,14 +164,18 @@ export interface VM<N = HostNode, E = HostElement> {
     children: VNodes;
     /** The list of adopted children VNodes. */
     aChildren: VNodes;
-    /** The list of custom elements VNodes currently rendered in the shadow tree. We keep track of
+    /**
+     * The list of custom elements VNodes currently rendered in the shadow tree. We keep track of
      * those elements to efficiently unmount them when the parent component is disconnected without
-     * having to traverse the VNode tree. */
+     * having to traverse the VNode tree.
+     */
     velements: VCustomElement[];
     /** The component public properties. */
     cmpProps: { [name: string]: any };
-    /** Contains information about the mapping between the slot names and the slotted VNodes, and
-     *  the owner of the slot content. */
+    /**
+     * Contains information about the mapping between the slot names and the slotted VNodes, and
+     *  the owner of the slot content.
+     */
     cmpSlots: SlotSet;
     /** The component internal reactive properties. */
     cmpFields: { [name: string]: any };
@@ -185,28 +191,39 @@ export interface VM<N = HostNode, E = HostElement> {
     component: LightningElement;
     /** The custom element shadow root. */
     shadowRoot: ShadowRoot | null;
-    /** The component render root. If the component is a shadow DOM component, it is its shadow
-     * root. If the component is a light DOM component it the element itself. */
+    /**
+     * The component render root. If the component is a shadow DOM component, it is its shadow
+     * root. If the component is a light DOM component it the element itself.
+     */
     renderRoot: ShadowRoot | HostElement;
     /** The template reactive observer. */
     tro: ReactiveObserver;
-    /** Hook invoked whenever a property is accessed on the host element. This hook is used by
-     *  Locker only. */
+    /**
+     * Hook invoked whenever a property is accessed on the host element. This hook is used by
+     *  Locker only.
+     */
     setHook: (cmp: LightningElement, prop: PropertyKey, newValue: any) => void;
-    /** Hook invoked whenever a property is set on the host element. This hook is used by Locker
-     *  only. */
+    /**
+     * Hook invoked whenever a property is set on the host element. This hook is used by Locker
+     *  only.
+     */
     getHook: (cmp: LightningElement, prop: PropertyKey) => any;
-    /** Hook invoked whenever a method is called on the component (life-cycle hooks, public
-     *  properties and event handlers). This hook is used by Locker. */
+    /**
+     * Hook invoked whenever a method is called on the component (life-cycle hooks, public
+     *  properties and event handlers). This hook is used by Locker.
+     */
     callHook: (cmp: LightningElement | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
     /**
-     * Renderer API */
+     * Renderer API
+     */
     renderer: RendererAPI;
     /**
-     * Debug info bag. Stores useful debug information about the component. */
+     * Debug info bag. Stores useful debug information about the component.
+     */
     debugInfo?: Record<string, any>;
     /**
-     * Any stylesheets associated with the component */
+     * Any stylesheets associated with the component
+     */
     stylesheets: TemplateStylesheetFactories | null;
     /**
      * API version associated with this VM

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -808,6 +808,7 @@ function runLightChildNodesDisconnectedCallback(vm: VM) {
  * need to continue into its children because by attempting to disconnect the
  * custom element itself will trigger the removal of anything slotted or anything
  * defined on its shadow.
+ * @param vnodes
  */
 function recursivelyDisconnectChildren(vnodes: VNodes) {
     for (let i = 0, len = vnodes.length; i < len; i += 1) {

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -24,9 +24,7 @@ type HTMLElementConstructor = typeof HTMLElement;
 /**
  * This function builds a Web Component class from a LWC constructor so it can be
  * registered as a new element via customElements.define() at any given time.
- *
  * @deprecated since version 1.3.11
- *
  * @example
  * ```
  * import { buildCustomElementConstructor } from 'lwc';

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -24,6 +24,7 @@ type HTMLElementConstructor = typeof HTMLElement;
 /**
  * This function builds a Web Component class from a LWC constructor so it can be
  * registered as a new element via customElements.define() at any given time.
+ * @param Ctor
  * @deprecated since version 1.3.11
  * @example
  * ```

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -81,16 +81,25 @@ function monkeyPatchDomAPIs() {
     } as Pick<Node, 'appendChild' | 'insertBefore' | 'removeChild' | 'replaceChild'>);
 }
 
+// For some reason, JSDOC says "options.is" is a syntax error. And we can't disable the rule using
+// `eslint-disable-next-line` because that gets included in the JSDOC, so we need this workaround.
+/* eslint-disable jsdoc/valid-types */
 /**
  * EXPERIMENTAL: This function is almost identical to document.createElement with the slightly
  * difference that in the options, you can pass the `is` property set to a Constructor instead of
  * just a string value. The intent is to allow the creation of an element controlled by LWC without
  * having to register the element as a custom element.
+ * @param sel
+ * @param options
+ * @param options.is description
+ * @param options.mode
  * @example
  * ```
  * const el = createElement('x-foo', { is: FooCtor });
  * ```
  */
+/* eslint-enable jsdoc/valid-types */
+
 export function createElement(
     sel: string,
     options: {
@@ -133,6 +142,7 @@ export function createElement(
      * with a callback as the first argument, we could implement a more advanced
      * mechanism that only passes that argument if the constructor is known to be
      * an upgradable custom element.
+     * @param elm
      */
     const upgradeCallback = (elm: HTMLElement) => {
         createVM(elm, Ctor, renderer, {

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -86,7 +86,6 @@ function monkeyPatchDomAPIs() {
  * difference that in the options, you can pass the `is` property set to a Constructor instead of
  * just a string value. The intent is to allow the creation of an element controlled by LWC without
  * having to register the element as a custom element.
- *
  * @example
  * ```
  * const el = createElement('x-foo', { is: FooCtor });

--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -21,6 +21,7 @@ const _Node = Node;
 /**
  * EXPERIMENTAL: The purpose of this function is to detect shadowed nodes. THIS API WILL BE REMOVED
  * ONCE LOCKER V1 IS NO LONGER SUPPORTED.
+ * @param node
  */
 function isNodeShadowed(node: Node): boolean {
     if (isFalse(node instanceof _Node)) {

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -10,7 +10,6 @@ import { isUndefined, keys } from '@lwc/shared';
 
 /**
  * Displays the header for a custom element.
- *
  * @param ce the custom element
  * @param componentInstance component instance associated with the custom element.
  */

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -34,7 +34,6 @@ export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : San
  * Example usage:
  * import { renderer, rendererFactory } from 'lwc';
  * const customRenderer = rendererFactory(renderer);
- *
  * @param baseRenderer Either null or the base renderer imported from 'lwc'.
  */
 export function rendererFactory<T extends RendererAPI | null>(baseRenderer: T): RendererAPIType<T> {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -62,7 +62,6 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
  * This is a replacement for Prettier HTML formatting. Prettier formatting is too aggressive for
  * fixture testing. It not only indent the HTML code but also fixes HTML issues. For testing we want
  * to make sure that the fixture file is as close as possible to what the engine produces.
- *
  * @param src the original HTML fragment.
  * @returns the formatter HTML fragment.
  */

--- a/packages/@lwc/errors/src/compiler/errors.ts
+++ b/packages/@lwc/errors/src/compiler/errors.ts
@@ -43,7 +43,6 @@ export function generateErrorMessage(errorInfo: LWCErrorInfo, args?: any[]): str
  * info about the error's code and its origin (filename, line, column) when applicable.
  * @param errorInfo The object holding the error metadata.
  * @param config A config object providing any message arguments and origin info needed to create the error.
- * @returns
  */
 export function generateCompilerDiagnostic(
     errorInfo: LWCErrorInfo,
@@ -70,7 +69,6 @@ export function generateCompilerDiagnostic(
  * the error's code and its origin (filename, line, column) when applicable.
  * @param errorInfo The object holding the error metadata.
  * @param config A config object providing any message arguments and origin info needed to create the error.
- * @returns
  */
 export function generateCompilerError(
     errorInfo: LWCErrorInfo,
@@ -100,7 +98,6 @@ export function invariant(condition: boolean, errorInfo: LWCErrorInfo, args?: an
  * @param errorInfo
  * @param error
  * @param origin
- * @returns
  */
 export function normalizeToCompilerError(
     errorInfo: LWCErrorInfo,
@@ -128,9 +125,9 @@ export function normalizeToCompilerError(
 
 /**
  * Normalizes a received error into a CompilerDiagnostic. Adds any provided additional origin info.
+ * @param errorInfo
  * @param error
  * @param origin
- * @returns
  */
 export function normalizeToDiagnostic(
     errorInfo: LWCErrorInfo,

--- a/packages/@lwc/errors/src/compiler/errors.ts
+++ b/packages/@lwc/errors/src/compiler/errors.ts
@@ -41,10 +41,9 @@ export function generateErrorMessage(errorInfo: LWCErrorInfo, args?: any[]): str
  * Generates a compiler diagnostic. This function is used to look up the specified errorInfo
  * and generate a friendly and consistent diagnostic object. Diagnostic contains
  * info about the error's code and its origin (filename, line, column) when applicable.
- *
- * @param {LWCErrorInfo} errorInfo The object holding the error metadata.
- * @param {ErrorConfig} config A config object providing any message arguments and origin info needed to create the error.
- * @return {CompilerDiagnostic}
+ * @param errorInfo The object holding the error metadata.
+ * @param config A config object providing any message arguments and origin info needed to create the error.
+ * @returns
  */
 export function generateCompilerDiagnostic(
     errorInfo: LWCErrorInfo,
@@ -69,10 +68,9 @@ export function generateCompilerDiagnostic(
  * Generates a compiler error. This function is used to look up the specified errorInfo
  * and generate a friendly and consistent error object. Error object contains info about
  * the error's code and its origin (filename, line, column) when applicable.
- *
- * @param {LWCErrorInfo} errorInfo The object holding the error metadata.
- * @param {ErrorConfig} config A config object providing any message arguments and origin info needed to create the error.
- * @return {CompilerError}
+ * @param errorInfo The object holding the error metadata.
+ * @param config A config object providing any message arguments and origin info needed to create the error.
+ * @returns
  */
 export function generateCompilerError(
     errorInfo: LWCErrorInfo,
@@ -102,8 +100,7 @@ export function invariant(condition: boolean, errorInfo: LWCErrorInfo, args?: an
  * @param errorInfo
  * @param error
  * @param origin
- *
- * @return {CompilerError}
+ * @returns
  */
 export function normalizeToCompilerError(
     errorInfo: LWCErrorInfo,
@@ -133,8 +130,7 @@ export function normalizeToCompilerError(
  * Normalizes a received error into a CompilerDiagnostic. Adds any provided additional origin info.
  * @param error
  * @param origin
- *
- * @return {CompilerDiagnostic}
+ * @returns
  */
 export function normalizeToDiagnostic(
     errorInfo: LWCErrorInfo,

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -31,6 +31,8 @@ const flags: Partial<FeatureFlagMap> = (globalThis as any).lwcRuntimeFlags;
 /**
  * Set the value at runtime of a given feature flag. This method only be invoked once per feature
  * flag. It is meant to be used during the app initialization.
+ * @param name
+ * @param value
  */
 export function setFeatureFlag(name: FeatureFlagName, value: FeatureFlagValue): void {
     if (!isBoolean(value)) {
@@ -71,6 +73,8 @@ export function setFeatureFlag(name: FeatureFlagName, value: FeatureFlagValue): 
 /**
  * Set the value at runtime of a given feature flag. This method should only be used for testing
  * purposes. It is a no-op when invoked in production mode.
+ * @param name
+ * @param value
  */
 export function setFeatureFlagForTest(name: FeatureFlagName, value: FeatureFlagValue): void {
     // This may seem redundant, but `process.env.NODE_ENV === 'test-karma-lwc'` is replaced by Karma tests

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -349,8 +349,8 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
 
     /**
      *
-     * @param {jasmine.Spy} dispatcher
-     * @param {String[]} runtimeEvents List of runtime events to filter by. If no list is provided, all events will be dispatched.
+     * @param dispatcher
+     * @param runtimeEvents List of runtime events to filter by. If no list is provided, all events will be dispatched.
      */
     function attachReportingControlDispatcher(dispatcher, runtimeEvents) {
         lwc.__unstable__ReportingControl.attachDispatcher((eventName, payload) => {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/base.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/base.js
@@ -49,6 +49,7 @@ function getFiles() {
 /**
  * More details here:
  * https://karma-runner.github.io/3.0/config/configuration-file.html
+ * @param config
  */
 module.exports = (config) => {
     config.set({

--- a/packages/@lwc/integration-karma/scripts/karma-configs/test/base.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/test/base.js
@@ -63,6 +63,7 @@ function getFiles() {
 /**
  * More details here:
  * https://karma-runner.github.io/3.0/config/configuration-file.html
+ * @param config
  */
 module.exports = (config) => {
     config.set({

--- a/packages/@lwc/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
@@ -122,7 +122,7 @@ describe('disconnectedCallback for host with slots', () => {
      * Automation for issue #1090
      * In this scenario the slot content from the parent's template is unrendered.
      * disconnecting the slot receiver was causing errors
-     **/
+     */
     it('should invoke disconnectedCallback on child that has unrendered slot content', () => {
         parent.hideChildIgnoresSlots = true;
 

--- a/packages/@lwc/integration-karma/test/context/x/simpleProvider/simpleProvider.js
+++ b/packages/@lwc/integration-karma/test/context/x/simpleProvider/simpleProvider.js
@@ -71,6 +71,9 @@ const contextualizer = createContextProvider(WireAdapter);
 /**
  * Note: spy and skipInitialProvision parameters (and all code related to them) are meant for test purposes only,
  *       and should not be part of other implementations based on this reference implementation.
+ * @param target
+ * @param spy
+ * @param skipInitialProvision
  */
 export function installCustomContext(target, spy, skipInitialProvision) {
     const { connected = () => {}, disconnected = () => {} } = spy || {};

--- a/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -156,9 +156,8 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
     describe('slots', () => {
         /**
          * Utility function to verify that slot content is properly assigned in XparentWithSlot
-         *
-         * @param {Element} child Child element to verify.
-         * @param {Boolean} condition Whether slot content is expected or not expected.
+         * @param child Child element to verify.
+         * @param condition Whether slot content is expected or not expected.
          */
         function verifyExpectedSlotContent(child, condition) {
             const assignedNodes = child.shadowRoot.querySelector('slot').assignedNodes();
@@ -249,9 +248,8 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
         describe('named slots', () => {
             /**
              * Utility function to verify that named slot content is properly assigned in XparentWithNamedSlot.
-             *
-             * @param {Element} child Child element to verify.
-             * @param {Boolean} condition Whether slot content is expected or not expected.
+             * @param child Child element to verify.
+             * @param condition Whether slot content is expected or not expected.
              */
             function verifyExpectedNamedSlotContent(child, condition) {
                 const assignedNodes = child.shadowRoot.querySelector('slot').assignedNodes();
@@ -269,8 +267,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
 
             /**
              * Utility function to verify that default slot content is properly assigned in XparentWithNamedSlot.
-             *
-             * @param {Element} child Child element to verify.
+             * @param child Child element to verify.
              */
             function verifyDefaultSlotContent(child) {
                 const assignedNodes = child.shadowRoot.querySelectorAll('slot')[1].assignedNodes();

--- a/packages/@lwc/perf-benchmarks/src/utils/utils.js
+++ b/packages/@lwc/perf-benchmarks/src/utils/utils.js
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-/** Assert presence of an HTMLElement matching a querySelector */
+/**
+ * Assert presence of an HTMLElement matching a querySelector
+ * @param selector
+ */
 export function assertElement(selector) {
     const node = document.querySelector(selector);
 
@@ -15,7 +18,11 @@ export function assertElement(selector) {
     return node;
 }
 
-/** Assert present of text in a HTML Element */
+/**
+ * Assert present of text in a HTML Element
+ * @param selector
+ * @param text
+ */
 export function assertText(selector, text) {
     const node = assertElement(selector);
 
@@ -24,12 +31,18 @@ export function assertText(selector, text) {
     }
 }
 
-/** Wait for the next rendering cycle to occur */
+/**
+ * Wait for the next rendering cycle to occur
+ * @param cb
+ */
 export function nextTick(cb) {
     return Promise.resolve().then(cb);
 }
 
-/** Wait for the next frame */
+/**
+ * Wait for the next frame
+ * @param cb
+ */
 export function nextFrame(cb) {
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     setTimeout(cb, 0);

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -37,6 +37,7 @@ function isHostPseudoClass(node: Node): node is Pseudo {
  * Add scoping attributes to all the matching selectors:
  *   h1 -> h1[x-foo_tmpl]
  *   p a -> p[x-foo_tmpl] a[x-foo_tmpl]
+ * @param selector
  */
 function scopeSelector(selector: Selector) {
     const compoundSelectors: ChildNode[][] = [[]];
@@ -104,6 +105,7 @@ function scopeSelector(selector: Selector) {
  * contextual selector it will generate a rule for each of them.
  *   :host -> [x-foo_tmpl-host]
  *   :host(.foo, .bar) -> [x-foo_tmpl-host].foo, [x-foo_tmpl-host].bar
+ * @param selector
  */
 function transformHost(selector: Selector) {
     // Locate the first :host pseudo-class

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/inner-html.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/inner-html.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ */
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/outer-html.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/outer-html.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ */
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -13,7 +13,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ */
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
@@ -16,7 +16,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ */
 export function retarget(refNode: EventTarget | null, path: EventTarget[]): EventTarget | null {
     if (isNull(refNode)) {
         return null;

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
@@ -9,6 +9,8 @@ import { pathComposer } from './path-composer';
 import { isSyntheticShadowRoot } from './../../faux-shadow/shadow-root';
 
 /**
+ * @param refNode
+ * @param path
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ */
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/events.ts
@@ -75,6 +75,7 @@ function getEventMap(elm: EventTarget): ListenerMap {
  * Events dispatched on shadow roots actually end up being dispatched on their hosts. This means that the event.target
  * property of events dispatched on shadow roots always resolve to their host. This function understands this
  * abstraction and properly returns a reference to the shadow root when appropriate.
+ * @param event
  */
 export function getActualTarget(event: Event): EventTarget {
     return eventToShadowRootMap.get(event) ?? eventTargetGetter.call(event);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -45,6 +45,7 @@ function tabIndexGetterPatched(this: HTMLElement) {
 
 /**
  * This method only applies to elements with a shadow attached to them
+ * @param value
  */
 function tabIndexSetterPatched(this: HTMLElement, value: any) {
     // This tabIndex setter might be confusing unless it is understood that HTML

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/legacy-shadow-token.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/legacy-shadow-token.ts
@@ -23,7 +23,7 @@ export function setLegacyShadowToken(node: Node, shadowToken: string | undefined
 /**
  * Patching Element.prototype.$legacyShadowToken$ to mark elements a portal:
  * Same as $shadowToken$ but for legacy CSS scope tokens.
- **/
+ */
 defineProperty(Element.prototype, KEY__LEGACY_SHADOW_TOKEN, {
     set(this: Element, shadowToken: string | undefined) {
         const oldShadowToken = (this as any)[KEY__LEGACY_SHADOW_TOKEN_PRIVATE];

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/no-patch-utils.ts
@@ -15,6 +15,8 @@ import { getAllMatches, getNodeOwner, getAllSlottedMatches } from './traverse';
 /**
  * This methods filters out elements that are not in the same shadow root of context.
  * It does not enforce shadow dom semantics if $context is not managed by LWC
+ * @param context
+ * @param unfilteredNodes
  */
 export function getNonPatchedFilteredArrayOfNodes<T extends Node>(
     context: Element,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -208,7 +208,7 @@ const getDocumentOrRootNode: (this: Node, options?: GetRootNodeOptions) => Node 
  *  Fallback to using the native getRootNode() to discover the root node.
  *  This is because, it is not possible to inspect the node and decide if it is part
  *  of a native shadow or the synthetic shadow.
- * @param {Node} node
+ * @param node
  */
 function getNearestRoot(node: Node): Node {
     const ownerNode: HTMLElement | null = getNodeOwner(node);
@@ -239,7 +239,7 @@ function getNearestRoot(node: Node): Node {
  *
  * _Spec_: https://dom.spec.whatwg.org/#dom-node-getrootnode
  *
- **/
+ */
 function getRootNodePatched(this: Node, options?: GetRootNodeOptions): Node {
     const composed: boolean = isUndefined(options) ? false : !!options.composed;
     return isTrue(composed) ? getDocumentOrRootNode.call(this, options) : getNearestRoot(this);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -54,6 +54,7 @@ import {
  * based on the light-dom slotting mechanism. This applies to synthetic slot elements
  * and elements with shadow dom attached to them. It doesn't apply to native slot elements
  * because we don't want to patch the children getters for those elements.
+ * @param node
  */
 export function hasMountedChildren(node: Node): boolean {
     return isSyntheticSlotElement(node) || isSyntheticShadowHost(node);
@@ -229,16 +230,16 @@ function getNearestRoot(node: Node): Node {
  *
  * If looking for a shadow root of a node by calling `node.getRootNode({composed: false})` or `node.getRootNode()`,
  *
- *  1. Try to identify the host element that owns the give node.
- *     i. Identify the shadow tree that the node belongs to
- *     ii. If the node belongs to a shadow tree created by engine, return the shadowRoot of the host element that owns the shadow tree
- *  2. The host identification logic returns null in two cases:
- *     i. The node does not belong to a shadow tree created by engine
- *     ii. The engine is running in native shadow dom mode
- *     If so, use the original Node.prototype.getRootNode to fetch the root node(or manually climb up the dom tree where getRootNode() is unsupported)
+ * 1. Try to identify the host element that owns the give node.
+ * i. Identify the shadow tree that the node belongs to
+ * ii. If the node belongs to a shadow tree created by engine, return the shadowRoot of the host element that owns the shadow tree
+ * 2. The host identification logic returns null in two cases:
+ * i. The node does not belong to a shadow tree created by engine
+ * ii. The engine is running in native shadow dom mode
+ * If so, use the original Node.prototype.getRootNode to fetch the root node(or manually climb up the dom tree where getRootNode() is unsupported)
  *
  * _Spec_: https://dom.spec.whatwg.org/#dom-node-getrootnode
- *
+ * @param options
  */
 function getRootNodePatched(this: Node, options?: GetRootNodeOptions): Node {
     const composed: boolean = isUndefined(options) ? false : !!options.composed;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -135,7 +135,7 @@ function markElementAsPortal(elm: Element) {
  *  - at the moment, there is no way to undo this operation, once the element is
  *    marked as $domManual$, setting it to false does nothing.
  *
- **/
+ */
 // TODO [#1306]: rename this to $observerConnection$
 defineProperty(Element.prototype, '$domManual$', {
     set(this: Element, v: boolean) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
@@ -31,7 +31,7 @@ export function setShadowToken(node: Node, shadowToken: string | undefined) {
  *
  *  - this custom attribute must be unique.
  *
- **/
+ */
 defineProperty(Element.prototype, KEY__SHADOW_TOKEN, {
     set(this: Element, shadowToken: string | undefined) {
         const oldShadowToken = (this as any)[KEY__SHADOW_TOKEN_PRIVATE];

--- a/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/mutation-observer/polyfill.ts
@@ -41,7 +41,7 @@ function setNodeObservers(node: Node, observers: MutationObserver[]) {
 
 /**
  * Retarget the mutation record's target value to its shadowRoot
- * @param {MutationRecord} originalRecord
+ * @param originalRecord
  */
 function retargetMutationRecord(originalRecord: MutationRecord): MutationRecord {
     const { addedNodes, removedNodes, target, type } = originalRecord;
@@ -82,8 +82,8 @@ function retargetMutationRecord(originalRecord: MutationRecord): MutationRecord 
 /**
  * Utility to identify if a target node is being observed by the given observer
  * Start at the current node, if the observer is registered to observe the current node, the mutation qualifies
- * @param {MutationObserver} observer
- * @param {Node} target
+ * @param observer
+ * @param target
  */
 function isQualifiedObserver(observer: MutationObserver, target: Node): boolean {
     let parentNode: Node | null = target;
@@ -107,8 +107,8 @@ function isQualifiedObserver(observer: MutationObserver, target: Node): boolean 
  * The key logic here is to determine if a given observer has been registered to observe any nodes
  * between the target node of a mutation record to the target's root node.
  * This function also retargets records when mutations occur directly under the shadow root
- * @param {MutationRecords[]} mutations
- * @param {MutationObserver} observer
+ * @param mutations
+ * @param observer
  */
 function filterMutationRecords(
     mutations: MutationRecord[],
@@ -202,7 +202,7 @@ function getWrappedCallback(callback: MutationCallback): MutationCallback {
  * Patched MutationObserver constructor.
  * 1. Wrap the callback to filter out MutationRecords based on dom ownership
  * 2. Add a property field to track all observed targets of the observer instance
- * @param {MutationCallback} callback
+ * @param callback
  */
 function PatchedMutationObserver(
     this: MutationObserver,
@@ -235,8 +235,8 @@ function patchedDisconnect(this: MutationObserver): void {
 /**
  * A single mutation observer can observe multiple nodes(target).
  * Maintain a list of all targets that the observer chooses to observe
- * @param {Node} target
- * @param {Object} options
+ * @param target
+ * @param options
  */
 function patchedObserve(
     this: MutationObserver,

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -72,6 +72,7 @@ export function getNodeKey(node: Node): number | undefined {
  * This function does not traverse up for performance reasons, but is sufficient for most use
  * cases. If we need to traverse up and verify those nodes that don't have owner key, use
  * isNodeDeepShadowed instead.
+ * @param node
  */
 export function isNodeShadowed(node: Node): boolean {
     return !isUndefined(getNodeOwnerKey(node));

--- a/packages/@lwc/synthetic-shadow/src/shared/utils.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/utils.ts
@@ -47,6 +47,7 @@ export function isGlobalPatchingSkipped(node: Node): boolean {
 /**
  * This utility should be used to convert NodeList and HTMLCollection into an array before we
  * perform array operations on them. See issue #1545 for more details.
+ * @param collection
  */
 export function arrayFromCollection<T extends NodeList>(
     collection: T

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -294,6 +294,9 @@ export default class CodeGen {
 
     /**
      * Generates childs vnodes when slot content is static.
+     * @param slotName
+     * @param data
+     * @param children
      */
     getSlot(slotName: string, data: t.ObjectExpression, children: t.Expression) {
         this.slotNames.add(slotName);
@@ -308,6 +311,8 @@ export default class CodeGen {
 
     /**
      * Generates a factory function that inturn generates child vnodes for scoped slot content.
+     * @param callback
+     * @param slotName
      */
     getScopedSlotFactory(callback: t.FunctionExpression, slotName: t.Expression | t.SimpleLiteral) {
         return this._renderApiCall(RENDER_APIS.scopedSlotFactory, [slotName, callback]);
@@ -460,6 +465,7 @@ export default class CodeGen {
 
     /**
      * Searches the scopes to find an identifier with a matching name.
+     * @param identifier
      */
     isLocalIdentifier(identifier: t.Identifier): boolean {
         let scope: Scope | null = this.scope;
@@ -479,6 +485,7 @@ export default class CodeGen {
      * Bind the passed expression to the component instance. It applies the following transformation to the expression:
      * - {value} --> {$cmp.value}
      * - {value[index]} --> {$cmp.value[$cmp.index]}
+     * @param expression
      */
     bindExpression(expression: Expression | Literal | ComplexExpression): t.Expression {
         if (t.isIdentifier(expression)) {

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -353,7 +353,6 @@ export default class CodeGen {
      * This routine generates an expression that avoids
      * computing the sanitized html of a raw html if it does not change
      * between renders.
-     *
      * @param expr
      * @returns sanitizedHtmlExpr
      */

--- a/packages/@lwc/template-compiler/src/codegen/expression.ts
+++ b/packages/@lwc/template-compiler/src/codegen/expression.ts
@@ -34,6 +34,8 @@ type VariableNames = Set<string>;
  *    {(foo) => foo && $cmp.bar}
  *
  * Similar checks occur for local identifiers introduced via for:each or similar.
+ * @param expression
+ * @param codeGen
  */
 export function bindComplexExpression(
     expression: ComplexExpression,

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -47,7 +47,6 @@ function generateHoistedNodes(codegen: CodeGen): t.VariableDeclaration[] {
  * Generate an ES module AST from a template ESTree AST. The generated module imports the dependent
  * LWC components via import statements and expose the template function via a default export
  * statement.
- *
  * @example
  * ```js
  * import { registerTemplate } from 'lwc';

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -47,6 +47,8 @@ function generateHoistedNodes(codegen: CodeGen): t.VariableDeclaration[] {
  * Generate an ES module AST from a template ESTree AST. The generated module imports the dependent
  * LWC components via import statements and expose the template function via a default export
  * statement.
+ * @param templateFn
+ * @param codeGen
  * @example
  * ```js
  * import { registerTemplate } from 'lwc';

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -63,6 +63,8 @@ export function objectToAST(
  *
  * This function searches through the children to determine if flattening needs to occur in the runtime.
  * Children should be flattened if they contain an iterator, a dynamic directive or a slot inside a light dom element.
+ * @param codeGen
+ * @param children
  */
 export function shouldFlatten(codeGen: CodeGen, children: ChildNode[]): boolean {
     return children.some((child) => {
@@ -85,6 +87,7 @@ export function shouldFlatten(codeGen: CodeGen, children: ChildNode[]): boolean 
 
 /**
  * Returns true if the AST element or any of its descendants use an id attribute.
+ * @param node
  */
 export function hasIdAttribute(node: Node): boolean {
     if (isBaseElement(node)) {

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -250,7 +250,6 @@ function transform(codeGen: CodeGen): t.Expression {
 
     /**
      * Transforms an IfBlock or ElseifBlock along with both its direct descendants and its 'else' descendants.
-     *
      * @param conditionalParentBlock The IfBlock or ElseifBlock to transform into a conditional expression
      * @param key The key to use for this chain of IfBlock/ElseifBlock branches, if applicable
      * @returns A conditional expression representing the full conditional tree with conditionalParentBlock as the root node

--- a/packages/@lwc/template-compiler/src/codegen/optimize.ts
+++ b/packages/@lwc/template-compiler/src/codegen/optimize.ts
@@ -38,6 +38,7 @@ import * as t from '../shared/estree';
  *   };
  * }
  * ```
+ * @param templateFn
  */
 export function optimizeStaticExpressions(
     templateFn: t.FunctionDeclaration

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -24,6 +24,7 @@ const rawContentElements = new Set([
 /**
  * Escape all the characters that could break a JavaScript template string literal: "`" (backtick),
  * "${" (dollar + open curly) and "\" (backslash).
+ * @param str
  */
 function templateStringEscape(str: string): string {
     return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -248,6 +248,7 @@ function isTemplateDirective(attrName: string): boolean {
 
 /**
  * Convert attribute name from kebab case to camel case property name
+ * @param attrName
  */
 export function attributeToPropertyName(attrName: string): string {
     return ATTRS_PROPS_TRANFORMS[attrName] || toPropertyName(attrName);

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -285,11 +285,9 @@ interface ParseFragmentConfig {
 /**
  * Parse the LWC template using a customized parser & lexer that allow
  * for template expressions to be parsed correctly.
- *
- * @param      {string}               source  raw template markup
- * @param      {ParseFragmentConfig}  config
- *
- * @return     {DocumentFragment}     the parsed document
+ * @param               source  raw template markup
+ * @param  config
+ * @returns     the parsed document
  */
 export function parseFragment(source: string, config: ParseFragmentConfig): DocumentFragment {
     const { ctx, sourceCodeLocationInfo = true, onParseError } = config;

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -57,6 +57,8 @@ function getTrailingChars(str: string): string {
  * Notably, no examples of extraneous leading parens could be found - these result in a
  * parsing error in Acorn. However, this function still checks, in case there is an
  * unknown expression that would parse with an extraneous leading paren.
+ * @param leadingChars
+ * @param trailingChars
  */
 function validateMatchingExtraParens(leadingChars: string, trailingChars: string) {
     const numLeadingParens = leadingChars.split('(').length - 1;

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -176,6 +176,10 @@ function parseRoot(ctx: ParserCtx, parse5Elm: parse5Tools.Element): Root {
  *
  * Note: Not every node in the hierarchy is guaranteed to be created, for example,
  * <div></div> will only create an Element node.
+ * @param ctx
+ * @param parse5Elm
+ * @param parentNode
+ * @param parse5ParentLocation
  */
 function parseElement(
     ctx: ParserCtx,

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -158,6 +158,7 @@ export default class ParserCtx {
 
     /**
      * This method flattens the scopes into a single array for traversal.
+     * @param element
      * @yields Each node in the scope and its parent.
      */
     *ancestors(element?: ParentNode): IterableIterator<ParentWrapper> {
@@ -380,6 +381,9 @@ export default class ParserCtx {
 
     /**
      * This method throws a diagnostic error with the node's location.
+     * @param errorInfo
+     * @param node
+     * @param messageArgs
      */
     throwOnNode(errorInfo: LWCErrorInfo, node: BaseNode, messageArgs?: any[]): never {
         this.throw(errorInfo, messageArgs, node.location);
@@ -387,6 +391,9 @@ export default class ParserCtx {
 
     /**
      * This method throws a diagnostic error with location information.
+     * @param errorInfo
+     * @param location
+     * @param messageArgs
      */
     throwAtLocation(errorInfo: LWCErrorInfo, location: SourceLocation, messageArgs?: any[]): never {
         this.throw(errorInfo, messageArgs, location);
@@ -394,6 +401,9 @@ export default class ParserCtx {
 
     /**
      * This method throws a diagnostic error and will immediately exit the current routine.
+     * @param errorInfo
+     * @param messageArgs
+     * @param location
      */
     throw(errorInfo: LWCErrorInfo, messageArgs?: any[], location?: SourceLocation): never {
         throw generateCompilerError(errorInfo, {
@@ -406,6 +416,9 @@ export default class ParserCtx {
 
     /**
      * This method logs a diagnostic warning with the node's location.
+     * @param errorInfo
+     * @param node
+     * @param messageArgs
      */
     warnOnNode(errorInfo: LWCErrorInfo, node: BaseNode, messageArgs?: any[]): void {
         this.warn(errorInfo, messageArgs, node.location);
@@ -413,6 +426,9 @@ export default class ParserCtx {
 
     /**
      * This method logs a diagnostic warning with location information.
+     * @param errorInfo
+     * @param location
+     * @param messageArgs
      */
     warnAtLocation(errorInfo: LWCErrorInfo, location: SourceLocation, messageArgs?: any[]): void {
         this.warn(errorInfo, messageArgs, location);
@@ -420,6 +436,9 @@ export default class ParserCtx {
 
     /**
      * This method logs a diagnostic warning and will continue execution of the current routine.
+     * @param errorInfo
+     * @param messageArgs
+     * @param location
      */
     warn(errorInfo: LWCErrorInfo, messageArgs?: any[], location?: SourceLocation): void {
         this.addDiagnostic(

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -172,10 +172,9 @@ export default class ParserCtx {
      * This method returns an iterator over ancestor nodes, starting at the parent and ending at the root node.
      *
      * Note: There are instances when we want to terminate the traversal early, such as searching for a ForBlock parent.
-     *
-     * @param {ParentNode} startNode - Starting node to begin search, defaults to the tail of the current scope.
-     * @param {function} predicate - This callback is called once for each ancestor until it finds one where predicate returns true.
-     * @param {function} traversalCond - This callback is called after predicate and will terminate the traversal if it returns false.
+     * @param startNode - Starting node to begin search, defaults to the tail of the current scope.
+     * @param predicate - This callback is called once for each ancestor until it finds one where predicate returns true.
+     * @param traversalCond - This callback is called after predicate and will terminate the traversal if it returns false.
      * traversalCond is ignored if no value is provided.
      */
     findAncestor<A extends ParentNode>(
@@ -198,8 +197,7 @@ export default class ParserCtx {
 
     /**
      * This method searchs the current scope and returns the value that satisfies the predicate.
-     *
-     * @param {function} predicate - This callback is called once for each sibling in the current scope
+     * @param predicate - This callback is called once for each sibling in the current scope
      * until it finds one where predicate returns true.
      */
     findInCurrentElementScope<A extends ParentNode>(
@@ -339,7 +337,6 @@ export default class ParserCtx {
     /**
      * This method recovers from diagnostic errors that are encountered when fn is invoked.
      * All other errors are considered compiler errors and can not be recovered from.
-     *
      * @param fn - method to be invoked.
      */
     withErrorRecovery<T>(fn: () => T): T | undefined {

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -158,6 +158,7 @@ export default class ParserCtx {
 
     /**
      * This method flattens the scopes into a single array for traversal.
+     * @yields Each node in the scope and its parent.
      */
     *ancestors(element?: ParentNode): IterableIterator<ParentWrapper> {
         const ancestors = this.elementScopes.flat();

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -172,10 +172,10 @@ export default class ParserCtx {
      * This method returns an iterator over ancestor nodes, starting at the parent and ending at the root node.
      *
      * Note: There are instances when we want to terminate the traversal early, such as searching for a ForBlock parent.
-     * @param startNode - Starting node to begin search, defaults to the tail of the current scope.
      * @param predicate - This callback is called once for each ancestor until it finds one where predicate returns true.
      * @param traversalCond - This callback is called after predicate and will terminate the traversal if it returns false.
      * traversalCond is ignored if no value is provided.
+     * @param startNode - Starting node to begin search, defaults to the tail of the current scope.
      */
     findAncestor<A extends ParentNode>(
         predicate: (node: ParentNode) => node is A,

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -21,6 +21,8 @@ interface LegacyAdapterDataCallback extends DataCallback {
 
 /**
  * Registers a wire adapter factory for Lightning Platform.
+ * @param adapterId
+ * @param adapterEventTargetCallback
  * @deprecated
  */
 export function register(

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -23,6 +23,7 @@ const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
  * Jest uses CommonJS, which means that packages with no explicit export statements actually export
  * the default `module.exports` empty object. That export is an empty object with the prototype set
  * to an empty object with null prototype.
+ * @param mod
  */
 const hasExplicitDefaultExport = (mod: object) => {
     // No default export = self explanatory

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -207,7 +207,6 @@ declare module 'lwc' {
      *
      * in which 'GetRecordConfig' is the adapter config object type and 'RecordRepresentation'
      * is the returned value.
-     *
      * @param adapter the adapter used to provision data
      * @param config configuration object for the adapter
      */

--- a/scripts/jest/utils/index.ts
+++ b/scripts/jest/utils/index.ts
@@ -13,11 +13,9 @@ import CustomMatcherResult = jest.CustomMatcherResult;
 const { globSync } = glob;
 
 /**
- * src - the fixture content
- * @param receivedContent
- * @param filename
- * filename - the fixture absolute path
- * dirname - the fixture directory absolute path
+ * @param receivedContent - the fixture content
+ * @param filename - the fixture absolute path
+ * @returns matcher result
  */
 function toMatchFile(
     this: MatcherUtils,
@@ -137,7 +135,7 @@ type TestFixtureOutput = { [filename: string]: unknown };
  * expected to return an object representing the fixture outputs. The key represents the output
  * file name and the value, its associated content. An `undefined` or `null` value represents a
  * non existing file.
- * @param config
+ * @param config - The config object
  * @param config.pattern - The glob pattern to locate each individual fixture.
  * @param config.root - The directory from where the pattern is executed.
  * @param testFn - The test function executed for each fixture.

--- a/scripts/jest/utils/index.ts
+++ b/scripts/jest/utils/index.ts
@@ -13,10 +13,11 @@ import CustomMatcherResult = jest.CustomMatcherResult;
 const { globSync } = glob;
 
 /**
- * @typedef {Object} TestFixtureConfig
- * @property {string} src - the fixture content
- * @property {string} filename - the fixture absolute path
- * @property {string} dirname - the fixture directory absolute path
+ * src - the fixture content
+ * @param receivedContent
+ * @param filename
+ * filename - the fixture absolute path
+ * dirname - the fixture directory absolute path
  */
 function toMatchFile(
     this: MatcherUtils,
@@ -136,11 +137,10 @@ type TestFixtureOutput = { [filename: string]: unknown };
  * expected to return an object representing the fixture outputs. The key represents the output
  * file name and the value, its associated content. An `undefined` or `null` value represents a
  * non existing file.
- *
- * @param {Object} config
- * @param {string} config.pattern - The glob pattern to locate each individual fixture.
- * @param {string} config.root - The directory from where the pattern is executed.
- * @param {function(TestFixtureConfig)} testFn - The test function executed for each fixture.
+ * @param config
+ * @param config.pattern - The glob pattern to locate each individual fixture.
+ * @param config.root - The directory from where the pattern is executed.
+ * @param testFn - The test function executed for each fixture.
  */
 export function testFixtureDir(
     config: { pattern: string; root: string },

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,6 +957,15 @@
     buffer-crc32 "~0.2.3"
     fd-slicer2 "^1.2.0"
 
+"@es-joy/jsdoccomment@~0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.42.0.tgz#59e878708336aaee88c2b34c894f73dbf77ae2b0"
+  integrity sha512-R1w57YlVA6+YE01wch3GPYn6bCsrOV3YW/5oGGE2tmX6JcL9Nr+b5IikrjMPF+v9CV3ay+obImEdsDhovhJrzw==
+  dependencies:
+    comment-parser "1.4.1"
+    esquery "^1.5.0"
+    jsdoc-type-pratt-parser "~4.0.0"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -1334,9 +1343,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/jest-utils-lwc-internals@link:./scripts/jest/utils":
   version "0.0.0"
+  uid ""
 
 "@lwc/module-resolver@5.3.0":
   version "5.3.0"
@@ -2916,6 +2927,11 @@ archiver@^6.0.0:
     tar-stream "^3.0.0"
     zip-stream "^5.0.1"
 
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
+
 are-we-there-yet@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
@@ -3931,6 +3947,11 @@ commander@^9.3.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
+comment-parser@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
+  integrity sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -5039,6 +5060,21 @@ eslint-plugin-jest@^27.6.3:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
+eslint-plugin-jsdoc@^48.1.0:
+  version "48.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.1.0.tgz#565363770b433485bfc70dc862b50b7f780529ec"
+  integrity sha512-g9S8ukmTd1DVcV/xeBYPPXOZ6rc8WJ4yi0+MVxJ1jBOrz5kmxV9gJJQ64ltCqIWFnBChLIhLVx3tbTSarqVyFA==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.42.0"
+    are-docs-informative "^0.0.2"
+    comment-parser "1.4.1"
+    debug "^4.3.4"
+    escape-string-regexp "^4.0.0"
+    esquery "^1.5.0"
+    is-builtin-module "^3.2.1"
+    semver "^7.6.0"
+    spdx-expression-parse "^4.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -5118,7 +5154,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.2:
+esquery@^1.4.2, esquery@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -7405,6 +7441,11 @@ js-yaml@^3.10.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsdoc-type-pratt-parser@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
+  integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
 
 jsdom@^20.0.0:
   version "20.0.3"
@@ -10306,7 +10347,7 @@ semver-truncate@^1.1.2:
   dependencies:
     semver "^5.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@7.5.3, semver@7.5.4, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+"semver@2 || 3 || 4 || 5", semver@7.5.3, semver@7.5.4, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -10658,6 +10699,14 @@ spdx-expression-parse@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-expression-parse@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz#a23af9f3132115465dac215c099303e4ceac5794"
+  integrity sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==
   dependencies:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"


### PR DESCRIPTION
## Details

As part of documenting all top-level exports, it's helpful to enforce that the documentation is present and valid.

All file changes outside `.eslintrc` are linter auto fixes except [this commit](https://github.com/salesforce/lwc/pull/4006/commits/43605bef4afab53226d3ae50270e4be671f107f5) and [this one](https://github.com/salesforce/lwc/pull/4006/commits/d43a1a156a4221c029c6d03ccc6b6eb7a67a1d71).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
W-13278716

