### PR TITLE
test: add test for wired properties from consts

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties-const-from-obj/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties-const-from-obj/actual.js
@@ -1,0 +1,21 @@
+import { wire, LightningElement } from "lwc";
+import { getFoo } from "data-service";
+import * as importee from 'some/importee'
+
+const obj = { baz: 'baz', quux: 'quux' }
+
+const { foo } = importee;
+const bar = importee.bar;
+const { baz } = obj
+const quux = obj.quux
+
+// TODO [#3956]: Investigate whether we really want to support this
+export default class Test extends LightningElement {
+  @wire(getFoo, {
+    [foo]: '$foo',
+    [bar]: '$bar',
+    [baz]: '$baz',
+    [quux]: '$quux'
+  })
+  wiredIdentifier;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties-const-from-obj/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties-const-from-obj/expected.js
@@ -1,0 +1,43 @@
+import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
+import _tmpl from "./test.html";
+import { getFoo } from "data-service";
+import * as importee from 'some/importee';
+const obj = {
+  baz: 'baz',
+  quux: 'quux'
+};
+const {
+  foo
+} = importee;
+const bar = importee.bar;
+const {
+  baz
+} = obj;
+const quux = obj.quux;
+
+// TODO [#3956]: Investigate whether we really want to support this
+class Test extends LightningElement {
+  wiredIdentifier;
+  /*LWC compiler vX.X.X*/
+}
+_registerDecorators(Test, {
+  wire: {
+    wiredIdentifier: {
+      adapter: getFoo,
+      dynamic: [foo, bar, baz, quux],
+      config: function ($cmp) {
+        return {
+          [foo]: $cmp.foo,
+          [bar]: $cmp.bar,
+          [baz]: $cmp.baz,
+          [quux]: $cmp.quux
+        };
+      }
+    }
+  }
+});
+export default _registerComponent(Test, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  apiVersion: 9999999
+});


### PR DESCRIPTION
## Details

This adds a test to confirm that you can do the following:

```js
import * as importee from 'some/importee'
const obj = { baz: 'baz', quux: 'quux' }

const { foo } = importee;
const bar = importee.bar;
const { baz } = obj
const quux = obj.quux

export default class Test extends LightningElement {
  @wire(getFoo, {
    [foo]: '$foo',
    [bar]: '$bar',
    [baz]: '$baz',
    [quux]: '$quux'
  })
  yolo
```

In #3956 we are questioning how much we want to lock this down, and if maybe the current behavior is too permissive, but this test at least documents the existing behavior.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
