### PR TITLE
chore: more JSDoc rules! @W-13278716

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -171,7 +171,7 @@
         "jsdoc/informative-docs": "error",
         "jsdoc/no-bad-blocks": [
             "error",
-            { "ignore": ["__PURE__@", "ts-expect-error", "ts-ignore"] }
+            { "ignore": ["__PURE__", "__PURE__@", "ts-expect-error", "ts-ignore"] }
         ],
         "jsdoc/no-blank-blocks": "error",
         "jsdoc/no-defaults": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -165,7 +165,22 @@
         "@typescript-eslint/no-unsafe-return": "off",
         "@typescript-eslint/no-unsafe-argument": "off",
 
-        "jsdoc/require-jsdoc": ["warn", { "publicOnly": true }]
+        "jsdoc/require-jsdoc": ["warn", { "publicOnly": true }],
+        "jsdoc/check-indentation": "error",
+        "jsdoc/check-syntax": "error",
+        "jsdoc/informative-docs": "error",
+        "jsdoc/no-bad-blocks": [
+            "error",
+            { "ignore": ["__PURE__@", "ts-expect-error", "ts-ignore"] }
+        ],
+        "jsdoc/no-blank-blocks": "error",
+        "jsdoc/no-defaults": "error",
+        "jsdoc/no-types": "error",
+        "jsdoc/require-description": "error",
+        "jsdoc/require-example": "error",
+        "jsdoc/require-hyphen-before-param-description": ["error", "never"],
+        "jsdoc/require-throws": "error",
+        "jsdoc/sort-tags": "error"
     },
 
     "overrides": [
@@ -269,10 +284,24 @@
             }
         },
         {
-            // We don't control the 3rd party license, so don't complain about it
+            // Don't complain about 3rd party JSDoc
             "files": ["packages/@lwc/synthetic-shadow/src/3rdparty/**"],
             "rules": {
-                "jsdoc/check-values": "off"
+                "jsdoc/check-alignment": "off",
+                "jsdoc/check-indentation": "off",
+                "jsdoc/check-syntax": "off",
+                "jsdoc/check-values": "off",
+                "jsdoc/informative-docs": "off",
+                "jsdoc/no-bad-blocks": "off",
+                "jsdoc/no-blank-blocks": "off",
+                "jsdoc/no-defaults": "off",
+                "jsdoc/no-types": "off",
+                "jsdoc/require-description": "off",
+                "jsdoc/require-hyphen-before-param-description": "off",
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-param": "off",
+                "jsdoc/require-throws": "off",
+                "jsdoc/sort-tags": "off"
             }
         },
         {
@@ -301,9 +330,12 @@
             ],
             "rules": {
                 "jsdoc/require-jsdoc": "off",
-                // TODO [W-13278716]: All JSDOC should describe all params and returns
+                // TODO [W-13278716]: All JSDoc should fully describe functions
+                "jsdoc/require-description": "off",
+                "jsdoc/require-example": "off",
                 "jsdoc/require-param-description": "off",
-                "jsdoc/require-returns": "off"
+                "jsdoc/require-returns": "off",
+                "jsdoc/require-throws": "off"
             }
         }
     ]

--- a/packages/@lwc/babel-plugin-component/src/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/index.ts
@@ -24,8 +24,8 @@ export type { LwcBabelPluginOptions } from './types';
 
 /**
  * The transform is done in 2 passes:
- *    - First, apply in a single AST traversal the decorators and the component transformation.
- *    - Then, in a second path transform class properties using the official babel plugin "babel-plugin-transform-class-properties".
+ * - First, apply in a single AST traversal the decorators and the component transformation.
+ * - Then, in a second path transform class properties using the official babel plugin "babel-plugin-transform-class-properties".
  * @param api
  */
 export default function LwcClassTransform(api: BabelAPI): PluginObj<LwcBabelPluginPass> {

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -68,9 +68,9 @@ function traverseAndSetElements(root: Element, parts: VStaticPart[], renderer: R
 
 /**
  * Given an array of static parts, do all the mounting required for these parts.
- * @param root - the root element
- * @param vnode - the parent VStatic
- * @param renderer - the renderer to use
+ * @param root the root element
+ * @param vnode the parent VStatic
+ * @param renderer the renderer to use
  */
 export function mountStaticParts(root: Element, vnode: VStatic, renderer: RendererAPI): void {
     // On the server, we don't support ref (because it relies on renderedCallback), nor do we
@@ -98,8 +98,8 @@ export function mountStaticParts(root: Element, vnode: VStatic, renderer: Render
 
 /**
  * Mounts elements to the newly generated VStatic node
- * @param n1 - the previous VStatic vnode
- * @param n2 - the current VStatic vnode
+ * @param n1 the previous VStatic vnode
+ * @param n2 the current VStatic vnode
  */
 export function patchStaticParts(n1: VStatic, n2: VStatic) {
     // On the server, we don't support ref (because it relies on renderedCallback), nor do we

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -92,7 +92,7 @@ let enabled = false;
 export const reportingControl = {
     /**
      * Attach a new reporting control (aka dispatcher).
-     * @param dispatcher - reporting control
+     * @param dispatcher reporting control
      */
     attachDispatcher(dispatcher: ReportingDispatcher): void {
         enabled = true;
@@ -136,7 +136,7 @@ export function onReportingEnabled(callback: OnReportingEnabledCallback) {
 /**
  * Report to the current dispatcher, if there is one.
  * @param reportingEventId
- * @param payload - data to report
+ * @param payload data to report
  */
 export function report<T extends ReportingEventId>(
     reportingEventId: T,

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -124,7 +124,7 @@ export interface Context {
     styleVNodes: VNode[] | null;
     /**
      * Object used by the template function to store information that can be reused between
-     *  different render cycle of the same template.
+     * different render cycle of the same template.
      */
     tplCache: TemplateCache;
     /** List of wire hooks that are invoked when the component gets connected. */
@@ -174,7 +174,7 @@ export interface VM<N = HostNode, E = HostElement> {
     cmpProps: { [name: string]: any };
     /**
      * Contains information about the mapping between the slot names and the slotted VNodes, and
-     *  the owner of the slot content.
+     * the owner of the slot content.
      */
     cmpSlots: SlotSet;
     /** The component internal reactive properties. */
@@ -200,17 +200,17 @@ export interface VM<N = HostNode, E = HostElement> {
     tro: ReactiveObserver;
     /**
      * Hook invoked whenever a property is accessed on the host element. This hook is used by
-     *  Locker only.
+     * Locker only.
      */
     setHook: (cmp: LightningElement, prop: PropertyKey, newValue: any) => void;
     /**
      * Hook invoked whenever a property is set on the host element. This hook is used by Locker
-     *  only.
+     * only.
      */
     getHook: (cmp: LightningElement, prop: PropertyKey) => any;
     /**
      * Hook invoked whenever a method is called on the component (life-cycle hooks, public
-     *  properties and event handlers). This hook is used by Locker.
+     * properties and event handlers). This hook is used by Locker.
      */
     callHook: (cmp: LightningElement | undefined, fn: (...args: any[]) => any, args?: any[]) => any;
     /**

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -25,7 +25,6 @@ type HTMLElementConstructor = typeof HTMLElement;
  * This function builds a Web Component class from a LWC constructor so it can be
  * registered as a new element via customElements.define() at any given time.
  * @param Ctor
- * @deprecated since version 1.3.11
  * @example
  * ```
  * import { buildCustomElementConstructor } from 'lwc';
@@ -34,6 +33,7 @@ type HTMLElementConstructor = typeof HTMLElement;
  * customElements.define('x-foo', WC);
  * const elm = document.createElement('x-foo');
  * ```
+ * @deprecated since version 1.3.11
  */
 export function deprecatedBuildCustomElementConstructor(
     Ctor: ComponentConstructor

--- a/packages/@lwc/engine-dom/src/apis/lightning-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/lightning-element.ts
@@ -33,12 +33,11 @@ function getCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementCon
 
 /**
  * This static getter builds a Web Component class from a LWC constructor so it can be registered
- * as a new element via customElements.define() at any given time. E.g.:
- *
- *      import Foo from 'ns/foo';
- *      customElements.define('x-foo', Foo.CustomElementConstructor);
- *      const elm = document.createElement('x-foo');
- *
+ * as a new element via customElements.define() at any given time.
+ * @example
+ * import Foo from 'ns/foo';
+ * customElements.define('x-foo', Foo.CustomElementConstructor);
+ * const elm = document.createElement('x-foo');
  */
 defineProperty(LightningElement, 'CustomElementConstructor', {
     get() {

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -10,7 +10,7 @@ import { isUndefined, keys } from '@lwc/shared';
 
 /**
  * Displays the header for a custom element.
- * @param ce the custom element
+ * @param ce The custom element to get the header for.
  * @param componentInstance component instance associated with the custom element.
  */
 function getHeaderForCustomElement(ce: HTMLElement, componentInstance: LightningElement) {

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -8,13 +8,13 @@
 /**
  * Note: This module cannot import any modules because it is meant to be a self-contained function.
  * This is to allow external libraries to access the rendererFactory, toString it and recreate it.
- * For example:
- *  import { rendererFactory } from 'lwc';
- *  import sanitize from 'sanitizeLibrary';
+ * @example
+ * import { rendererFactory } from 'lwc';
+ * import sanitize from 'sanitizeLibrary';
  *
- *  const sandboxedRendererFactory = sanitize(rendererFactory.toString());
+ * const sandboxedRendererFactory = sanitize(rendererFactory.toString());
  *
- *   Type-Only imports are allowed.
+ * Type-Only imports are allowed.
  */
 import type { RendererAPI } from '@lwc/engine-core';
 

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -1,21 +1,21 @@
 /*
- * Copyright (c) 2023, Salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-/**
+/*
  * Note: This module cannot import any modules because it is meant to be a self-contained function.
  * This is to allow external libraries to access the rendererFactory, toString it and recreate it.
- * @example
+ * For example:
  * import { rendererFactory } from 'lwc';
  * import sanitize from 'sanitizeLibrary';
- *
  * const sandboxedRendererFactory = sanitize(rendererFactory.toString());
  *
  * Type-Only imports are allowed.
  */
+
 import type { RendererAPI } from '@lwc/engine-core';
 
 // Properties that are either not required to be sandboxed or rely on a globally shared information

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -9,9 +9,9 @@
  * A feature flag can have three different values:
  * - `null`: The feature is **present** and **disabled** by default. It can be enabled at runtime.
  * - `true`: The feature is **present** and **enabled**. The flag is enabled in the generated output
- *           and can't be disabled at runtime.
+ * and can't be disabled at runtime.
  * - `false`: The feature is entirely **disabled**. The code behind the flag is stripped away from
- *            the generated output.
+ * the generated output.
  */
 export type FeatureFlagValue = boolean | null;
 

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/transform-framework.js
@@ -44,10 +44,7 @@ function createPreprocessor(config, emitter, logger) {
         const magicString = new MagicString(content.replace(/\/\/# sourceMappingURL=\S+/, ''));
 
         /**
-         * This transformation replaces:
-         *     process.env.NODE_ENV === 'test-karma-lwc'
-         * with:
-         *     true
+         * This transformation replaces `process.env.NODE_ENV === 'test-karma-lwc'` with `true`.
          *
          * You might wonder why we replace the whole thing rather than just `process.env.NODE_ENV`. Well, because we need a way
          * to test `process.env.NODE_ENV === "production"` (prod mode) vs `process.env.NODE_ENV !== "production"` (dev mode).

--- a/packages/@lwc/integration-karma/test/context/x/simpleProvider/simpleProvider.js
+++ b/packages/@lwc/integration-karma/test/context/x/simpleProvider/simpleProvider.js
@@ -70,7 +70,7 @@ const contextualizer = createContextProvider(WireAdapter);
 
 /**
  * Note: spy and skipInitialProvision parameters (and all code related to them) are meant for test purposes only,
- *       and should not be part of other implementations based on this reference implementation.
+ * and should not be part of other implementations based on this reference implementation.
  * @param target
  * @param spy
  * @param skipInitialProvision

--- a/packages/@lwc/shared/src/aria.ts
+++ b/packages/@lwc/shared/src/aria.ts
@@ -78,7 +78,7 @@ export type AccessibleElementProperties = {
     [prop in (typeof AriaPropertyNames)[number]]: string | null;
 };
 
-const { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap } = /*@__PURE__*/ (() => {
+const { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap } = /**@__PURE__*/ (() => {
     const AriaAttrNameToPropNameMap: Record<string, string> = create(null);
     const AriaPropNameToAttrNameMap: Record<string, string> = create(null);
 
@@ -104,7 +104,7 @@ export function isAriaAttribute(attrName: string): boolean {
 
 // These attributes take either an ID or a list of IDs as values.
 // This includes aria-* attributes as well as the special non-ARIA "for" attribute
-export const ID_REFERENCING_ATTRIBUTES_SET: Set<string> = /*@__PURE__*/ new Set([
+export const ID_REFERENCING_ATTRIBUTES_SET: Set<string> = /**@__PURE__*/ new Set([
     'aria-activedescendant',
     'aria-controls',
     'aria-describedby',

--- a/packages/@lwc/shared/src/aria.ts
+++ b/packages/@lwc/shared/src/aria.ts
@@ -78,7 +78,7 @@ export type AccessibleElementProperties = {
     [prop in (typeof AriaPropertyNames)[number]]: string | null;
 };
 
-const { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap } = /**@__PURE__*/ (() => {
+const { AriaAttrNameToPropNameMap, AriaPropNameToAttrNameMap } = /*@__PURE__*/ (() => {
     const AriaAttrNameToPropNameMap: Record<string, string> = create(null);
     const AriaPropNameToAttrNameMap: Record<string, string> = create(null);
 
@@ -104,7 +104,7 @@ export function isAriaAttribute(attrName: string): boolean {
 
 // These attributes take either an ID or a list of IDs as values.
 // This includes aria-* attributes as well as the special non-ARIA "for" attribute
-export const ID_REFERENCING_ATTRIBUTES_SET: Set<string> = /**@__PURE__*/ new Set([
+export const ID_REFERENCING_ATTRIBUTES_SET: Set<string> = /*@__PURE__*/ new Set([
     'aria-activedescendant',
     'aria-controls',
     'aria-describedby',

--- a/packages/@lwc/shared/src/html-attributes.ts
+++ b/packages/@lwc/shared/src/html-attributes.ts
@@ -58,7 +58,7 @@ export function isBooleanAttribute(attrName: string, tagName: string): boolean {
 }
 
 // This list is based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
-const GLOBAL_ATTRIBUTE = /**@__PURE__*/ new Set([
+const GLOBAL_ATTRIBUTE = /*@__PURE__*/ new Set([
     'accesskey',
     'autocapitalize',
     'autofocus',

--- a/packages/@lwc/shared/src/html-attributes.ts
+++ b/packages/@lwc/shared/src/html-attributes.ts
@@ -58,7 +58,7 @@ export function isBooleanAttribute(attrName: string, tagName: string): boolean {
 }
 
 // This list is based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
-const GLOBAL_ATTRIBUTE = /*@__PURE__*/ new Set([
+const GLOBAL_ATTRIBUTE = /**@__PURE__*/ new Set([
     'accesskey',
     'autocapitalize',
     'autofocus',

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -194,7 +194,7 @@ export {
 
 /**
  * Determines whether the argument is `undefined`.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is `undefined`.
  */
 export function isUndefined(obj: unknown): obj is undefined {
@@ -203,7 +203,7 @@ export function isUndefined(obj: unknown): obj is undefined {
 
 /**
  * Determines whether the argument is `null`.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is `null`.
  */
 export function isNull(obj: unknown): obj is null {
@@ -212,7 +212,7 @@ export function isNull(obj: unknown): obj is null {
 
 /**
  * Determines whether the argument is `true`.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is `true`.
  */
 export function isTrue(obj: unknown): obj is true {
@@ -221,7 +221,7 @@ export function isTrue(obj: unknown): obj is true {
 
 /**
  * Determines whether the argument is `false`.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is `false`.
  */
 export function isFalse(obj: unknown): obj is false {
@@ -230,7 +230,7 @@ export function isFalse(obj: unknown): obj is false {
 
 /**
  * Determines whether the argument is a boolean.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is a boolean.
  */
 export function isBoolean(obj: unknown): obj is boolean {
@@ -239,7 +239,7 @@ export function isBoolean(obj: unknown): obj is boolean {
 
 /**
  * Determines whether the argument is a function.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is a function.
  */
 // Replacing `Function` with a narrower type that works for all our use cases is tricky...
@@ -250,7 +250,7 @@ export function isFunction(obj: unknown): obj is Function {
 
 /**
  * Determines whether the argument is an object or null.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is an object or null.
  */
 export function isObject(obj: unknown): obj is object | null {
@@ -259,7 +259,7 @@ export function isObject(obj: unknown): obj is object | null {
 
 /**
  * Determines whether the argument is a string.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is a string.
  */
 export function isString(obj: unknown): obj is string {
@@ -268,7 +268,7 @@ export function isString(obj: unknown): obj is string {
 
 /**
  * Determines whether the argument is a number.
- * @param obj - Value to test
+ * @param obj Value to test
  * @returns `true` if the value is a number.
  */
 export function isNumber(obj: unknown): obj is number {
@@ -284,7 +284,7 @@ const OtS = {}.toString;
 /**
  * Converts the argument to a string, safely accounting for objects with "null" prototype.
  * Note that `toString(null)` returns `"[object Null]"` rather than `"null"`.
- * @param obj - Value to convert to a string.
+ * @param obj Value to convert to a string.
  * @returns String representation of the value.
  */
 export function toString(obj: unknown): string {

--- a/packages/@lwc/shared/src/void-elements.ts
+++ b/packages/@lwc/shared/src/void-elements.ts
@@ -32,7 +32,7 @@ const VOID_ELEMENTS = [
 // See: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
 const DEPRECATED_VOID_ELEMENTS = ['param', 'keygen', 'menuitem'];
 
-const VOID_ELEMENTS_SET = /*@__PURE__*/ new Set([...VOID_ELEMENTS, ...DEPRECATED_VOID_ELEMENTS]);
+const VOID_ELEMENTS_SET = /**@__PURE__*/ new Set([...VOID_ELEMENTS, ...DEPRECATED_VOID_ELEMENTS]);
 
 /**
  *

--- a/packages/@lwc/shared/src/void-elements.ts
+++ b/packages/@lwc/shared/src/void-elements.ts
@@ -32,7 +32,7 @@ const VOID_ELEMENTS = [
 // See: https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features
 const DEPRECATED_VOID_ELEMENTS = ['param', 'keygen', 'menuitem'];
 
-const VOID_ELEMENTS_SET = /**@__PURE__*/ new Set([...VOID_ELEMENTS, ...DEPRECATED_VOID_ELEMENTS]);
+const VOID_ELEMENTS_SET = /*@__PURE__*/ new Set([...VOID_ELEMENTS, ...DEPRECATED_VOID_ELEMENTS]);
 
 /**
  *

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -35,8 +35,8 @@ function isHostPseudoClass(node: Node): node is Pseudo {
 
 /**
  * Add scoping attributes to all the matching selectors:
- *   h1 -> h1[x-foo_tmpl]
- *   p a -> p[x-foo_tmpl] a[x-foo_tmpl]
+ * - h1 -> h1[x-foo_tmpl]
+ * - p a -> p[x-foo_tmpl] a[x-foo_tmpl]
  * @param selector
  */
 function scopeSelector(selector: Selector) {
@@ -103,8 +103,8 @@ function scopeSelector(selector: Selector) {
 /**
  * Mark the :host selector with a placeholder. If the selector has a list of
  * contextual selector it will generate a rule for each of them.
- *   :host -> [x-foo_tmpl-host]
- *   :host(.foo, .bar) -> [x-foo_tmpl-host].foo, [x-foo_tmpl-host].bar
+ * - `:host -> [x-foo_tmpl-host]`
+ * - `:host(.foo, .bar) -> [x-foo_tmpl-host].foo, [x-foo_tmpl-host].bar`
  * @param selector
  */
 function transformHost(selector: Selector) {

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/inner-html.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/inner-html.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- */
+*/
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/outer-html.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/outer-html.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- */
+*/
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/path-composer.ts
@@ -13,7 +13,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- */
+*/
 
 import { isNull } from '@lwc/shared';
 import { getOwnerDocument } from '../../shared/utils';

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
@@ -9,8 +9,6 @@ import { pathComposer } from './path-composer';
 import { isSyntheticShadowRoot } from './../../faux-shadow/shadow-root';
 
 /**
- * @param refNode
- * @param path
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
@@ -18,7 +16,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- */
+*/
 export function retarget(refNode: EventTarget | null, path: EventTarget[]): EventTarget | null {
     if (isNull(refNode)) {
         return null;

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/text-content.ts
@@ -12,7 +12,7 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- */
+*/
 
 // This code is inspired by Polymer ShadyDOM Polyfill
 

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -206,9 +206,9 @@ const getDocumentOrRootNode: (this: Node, options?: GetRootNodeOptions) => Node 
  * Get the shadow root
  * getNodeOwner() returns the host element that owns the given node
  * Note: getNodeOwner() returns null when running in native-shadow mode.
- *  Fallback to using the native getRootNode() to discover the root node.
- *  This is because, it is not possible to inspect the node and decide if it is part
- *  of a native shadow or the synthetic shadow.
+ * Fallback to using the native getRootNode() to discover the root node.
+ * This is because, it is not possible to inspect the node and decide if it is part
+ * of a native shadow or the synthetic shadow.
  * @param node
  */
 function getNearestRoot(node: Node): Node {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -124,16 +124,13 @@ function markElementAsPortal(elm: Element) {
 
 /**
  * Patching Element.prototype.$domManual$ to mark elements as portal:
- *
- *  - we use a property to allow engines to signal that a particular element in
- *    a shadow supports manual insertion of child nodes.
- *
- *  - this signal comes as a boolean value, and we use it to install the MO instance
- *    onto the element, to propagate the $ownerKey$ and $shadowToken$ to all new
- *    child nodes.
- *
- *  - at the moment, there is no way to undo this operation, once the element is
- *    marked as $domManual$, setting it to false does nothing.
+ * - we use a property to allow engines to signal that a particular element in
+ * a shadow supports manual insertion of child nodes.
+ * - this signal comes as a boolean value, and we use it to install the MO instance
+ * onto the element, to propagate the $ownerKey$ and $shadowToken$ to all new
+ * child nodes.
+ * - at the moment, there is no way to undo this operation, once the element is
+ * marked as $domManual$, setting it to false does nothing.
  *
  */
 // TODO [#1306]: rename this to $observerConnection$

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-token.ts
@@ -25,12 +25,9 @@ export function setShadowToken(node: Node, shadowToken: string | undefined) {
 
 /**
  * Patching Element.prototype.$shadowToken$ to mark elements a portal:
- *
- *  - we use a property to allow engines to set a custom attribute that should be
- *    placed into the element to sandbox the css rules defined for the template.
- *
- *  - this custom attribute must be unique.
- *
+ * - we use a property to allow engines to set a custom attribute that should be
+ * placed into the element to sandbox the css rules defined for the template.
+ * - this custom attribute must be unique.
  */
 defineProperty(Element.prototype, KEY__SHADOW_TOKEN, {
     set(this: Element, shadowToken: string | undefined) {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -106,9 +106,8 @@ export function assignedSlotGetterPatched(this: Element | Text): HTMLSlotElement
 
     /**
      * The node is assigned to a slot if:
-     *  - it has a parent and its parent is a slot element
-     *  - and if the slot owner key is different than the node owner key.
-     *
+     * - it has a parent and its parent is a slot element
+     * - and if the slot owner key is different than the node owner key.
      * When the slot and the slotted node are 2 different shadow trees, the owner keys will be
      * different. When the slot is in a shadow tree and the slotted content is a light DOM node,
      * the light DOM node doesn't have an owner key and therefor the slot owner key will be

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -71,7 +71,7 @@ function isNodeSlotted(host: Element, node: Node): boolean {
             // have different owner key. for slotted elements, this is possible
             // if the parent happens to be a slot.
             if (isSlotElement(parent)) {
-                /**
+                /*
                  * the slot parent might be allocated inside another slot, think of:
                  * <x-root> (<--- root element)
                  *    <x-parent> (<--- own by x-root)

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -359,7 +359,7 @@ export default class CodeGen {
      * computing the sanitized html of a raw html if it does not change
      * between renders.
      * @param expr
-     * @returns sanitizedHtmlExpr
+     * @returns The generated expression
      */
     genSanitizedHtmlExpr(expr: t.Expression) {
         const instance = this.innerHtmlInstances++;

--- a/packages/@lwc/template-compiler/src/codegen/expression.ts
+++ b/packages/@lwc/template-compiler/src/codegen/expression.ts
@@ -19,19 +19,19 @@ type VariableNames = Set<string>;
 /**
  * Bind the passed expression to the component instance. It applies the following
  * transformation to the expression:
- *    {value} --> {$cmp.value}
- *    {value[index]} --> {$cmp.value[$cmp.index]}
- *    {foo ?? bar} --> {$cmp.foo ?? $cmp.bar}
- *    {foo?.bar} --> {$cmp.foo?.bar}
+ * - `{value}` --> `{$cmp.value}`
+ * - `{value[index]}` --> `{$cmp.value[$cmp.index]}`
+ * - `{foo ?? bar}` --> `{$cmp.foo ?? $cmp.bar}`
+ * - `{foo?.bar}` --> `{$cmp.foo?.bar}`
  *
  * However, parameter variables are not be transformed in this way. For example,
  * the following transformations do not happen:
- *    {(foo) => foo && bar} -> {(foo) => $cmp.foo && $cmp.bar}
- *    {(foo) => foo && bar} -> {($cmp.foo) => foo && $cmp.bar}
- *    {(foo) => foo && bar} -> {($cmp.foo) => $cmp.foo && $cmp.bar}
+ * - `{(foo) => foo && bar}` --> `{(foo) => $cmp.foo && $cmp.bar}`
+ * - `{(foo) => foo && bar}` --> `{($cmp.foo) => foo && $cmp.bar}`
+ * - `{(foo) => foo && bar}` --> `{($cmp.foo) => $cmp.foo && $cmp.bar}`
  *
  * Instead, the scopes are respected:
- *    {(foo) => foo && $cmp.bar}
+ * - `{(foo) => foo && $cmp.bar}`
  *
  * Similar checks occur for local identifiers introduced via for:each or similar.
  * @param expression

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -21,25 +21,26 @@ export interface Config {
     customRendererConfig?: CustomRendererConfig;
 
     /**
-     * Enable computed member expression in the template. eg:
-     *    <template>
-     *        {list[0].name}
-     *    </template>
+     * Enable computed member expression in the template.
+     * @example
+     * <template>
+     *     {list[0].name}
+     * </template>
      */
     experimentalComputedMemberExpression?: boolean;
 
     // TODO [#3370]: remove experimental template expression flag
     /**
      * Enable use of (a subset of) JavaScript expressions in place of template bindings.
-     *
-     *    <template>
-     *        <input
-     *            attr={complex ?? expressions()}
-     *            onchange={({ target }) => componentMethod(target.value)}
-     *        >
-     *            Hey there {inAustralia ? 'mate' : 'friend'}
-     *        </input>
-     *    </template>
+     * @example
+     * <template>
+     *     <input
+     *         attr={complex ?? expressions()}
+     *         onchange={({ target }) => componentMethod(target.value)}
+     *     >
+     *         Hey there {inAustralia ? 'mate' : 'friend'}
+     *     </input>
+     * </template>
      */
     experimentalComplexExpressions?: boolean;
 

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -41,18 +41,18 @@ function getTrailingChars(str: string): string {
  * This function checks for "unbalanced" extraneous parentheses surrounding the expression.
  *
  * Examples of balanced extraneous parentheses (validation passes):
- *   {(foo.bar)}        <-- the MemberExpressions does not account for the surrounding parens
- *   {(foo())}          <-- the CallExpression does not account for the surrounding parens
- *   {((foo ?? bar)())} <-- the CallExpression does not account for the surrounding parens
+ * - `{(foo.bar)}`        <-- the MemberExpressions does not account for the surrounding parens
+ * - `{(foo())}`          <-- the CallExpression does not account for the surrounding parens
+ * - `{((foo ?? bar)())}` <-- the CallExpression does not account for the surrounding parens
  *
  * Examples of unbalanced extraneous parentheses (validation fails):
- *   {(foo.bar))}       <-- there is an extraneous trailing paren
- *   {foo())}           <-- there is an extraneous trailing paren
+ * - `{(foo.bar))}`       <-- there is an extraneous trailing paren
+ * - `{foo())}`           <-- there is an extraneous trailing paren
  *
  * Examples of no extraneous parentheses (validation passes):
- *   {foo()}            <-- the CallExpression accounts for the trailing paren
- *   {(foo ?? bar).baz} <-- the outer MemberExpression accounts for the leading paren
- *   {(foo).bar}        <-- the outer MemberExpression accounts for the leading paren
+ * - `{foo()}`            <-- the CallExpression accounts for the trailing paren
+ * - `{(foo ?? bar).baz}` <-- the outer MemberExpression accounts for the leading paren
+ * - `{(foo).bar}`        <-- the outer MemberExpression accounts for the leading paren
  *
  * Notably, no examples of extraneous leading parens could be found - these result in a
  * parsing error in Acorn. However, this function still checks, in case there is an
@@ -75,8 +75,8 @@ function validateMatchingExtraParens(leadingChars: string, trailingChars: string
  *
  * Its behavior diverges from that specified in the WHATWG HTML spec
  * in two places:
- *   - 13.2.5.38 - unquoted attribute values
- *   - 13.2.5.1 - the "data" state, which corresponds to parsing outside of tags
+ * - 13.2.5.38 - unquoted attribute values
+ * - 13.2.5.1 - the "data" state, which corresponds to parsing outside of tags
  *
  * Specifically, this tokenizer defers to Acorn's JavaScript parser when
  * encountering a `{` character for an attribute value or within a text

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -174,10 +174,10 @@ export default class ParserCtx {
      * This method returns an iterator over ancestor nodes, starting at the parent and ending at the root node.
      *
      * Note: There are instances when we want to terminate the traversal early, such as searching for a ForBlock parent.
-     * @param predicate - This callback is called once for each ancestor until it finds one where predicate returns true.
-     * @param traversalCond - This callback is called after predicate and will terminate the traversal if it returns false.
+     * @param predicate This callback is called once for each ancestor until it finds one where predicate returns true.
+     * @param traversalCond This callback is called after predicate and will terminate the traversal if it returns false.
      * traversalCond is ignored if no value is provided.
-     * @param startNode - Starting node to begin search, defaults to the tail of the current scope.
+     * @param startNode Starting node to begin search, defaults to the tail of the current scope.
      */
     findAncestor<A extends ParentNode>(
         predicate: (node: ParentNode) => node is A,
@@ -199,7 +199,7 @@ export default class ParserCtx {
 
     /**
      * This method searchs the current scope and returns the value that satisfies the predicate.
-     * @param predicate - This callback is called once for each sibling in the current scope
+     * @param predicate This callback is called once for each sibling in the current scope
      * until it finds one where predicate returns true.
      */
     findInCurrentElementScope<A extends ParentNode>(
@@ -339,7 +339,7 @@ export default class ParserCtx {
     /**
      * This method recovers from diagnostic errors that are encountered when fn is invoked.
      * All other errors are considered compiler errors and can not be recovered from.
-     * @param fn - method to be invoked.
+     * @param fn method to be invoked.
      */
     withErrorRecovery<T>(fn: () => T): T | undefined {
         try {

--- a/scripts/eslint-plugin/rules/no-invalid-todo.js
+++ b/scripts/eslint-plugin/rules/no-invalid-todo.js
@@ -12,9 +12,9 @@ const VALID_TODO_REGEX = /\*?\s+(TODO|todo) \[((#\d+)|(\S+\/\S+#\d+)|(W-\d+))\]:
  * bug.
  *
  * Valid comment formats:
- *   - `// TODO [#1234]: This is a todo`
- *   - `// TODO [salesforce/observable-membrane#1234]: This is a todo`
- *   - `// TODO [W-123456]: this is a todo`
+ * - `// TODO [#1234]: This is a todo`
+ * - `// TODO [salesforce/observable-membrane#1234]: This is a todo`
+ * - `// TODO [W-123456]: this is a todo`
  */
 module.exports = {
     meta: {

--- a/scripts/jest/utils/index.ts
+++ b/scripts/jest/utils/index.ts
@@ -13,9 +13,11 @@ import CustomMatcherResult = jest.CustomMatcherResult;
 const { globSync } = glob;
 
 /**
- * @param receivedContent - the fixture content
- * @param filename - the fixture absolute path
+ * Jest matcher to assert that the content received matches the content in fixture file.
+ * @param receivedContent the fixture content
+ * @param filename the fixture absolute path
  * @returns matcher result
+ * @example expect(content).toMatchFile(outputPath)
  */
 function toMatchFile(
     this: MatcherUtils,
@@ -135,10 +137,20 @@ type TestFixtureOutput = { [filename: string]: unknown };
  * expected to return an object representing the fixture outputs. The key represents the output
  * file name and the value, its associated content. An `undefined` or `null` value represents a
  * non existing file.
- * @param config - The config object
- * @param config.pattern - The glob pattern to locate each individual fixture.
- * @param config.root - The directory from where the pattern is executed.
- * @param testFn - The test function executed for each fixture.
+ * @param config The config object
+ * @param config.pattern The glob pattern to locate each individual fixture.
+ * @param config.root The directory from where the pattern is executed.
+ * @param testFn The test function executed for each fixture.
+ * @throws On invalid input or output
+ * @example
+ * testFixtureDir(
+ *   { root: 'fixtures', pattern: '**\/actual.js' },
+ *   ({src}) => {
+ *     let result, error
+ *     try { result = transform(src) } catch (e) { error = e }
+ *     return { 'expected.js': result, 'error.txt': error }
+ *   }
+ * )
  */
 export function testFixtureDir(
     config: { pattern: string; root: string },


### PR DESCRIPTION
## Details

#4006 added `eslint-plugin-jsdoc` and used their recommended ruleset, this just another pile of extra rules. There were some manual fixes applied, but they were mostly just formatting that the auto-fixer couldn't handle.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
W-13278716
