### PR TITLE
test: add tests for invocation order in light DOM

### DIFF
--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/foo/foo.js
@@ -14,6 +14,8 @@ export default class Foo extends LightningElement {
         window.timingBuffer.push(`foo-${this.externalClassName}:renderedCallback`);
     }
     disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
         if (window.timingBuffer) {
             window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
         }

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightContainer/lightContainer.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightContainer/lightContainer.html
@@ -1,0 +1,9 @@
+<template lwc:render-mode="light">
+    <invocationorder-light-foo class="a">
+        <invocationorder-light-foo class="b">
+            <invocationorder-light-foo class="c"></invocationorder-light-foo>
+        </invocationorder-light-foo>
+        <invocationorder-light-foo class="d"></invocationorder-light-foo>
+    </invocationorder-light-foo>
+    <invocationorder-light-foo class="e"></invocationorder-light-foo>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightContainer/lightContainer.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightContainer/lightContainer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <h1>child: {externalClassName}</h1>
+    <invocationorder-light-foo-internal class={internalClassName}></invocationorder-light-foo-internal>
+    <slot></slot>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.js
@@ -1,0 +1,22 @@
+import { LightningElement } from 'lwc';
+
+export default class Foo extends LightningElement {
+    static renderMode = 'light';
+    get externalClassName() {
+        return this.getAttribute('class');
+    }
+    get internalClassName() {
+        return `foo-internal-${this.externalClassName}`;
+    }
+    connectedCallback() {
+        window.timingBuffer.push(`foo-${this.externalClassName}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`foo-${this.externalClassName}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFoo/lightFoo.js
@@ -15,6 +15,8 @@ export default class Foo extends LightningElement {
         window.timingBuffer.push(`foo-${this.externalClassName}:renderedCallback`);
     }
     disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
         if (window.timingBuffer) {
             window.timingBuffer.push(`foo-${this.externalClassName}:disconnectedCallback`);
         }

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFooInternal/lightFooInternal.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFooInternal/lightFooInternal.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <h1>foo internal: {externalClassName}</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFooInternal/lightFooInternal.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/invocationorder/lightFooInternal/lightFooInternal.js
@@ -1,0 +1,19 @@
+import { LightningElement } from 'lwc';
+
+export default class FooInternal extends LightningElement {
+    static renderMode = 'light';
+    get externalClassName() {
+        return this.getAttribute('class');
+    }
+    connectedCallback() {
+        window.timingBuffer.push(`${this.externalClassName}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`${this.externalClassName}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`${this.externalClassName}:disconnectedCallback`);
+        }
+    }
+}


### PR DESCRIPTION
## Details

Follow-up to #4009 to add tests for light DOM.

Interestingly, this test shows the same behavior between light DOM and synthetic shadow, so I may need to do some extra tests to figure out why #4013 is showing bizarre behavior for `renderedCallback` only in light DOM.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
