### PR TITLE
fix(synthetic-shadow): retargeting does not correctly account for native shadow roots

### DIFF
--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/index.spec.js
@@ -1,0 +1,29 @@
+import { createElement } from 'lwc';
+import SyntheticParent from 'x/syntheticParent';
+
+function test(name, selector) {
+    it(name, () => {
+        const elm = createElement('x-synthetic-parent', { is: SyntheticParent });
+        document.body.appendChild(elm);
+        return Promise.resolve().then(() => {
+            let target;
+            elm.addEventListener('click', (event) => {
+                target = event.target;
+            });
+            elm.shadowRoot.querySelector(selector).click();
+
+            expect(target).toBe(elm);
+        });
+    });
+}
+
+describe('retargeting should resolve to the outermost host element', () => {
+    describe('when event dispatched on an element slotted into a native shadow root', () => {
+        test('lwc component native shadow', '.lwc-slotted-button');
+        test('native web component', '.native-wc-slotted');
+    });
+    describe('when event dispatched on an element inside a native shadow root', () => {
+        test('lwc component native shadow', 'x-native-child-button');
+        test('native web component', 'mixed-shadow-mode-retargeting');
+    });
+});

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/index.spec.js
@@ -17,13 +17,13 @@ function test(name, selector) {
     });
 }
 
-describe('retargeting should resolve to the outermost host element', () => {
+describe('should resolve to the outermost host element', () => {
     describe('when event dispatched on an element slotted into a native shadow root', () => {
         test('lwc component native shadow', '.lwc-slotted-button');
-        test('native web component', '.native-wc-slotted');
+        test('native web component', '.native-wc-slotted-button');
     });
     describe('when event dispatched on an element inside a native shadow root', () => {
-        test('lwc component native shadow', 'x-native-child-button');
+        test('lwc component native shadow', 'x-native-child');
         test('native web component', 'mixed-shadow-mode-retargeting');
     });
 });

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/nativeChild/nativeChild.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/nativeChild/nativeChild.html
@@ -1,0 +1,4 @@
+<template>
+    <slot></slot>
+    <button lwc:ref="button"></button>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/nativeChild/nativeChild.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/nativeChild/nativeChild.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static shadowSupportMode = 'native';
+
+    @api click() {
+        this.refs.button.click();
+    }
+}

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/syntheticParent/syntheticParent.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/syntheticParent/syntheticParent.html
@@ -1,0 +1,9 @@
+<template>
+    <x-native-child>
+        <button class="lwc-slotted-button"></button>
+    </x-native-child>
+
+    <mixed-shadow-mode-retargeting lwc:external>
+        <button class="native-wc-slotted-button"></button>
+    </mixed-shadow-mode-retargeting>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/syntheticParent/syntheticParent.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/retargeting/x/syntheticParent/syntheticParent.js
@@ -1,0 +1,19 @@
+import { LightningElement } from 'lwc';
+
+if (!customElements.get('mixed-shadow-mode-retargeting')) {
+    customElements.define(
+        'mixed-shadow-mode-retargeting',
+        class extends HTMLElement {
+            constructor() {
+                super();
+                this._shadowRoot = this.attachShadow({ mode: 'closed' });
+                this._shadowRoot.innerHTML = `<slot></slot><button></button>`;
+            }
+            click() {
+                this._shadowRoot.querySelector('button').click();
+            }
+        }
+    );
+}
+
+export default class extends LightningElement {}

--- a/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
+++ b/packages/@lwc/synthetic-shadow/src/3rdparty/polymer/retarget.ts
@@ -6,7 +6,6 @@
  */
 import { isNull, isUndefined } from '@lwc/shared';
 import { pathComposer } from './path-composer';
-import { isSyntheticShadowRoot } from './../../faux-shadow/shadow-root';
 
 /**
 @license
@@ -32,7 +31,7 @@ export function retarget(refNode: EventTarget | null, path: EventTarget[]): Even
             rootIdx = refNodePath.indexOf(root);
             lastRoot = root;
         }
-        if (!isSyntheticShadowRoot(root) || (!isUndefined(rootIdx) && rootIdx > -1)) {
+        if (!isUndefined(rootIdx) && rootIdx > -1) {
             return ancestor;
         }
     }


### PR DESCRIPTION
## Details

Fixes #3958

## Does this pull request introduce a breaking change?

Yes, but only as a bug fix for events dispatched on elements that were slotted into a native shadow.

## Does this pull request introduce an observable change?

Yes, but only as a bug fix for events dispatched on elements that were slotted into a native shadow.

## GUS work item

W-15120294