### PR TITLE
test: enable test for native shadow

### DIFF
--- a/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -30,18 +30,14 @@ describe('post-dispatch event state', () => {
             expect(event.target).toBe(nodes['x-container']);
         });
 
-        // WebKit bug - https://bugs.webkit.org/show_bug.cgi?id=206374
-        // In Safari, the event target is not null.
-        if (!process.env.NATIVE_SHADOW) {
-            it('{ bubbles: true, composed: false }', () => {
-                const nodes = createComponent();
-                const event = new CustomEvent('test', { bubbles: true, composed: false });
-                nodes.container_div.dispatchEvent(event);
+        it('{ bubbles: true, composed: false }', () => {
+            const nodes = createComponent();
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            nodes.container_div.dispatchEvent(event);
 
-                assertEventStateReset(event);
-                expect(event.target).toBe(null);
-            });
-        }
+            assertEventStateReset(event);
+            expect(event.target).toBe(null);
+        });
     });
 
     describe('lwc:dom="manual" element', () => {
@@ -57,21 +53,17 @@ describe('post-dispatch event state', () => {
             });
         });
 
-        // WebKit bug - https://bugs.webkit.org/show_bug.cgi?id=206374
-        // In Safari, the event target is not null.
-        if (!process.env.NATIVE_SHADOW) {
-            it('{ bubbles: true, composed: false }', () => {
-                const nodes = createComponent();
-                const event = new CustomEvent('test', { bubbles: true, composed: false });
-                nodes.container_span_manual.dispatchEvent(event);
+        it('{ bubbles: true, composed: false }', () => {
+            const nodes = createComponent();
+            const event = new CustomEvent('test', { bubbles: true, composed: false });
+            nodes.container_span_manual.dispatchEvent(event);
 
-                // lwc:dom=manual is async due to MutationObserver
-                return new Promise(setTimeout).then(() => {
-                    assertEventStateReset(event);
-                    expect(event.target).toBe(null);
-                });
+            // lwc:dom=manual is async due to MutationObserver
+            return new Promise(setTimeout).then(() => {
+                assertEventStateReset(event);
+                expect(event.target).toBe(null);
             });
-        }
+        });
     });
 
     describe('component', () => {


### PR DESCRIPTION
## Details

Safari fixed their bug a while back so these tests should pass for native shadow now:
https://bugs.webkit.org/show_bug.cgi?id=206374

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.
