### PR TITLE
refactor: move fragment cache-busting to Karma-only

### DIFF
--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -13,6 +13,8 @@ import {
     isTrue,
     isUndefined,
     KEY__SCOPED_CSS,
+    keys,
+    noop,
     toString,
 } from '@lwc/shared';
 
@@ -111,7 +113,27 @@ function validateLightDomTemplate(template: Template, vm: VM) {
 const enum FragmentCache {
     HAS_SCOPED_STYLE = 1 << 0,
     SHADOW_MODE_SYNTHETIC = 1 << 1,
-    HAS_LEGACY_SCOPE_TOKEN = 1 << 2,
+}
+
+// This should be a no-op outside of LWC's Karma tests, where it's not needed
+let registerFragmentCache: (fragmentCache: any) => void = noop;
+
+// Only used in LWC's Karma tests
+if (process.env.NODE_ENV === 'test-karma-lwc') {
+    // Keep track of fragmentCaches, so we can clear them in LWC's Karma tests
+    const fragmentCaches: any[] = [];
+    registerFragmentCache = (fragmentCache: any) => {
+        fragmentCaches.push(fragmentCache);
+    };
+
+    // @ts-ignore
+    window.__lwcResetFragmentCaches = () => {
+        for (const fragmentCache of fragmentCaches) {
+            for (const key of keys(fragmentCache)) {
+                delete fragmentCache[key];
+            }
+        }
+    };
 }
 
 function buildParseFragmentFn(
@@ -119,6 +141,8 @@ function buildParseFragmentFn(
 ): (strings: string[], ...keys: number[]) => () => Element {
     return (strings: string[], ...keys: number[]) => {
         const cache = create(null);
+
+        registerFragmentCache(cache);
 
         return function (): Element {
             const {
@@ -137,11 +161,6 @@ function buildParseFragmentFn(
             }
             if (hasStyleToken && isSyntheticShadow) {
                 cacheKey |= FragmentCache.SHADOW_MODE_SYNTHETIC;
-            }
-            if (hasLegacyToken) {
-                // This isn't strictly required for prod, but it's required for our karma tests
-                // since the lwcRuntimeFlag may change over time
-                cacheKey |= FragmentCache.HAS_LEGACY_SCOPE_TOKEN;
             }
 
             if (!isUndefined(cache[cacheKey])) {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -126,8 +126,7 @@ if (process.env.NODE_ENV === 'test-karma-lwc') {
         fragmentCaches.push(fragmentCache);
     };
 
-    // @ts-ignore
-    window.__lwcResetFragmentCaches = () => {
+    (window as any).__lwcResetFragmentCaches = () => {
         for (const fragmentCache of fragmentCaches) {
             for (const key of keys(fragmentCache)) {
                 delete fragmentCache[key];

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
@@ -11,6 +11,9 @@ describe('legacy scope tokens', () => {
 
             afterEach(() => {
                 setFeatureFlagForTest('ENABLE_LEGACY_SCOPE_TOKENS', false);
+                // We keep a cache of parsed static fragments; these need to be reset
+                // since they can vary based on whether we use the legacy scope token or not.
+                window.__lwcResetFragmentCaches();
             });
 
             function getAttributes(elm) {


### PR DESCRIPTION
## Details

This moves some logic that we only need for Karma tests into Karma-only code. There's no reason for us to have code that affects prod if it's only used in our own tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
