### PR TITLE
fix(template-compiler): avoid discarding text content whitespace for complex expressions

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/ast.json
@@ -207,6 +207,22 @@
                                     "start": 67,
                                     "end": 79
                                 }
+                            },
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 4,
+                                    "startColumn": 26,
+                                    "endLine": 4,
+                                    "endColumn": 27,
+                                    "start": 79,
+                                    "end": 80
+                                }
                             }
                         ]
                     },
@@ -243,6 +259,22 @@
                         "directives": [],
                         "listeners": [],
                         "children": [
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 5,
+                                    "startColumn": 14,
+                                    "endLine": 5,
+                                    "endColumn": 15,
+                                    "start": 100,
+                                    "end": 101
+                                }
+                            },
                             {
                                 "type": "Text",
                                 "raw": "{spaceLeft}",
@@ -433,6 +465,22 @@
                         "directives": [],
                         "listeners": [],
                         "children": [
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 7,
+                                    "startColumn": 14,
+                                    "endLine": 7,
+                                    "endColumn": 15,
+                                    "start": 162,
+                                    "end": 163
+                                }
+                            },
                             {
                                 "type": "Text",
                                 "raw": "{one}",
@@ -627,6 +675,22 @@
                                     "start": 198,
                                     "end": 203
                                 }
+                            },
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 8,
+                                    "startColumn": 24,
+                                    "endLine": 8,
+                                    "endColumn": 25,
+                                    "start": 203,
+                                    "end": 204
+                                }
                             }
                         ]
                     },
@@ -701,6 +765,22 @@
                                     "endColumn": 19,
                                     "start": 224,
                                     "end": 229
+                                }
+                            },
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 9,
+                                    "startColumn": 19,
+                                    "endLine": 9,
+                                    "endColumn": 20,
+                                    "start": 229,
+                                    "end": 230
                                 }
                             },
                             {
@@ -780,6 +860,22 @@
                         "children": [
                             {
                                 "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 10,
+                                    "startColumn": 14,
+                                    "endLine": 10,
+                                    "endColumn": 15,
+                                    "start": 255,
+                                    "end": 256
+                                }
+                            },
+                            {
+                                "type": "Text",
                                 "raw": "{one}",
                                 "value": {
                                     "type": "Identifier",
@@ -816,6 +912,22 @@
                                     "endColumn": 20,
                                     "start": 256,
                                     "end": 261
+                                }
+                            },
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 10,
+                                    "startColumn": 20,
+                                    "endLine": 10,
+                                    "endColumn": 21,
+                                    "start": 261,
+                                    "end": 262
                                 }
                             },
                             {
@@ -935,6 +1047,22 @@
                             },
                             {
                                 "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 11,
+                                    "startColumn": 19,
+                                    "endLine": 11,
+                                    "endColumn": 20,
+                                    "start": 292,
+                                    "end": 293
+                                }
+                            },
+                            {
+                                "type": "Text",
                                 "raw": "{two}",
                                 "value": {
                                     "type": "Identifier",
@@ -971,6 +1099,22 @@
                                     "endColumn": 25,
                                     "start": 293,
                                     "end": 298
+                                }
+                            },
+                            {
+                                "type": "Text",
+                                "raw": " ",
+                                "value": {
+                                    "type": "Literal",
+                                    "value": " "
+                                },
+                                "location": {
+                                    "startLine": 11,
+                                    "startColumn": 25,
+                                    "endLine": 11,
+                                    "endColumn": 26,
+                                    "start": 298,
+                                    "end": 299
                                 }
                             }
                         ]

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/expected.js
@@ -34,25 +34,33 @@ function tmpl($api, $cmp, $slotset, $ctx) {
   return [
     api_element("section", stc0, [
       api_element("div", stc1, [api_text(api_dynamic_text($cmp.noSpace))]),
-      api_element("div", stc2, [api_text(api_dynamic_text($cmp.spaceRight))]),
-      api_element("div", stc3, [api_text(api_dynamic_text($cmp.spaceLeft))]),
+      api_element("div", stc2, [
+        api_text(api_dynamic_text($cmp.spaceRight) + " "),
+      ]),
+      api_element("div", stc3, [
+        api_text(" " + api_dynamic_text($cmp.spaceLeft)),
+      ]),
       api_element("div", stc4, [
         api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
       ]),
       api_element("div", stc5, [
-        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
+        api_text(" " + api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
       ]),
       api_element("div", stc6, [
-        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
+        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two) + " "),
       ]),
       api_element("div", stc7, [
-        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
+        api_text(api_dynamic_text($cmp.one) + " " + api_dynamic_text($cmp.two)),
       ]),
       api_element("div", stc8, [
-        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
+        api_text(
+          " " + api_dynamic_text($cmp.one) + " " + api_dynamic_text($cmp.two)
+        ),
       ]),
       api_element("div", stc9, [
-        api_text(api_dynamic_text($cmp.one) + api_dynamic_text($cmp.two)),
+        api_text(
+          api_dynamic_text($cmp.one) + " " + api_dynamic_text($cmp.two) + " "
+        ),
       ]),
     ]),
   ];

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -467,7 +467,23 @@ function parseText(ctx: ParserCtx, parse5Text: parse5Tools.TextNode): Text[] {
     // Extract the raw source to avoid HTML entity decoding done by parse5
     const rawText = cleanTextNode(ctx.getSource(location.startOffset, location.endOffset));
 
-    if (!rawText.trim().length) {
+    /*
+    The original job of this if-block was to discard the whitespace between HTML tags, HTML
+    comments, and HTML tags and HTML comments. The whitespace inside the text content of HTML tags
+    would never be considered here because they would not be parsed into individual text nodes until
+    later (several lines below).
+
+    ["Hello {first} {last}!"] => ["Hello ", "{first}", " ", "{last}", "!"]
+
+    With the implementation of complex template expressions, whitespace that shouldn't be discarded
+    has already been parsed into individual text nodes at this point so we only discard when
+    experimentalComplexExpressions is disabled.
+
+    When removing the experimentalComplexExpressions flag, we need to figure out how to best discard
+    the HTML whitespace while preserving text content whitespace, while also taking into account how
+    comments are sometimes preserved (in which case we need to keep the HTML whitespace).
+    */
+    if (!rawText.trim().length && !ctx.config.experimentalComplexExpressions) {
         return parsedTextNodes;
     }
 


### PR DESCRIPTION
## Details

The logic used to discard unnecessary HTML whitespace was being applied to text content whitespace due to a change in the timing that the text content whitespace is being parsed. Detailed comment added for posterity when we need to integrate the complex expression changes.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

[W-14631165](https://gus.lightning.force.com/a07EE00001g6aQOYAY)