### PR TITLE
test: add test to confirm export behavior

### DIFF
--- a/packages/@lwc/integration-karma/test/component/default-export/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/default-export/index.spec.js
@@ -1,6 +1,13 @@
 import Component from 'x/component';
 import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
+import ExportAsDefault from 'x/exportAsDefault';
+import ExportAsDefaultWithOtherExports, {
+    exportee as exporteeAsDefault,
+} from 'x/exportAsDefaultWithOtherExports';
+import ExportDefaultClassWithOtherExports, {
+    exportee as exporteeDefaultClass,
+} from 'x/exportDefaultClassWithOtherExports';
 
 describe('default export', () => {
     it('should work when a module exports non-components as default', () => {
@@ -12,5 +19,34 @@ describe('default export', () => {
         expect(nodes.nil.textContent).toEqual('null');
         expect(nodes.zero.textContent).toEqual('0');
         expect(nodes.string.textContent).toEqual('"bar"');
+    });
+
+    it('should work with `export default class` syntax and other exports', async () => {
+        expect(exporteeDefaultClass).toBe('foo');
+        const elm = createElement('x-export-default-class-with-other-exports', {
+            is: ExportDefaultClassWithOtherExports,
+        });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('h1').textContent).toBe('hello world');
+    });
+
+    // TODO [#4020]: support additional syntax for default export
+    xit('should work with `export { ... as default }` syntax', async () => {
+        const elm = createElement('x-export-as-default', { is: ExportAsDefault });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('h1').textContent).toBe('hello world');
+    });
+
+    // TODO [#4020]: support additional syntax for default export
+    xit('should work with `export { ... as default }` syntax and other exports', async () => {
+        expect(exporteeAsDefault).toBe('foo');
+        const elm = createElement('x-export-as-default-with-other-exports', {
+            is: ExportAsDefaultWithOtherExports,
+        });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('h1').textContent).toBe('hello world');
     });
 });

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefault/exportAsDefault.html
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefault/exportAsDefault.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello world</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefault/exportAsDefault.js
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefault/exportAsDefault.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+class ExportAsDefault extends LightningElement {}
+
+export { ExportAsDefault as default };

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefaultWithOtherExports/exportAsDefaultWithOtherExports.html
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefaultWithOtherExports/exportAsDefaultWithOtherExports.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello world</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefaultWithOtherExports/exportAsDefaultWithOtherExports.js
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportAsDefaultWithOtherExports/exportAsDefaultWithOtherExports.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+const exportee = 'foo';
+
+class ExportAsDefaultWithOtherExports extends LightningElement {}
+
+export { ExportAsDefaultWithOtherExports as default, exportee };

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportDefaultClassWithOtherExports/exportDefaultClassWithOtherExports.html
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportDefaultClassWithOtherExports/exportDefaultClassWithOtherExports.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello world</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/component/default-export/x/exportDefaultClassWithOtherExports/exportDefaultClassWithOtherExports.js
+++ b/packages/@lwc/integration-karma/test/component/default-export/x/exportDefaultClassWithOtherExports/exportDefaultClassWithOtherExports.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+const exportee = 'foo';
+
+export default class ExportDefaultClassWithOtherExports extends LightningElement {}
+
+export { exportee };


### PR DESCRIPTION
## Details

This just adds skipped tests for #4020 as well as confirming that we aren't currently breaking non-default exports mixed with a default export, as long as the default export uses the `export default class extends LightningElement` syntax.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
