### PR TITLE
docs: add more JSDoc for top-level exports @W-13278716

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -312,7 +312,6 @@
                 "packages/@lwc/perf-benchmarks-components/**",
                 "packages/@lwc/perf-benchmarks/**",
                 // TODO [W-13278716]: All top-level exports should have JSDOC enforced
-                "packages/@lwc/compiler/**",
                 "packages/@lwc/engine-core/**",
                 "packages/@lwc/engine-dom/**",
                 "packages/@lwc/engine-server/**",
@@ -340,6 +339,7 @@
         {
             "files": [
                 "packages/@lwc/babel-plugin-component/**",
+                "packages/@lwc/compiler/**",
                 "packages/@lwc/errors/**",
                 "packages/@lwc/rollup-plugin/**",
                 "packages/@lwc/wire-service/**"

--- a/.eslintrc
+++ b/.eslintrc
@@ -306,7 +306,6 @@
         },
         {
             "files": [
-                "packages/lwc/**",
                 // Private packages - documentation isn't required (but should still be good, if present)
                 "packages/@lwc/integration-karma/**",
                 "packages/@lwc/integration-tests/**",

--- a/.eslintrc
+++ b/.eslintrc
@@ -313,11 +313,11 @@
                 "packages/@lwc/perf-benchmarks/**",
                 // TODO [W-13278716]: All top-level exports should have JSDOC enforced
                 "packages/@lwc/engine-core/**",
-                "packages/@lwc/engine-dom/**",
                 // "packages/@lwc/engine-server/**",
                 // Package-level exports are documented, but not all file-level exports are, so we
                 // should keep these disabled for now
                 "packages/@lwc/babel-plugin-component/**",
+                "packages/@lwc/engine-dom/**",
                 "packages/@lwc/engine-server/**",
                 "packages/@lwc/module-resolver/**",
                 "packages/@lwc/shared/**",
@@ -342,6 +342,7 @@
                 "packages/@lwc/babel-plugin-component/**",
                 "packages/@lwc/compiler/**",
                 "packages/@lwc/errors/**",
+                "packages/@lwc/engine-dom/**",
                 "packages/@lwc/rollup-plugin/**",
                 "packages/@lwc/wire-service/**"
             ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -314,10 +314,11 @@
                 // TODO [W-13278716]: All top-level exports should have JSDOC enforced
                 "packages/@lwc/engine-core/**",
                 "packages/@lwc/engine-dom/**",
-                "packages/@lwc/engine-server/**",
+                // "packages/@lwc/engine-server/**",
                 // Package-level exports are documented, but not all file-level exports are, so we
                 // should keep these disabled for now
                 "packages/@lwc/babel-plugin-component/**",
+                "packages/@lwc/engine-server/**",
                 "packages/@lwc/module-resolver/**",
                 "packages/@lwc/shared/**",
                 "packages/@lwc/style-compiler/**",

--- a/packages/@lwc/compiler/src/index.ts
+++ b/packages/@lwc/compiler/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -15,4 +15,5 @@ export {
     OutputConfig,
 } from './options';
 
-export const version = process.env.LWC_VERSION as string;
+/** The version of LWC being used. */
+export const version = process.env.LWC_VERSION!;

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -52,7 +52,7 @@ const DEFAULT_OUTPUT_CONFIG: Required<OutputConfig> = {
 export type CustomPropertiesResolution = { type: 'native' } | { type: 'module'; name: string };
 
 /**
- * @deprecated - Custom property transforms are deprecated because IE11 and other legacy browsers are no longer supported.
+ * @deprecated Custom property transforms are deprecated because IE11 and other legacy browsers are no longer supported.
  */
 // TODO [#3266]: Remove StylesheetConfig as part of breaking change wishlist
 export interface StylesheetConfig {
@@ -79,29 +79,53 @@ export interface DynamicImportConfig {
     strictSpecifier?: boolean;
 }
 
+/**
+ * Options used to change the behavior of the compiler. At a minimum, `name` and `namespace` are
+ * required.
+ */
 export interface TransformOptions {
+    /** The name of the component. For example, the name in `<my-component>` is `"component"`. */
     name?: string;
+    /** The namespace of the component. For example, the namespace in `<my-component>` is `"my"`. */
     namespace?: string;
+    /** @deprecated Ignored by compiler. */
     stylesheetConfig?: StylesheetConfig;
     // TODO [#3331]: deprecate / rename this compiler option in 246
-    /* Config applied in usage of dynamic import statements in javascript */
+    /** Config applied in usage of dynamic import statements in javascript */
     experimentalDynamicComponent?: DynamicImportConfig;
-    /* Flag to enable usage of dynamic component(lwc:dynamic) directive in HTML template */
+    /** Flag to enable usage of dynamic component(lwc:dynamic) directive in HTML template */
     experimentalDynamicDirective?: boolean;
-    /* Flag to enable usage of dynamic component(lwc:is) directive in HTML template */
+    /** Flag to enable usage of dynamic component(lwc:is) directive in HTML template */
     enableDynamicComponents?: boolean;
     // TODO [#3370]: remove experimental template expression flag
+    /** Flag to enable use of (a subset of) JavaScript expressions in place of template bindings. Passed to `@lwc/template-compiler`. */
     experimentalComplexExpressions?: boolean;
+    /** Options to control what output gets generated. */
     outputConfig?: OutputConfig;
+    /** Whether this is an explicit import. Passed to `@lwc/babel-plugin-component`. */
     isExplicitImport?: boolean;
+    /** Whether the compiled HTML should include comments present in the source. */
     preserveHtmlComments?: boolean;
+    /** Whether the CSS file being compiled is a scoped stylesheet. Passed to `@lwc/style-compiler`. */
     scopedStyles?: boolean;
+    /** Whether the static content optimization should be enabled. Passed to `@lwc/template-compiler`. */
     enableStaticContentOptimization?: boolean;
+    /** Custom renderer config to pass to `@lwc/template-compiler`. See that package's README for details. */
     customRendererConfig?: CustomRendererConfig;
+    /** @deprecated Ignored by compiler. `lwc:spread` is always enabled. */
     enableLwcSpread?: boolean;
+    /** Set to true if synthetic shadow DOM support is not needed, which can result in smaller output. */
     disableSyntheticShadowSupport?: boolean;
+    /**
+     * Enable transformations specific to {@link https://developer.salesforce.com/docs/platform/lwc/guide/security-lwsec-intro.html Lighting Web Security}.
+     */
     enableLightningWebSecurityTransforms?: boolean;
+    /**
+     * Instrumentation object to gather metrics and non-error logs for internal use.
+     * See the `@lwc/errors` package for details on the interface.
+     */
     instrumentation?: InstrumentationObject;
+    /** API version to associate with the compiled module. Values correspond to Salesforce platform releases. */
     apiVersion?: number;
 }
 
@@ -131,6 +155,16 @@ export interface NormalizedTransformOptions extends RecursiveRequired<RequiredTr
     instrumentation?: InstrumentationObject;
 }
 
+/**
+ * Validates that the options conform to the expected shape and normalizes them to a standard format
+ * @param options Input options
+ * @returns Normalized options
+ * @example
+ * const normalizedOptions = validateTransformOptions({
+ *   namespace: 'c',
+ *   name: 'app',
+ * })
+ */
 export function validateTransformOptions(options: TransformOptions): NormalizedTransformOptions {
     validateOptions(options);
     return normalizeOptions(options);

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -19,6 +19,15 @@ import { NormalizedTransformOptions } from '../options';
 import { TransformResult } from './transformer';
 import type { LwcBabelPluginOptions } from '@lwc/babel-plugin-component';
 
+/**
+ * Transforms a JavaScript file.
+ * @param code The source code to transform
+ * @param filename The source filename, with extension.
+ * @param options Transformation options.
+ * @returns Compiled code
+ * @throws Compilation errors
+ * @example
+ */
 export default function scriptTransform(
     code: string,
     filename: string,

--- a/packages/@lwc/compiler/src/transformers/style.ts
+++ b/packages/@lwc/compiler/src/transformers/style.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -10,6 +10,15 @@ import { normalizeToCompilerError, TransformerErrors } from '@lwc/errors';
 import { NormalizedTransformOptions } from '../options';
 import { TransformResult } from './transformer';
 
+/**
+ * Transform the passed source code
+ * @param src The source to be transformed. Can be the content of a JavaScript, HTML, or CSS file.
+ * @param filename The source filename, with extension.
+ * @param config The transformation options. The `name` and the `namespace` of the component is the
+ * minimum required for transformation.
+ * @returns An object with the generated code, source map and gathered metadata.
+ * @throws Compilation errors
+ */
 export default function styleTransform(
     src: string,
     filename: string,

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -21,9 +21,12 @@ import { TransformResult } from './transformer';
  * Transforms a HTML template into module exporting a template function.
  * The transform also add a style import for the default stylesheet associated with
  * the template regardless if there is an actual style or not.
- * @param src
- * @param filename
- * @param options
+ * @param src HTML source
+ * @param filename Source filename, with extension.
+ * @param options Transformation options
+ * @returns Transformed code, source map, and metadata
+ * @throws Compiler errors, when compilation fails.
+ * @example
  */
 export default function templateTransform(
     src: string,

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -19,20 +19,40 @@ import styleTransform from './style';
 import templateTransformer from './template';
 import scriptTransformer from './javascript';
 
+/** The object returned after transforming code. */
 export interface TransformResult {
+    /** The compiled source code. */
     code: string;
+    /** The generated source map. */
     map: unknown;
+    /** Any diagnostic warnings that may have occurred. */
     warnings?: CompilerDiagnostic[];
+    /**
+     * String tokens used for style scoping in synthetic shadow DOM and `*.scoped.css`, as either
+     * attributes or classes.
+     */
     cssScopeTokens?: string[];
 }
 
 /**
- * Transforms the passed code. Returning a Promise of an object with the generated code, source map
- * and gathered metadata.
- * @param src
- * @param filename
- * @param options
- * @deprecated Use transformSync instead.
+ * Transform the passed source code.
+ * @param src The source to be transformed. Can be the content of a JavaScript, HTML, or CSS file.
+ * @param filename The source filename, with extension.
+ * @param options The transformation options. The `name` and the `namespace` of the component is the
+ * minimum required for transformation.
+ * @returns A promise resolving to an object with the generated code, source map and gathered metadata.
+ * @example
+ * const source = `
+ *     import { LightningElement } from 'lwc';
+ *     export default class App extends LightningElement {}
+ * `;
+ * const filename = 'app.js';
+ * const options = {
+ *     namespace: 'c',
+ *     name: 'app',
+ * };
+ * const { code } = await transform(source, filename, options);
+ * @deprecated Use {@linkcode transformSync} instead
  */
 export function transform(
     src: string,
@@ -51,11 +71,24 @@ export function transform(
 }
 
 /**
- * Transform the passed source code. Returning an object with the generated code, source map and
- * gathered metadata.
- * @param src
- * @param filename
- * @param options
+ * Transform the passed source code
+ * @param src The source to be transformed. Can be the content of a JavaScript, HTML, or CSS file.
+ * @param filename The source filename, with extension.
+ * @param options The transformation options. The `name` and the `namespace` of the component is the
+ * minimum required for transformation.
+ * @returns An object with the generated code, source map and gathered metadata.
+ * @example
+ *
+ * const source = `
+ *     import { LightningElement } from 'lwc';
+ *     export default class App extends LightningElement {}
+ * `;
+ * const filename = 'app.js';
+ * const options = {
+ *     namespace: 'c',
+ *     name: 'app',
+ * };
+ * const { code } = transformSync(source, filename, options);
  */
 export function transformSync(
     src: string,

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -24,15 +24,14 @@ type HTMLElementConstructor = typeof HTMLElement;
 /**
  * This function builds a Web Component class from a LWC constructor so it can be
  * registered as a new element via customElements.define() at any given time.
- * @param Ctor
+ * @param Ctor LWC constructor to build
+ * @returns A Web Component class
  * @example
- * ```
  * import { buildCustomElementConstructor } from 'lwc';
  * import Foo from 'ns/foo';
  * const WC = buildCustomElementConstructor(Foo);
  * customElements.define('x-foo', WC);
  * const elm = document.createElement('x-foo');
- * ```
  * @deprecated since version 1.3.11
  */
 export function deprecatedBuildCustomElementConstructor(
@@ -56,6 +55,13 @@ function clearNode(node: Node) {
     }
 }
 
+/**
+ * The real `buildCustomElementConstructor`. Should not be accessible to external users!
+ * @internal
+ * @param Ctor LWC constructor to build
+ * @returns A Web Component class
+ * @see {@linkcode deprecatedBuildCustomElementConstructor}
+ */
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {
     const HtmlPrototype = getComponentHtmlPrototype(Ctor);
     const { observedAttributes } = HtmlPrototype as any;

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -89,18 +89,17 @@ function monkeyPatchDomAPIs() {
  * difference that in the options, you can pass the `is` property set to a Constructor instead of
  * just a string value. The intent is to allow the creation of an element controlled by LWC without
  * having to register the element as a custom element.
- * @param sel
- * @param options
- * @param options.is description
- * @param options.mode
+ * @param sel The tagname of the element to create
+ * @param options Control the behavior of the created element
+ * @param options.is The LWC component that the element should be
+ * @param options.mode What kind of shadow root to use
+ * @returns The created HTML element
+ * @throws Throws when called with invalid parameters.
  * @example
- * ```
  * const el = createElement('x-foo', { is: FooCtor });
- * ```
  */
-/* eslint-enable jsdoc/valid-types */
-
 export function createElement(
+    /* eslint-enable jsdoc/valid-types */
     sel: string,
     options: {
         is: typeof LightningElement;
@@ -137,12 +136,11 @@ export function createElement(
         isAPIFeatureEnabled(APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE, apiVersion);
 
     // the custom element from the registry is expecting an upgrade callback
-    /**
+    /*
      * Note: if the upgradable constructor does not expect, or throw when we new it
      * with a callback as the first argument, we could implement a more advanced
      * mechanism that only passes that argument if the constructor is known to be
      * an upgradable custom element.
-     * @param elm
      */
     const upgradeCallback = (elm: HTMLElement) => {
         createVM(elm, Ctor, renderer, {

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -46,6 +46,18 @@ function createVMWithProps(element: Element, Ctor: typeof LightningElement, prop
     return vm;
 }
 
+/**
+ * Replaces an existing DOM node with an LWC component.
+ * @param element The existing node in the DOM that where the root component should be attached.
+ * @param Ctor The LWC class to use as the root component.
+ * @param props Any props for the root component as part of initial client-side rendering. The props must be identical to those passed to renderComponent during SSR.
+ * @throws Throws when called with invalid parameters.
+ * @example
+ * import { hydrateComponent } from 'lwc';
+ * import App from 'x/App';
+ * const elm = document.querySelector('x-app');
+ * hydrateComponent(elm, App, { name: 'Hello World' });
+ */
 export function hydrateComponent(
     element: Element,
     Ctor: typeof LightningElement,

--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -21,7 +21,9 @@ const _Node = Node;
 /**
  * EXPERIMENTAL: The purpose of this function is to detect shadowed nodes. THIS API WILL BE REMOVED
  * ONCE LOCKER V1 IS NO LONGER SUPPORTED.
- * @param node
+ * @param node Node to check
+ * @returns `true` if the the node is shadowed
+ * @example isNodeShadowed(document.querySelector('my-component'))
  */
 function isNodeShadowed(node: Node): boolean {
     if (isFalse(node instanceof _Node)) {

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -38,7 +38,7 @@ export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : San
  * const customRenderer = rendererFactory(renderer);
  */
 export function rendererFactory<T extends RendererAPI | null>(baseRenderer: T): RendererAPIType<T> {
-    // `process.env.RENDERER` is replaced by rollup with an object, not a string. Gross!
+    // Type assertion because this is replaced by rollup with an object, not a string.
     // See `injectInlineRenderer` in /scripts/rollup/rollup.config.js
     const renderer = process.env.RENDERER as unknown as RendererAPIType<T>;
     // Meant to inherit any properties passed via the base renderer as the argument to the factory.

--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -31,12 +31,15 @@ export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : San
  * A factory function that produces a renderer.
  * Renderer encapsulates operations that are required to render an LWC component into the underlying
  * runtime environment. In the case of @lwc/enigne-dom, it is meant to be used in a DOM environment.
- * Example usage:
+ * @param baseRenderer Either null or the base renderer imported from 'lwc'.
+ * @returns The created renderer
+ * @example
  * import { renderer, rendererFactory } from 'lwc';
  * const customRenderer = rendererFactory(renderer);
- * @param baseRenderer Either null or the base renderer imported from 'lwc'.
  */
 export function rendererFactory<T extends RendererAPI | null>(baseRenderer: T): RendererAPIType<T> {
+    // `process.env.RENDERER` is replaced by rollup with an object, not a string. Gross!
+    // See `injectInlineRenderer` in /scripts/rollup/rollup.config.js
     const renderer = process.env.RENDERER as unknown as RendererAPIType<T>;
     // Meant to inherit any properties passed via the base renderer as the argument to the factory.
     Object.setPrototypeOf(renderer, baseRenderer);

--- a/packages/@lwc/engine-dom/src/renderer/context.ts
+++ b/packages/@lwc/engine-dom/src/renderer/context.ts
@@ -33,6 +33,11 @@ export class WireContextSubscriptionEvent extends CustomEvent<undefined> {
     }
 }
 
+/**
+ * Creates a context provider, given a wire adapter constructor.
+ * @param adapter The wire adapter to create a context provider for.
+ * @returns A new context provider.
+ */
 export function createContextProvider(adapter: WireAdapterConstructor) {
     return createContextProviderWithRegister(adapter, registerContextProvider);
 }

--- a/packages/@lwc/engine-server/src/apis/create-element.ts
+++ b/packages/@lwc/engine-server/src/apis/create-element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -11,7 +11,8 @@
  *
  * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
  * an error being thrown by the import itself.
+ * @throws Always throws, as it should not be used.
  */
-export function createElement() {
+export function createElement(): never {
     throw new Error('createElement is not supported in @lwc/engine-server, only @lwc/engine-dom.');
 }

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -32,6 +32,18 @@ const FakeRootElement: HostElement = {
     [HostContextProvidersKey]: new Map(),
 };
 
+/**
+ * Renders a string representation of a serialized component tree.
+ * @param tagName The name of the tag to render.
+ * @param Ctor The LWC constructor to render with.
+ * @returns A string representation of the serialized component tree.
+ * @throws Throws when called with invalid parameters.
+ * @example
+ * import { renderComponent } from '@lwc/engine-server';
+ * import LightningHello from 'lightning/hello';
+ * const componentProps = {};
+ * const serialized = renderComponent('lightning-hello', LightningHello, componentProps);
+ */
 export function renderComponent(
     tagName: string,
     Ctor: typeof LightningElement,

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -59,6 +59,11 @@ function serializeShadowRoot(shadowRoot: HostShadowRoot): string {
     )}</template>`;
 }
 
+/**
+ * Serializes an element into a string
+ * @param element The element to serialize
+ * @returns A string representation of the element
+ */
 export function serializeElement(element: HostElement): string {
     let output = '';
 

--- a/packages/@lwc/engine-server/src/utils/classes.ts
+++ b/packages/@lwc/engine-server/src/utils/classes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,10 +7,22 @@
 
 const CLASSNAMES_SEPARATOR = /\s+/g;
 
+/**
+ * Splits the given space-delimited string into unique values.
+ * @param value The string to split
+ * @returns Set of unique values
+ * @example classNametoTokenList('foo  bar foo') // Set(2) { 'foo', 'bar' }
+ */
 export function classNameToTokenList(value: string): Set<string> {
     return new Set(value.split(CLASSNAMES_SEPARATOR).filter((str) => str.length));
 }
 
+/**
+ * Converts a set of values into a space-delimited string
+ * @param values The set of values to join
+ * @returns A space-delimited string
+ * @example tokenListToClassName(new Set(['hello', 'world'])) // 'hello world'
+ */
 export function tokenListToClassName(values: Set<string>): string {
     return Array.from(values).join(' ');
 }

--- a/packages/@lwc/engine-server/src/utils/validate-style-text-contents.ts
+++ b/packages/@lwc/engine-server/src/utils/validate-style-text-contents.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -24,13 +24,20 @@ function isSingleStyleNodeContainingSingleTextNode(node: DocumentFragment) {
     return textNode.nodeName === '#text';
 }
 
-// The text content inside `<style>` is a special case. It is _only_ rendered by the LWC engine itself; <style> tags
-// are disallowed inside of templates. Also, we want to avoid over-escaping, since CSS containing strings like
-// `&amp;` and `&quot;` is not valid CSS (even when inside a `<style>` element).
-//
-// However, to avoid XSS attacks, we still need to check for things like `</style><script>alert("pwned")</script>`,
-// since a user could use that inside of a *.css file to break out of a <style> element.
-// See: https://github.com/salesforce/lwc/issues/3439
+/**
+ * The text content inside `<style>` is a special case. It is _only_ rendered by the LWC engine itself; <style> tags
+ * are disallowed inside of templates. Also, we want to avoid over-escaping, since CSS containing strings like
+ * `&amp;` and `&quot;` is not valid CSS (even when inside a `<style>` element).
+ *
+ * However, to avoid XSS attacks, we still need to check for things like `</style><script>alert("pwned")</script>`,
+ * since a user could use that inside of a *.css file to break out of a <style> element.
+ * @param contents CSS source to validate
+ * @throws Throws if the contents provided are not valid.
+ * @see https://github.com/salesforce/lwc/issues/3439
+ * @example
+ * validateStyleTextContents('div { color: red }') // Ok
+ * validateStyleTextContents('</style><script>alert("pwned")</script>') // Throws
+ */
 export function validateStyleTextContents(contents: string): void {
     // If parse5 parses this as more than one `<style>` tag, then it is unsafe to be rendered as-is
     const fragment = parse5.parseFragment(`<style>${contents}</style>`);

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -9,6 +9,7 @@ import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 // When deprecating a feature flag, ensure that it is also no longer set in the application. For
 // example, in core, the flag should be removed from LwcPermAndPrefUtilImpl.java
+/** List of all feature flags available, with the default value `null`. */
 const features: FeatureFlagMap = {
     PLACEHOLDER_TEST_FLAG: null,
     ENABLE_FORCE_NATIVE_SHADOW_MODE_FOR_TEST: null,
@@ -26,6 +27,7 @@ if (!(globalThis as any).lwcRuntimeFlags) {
     Object.defineProperty(globalThis, 'lwcRuntimeFlags', { value: create(null) });
 }
 
+/** Feature flags that have been set. */
 const flags: Partial<FeatureFlagMap> = (globalThis as any).lwcRuntimeFlags;
 
 /**
@@ -96,5 +98,6 @@ export {
 export type { FeatureFlagMap };
 
 declare global {
+    /** Feature flags that have been set. */
     const lwcRuntimeFlags: Partial<FeatureFlagMap>;
 }

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -15,9 +15,14 @@
  */
 export type FeatureFlagValue = boolean | null;
 
+/**
+ * Map of feature flags to whether each feature is enabled. Feature flags can be toggled to change
+ * the behavior of LWC components.
+ */
 export interface FeatureFlagMap {
     /**
      * This is only used to test that feature flags are actually working
+     * @internal
      */
     PLACEHOLDER_TEST_FLAG: FeatureFlagValue;
 

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -78,6 +78,10 @@ type ConfigListener = (config: ConfigListenerArgument) => void;
 
 type WireEventTargetListener = NoArgumentListener | ConfigListener;
 
+/**
+ * An implementation of the {@linkcode https://developer.mozilla.org/en-US/docs/Web/API/EventTarget EventTarget}
+ * interface for the wire adapter.
+ */
 export interface WireEventTarget {
     addEventListener: (type: string, listener: WireEventTargetListener) => void;
     removeEventListener: (type: string, listener: WireEventTargetListener) => void;

--- a/packages/@lwc/wire-service/src/value-changed-event.ts
+++ b/packages/@lwc/wire-service/src/value-changed-event.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -11,6 +11,7 @@ const ValueChangedEventType = 'ValueChangedEvent';
  * Event fired by wire adapters to emit a new value.
  */
 export class ValueChangedEvent {
+    /** The new value. */
     value: any;
     type: string;
     constructor(value: any) {

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -19,11 +19,10 @@ const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
     expect(contents).toMatch(exportDefaultFromPackage);
 };
 
-/**
+/*
  * Jest uses CommonJS, which means that packages with no explicit export statements actually export
  * the default `module.exports` empty object. That export is an empty object with the prototype set
  * to an empty object with null prototype.
- * @param mod
  */
 const hasExplicitDefaultExport = (mod: object) => {
     // No default export = self explanatory

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -209,6 +209,12 @@ declare module 'lwc' {
      * is the returned value.
      * @param adapter the adapter used to provision data
      * @param config configuration object for the adapter
+     * @returns A decorator function
+     * @example
+     * export default class WireExample extends LightningElement {
+     *   \@api bookId;
+     *   \@wire(getBook, { id: '$bookId'}) book;
+     * }
      */
     export function wire<
         Config extends StringKeyedRecord,


### PR DESCRIPTION
## Details
Like it says on the tin.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-13278716
