### PR TITLE
chore: avoid @ts-ignore

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -146,8 +146,6 @@
         /*
          * TODO: Address violations and re-enable these rules
          */
-        // All @ts-ignore should either be refactored or changed to @ts-expect-error <reason>
-        "@typescript-eslint/ban-ts-comment": "off",
         // Enums are a pain to deal with...
         "@typescript-eslint/no-unsafe-enum-comparison": "off",
         // We might just want to leave this one disabled

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -98,7 +98,7 @@ function createAttributeChangedCallback(
             if (!isUndefined(superAttributeChangedCallback)) {
                 // delegate unknown attributes to the super.
                 // Typescript does not like it when you treat the `arguments` object as an array
-                // @ts-ignore type-mismatch
+                // @ts-expect-error type-mismatch
                 superAttributeChangedCallback.apply(this, arguments);
             }
             return;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -624,7 +624,7 @@ function createElementInternalsProxy(
 
     // TODO: fix?
     // @ts-expect-error base type doesn't allow returning undefined
-    get refs(): RefNodes | undefined {
+    get refs(): RefNodes {
         const vm = getAssociatedVM(this);
 
         if (isUpdatingTemplate) {
@@ -719,15 +719,16 @@ function createElementInternalsProxy(
         return renderer.getChildren(vm.elm);
     },
 
-    // TODO: fix?
-    // @ts-expect-error base type doesn't allow returning undefined
     get childNodes() {
         const vm = getAssociatedVM(this);
         const renderer = vm.renderer;
         if (process.env.NODE_ENV !== 'production') {
             warnIfInvokedDuringConstruction(vm, 'childNodes');
         }
-        return renderer.getChildNodes(vm.elm);
+        // getChildNodes returns a NodeList, which has `item(index: number): Node | null`.
+        // NodeListOf<T> extends NodeList, but claims to not return null. That seems inaccurate,
+        // but these are built-in types, so ultimately not our problem.
+        return renderer.getChildNodes(vm.elm) as NodeListOf<ChildNode>;
     },
 
     get firstChild() {

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -193,7 +193,7 @@ const refsCache: WeakMap<RefVNodes, RefNodes> = new WeakMap();
 export interface LightningElement extends HTMLElementTheGoodParts, AccessibleElementProperties {
     constructor: LightningElementConstructor;
     template: ShadowRoot | null;
-    refs: RefNodes;
+    refs: RefNodes | undefined;
     render(): Template;
     connectedCallback?(): void;
     disconnectedCallback?(): void;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -207,10 +207,7 @@ export interface LightningElement extends HTMLElementTheGoodParts, AccessibleEle
  * This class is the base class for any LWC element.
  * Some elements directly extends this class, others implement it via inheritance.
  */
-// @ts-ignore
-export const LightningElement: LightningElementConstructor = function (
-    this: LightningElement
-): LightningElement {
+export const LightningElement = function (this: LightningElement): LightningElement {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
         // Thrown when doing something like `new LightningElement()` or
@@ -267,6 +264,8 @@ export const LightningElement: LightningElementConstructor = function (
 
     return this;
 };
+
+export const x: LightningElementConstructor = LightningElement;
 
 function doAttachShadow(vm: VM): ShadowRoot {
     const {
@@ -397,8 +396,7 @@ function createElementInternalsProxy(
     return elementInternalsProxy;
 }
 
-// @ts-ignore
-LightningElement.prototype = {
+const proto: LightningElement = {
     constructor: LightningElement,
 
     dispatchEvent(event: Event): boolean {
@@ -622,6 +620,8 @@ LightningElement.prototype = {
         return vm.shadowRoot;
     },
 
+    // TODO: fix
+    // @ts-expect-error Returning `undefined` is not compatible with the base type
     get refs(): RefNodes | undefined {
         const vm = getAssociatedVM(this);
 
@@ -850,3 +850,6 @@ defineProperty(LightningElement, 'CustomElementConstructor', {
     },
     configurable: true,
 });
+
+// @ts-expect-error TypeScript doesn't like modifying the prototype
+LightningElement.prototype = proto;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -624,7 +624,7 @@ function createElementInternalsProxy(
         return vm.shadowRoot;
     },
 
-    get refs() {
+    get refs(): RefNodes | undefined {
         const vm = getAssociatedVM(this);
 
         if (isUpdatingTemplate) {

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Salesforce, Inc.
+ * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -207,7 +207,10 @@ export interface LightningElement extends HTMLElementTheGoodParts, AccessibleEle
  * This class is the base class for any LWC element.
  * Some elements directly extends this class, others implement it via inheritance.
  */
-export const LightningElement = function (this: LightningElement): LightningElement {
+// @ts-expect-error When exported, it will conform, but we need to build it first!
+export const LightningElement: LightningElementConstructor = function (
+    this: LightningElement
+): LightningElement {
     // This should be as performant as possible, while any initialization should be done lazily
     if (isNull(vmBeingConstructed)) {
         // Thrown when doing something like `new LightningElement()` or
@@ -264,8 +267,6 @@ export const LightningElement = function (this: LightningElement): LightningElem
 
     return this;
 };
-
-export const x: LightningElementConstructor = LightningElement;
 
 function doAttachShadow(vm: VM): ShadowRoot {
     const {
@@ -396,7 +397,8 @@ function createElementInternalsProxy(
     return elementInternalsProxy;
 }
 
-const proto: LightningElement = {
+// Type assertion because the prototype is readonly, but we need to initialize it
+(LightningElement as { prototype: LightningElement }).prototype = {
     constructor: LightningElement,
 
     dispatchEvent(event: Event): boolean {
@@ -620,8 +622,8 @@ const proto: LightningElement = {
         return vm.shadowRoot;
     },
 
-    // TODO: fix
-    // @ts-expect-error Returning `undefined` is not compatible with the base type
+    // TODO: fix?
+    // @ts-expect-error base type doesn't allow returning undefined
     get refs(): RefNodes | undefined {
         const vm = getAssociatedVM(this);
 
@@ -691,6 +693,8 @@ const proto: LightningElement = {
     },
 
     // For backwards compat, we allow component authors to set `refs` as an expando
+    // TODO: fix?
+    // @ts-expect-error base type doesn't allow returning undefined in the getter
     set refs(value: any) {
         defineProperty(this, 'refs', {
             configurable: true,
@@ -715,6 +719,8 @@ const proto: LightningElement = {
         return renderer.getChildren(vm.elm);
     },
 
+    // TODO: fix?
+    // @ts-expect-error base type doesn't allow returning undefined
     get childNodes() {
         const vm = getAssociatedVM(this);
         const renderer = vm.renderer;
@@ -850,6 +856,3 @@ defineProperty(LightningElement, 'CustomElementConstructor', {
     },
     configurable: true,
 });
-
-// @ts-expect-error TypeScript doesn't like modifying the prototype
-LightningElement.prototype = proto;

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -179,6 +179,7 @@ type HTMLElementTheGoodParts = { toString: () => string } & Pick<
     | 'removeEventListener'
     | 'setAttribute'
     | 'setAttributeNS'
+    | 'shadowRoot'
     | 'spellcheck'
     | 'tabIndex'
     | 'tagName'
@@ -191,7 +192,6 @@ const refsCache: WeakMap<RefVNodes, RefNodes> = new WeakMap();
 
 export interface LightningElement extends HTMLElementTheGoodParts, AccessibleElementProperties {
     constructor: LightningElementConstructor;
-    shadowRoot: ShadowRoot | null;
     template: ShadowRoot | null;
     refs: RefNodes;
     render(): Template;

--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -17,8 +17,7 @@ let warned = false;
 
 // Only used in LWC's Karma tests
 if (process.env.NODE_ENV === 'test-karma-lwc') {
-    // @ts-ignore
-    window.__lwcResetWarnedOnVersionMismatch = () => {
+    (window as any).__lwcResetWarnedOnVersionMismatch = () => {
         warned = false;
     };
 }

--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -118,7 +118,7 @@ function warnOnArrayMutation(stylesheets: TemplateStylesheetFactories) {
         const originalArrayMethod = getOriginalArrayMethod(prop);
         stylesheets[prop] = function arrayMutationWarningWrapper() {
             reportTemplateViolation('stylesheets');
-            // @ts-ignore
+            // @ts-expect-error can't properly determine the right `this`
             return originalArrayMethod.apply(this, arguments);
         };
     }

--- a/packages/@lwc/engine-core/src/framework/restrictions.ts
+++ b/packages/@lwc/engine-core/src/framework/restrictions.ts
@@ -195,7 +195,7 @@ function getShadowRootRestrictionsDescriptors(sr: ShadowRoot): PropertyDescripto
                     );
                 }
                 // Typescript does not like it when you treat the `arguments` object as an array
-                // @ts-ignore type-mismatch
+                // @ts-expect-error type-mismatch
                 return originalAddEventListener.apply(this, arguments);
             },
         }),
@@ -256,7 +256,7 @@ function getCustomElementRestrictionsDescriptors(elm: HTMLElement): PropertyDesc
                     );
                 }
                 // Typescript does not like it when you treat the `arguments` object as an array
-                // @ts-ignore type-mismatch
+                // @ts-expect-error type-mismatch
                 return originalAddEventListener.apply(this, arguments);
             },
         }),

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -303,11 +303,7 @@ function resetComponentStateWhenRemoved(vm: VM) {
 // old vnode.children is removed from the DOM.
 export function removeVM(vm: VM) {
     if (process.env.NODE_ENV !== 'production') {
-        if (
-            !shouldUseNativeCustomElementLifecycle(
-                vm.component.constructor as LightningElementConstructor
-            )
-        ) {
+        if (!shouldUseNativeCustomElementLifecycle(vm.component.constructor)) {
             // With native lifecycle, we cannot be certain that connectedCallback was called before a component
             // was removed from the VDOM. If the component is disconnected, then connectedCallback will not fire
             // in native mode, although it will fire in synthetic mode due to appendChild triggering it.
@@ -718,9 +714,7 @@ export function runConnectedCallback(vm: VM) {
     // we're in dev mode. This is to detect a particular issue with synthetic lifecycle.
     if (
         process.env.IS_BROWSER &&
-        !shouldUseNativeCustomElementLifecycle(
-            vm.component.constructor as LightningElementConstructor
-        ) &&
+        !shouldUseNativeCustomElementLifecycle(vm.component.constructor) &&
         (process.env.NODE_ENV !== 'production' || isReportingEnabled())
     ) {
         if (!vm.renderer.isConnected(vm.elm)) {

--- a/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
@@ -77,7 +77,7 @@ function createConfigWatcher(
         ro.observe(() => (config = configCallback(component)));
         // eslint-disable-next-line @lwc/lwc-internal/no-invalid-todo
         // TODO: dev-mode validation of config based on the adapter.configSchema
-        // @ts-ignore it is assigned in the observe() callback
+        // @ts-expect-error it is assigned in the observe() callback
         callbackWhenConfigIsReady(config);
     };
     return {
@@ -191,7 +191,7 @@ function createConnector(
         });
     }
     return {
-        // @ts-ignore the boundary protection executes sync, connector is always defined
+        // @ts-expect-error the boundary protection executes sync, connector is always defined
         connector,
         computeConfigAndUpdate,
         resetConfigWatcher: () => ro.reset(),

--- a/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
@@ -100,19 +100,19 @@ function enableDetection() {
                 throw new Error('detect-non-standard-aria.ts loaded before @lwc/aria-reflection');
             }
         }
-        // @ts-ignore
-        const { get, set } = descriptor;
+
+        const { get, set } = descriptor!;
         // It's important for this defineProperty call to happen _after_ ARIA accessors are applied to the
         // BaseBridgeElement and LightningElement prototypes. Otherwise, we will log/report for access of non-standard
         // props on these prototypes, which we actually don't want. We only care about access on generic HTMLElements.
         defineProperty(prototype, prop, {
             get() {
                 checkAndReportViolation(this, prop, false, undefined);
-                return get.call(this);
+                return get!.call(this);
             },
             set(val) {
                 checkAndReportViolation(this, prop, true, val);
-                return set.call(this, val);
+                return set!.call(this, val);
             },
             configurable: true,
             enumerable: true,

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -13,8 +13,7 @@ const alreadyLoggedMessages = new Set();
 
 // Only used in LWC's Karma tests
 if (process.env.NODE_ENV === 'test-karma-lwc') {
-    // @ts-ignore
-    window.__lwcResetAlreadyLoggedMessages = () => {
+    (window as any).__lwcResetAlreadyLoggedMessages = () => {
         alreadyLoggedMessages.clear();
     };
 }

--- a/packages/@lwc/engine-dom/src/styles.ts
+++ b/packages/@lwc/engine-dom/src/styles.ts
@@ -52,8 +52,7 @@ const stylesheetCache: Map<string, CacheData> = new Map();
 
 // Only used in LWC's Karma tests
 if (process.env.NODE_ENV === 'test-karma-lwc') {
-    // @ts-ignore
-    window.__lwcResetGlobalStylesheets = () => {
+    (window as any).__lwcResetGlobalStylesheets = () => {
         stylesheetCache.clear();
     };
 }

--- a/packages/@lwc/features/src/__tests__/features.spec.ts
+++ b/packages/@lwc/features/src/__tests__/features.spec.ts
@@ -16,7 +16,7 @@ describe('features', () => {
     });
 
     it('unknown flags in the features map are undefined', () => {
-        // @ts-ignore
+        // @ts-expect-error explicitly testing JS behavior that violates TS types
         expect(features.DOES_NOT_EXIST).toBeUndefined();
     });
 });

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -13,7 +13,7 @@ describe('lwcRuntimeFlags', () => {
     });
 
     it('unknown flags default to undefined', () => {
-        // @ts-ignore
+        // @ts-expect-error Explicitly testing JS behavior that violates TS types
         expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
     });
 });

--- a/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
+++ b/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
@@ -32,7 +32,7 @@ describe('setFeatureFlag', () => {
                 const expectedError =
                     'Failed to set the value "foo" for the runtime feature flag "PLACEHOLDER_TEST_FLAG". Runtime feature flags can only be set to a boolean value.';
                 const callback = () => {
-                    // @ts-ignore
+                    // @ts-expect-error Explicitly testing JS behavior that violates TS types
                     setFeatureFlag('PLACEHOLDER_TEST_FLAG', 'foo');
                 };
                 if (env === 'production') {
@@ -47,14 +47,14 @@ describe('setFeatureFlag', () => {
             });
 
             it('logs and does nothing when the flag is unknown', () => {
-                // @ts-ignore
+                // @ts-expect-error Explicitly testing JS behavior that violates TS types
                 setFeatureFlag('DOES_NOT_EXIST', true);
                 expect(info).toHaveBeenCalledWith(
                     expect.stringMatching(/Attempt to set a value on an unknown feature flag/)
                 );
 
                 // value is not changed
-                // @ts-ignore
+                // @ts-expect-error Explicitly testing JS behavior that violates TS types
                 expect(lwcRuntimeFlags.DOES_NOT_EXIST).toBeUndefined();
             });
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
@@ -50,7 +50,7 @@ describe('API versioning', () => {
 
     it('handles apiVersion lower than lower bound', async () => {
         const { code, warnings } = await runRollup('fixtures/basic/basic.js', {
-            // @ts-ignore
+            // @ts-expect-error Explicitly testing JS behavior that violates TS types
             apiVersion: 0,
         });
         expect(code).toContain(`apiVersion: ${LOWEST_API_VERSION}`);
@@ -59,7 +59,6 @@ describe('API versioning', () => {
 
     it('handles apiVersion higher than high bound', async () => {
         const { code, warnings } = await runRollup('fixtures/basic/basic.js', {
-            // @ts-ignore
             apiVersion: Number.MAX_SAFE_INTEGER,
         });
         expect(code).toContain(`apiVersion: ${HIGHEST_API_VERSION}`);
@@ -68,7 +67,7 @@ describe('API versioning', () => {
 
     it('if within bounds, finds the lowest known version matching the specification', async () => {
         const { code, warnings } = await runRollup('fixtures/basic/basic.js', {
-            // @ts-ignore`
+            // @ts-expect-error Explicitly testing JS behavior that violates TS types
             apiVersion: 58.5,
         });
         expect(code).toContain(`apiVersion: 58`);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/focus.ts
@@ -118,7 +118,7 @@ export function hostElementFocus(this: HTMLElement) {
         // observable differences for component authors between synthetic and native.
         const focusable = querySelector.call(this, FocusableSelector) as HTMLElement;
         if (!isNull(focusable)) {
-            // @ts-ignore type-mismatch
+            // @ts-expect-error type-mismatch
             focusable.focus.apply(focusable, arguments);
         }
         return;
@@ -139,7 +139,7 @@ export function hostElementFocus(this: HTMLElement) {
     let didFocus = false;
     while (!didFocus && focusables.length !== 0) {
         const focusable = focusables.shift()!;
-        // @ts-ignore type-mismatch
+        // @ts-expect-error type-mismatch
         focusable.focus.apply(focusable, arguments);
         // Get the root node of the current focusable in case it was slotted.
         const currentRootNode = focusable.getRootNode() as unknown as DocumentOrShadowRoot;

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/html-element.ts
@@ -141,7 +141,7 @@ function focusPatched(this: HTMLElement) {
     }
 
     // Typescript does not like it when you treat the `arguments` object as an array
-    // @ts-ignore type-mismatch
+    // @ts-expect-error type-mismatch
     focus.apply(this, arguments);
 
     // Restore state by enabling if originally enabled
@@ -183,7 +183,7 @@ defineProperties(HTMLElement.prototype, {
     focus: {
         value(this: HTMLElement) {
             // Typescript does not like it when you treat the `arguments` object as an array
-            // @ts-ignore type-mismatch
+            // @ts-expect-error type-mismatch
             focusPatched.apply(this, arguments);
         },
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -353,7 +353,7 @@ const NodePatchDescriptors = {
         value(this: ShadowRoot, evt: Event): boolean {
             eventToShadowRootMap.set(evt, this);
             // Typescript does not like it when you treat the `arguments` object as an array
-            // @ts-ignore type-mismatch
+            // @ts-expect-error type-mismatch
             return dispatchEvent.apply(getHost(this), arguments);
         },
     },

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/slot.ts
@@ -75,7 +75,7 @@ function getFilteredSlotFlattenNodes(slot: HTMLElement): Node[] {
     const childNodes = arrayFromCollection(childNodesGetter.call(slot));
     // Typescript is inferring the wrong function type for this particular
     // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-    // @ts-ignore type-mismatch
+    // @ts-expect-error type-mismatch
     return ArrayReduce.call(
         childNodes,
         (seed, child) => {

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -243,7 +243,7 @@ export function getFilteredChildNodes(node: Node): Element[] {
         const resolver = getShadowRootResolver(getShadowRoot(node));
         // Typescript is inferring the wrong function type for this particular
         // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-        // @ts-ignore type-mismatch
+        // @ts-expect-error type-mismatch
         return ArrayReduce.call(
             slots,
             (seed, slot) => {

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
@@ -25,7 +25,7 @@ function patchedAddEventListener(
 ) {
     if (isSyntheticShadowHost(this)) {
         // Typescript does not like it when you treat the `arguments` object as an array
-        // @ts-ignore type-mismatch
+        // @ts-expect-error type-mismatch
         return addCustomElementEventListener.apply(this, arguments);
     }
     if (arguments.length < 2) {
@@ -36,7 +36,7 @@ function patchedAddEventListener(
             args[1] = getEventListenerWrapper(args[1]);
         }
         // Ignore types because we're passing through to native method
-        // @ts-ignore type-mismatch
+        // @ts-expect-error type-mismatch
         return nativeAddEventListener.apply(this, args);
     }
     // Fast path. This function is optimized to avoid ArraySlice because addEventListener is called
@@ -55,7 +55,7 @@ function patchedRemoveEventListener(
 ) {
     if (isSyntheticShadowHost(this)) {
         // Typescript does not like it when you treat the `arguments` object as an array
-        // @ts-ignore type-mismatch
+        // @ts-expect-error type-mismatch
         return removeCustomElementEventListener.apply(this, arguments);
     }
     const args = ArraySlice.call(arguments);
@@ -63,11 +63,11 @@ function patchedRemoveEventListener(
         args[1] = getEventListenerWrapper(args[1]);
     }
     // Ignore types because we're passing through to native method
-    // @ts-ignore type-mismatch
+    // @ts-expect-error type-mismatch
     nativeRemoveEventListener.apply(this, args);
     // Account for listeners that were added before this polyfill was applied
     // Typescript does not like it when you treat the `arguments` object as an array
-    // @ts-ignore type-mismatch
+    // @ts-expect-error type-mismatch
     nativeRemoveEventListener.apply(this, arguments);
 }
 

--- a/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
@@ -10,7 +10,7 @@ import compile, { Config, parse } from '../index';
 describe('option validation', () => {
     it('validated presence of options', () => {
         expect(() => {
-            // @ts-ignore
+            // @ts-expect-error Explicitly testing JS behavior that violates TS types
             compile(`<template></template>`);
         }).toThrow(/Compiler options must be an object/);
     });

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -89,7 +89,7 @@ function validateMatchingExtraParens(leadingChars: string, trailingChars: string
  * specified by the HTML spec.
  */
 class TemplateHtmlTokenizer extends Tokenizer {
-    // @ts-ignore
+    // @ts-expect-error This Preprocessor is an incomplete customization of parse5's Preprocessor
     preprocessor!: Preprocessor;
 
     parser: TemplateHtmlParser;
@@ -171,7 +171,7 @@ class TemplateHtmlTokenizer extends Tokenizer {
             // coming later in an unquoted attr value should not be considered
             // the beginning of a template expression.
             this.checkedAttrs.add(this.currentAttr);
-            // @ts-ignore
+            // @ts-expect-error private method
             super._stateAttributeValueUnquoted(codePoint);
         }
     }
@@ -210,7 +210,7 @@ class TemplateHtmlTokenizer extends Tokenizer {
             this.currentToken = null;
             this.currentCharacterToken = null;
         } else {
-            // @ts-ignore
+            // @ts-expect-error private method
             super._stateData(codePoint);
         }
     }

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -107,7 +107,7 @@ declare module 'lwc' {
         role: string | null;
     }
 
-    // @ts-ignore type-mismatch
+    // @ts-expect-error type-mismatch
     interface ShadowRootTheGoodPart extends NodeSelector {
         mode: string;
         readonly activeElement: Element | null;


### PR DESCRIPTION
## Details

In #3995 I claimed to leverage the full power of `@typescript-eslint`. That was a lie! I focused on the rules that were auto-fixable or minimal manual fixes, and disabled the ones requiring manual fixes. In #4025, a new `@ts-ignore` was introduced, so I decided that it seemed like a good time to re-enable the rule saying "hey, don't do that!"

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
