### PR TITLE
feat: support generating inlined sourcemaps when transforming js file…

### DIFF
--- a/packages/@lwc/compiler/README.md
+++ b/packages/@lwc/compiler/README.md
@@ -46,7 +46,7 @@ const { code } = transformSync(source, filename, options);
     -   `experimentalDynamicDirective` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable deprecated dynamic components.
     -   `enableDynamicComponents` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable dynamic components.
     -   `outputConfig` (type: `object`, optional) - see below:
-        -   `sourcemap` (type: `boolean`, optional) - if `true`, a sourcemap is generated for the transformed file.
+        -   `sourcemap` (type: `boolean` | `'inline'`, optional) - if `true`, a sourcemap is generated for the transformed file. If `'inline'`, an inline sourcemap is generated and appended to the transformed file.
         -   `minify` (type: `boolean`, optional, deprecated) - this option has no effect.
     -   `experimentalComplexExpressions` (type: `boolean`, optional) - set to true to enable use of (a subset of) JavaScript expressions in place of template bindings. Passed to `@lwc/template-compiler`.
     -   `isExplicitImport` (type: `boolean`, optional) - true if this is an explicit import, passed to `@lwc/babel-plugin-component`.

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -64,9 +64,10 @@ export interface StylesheetConfig {
 export interface OutputConfig {
     /**
      * If `true` a source map is generated for the transformed file.
+     * If `inline`, an inline source map is generated and appended to the end of the transformed file.
      * @default false
      */
-    sourcemap?: boolean;
+    sourcemap?: boolean | 'inline';
 
     /**
      * @deprecated The minify property has no effect on the generated output.
@@ -202,7 +203,7 @@ function isUndefinedOrBoolean(property: any): boolean {
 
 function validateOutputConfig(config: OutputConfig) {
     invariant(
-        isUndefinedOrBoolean(config.sourcemap),
+        isUndefinedOrBoolean(config.sourcemap) || config.sourcemap === 'inline',
         CompilerValidationErrors.INVALID_SOURCEMAP_PROPERTY,
         [config.sourcemap]
     );

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -227,6 +227,21 @@ describe('sourcemaps', () => {
         expect(map).toBeNull();
     });
 
+    it("should generate sourcemaps when the sourcemap configuration value is 'true'", () => {
+        const source = `
+            import { LightningElement } from 'lwc';
+            export default class Foo extends LightningElement {}
+        `;
+
+        const { map } = transformSync(source, 'foo.js', {
+            ...TRANSFORMATION_OPTIONS,
+            outputConfig: {
+                sourcemap: true,
+            },
+        });
+        expect(map).not.toBeNull();
+    });
+
     describe("should fail validation of options if sourcemap configuration value is neither boolean nor 'inline'.", () => {
         const source = `
             import { LightningElement } from 'lwc';

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -227,22 +227,30 @@ describe('sourcemaps', () => {
         expect(map).toBeNull();
     });
 
-    it("should fail to validate options if sourcemap is a string other than 'inline'.", () => {
+    describe("should fail validation of options if sourcemap configuration value is neither boolean nor 'inline'.", () => {
         const source = `
             import { LightningElement } from 'lwc';
             export default class Foo extends LightningElement {}
         `;
 
-        expect(() =>
-            transformSync(source, 'foo.js', {
-                ...TRANSFORMATION_OPTIONS,
-                outputConfig: {
-                    // @ts-expect-error Property can be passed from JS environments with no type checking.
-                    sourcemap: 'invalid',
-                },
-            })
-        ).toThrow(
-            'LWC1021: Expected a boolean value or \'inline\' for outputConfig.sourcemap, received "invalid".'
-        );
+        [
+            { name: 'invalid string', sourcemap: 'invalid' },
+            { name: 'object', sourcemap: {} },
+            { name: 'numbers', sourcemap: 123 },
+        ].forEach(({ name, sourcemap }) => {
+            it(name, () => {
+                expect(() =>
+                    transformSync(source, 'foo.js', {
+                        ...TRANSFORMATION_OPTIONS,
+                        outputConfig: {
+                            // @ts-expect-error Property can be passed from JS environments with no type checking.
+                            sourcemap,
+                        },
+                    })
+                ).toThrow(
+                    `LWC1021: Expected a boolean value or 'inline' for outputConfig.sourcemap, received "${sourcemap}".`
+                );
+            });
+        });
     });
 });

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -209,3 +209,40 @@ describe('unnecessary registerDecorators', () => {
         expect(code).toContain('registerDecorators');
     });
 });
+
+describe('sourcemaps', () => {
+    it("should generate inline sourcemaps when the output config includes the 'inline' option for sourcemaps", () => {
+        const source = `
+            import { LightningElement } from 'lwc';
+            export default class Foo extends LightningElement {}
+        `;
+
+        const { code, map } = transformSync(source, 'foo.js', {
+            ...TRANSFORMATION_OPTIONS,
+            outputConfig: {
+                sourcemap: 'inline',
+            },
+        });
+        expect(code).toContain('//# sourceMappingURL=data:application/json;');
+        expect(map).toBeNull();
+    });
+
+    it("should fail to validate options if sourcemap is a string other than 'inline'.", () => {
+        const source = `
+            import { LightningElement } from 'lwc';
+            export default class Foo extends LightningElement {}
+        `;
+
+        expect(() =>
+            transformSync(source, 'foo.js', {
+                ...TRANSFORMATION_OPTIONS,
+                outputConfig: {
+                    // @ts-expect-error Property can be passed from JS environments with no type checking.
+                    sourcemap: 'invalid',
+                },
+            })
+        ).toThrow(
+            'LWC1021: Expected a boolean value or \'inline\' for outputConfig.sourcemap, received "invalid".'
+        );
+    });
+});

--- a/packages/@lwc/errors/src/compiler/error-info/compiler.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/compiler.ts
@@ -62,7 +62,8 @@ export const CompilerValidationErrors = {
 
     INVALID_SOURCEMAP_PROPERTY: {
         code: 1021,
-        message: 'Expected a boolean value for outputConfig.sourcemap, received "{0}".',
+        message:
+            'Expected a boolean value or \'inline\' for outputConfig.sourcemap, received "{0}".',
         level: DiagnosticLevel.Error,
         url: '',
     },

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -22,8 +22,8 @@ export interface RollupLwcOptions {
     exclude?: FilterPattern;
     /** The LWC root module directory. */
     rootDir?: string;
-    /** If `true` the plugin will produce source maps. */
-    sourcemap?: boolean;
+    /** If `true` the plugin will produce source maps. If `'inline'`, the plugin will produce inlined source maps and append them to the end of the generated file. */
+    sourcemap?: boolean | 'inline';
     /** The [module resolution](https://lwc.dev/guide/es_modules#module-resolution) overrides passed to the `@lwc/module-resolver`. */
     modules?: ModuleRecord[];
     /** The stylesheet compiler configuration to pass to the `@lwc/style-compiler` */


### PR DESCRIPTION
…s in the LWC compiler

## Details
Supports passing the string 'inline' for the compiler's outputConfig's `sourcemap` property. This in turn is passed down to the Babel compiler and delegates sourcemap generation to Babel.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
This is a new API surface for developers with direct access to configure the LWC compiler. Additional work is needed to expose this property through existing compilation pipelines where the end developer might not have access to configure the compiler.

## GUS work item
<!-- Work ID in text, if applicable. -->
