### PR TITLE
chore: pin CI tests to chrome 121

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -33,11 +33,11 @@ jobs:
           cache: 'yarn'
 
       # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
-      # version numbers can be found here https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64/121
+      # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
       - name: Setup chrome v121
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 1216529
+          chrome-version: 121
         id: setup-chrome
 
       - name: Install dependencies

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,12 +32,12 @@ jobs:
           node-version: "18.18.0"
           cache: 'yarn'
 
-      # Needed for perf smoke tests, matches the chromedriver version installed by tachometer(https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
-      # version number can be found here https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64/119
-      - name: Setup chrome v119
+      # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
+      # version numbers can be found here https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json
+      - name: Setup chrome v121
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 1194751
+          chrome-version: 1233107
         id: setup-chrome
 
       - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
       # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
       # See: https://github.com/google/tachometer#on-demand-dependencies
-      - name: Install chromedriver v119
-        run: yarn add -W chromedriver@^119
+      - name: Install chromedriver v121
+        run: yarn add -W chromedriver@^121
 
       - name: Check package.json integrity
         run: node ./scripts/tasks/check-and-rewrite-package-json.js --test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -33,11 +33,11 @@ jobs:
           cache: 'yarn'
 
       # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
-      # version numbers can be found here https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json
+      # version numbers can be found here https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64/121
       - name: Setup chrome v121
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 1233107
+          chrome-version: 1216529
         id: setup-chrome
 
       - name: Install dependencies


### PR DESCRIPTION
## Details

The chromedriver v119 endpoints are throwing a 500 error for some reason, but 121 is not. We just need a pinned version; either 121 or 119 should work fine.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
