### PR TITLE
test(integration-karma): improve lifecycle timing tests

### DIFF
--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -144,63 +144,61 @@ orderings. For any given component, the invariants are:
 
 It's ok to update the orderings below after a refactor, as long as these invariants hold!
 */
-if (process.env.NATIVE_SHADOW) {
-    it(`should invoke connectedCallback and renderedCallback in the expected order (native shadow)`, () => {
-        const elm = createElement('order-container', { is: Container });
-        document.body.appendChild(elm);
-        expect(window.timingBuffer).toEqual(
-            nativeCustomElementLifecycleEnabled
-                ? [
-                      'foo-a:connectedCallback',
-                      'foo-internal-a:connectedCallback',
-                      'foo-internal-a:renderedCallback',
-                      'foo-a:renderedCallback',
-                      'foo-b:connectedCallback',
-                      'foo-internal-b:connectedCallback',
-                      'foo-internal-b:renderedCallback',
-                      'foo-b:renderedCallback',
-                      'foo-c:connectedCallback',
-                      'foo-internal-c:connectedCallback',
-                      'foo-internal-c:renderedCallback',
-                      'foo-c:renderedCallback',
-                      'foo-d:connectedCallback',
-                      'foo-internal-d:connectedCallback',
-                      'foo-internal-d:renderedCallback',
-                      'foo-d:renderedCallback',
-                      'foo-e:connectedCallback',
-                      'foo-internal-e:connectedCallback',
-                      'foo-internal-e:renderedCallback',
-                      'foo-e:renderedCallback',
-                  ]
-                : [
-                      'foo-a:connectedCallback',
-                      'foo-b:connectedCallback',
-                      'foo-c:connectedCallback',
-                      'foo-internal-c:connectedCallback',
-                      'foo-internal-c:renderedCallback',
-                      'foo-c:renderedCallback',
-                      'foo-internal-b:connectedCallback',
-                      'foo-internal-b:renderedCallback',
-                      'foo-b:renderedCallback',
-                      'foo-d:connectedCallback',
-                      'foo-internal-d:connectedCallback',
-                      'foo-internal-d:renderedCallback',
-                      'foo-d:renderedCallback',
-                      'foo-internal-a:connectedCallback',
-                      'foo-internal-a:renderedCallback',
-                      'foo-a:renderedCallback',
-                      'foo-e:connectedCallback',
-                      'foo-internal-e:connectedCallback',
-                      'foo-internal-e:renderedCallback',
-                      'foo-e:renderedCallback',
-                  ]
-        );
-    });
-} else {
-    it(`should invoke connectedCallback and renderedCallback in the expected order (synthetic shadow)`, () => {
-        const elm = createElement('order-container', { is: Container });
-        document.body.appendChild(elm);
-        expect(window.timingBuffer).toEqual([
+it('should invoke connectedCallback and renderedCallback in the expected order', () => {
+    const elm = createElement('order-container', { is: Container });
+    document.body.appendChild(elm);
+
+    let expected;
+    if (process.env.NATIVE_SHADOW) {
+        if (nativeCustomElementLifecycleEnabled) {
+            expected = [
+                'foo-a:connectedCallback',
+                'foo-internal-a:connectedCallback',
+                'foo-internal-a:renderedCallback',
+                'foo-a:renderedCallback',
+                'foo-b:connectedCallback',
+                'foo-internal-b:connectedCallback',
+                'foo-internal-b:renderedCallback',
+                'foo-b:renderedCallback',
+                'foo-c:connectedCallback',
+                'foo-internal-c:connectedCallback',
+                'foo-internal-c:renderedCallback',
+                'foo-c:renderedCallback',
+                'foo-d:connectedCallback',
+                'foo-internal-d:connectedCallback',
+                'foo-internal-d:renderedCallback',
+                'foo-d:renderedCallback',
+                'foo-e:connectedCallback',
+                'foo-internal-e:connectedCallback',
+                'foo-internal-e:renderedCallback',
+                'foo-e:renderedCallback',
+            ];
+        } else {
+            expected = [
+                'foo-a:connectedCallback',
+                'foo-b:connectedCallback',
+                'foo-c:connectedCallback',
+                'foo-internal-c:connectedCallback',
+                'foo-internal-c:renderedCallback',
+                'foo-c:renderedCallback',
+                'foo-internal-b:connectedCallback',
+                'foo-internal-b:renderedCallback',
+                'foo-b:renderedCallback',
+                'foo-d:connectedCallback',
+                'foo-internal-d:connectedCallback',
+                'foo-internal-d:renderedCallback',
+                'foo-d:renderedCallback',
+                'foo-internal-a:connectedCallback',
+                'foo-internal-a:renderedCallback',
+                'foo-a:renderedCallback',
+                'foo-e:connectedCallback',
+                'foo-internal-e:connectedCallback',
+                'foo-internal-e:renderedCallback',
+                'foo-e:renderedCallback',
+            ];
+        }
+    } else {
+        expected = [
             'foo-a:connectedCallback',
             'foo-internal-a:connectedCallback',
             'foo-internal-a:renderedCallback',
@@ -221,9 +219,34 @@ if (process.env.NATIVE_SHADOW) {
             'foo-internal-e:connectedCallback',
             'foo-internal-e:renderedCallback',
             'foo-e:renderedCallback',
-        ]);
-    });
-}
+        ];
+    }
+
+    expect(window.timingBuffer).toEqual(expected);
+});
+
+it(`should invoke disconnectedCallback in the expected order`, () => {
+    const elm = createElement('order-container', { is: Container });
+    document.body.appendChild(elm);
+
+    resetTimingBuffer();
+    document.body.removeChild(elm);
+
+    const expected = [
+        'foo-e:disconnectedCallback',
+        'foo-internal-e:disconnectedCallback',
+        'foo-a:disconnectedCallback',
+        'foo-internal-a:disconnectedCallback',
+        'foo-b:disconnectedCallback',
+        'foo-internal-b:disconnectedCallback',
+        'foo-c:disconnectedCallback',
+        'foo-internal-c:disconnectedCallback',
+        'foo-d:disconnectedCallback',
+        'foo-internal-d:disconnectedCallback',
+    ];
+
+    expect(window.timingBuffer).toEqual(expected);
+});
 
 describe('dispatchEvent from connectedCallback/disconnectedCallback', () => {
     // global events behave differently due to element being disconnected from the DOM

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
@@ -14,6 +14,8 @@ export default class Foo extends LightningElement {
         window.timingBuffer.push(`foo-${this.externalClassName}:renderedCallback`);
     }
     disconnectedCallback() {
-        window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
+        }
     }
 }

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
@@ -13,4 +13,7 @@ export default class Foo extends LightningElement {
     renderedCallback() {
         window.timingBuffer.push(`foo-${this.externalClassName}:renderedCallback`);
     }
+    disconnectedCallback() {
+        window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
+    }
 }

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/fooInternal/fooInternal.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/fooInternal/fooInternal.js
@@ -11,6 +11,8 @@ export default class FooInternal extends LightningElement {
         window.timingBuffer.push(`${this.externalClassName}:renderedCallback`);
     }
     disconnectedCallback() {
-        window.timingBuffer.push(`${this.externalClassName}:disconnectedCallback`);
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`${this.externalClassName}:disconnectedCallback`);
+        }
     }
 }

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/fooInternal/fooInternal.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/fooInternal/fooInternal.js
@@ -10,4 +10,7 @@ export default class FooInternal extends LightningElement {
     renderedCallback() {
         window.timingBuffer.push(`${this.externalClassName}:renderedCallback`);
     }
+    disconnectedCallback() {
+        window.timingBuffer.push(`${this.externalClassName}:disconnectedCallback`);
+    }
 }


### PR DESCRIPTION
## Details

While documenting [timing differences in lifecycle callbacks in LWC v6](https://github.com/salesforce/lwc/releases/tag/v6.0.0#new-timing), I realized we didn't have corresponding tests for the ordering of `disconnectedCallback`, in addition to `connectedCallback`/`renderedCallback`. This adds those tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
