### PR TITLE
refactor: organize API versioning tests

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -315,8 +315,6 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         return error;
     }
 
-    var nativeCustomElementLifecycleEnabled = process.env.API_VERSION >= 61;
-
     // For errors we expect to be thrown in the connectedCallback() phase
     // of a custom element, there are two possibilities:
     // 1) We're using non-native lifecycle callbacks, so the error is thrown synchronously
@@ -324,7 +322,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     //    only be caught with window.addEventListener('error')
     //      - Note native lifecycle callbacks are all thrown asynchronously.
     function customElementCallbackReactionErrorListener(callback) {
-        return nativeCustomElementLifecycleEnabled
+        return apiFeatures.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
             ? windowErrorListener(callback)
             : directErrorListener(callback);
     }
@@ -548,12 +546,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     ];
 
     const ariaProperties = Object.keys(ariaPropertiesMapping);
-
-    // Can't use Object.values because we need to support IE11
-    const ariaAttributes = [];
-    for (let i = 0; i < ariaProperties.length; i++) {
-        ariaAttributes.push(ariaPropertiesMapping[ariaProperties[i]]);
-    }
+    const ariaAttributes = Object.values(ariaPropertiesMapping);
 
     // Keep traversing up the prototype chain until a property descriptor is found
     function getPropertyDescriptor(object, prop) {
@@ -567,32 +560,37 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     }
 
     // These values are based on the API versions in @lwc/shared/api-version
-    const lightDomSlotForwardingEnabled = process.env.API_VERSION > 60;
-    const vFragBookEndEnabled = process.env.API_VERSION > 59;
+    const apiFeatures = {
+        LOWERCASE_SCOPE_TOKENS: process.env.API_VERSION >= 59,
+        USE_COMMENTS_FOR_FRAGMENT_BOOKENDS: process.env.API_VERSION >= 60,
+        USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS: process.env.API_VERSION >= 60,
+        DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION: process.env.API_VERSION >= 60,
+        ENABLE_ELEMENT_INTERNALS: process.env.API_VERSION >= 61,
+        ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: process.env.API_VERSION >= 61,
+        USE_LIGHT_DOM_SLOT_FORWARDING: process.env.API_VERSION >= 61,
+    };
 
     return {
-        clearRegister: clearRegister,
-        extractDataIds: extractDataIds,
-        extractShadowDataIds: extractShadowDataIds,
-        getHostChildNodes: getHostChildNodes,
-        isNativeShadowRootInstance: isNativeShadowRootInstance,
-        isSyntheticShadowRootInstance: isSyntheticShadowRootInstance,
-        load: load,
-        registerForLoad: registerForLoad,
-        getHooks: getHooks,
-        setHooks: setHooks,
-        spyConsole: spyConsole,
-        customElementCallbackReactionErrorListener: customElementCallbackReactionErrorListener,
-        ariaPropertiesMapping: ariaPropertiesMapping,
-        ariaProperties: ariaProperties,
-        ariaAttributes: ariaAttributes,
-        nonStandardAriaProperties: nonStandardAriaProperties,
-        nonPolyfilledAriaProperties: nonPolyfilledAriaProperties,
-        getPropertyDescriptor: getPropertyDescriptor,
-        attachReportingControlDispatcher: attachReportingControlDispatcher,
-        detachReportingControlDispatcher: detachReportingControlDispatcher,
-        nativeCustomElementLifecycleEnabled: nativeCustomElementLifecycleEnabled,
-        lightDomSlotForwardingEnabled: lightDomSlotForwardingEnabled,
-        vFragBookEndEnabled: vFragBookEndEnabled,
+        clearRegister,
+        extractDataIds,
+        extractShadowDataIds,
+        getHostChildNodes,
+        isNativeShadowRootInstance,
+        isSyntheticShadowRootInstance,
+        load,
+        registerForLoad,
+        getHooks,
+        setHooks,
+        spyConsole,
+        customElementCallbackReactionErrorListener,
+        ariaPropertiesMapping,
+        ariaProperties,
+        ariaAttributes,
+        nonStandardAriaProperties,
+        nonPolyfilledAriaProperties,
+        getPropertyDescriptor,
+        attachReportingControlDispatcher,
+        detachReportingControlDispatcher,
+        ...apiFeatures,
     };
 })(LWC, jasmine, beforeAll);

--- a/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/CustomElementConstructor-getter/index.spec.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
-import { vFragBookEndEnabled } from 'test-utils';
+import { USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 
 import ReflectElement from 'x/reflect';
 import LifecycleParent from 'x/lifecycleParent';
@@ -11,7 +11,7 @@ import ReflectCamel from 'x/reflectCamel';
 import WithChildElmsHasSlot from 'x/withChildElmsHasSlot';
 import WithChildElmsHasSlotLight from 'x/withChildElmsHasSlotLight';
 
-const vFragBookend = vFragBookEndEnabled ? '<!---->' : '';
+const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 it('should throw when trying to claim abstract LightningElement as custom element', () => {
     expect(() => LightningElement.CustomElementConstructor).toThrowError(

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { customElementCallbackReactionErrorListener } from 'test-utils';
+import { customElementCallbackReactionErrorListener, ENABLE_ELEMENT_INTERNALS } from 'test-utils';
 
 import ShadowDomCmp from 'ai/shadowDom';
 import LightDomCmp from 'ai/lightDom';
@@ -54,7 +54,7 @@ const attachInternalsSanityTest = (tagName, ctor) => {
     });
 };
 
-if (process.env.API_VERSION >= 61) {
+if (ENABLE_ELEMENT_INTERNALS) {
     if (typeof ElementInternals !== 'undefined') {
         // ElementInternals API is supported in the browser
         if (process.env.NATIVE_SHADOW) {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -1,11 +1,12 @@
 import { createElement } from 'lwc';
+import { ENABLE_ELEMENT_INTERNALS } from 'test-utils';
 
 import NotFormAssociated from 'x/notFormAssociated';
 import FormAssociated from 'x/formAssociated';
 import FormAssociatedFalse from 'x/formAssociatedFalse';
 
 if (
-    process.env.API_VERSION >= 61 &&
+    ENABLE_ELEMENT_INTERNALS &&
     typeof ElementInternals !== 'undefined' &&
     !process.env.SYNTHETIC_SHADOW_ENABLED
 ) {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -1,10 +1,10 @@
 import { createElement } from 'lwc';
-import { ariaProperties, ariaAttributes } from 'test-utils';
+import { ariaProperties, ariaAttributes, ENABLE_ELEMENT_INTERNALS } from 'test-utils';
 
 import ElementInternal from 'ei/component';
 
 if (
-    process.env.API_VERSION >= 61 &&
+    ENABLE_ELEMENT_INTERNALS &&
     process.env.NATIVE_SHADOW &&
     typeof ElementInternals !== 'undefined'
 ) {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import XBoundaryChildConstructorThrow from 'x/boundaryChildConstructorThrow';
 import XBoundaryChildConnectedThrow from 'x/boundaryChildConnectedThrow';
@@ -372,7 +372,7 @@ describe('errorCallback throws after value mutation', () => {
         'when child throws in connectedCallback',
         'x-parent-throws-on-mutate-child-connected-throws',
         XParentThrowsOnMutateChildConnectedThrows,
-        nativeCustomElementLifecycleEnabled
+        ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
     );
     testStub(
         'when child throws in constructor',
@@ -390,6 +390,6 @@ describe('errorCallback throws after value mutation', () => {
         'when child throws in renderedCallback',
         'x-parent-throws-on-mutate-child-rendered-throws',
         XParentThrowsOnMutateChildRenderedThrows,
-        nativeCustomElementLifecycleEnabled
+        ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
     );
 });

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE, ENABLE_ELEMENT_INTERNALS } from 'test-utils';
 
 import Container from 'face/container';
 import FormAssociated from 'face/formAssociated';
@@ -52,7 +52,7 @@ const faceSanityTest = (tagName, ctor) => {
             const container = document.body.querySelector('face-container');
             container.shadowRoot.appendChild(form2);
 
-            if (process.env.API_VERSION >= 61) {
+            if (ENABLE_ELEMENT_INTERNALS) {
                 expect(face.internals.form.className).toEqual('form1');
                 expect(face2.internals.form.className).toEqual('form2');
             }
@@ -105,7 +105,7 @@ const testFaceLifecycleMethodsNotCallable = (face) => {
 };
 
 if (typeof ElementInternals !== 'undefined') {
-    if (nativeCustomElementLifecycleEnabled) {
+    if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         // native lifecycle enabled
         describe('native lifecycle', () => {
             if (process.env.NATIVE_SHADOW) {

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import Single from 'x/single';
 import Parent from 'x/parent';
@@ -167,7 +167,7 @@ describe('invocation order', () => {
 
                 let expected;
                 if (testName === 'shadow' && process.env.NATIVE_SHADOW) {
-                    if (nativeCustomElementLifecycleEnabled) {
+                    if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
                         expected = [
                             'foo-a:connectedCallback',
                             'foo-internal-a:connectedCallback',

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -2,13 +2,13 @@ import { createElement } from 'lwc';
 import {
     attachReportingControlDispatcher,
     detachReportingControlDispatcher,
-    nativeCustomElementLifecycleEnabled,
+    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
 } from 'test-utils';
 
 import Component from 'x/component';
 import Parent from 'x/parent';
 
-if (!nativeCustomElementLifecycleEnabled) {
+if (!ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
     describe('ConnectedCallbackWhileDisconnected reporting', () => {
         let logger;
         let dispatcher;

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/if-block/index.spec.js
@@ -1,9 +1,9 @@
 import { createElement } from 'lwc';
-import { vFragBookEndEnabled } from 'test-utils';
+import { USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 
 import MixedSlotParent from 'x/mixedSlotParent';
 
-const vFragBookend = vFragBookEndEnabled ? '<!---->' : '';
+const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 describe('if-block', () => {
     it('should work when parent and child have matching slot types', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { lightDomSlotForwardingEnabled, vFragBookEndEnabled } from 'test-utils';
+import { USE_LIGHT_DOM_SLOT_FORWARDING, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 
 import BasicParent from 'x/basicParent';
 import ParentOfChildWithForEach from 'x/parentOfChildWithForEach';
@@ -7,7 +7,7 @@ import ParentWNoSlotContent from 'x/parentWNoSlotContent';
 import ParentOfChildWithNamedSlots from 'x/parentOfChildWithNamedSlots';
 import NestedSlots from 'x/nestedSlots';
 
-const vFragBookend = vFragBookEndEnabled ? '<!---->' : '';
+const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 describe('scoped slots', () => {
     it('scoped slots work with default slots', () => {
@@ -62,7 +62,7 @@ describe('scoped slots', () => {
         // For standard slot content, "slot" attribute goes directly on the element unlike scoped
         //  slots where the attribute goes on the template tag
         expect(child.querySelector('.slotname3').innerHTML).toBe(
-            lightDomSlotForwardingEnabled
+            USE_LIGHT_DOM_SLOT_FORWARDING
                 ? `${vFragBookend}<p>MLB</p>${vFragBookend}`
                 : `${vFragBookend}<p slot="slotname3">MLB</p>${vFragBookend}`
         );

--- a/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/scoped-slot/runtime-checks/index.spec.js
@@ -1,10 +1,10 @@
 import { createElement } from 'lwc';
-import { vFragBookEndEnabled } from 'test-utils';
+import { USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 
 import ParentWithScopedSlotContent from 'x/parentWithScopedSlotContent';
 import ParentWithStandardSlotContent from 'x/parentWithStandardSlotContent';
 
-const vFragBookend = vFragBookEndEnabled ? '<!---->' : '';
+const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 describe('runtime validation of slot content and slot', () => {
     it('Ignores content when parent uses scoped slot and child has standard slot', () => {

--- a/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/forwarding/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/forwarding/index.spec.js
@@ -1,5 +1,9 @@
 import { createElement } from 'lwc';
-import { extractDataIds, lightDomSlotForwardingEnabled, vFragBookEndEnabled } from 'test-utils';
+import {
+    extractDataIds,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+} from 'test-utils';
 
 import LightContainer from './x/lightContainer/lightContainer';
 
@@ -39,7 +43,7 @@ const slotAssignmentWithoutForwarding = {
     },
 };
 
-const expectedSlotAssignment = lightDomSlotForwardingEnabled
+const expectedSlotAssignment = USE_LIGHT_DOM_SLOT_FORWARDING
     ? slotAssignmentWithForwarding
     : slotAssignmentWithoutForwarding;
 
@@ -84,14 +88,14 @@ describe('slot forwarding', () => {
         expect(remappedDefaultSlotContent[0].innerText).toEqual(expectedDefaultSlot.innerText);
 
         // These are to cover API versions 60, 59 and below
-        const defaultSlotTextIndex = lightDomSlotForwardingEnabled
+        const defaultSlotTextIndex = USE_LIGHT_DOM_SLOT_FORWARDING
             ? 12
-            : vFragBookEndEnabled
+            : USE_COMMENTS_FOR_FRAGMENT_BOOKENDS
             ? 11
             : 4;
-        const defaultSlotCommentIndex = lightDomSlotForwardingEnabled
+        const defaultSlotCommentIndex = USE_LIGHT_DOM_SLOT_FORWARDING
             ? 13
-            : vFragBookEndEnabled
+            : USE_COMMENTS_FOR_FRAGMENT_BOOKENDS
             ? 12
             : 5;
 
@@ -128,7 +132,7 @@ describe('slot forwarding', () => {
             expect(defaultSlotContent[1]).toEqual(commentNode);
         }
 
-        if (lightDomSlotForwardingEnabled) {
+        if (USE_LIGHT_DOM_SLOT_FORWARDING) {
             // With slot forwarding
             const reassginedDefaultSlot = slots['default-slot-reassigned'].assignedNodes();
             // Verify static vnode `slot` attribute is reassigned
@@ -155,7 +159,7 @@ describe('slot forwarding', () => {
         // slot attribute to be remapped to the slot attribute on the light DOM slot.
         // Verify the slot attribute was correctly updated.
         // Api versions < 61 slot forwarding is not enabled, so the slot attribute is untouched
-        expect(upperSlot.hasAttribute('slot')).toBe(!lightDomSlotForwardingEnabled);
+        expect(upperSlot.hasAttribute('slot')).toBe(!USE_LIGHT_DOM_SLOT_FORWARDING);
 
         const upperSlotContent = upperSlot.assignedNodes();
         // Note that because the shadow slot is passed, the slot element is what's updated.
@@ -166,7 +170,7 @@ describe('slot forwarding', () => {
         expect(upperSlotContent[1].innerText).toEqual(expectedUpperSlot.content);
 
         const lowerSlot = slots['lower-slot'];
-        expect(lowerSlot.hasAttribute('slot')).toBe(!lightDomSlotForwardingEnabled);
+        expect(lowerSlot.hasAttribute('slot')).toBe(!USE_LIGHT_DOM_SLOT_FORWARDING);
 
         const lowerSlotContent = lowerSlot.assignedNodes();
         expect(lowerSlotContent[0].getAttribute('slot')).toBe('upper');
@@ -175,7 +179,7 @@ describe('slot forwarding', () => {
         expect(lowerSlotContent[1].innerText).toEqual(expectedLowerSlot.content);
 
         const defaultSlot = slots['default-slot'];
-        expect(defaultSlot.hasAttribute('slot')).toBe(!lightDomSlotForwardingEnabled);
+        expect(defaultSlot.hasAttribute('slot')).toBe(!USE_LIGHT_DOM_SLOT_FORWARDING);
 
         // Note since the content forwarded to the default shadow slot are wrapped in an actual slot element,
         // all content inside of it is forwarded together.

--- a/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/reactivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/reactivity/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { extractDataIds, lightDomSlotForwardingEnabled } from 'test-utils';
+import { extractDataIds, USE_LIGHT_DOM_SLOT_FORWARDING } from 'test-utils';
 
 import LightContainer from './x/lightContainer/lightContainer';
 
@@ -42,7 +42,7 @@ describe('light DOM slot forwarding reactivity', () => {
         },
         {
             slotAssignment:
-                shadowMode.includes('shadow') || lightDomSlotForwardingEnabled ? '' : null,
+                shadowMode.includes('shadow') || USE_LIGHT_DOM_SLOT_FORWARDING ? '' : null,
             slotContent: 'Default slot content',
         },
     ];
@@ -58,7 +58,7 @@ describe('light DOM slot forwarding reactivity', () => {
         },
         {
             slotAssignment:
-                shadowMode.includes('shadow') || lightDomSlotForwardingEnabled ? '' : null,
+                shadowMode.includes('shadow') || USE_LIGHT_DOM_SLOT_FORWARDING ? '' : null,
             slotContent: 'Default slot content',
         },
     ];
@@ -82,21 +82,21 @@ describe('light DOM slot forwarding reactivity', () => {
         {
             slotAssignment: 'lower',
             slotContent:
-                shadowMode.includes('shadow') && !lightDomSlotForwardingEnabled
+                shadowMode.includes('shadow') && !USE_LIGHT_DOM_SLOT_FORWARDING
                     ? 'Lower slot content'
                     : 'Upper slot content',
         },
         {
             slotAssignment: '',
             slotContent:
-                shadowMode.includes('shadow') && !lightDomSlotForwardingEnabled
+                shadowMode.includes('shadow') && !USE_LIGHT_DOM_SLOT_FORWARDING
                     ? 'Upper slot content'
                     : 'Default slot content',
         },
         {
             slotAssignment: 'upper',
             slotContent:
-                shadowMode.includes('shadow') && !lightDomSlotForwardingEnabled
+                shadowMode.includes('shadow') && !USE_LIGHT_DOM_SLOT_FORWARDING
                     ? 'Default slot content'
                     : 'Lower slot content',
         },
@@ -126,13 +126,13 @@ describe('light DOM slot forwarding reactivity', () => {
             testName: 'lightLight',
             expectedDefaultSlotContent: expectedDefaultSlotContent('light'),
             expectedSlotContentAfterParentMutation: expectedSlotContentAfterParentMutation('light'),
-            expectedSlotContentAfterForwardedSlotMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterForwardedSlotMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterForwardedSlotMutation
                 : expectedSlotContentAfterParentMutation('light'),
-            expectedSlotContentAfterLeafMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterLeafMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterLeafMutation('light')
                 : expectedSlotContentAfterParentMutation('light'),
-            expectedSlotContentAfterConditionalMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterConditionalMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterConditionalMutation
                 : [
                       {
@@ -158,11 +158,11 @@ describe('light DOM slot forwarding reactivity', () => {
             expectedDefaultSlotContent: expectedDefaultSlotContent('shadow'),
             expectedSlotContentAfterParentMutation:
                 expectedSlotContentAfterParentMutation('shadow'),
-            expectedSlotContentAfterForwardedSlotMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterForwardedSlotMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterForwardedSlotMutation
                 : expectedSlotContentAfterParentMutation('shadow'),
             expectedSlotContentAfterLeafMutation: expectedSlotContentAfterLeafMutation('shadow'),
-            expectedSlotContentAfterConditionalMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterConditionalMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterConditionalMutation
                 : [
                       {
@@ -193,10 +193,10 @@ describe('light DOM slot forwarding reactivity', () => {
             expectedSlotContentAfterParentMutation:
                 expectedSlotContentAfterParentMutation('shadow'),
             expectedSlotContentAfterForwardedSlotMutation,
-            expectedSlotContentAfterLeafMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterLeafMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterLeafMutation('shadow')
                 : expectedSlotContentAfterForwardedSlotMutation,
-            expectedSlotContentAfterConditionalMutation: lightDomSlotForwardingEnabled
+            expectedSlotContentAfterConditionalMutation: USE_LIGHT_DOM_SLOT_FORWARDING
                 ? expectedSlotContentAfterConditionalMutation
                 : [
                       {

--- a/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slotting/index.spec.js
@@ -1,7 +1,11 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
 import { extractDataIds } from 'test-utils';
 
-import { vFragBookEndEnabled, lightDomSlotForwardingEnabled } from 'test-utils';
+import {
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS,
+} from 'test-utils';
 
 import BasicSlot from 'x/basicSlot';
 import DynamicChildren from 'x/dynamicChildren';
@@ -11,7 +15,7 @@ import ConditionalSlot from 'x/conditionalSlot';
 import ConditionalSlotted from 'x/conditionalSlotted';
 import ForwardedSlotConsumer from 'x/forwardedSlotConsumer';
 
-const vFragBookend = vFragBookEndEnabled ? '<!---->' : '';
+const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 function createTestElement(tag, component) {
     const elm = createElement(tag, { is: component });
@@ -97,7 +101,7 @@ describe('Slotting', () => {
         const nodes = createTestElement('x-forwarded-slot-consumer', ForwardedSlotConsumer);
         const elm = nodes['x-forwarded-slot-consumer'];
         expect(elm.innerHTML).toEqual(
-            lightDomSlotForwardingEnabled
+            USE_LIGHT_DOM_SLOT_FORWARDING
                 ? `<x-forwarded-slot><x-light-container>${vFragBookend}<p>Upper slot content forwarded</p>${vFragBookend}${vFragBookend}<p>Default slot forwarded</p>${vFragBookend}${vFragBookend}<p>Lower slot content forwarded</p>${vFragBookend}</x-light-container></x-forwarded-slot>`
                 : `<x-forwarded-slot><x-light-container>${vFragBookend}<p slot="upper">Upper slot content forwarded</p>${vFragBookend}${vFragBookend}<p>Default slot forwarded</p>${vFragBookend}${vFragBookend}<p slot="lower">Lower slot content forwarded</p>${vFragBookend}</x-light-container></x-forwarded-slot>`
         );
@@ -121,10 +125,10 @@ describe('Slotting', () => {
         const commentNodes = [...container.childNodes].filter(
             (_) => _.nodeType === Node.COMMENT_NODE
         );
-        if (process.env.API_VERSION <= 59) {
-            expect(commentNodes.length).toBe(0); // old implementation does not use fragments, just flattening
-        } else {
+        if (USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS) {
             expect(commentNodes.length).toBe(6); // 3 slots, so 3*2=6 comment nodes
+        } else {
+            expect(commentNodes.length).toBe(0); // old implementation does not use fragments, just flattening
         }
     });
 

--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { LOWERCASE_SCOPE_TOKENS } from 'test-utils';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
@@ -11,7 +12,7 @@ if (!process.env.NATIVE_SHADOW) {
 
             // shadow grandparent
             expect(elm.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58 ? 'x-container_container' : 'lwc-7c9hba002d8'
+                LOWERCASE_SCOPE_TOKENS ? 'lwc-7c9hba002d8' : 'x-container_container'
             );
             expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
                 'rgb(0, 128, 0)'
@@ -27,7 +28,7 @@ if (!process.env.NATIVE_SHADOW) {
             // shadow grandchild
             const grandchild = child.querySelector('x-grandchild');
             expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toContain(
-                process.env.API_VERSION <= 58 ? 'x-grandchild_grandchild' : 'lwc-42b236sbaik'
+                LOWERCASE_SCOPE_TOKENS ? 'lwc-42b236sbaik' : 'x-grandchild_grandchild'
             );
             expect(
                 getComputedStyle(grandchild.shadowRoot.querySelector('h1')).outlineColor

--- a/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/lifecycle-remove-disconnected/lifecycle-remove-disconnected.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 import Parent from 'x/parent';
 
 describe('vdom removes component while it is already disconnected', () => {
@@ -10,7 +10,7 @@ describe('vdom removes component while it is already disconnected', () => {
     });
 
     afterEach(() => {
-        if (nativeCustomElementLifecycleEnabled || process.env.NODE_ENV === 'production') {
+        if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE || process.env.NODE_ENV === 'production') {
             expect(spy).not.toHaveBeenCalled();
         } else {
             // expected since the engine calls appendChild to a disconnected DOM node

--- a/packages/@lwc/integration-karma/test/misc/object-rest-spread/index.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/object-rest-spread/index.spec.js
@@ -1,3 +1,5 @@
+import { DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION } from 'test-utils';
+
 // It's useful to have Karma tests for this, so that we confirm legacy browsers still work
 describe('object rest spread transformation', () => {
     it('applies the correct transformation based on API version', () => {
@@ -10,12 +12,12 @@ describe('object rest spread transformation', () => {
 
         expect(test()).toEqual({ foo: 'foo', bar: 'bar' });
 
-        if (process.env.API_VERSION <= 59) {
-            // babel polyfill format
-            expect(test.toString()).not.toContain('...');
-        } else {
+        if (DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION) {
             // native format
             expect(test.toString()).toContain('...');
+        } else {
+            // babel polyfill format
+            expect(test.toString()).not.toContain('...');
         }
     });
 });

--- a/packages/@lwc/integration-karma/test/misc/performance-timing/index.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/performance-timing/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import Child from 'x/child';
 import Parent from 'x/parent';
@@ -164,7 +164,7 @@ if (isUserTimingSupported && process.env.NODE_ENV !== 'production') {
 
         // Timing is slightly different with native custom element lifecycle callbacks
         testNestedTree(
-            nativeCustomElementLifecycleEnabled
+            ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                 ? [
                       { label: '<x-parent> - constructor', children: [] },
                       {

--- a/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 import Synthetic from 'x/synthetic';
 
 describe('[W-9846457] event access when using native shadow dom', () => {
@@ -141,7 +141,7 @@ describe('[W-9846457] event access when using native shadow dom', () => {
         native.attachShadow({ mode: 'open' });
 
         const doAppend = () => native.shadowRoot.appendChild(synthetic);
-        if (nativeCustomElementLifecycleEnabled) {
+        if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             doAppend();
         } else {
             // Expected warning, since we are working with disconnected nodes

--- a/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/callback-invocation-order/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import ShadowParent from 'x/shadowParent';
 import ShadowLightParent from 'x/shadowLightParent';
@@ -23,7 +23,7 @@ const fixtures = [
         tagName: 'x-shadow-parent',
         ctor: ShadowParent,
         connect: process.env.NATIVE_SHADOW
-            ? nativeCustomElementLifecycleEnabled
+            ? ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                 ? [
                       'shadowParent:connectedCallback',
                       'leaf:before-container:connectedCallback',
@@ -119,7 +119,7 @@ const fixtures = [
         tagName: 'x-light-shadow-parent',
         ctor: LightShadowParent,
         connect: process.env.NATIVE_SHADOW
-            ? nativeCustomElementLifecycleEnabled
+            ? ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                 ? [
                       'lightShadowContainer:connectedCallback',
                       'shadowContainer:connectedCallback',
@@ -171,7 +171,7 @@ it('should invoke callbacks on the right order (issue #1199 and #1198)', () => {
     document.body.appendChild(elm);
     expect(window.timingBuffer).toEqual(
         process.env.NATIVE_SHADOW
-            ? nativeCustomElementLifecycleEnabled
+            ? ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                 ? [
                       'shadowContainer:connectedCallback',
                       'leaf:before-slot:connectedCallback',
@@ -206,7 +206,7 @@ it('should invoke callbacks on the right order (issue #1199 and #1198)', () => {
     elm.hide = true;
     return Promise.resolve().then(() => {
         expect(window.timingBuffer).toEqual(
-            nativeCustomElementLifecycleEnabled
+            ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                 ? [
                       'shadowContainer:disconnectedCallback',
                       'leaf:after-slot:disconnectedCallback',
@@ -252,7 +252,7 @@ it('should invoke callbacks on the right order when multiple templates are used 
             // disconnect x-shadow-parent +
             // connect x-shadow-container with 2 parents, 'a' and 'b'
             expect(window.timingBuffer).toEqual(
-                nativeCustomElementLifecycleEnabled
+                ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                     ? [
                           'leaf:T1-1:disconnectedCallback',
                           'leaf:T1-2:disconnectedCallback',
@@ -329,7 +329,7 @@ describe('regression test (#3827)', () => {
             ifBlock: (currentLeafName, previousLeafName) =>
                 process.env.NATIVE_SHADOW
                     ? []
-                    : nativeCustomElementLifecycleEnabled
+                    : ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                     ? [
                           `leaf:${currentLeafName}:connectedCallback`,
                           `leaf:${previousLeafName}:disconnectedCallback`,
@@ -338,7 +338,7 @@ describe('regression test (#3827)', () => {
             elseIfBlock: (currentLeafName, previousLeafName) =>
                 process.env.NATIVE_SHADOW
                     ? []
-                    : nativeCustomElementLifecycleEnabled
+                    : ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                     ? [
                           `leaf:${currentLeafName}:connectedCallback`,
                           `leaf:${previousLeafName}:disconnectedCallback`,
@@ -355,7 +355,7 @@ describe('regression test (#3827)', () => {
                 `leaf:${currentLeafName}:connectedCallback`,
             ],
             ifBlock: (currentLeafName, previousLeafName) =>
-                nativeCustomElementLifecycleEnabled
+                ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
                     ? [
                           `leaf:${currentLeafName}:connectedCallback`,
                           `leaf:${previousLeafName}:disconnectedCallback`,

--- a/packages/@lwc/integration-karma/test/rendering/dynamic-slots/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/dynamic-slots/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 import Parent from 'x/parent';
 import LightParent from 'x/lightParent';
 import Symbol from 'x/symbol';
@@ -73,7 +73,7 @@ describe('dynamic slotting', () => {
         document.body.appendChild(elm);
         expect(elm.shadowRoot.textContent).toEqual('BigInt');
     });
-    if (!nativeCustomElementLifecycleEnabled) {
+    if (!ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         // it actually throws in this scenario as well, but in a different callstack, so we can't assert
         it('should throw on symbol', () => {
             expect(() => {
@@ -82,7 +82,7 @@ describe('dynamic slotting', () => {
             }).toThrowError(/convert.*symbol.*string.*/i); // cannot convert symbol to string (and variations of this message across browsers)
         });
     }
-    if (!nativeCustomElementLifecycleEnabled) {
+    if (!ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         it('should throw on empty object', () => {
             expect(() => {
                 const elm = createElement('x-emptyobject', { is: EmptyObject });

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement, setFeatureFlagForTest } from 'lwc';
+import { LOWERCASE_SCOPE_TOKENS } from 'test-utils';
 import Light from 'x/light';
 import Shadow from 'x/shadow';
 
@@ -36,7 +37,7 @@ describe('legacy scope tokens', () => {
                 return [
                     ...new Set(
                         [
-                            process.env.API_VERSION <= 58 ? legacy : modern,
+                            LOWERCASE_SCOPE_TOKENS ? modern : legacy,
                             enableLegacyScopeTokens && legacy,
                         ].filter(Boolean)
                     ),

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 import Slotted from 'x/slotted';
 import Container from 'x/container';
 import ManualNodes from 'x/manualNodes';
@@ -39,7 +39,7 @@ describe('Node.getRootNode', () => {
         const frag = document.createDocumentFragment();
         const doAppend = () => frag.appendChild(elm);
 
-        if (nativeCustomElementLifecycleEnabled) {
+        if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             doAppend();
         } else {
             // Expected warning, since we are working with disconnected nodes

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.isConnected.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import Test from 'x/test';
 
@@ -14,7 +14,7 @@ describe('Node.isConnected', () => {
         const frag = document.createDocumentFragment();
         const doAppend = () => frag.appendChild(elm);
 
-        if (nativeCustomElementLifecycleEnabled) {
+        if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             doAppend();
         } else {
             // Expected warning, since we are working with disconnected nodes

--- a/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -2,7 +2,7 @@
 // https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/event-inside-shadow-tree.html
 
 import { createElement } from 'lwc';
-import { extractDataIds, nativeCustomElementLifecycleEnabled } from 'test-utils';
+import { extractDataIds, ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE } from 'test-utils';
 
 import Container from 'x/container';
 
@@ -35,7 +35,7 @@ function createDisconnectedTestElement() {
 
     const doAppend = () => fragment.appendChild(elm);
 
-    if (nativeCustomElementLifecycleEnabled) {
+    if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         doAppend();
     } else {
         // Expected warning, since we are working with disconnected nodes
@@ -534,7 +534,7 @@ describe('event propagation', () => {
 
     // This test does not work with native custom element lifecycle because disconnected
     // fragments cannot fire connectedCallback/disconnectedCallback events
-    if (!nativeCustomElementLifecycleEnabled) {
+    if (!ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         describe('dispatched within a disconnected tree', () => {
             it('{bubbles: true, composed: true}', () => {
                 const nodes = createDisconnectedTestElement();

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { extractDataIds } from 'test-utils';
+import { extractDataIds, LOWERCASE_SCOPE_TOKENS } from 'test-utils';
 import Container from 'x/container';
 import Escape from 'x/escape';
 import MultipleStyles from 'x/multipleStyles';
@@ -33,8 +33,7 @@ if (!process.env.NATIVE_SHADOW) {
                     .shadowRoot.querySelector('x-component')
                     .shadowRoot.querySelector('div');
 
-                const token =
-                    process.env.API_VERSION <= 58 ? 'x-component_component' : 'lwc-6a8uqob2ku4';
+                const token = LOWERCASE_SCOPE_TOKENS ? 'lwc-6a8uqob2ku4' : 'x-component_component';
                 expect(syntheticMode.hasAttribute(token)).toBe(true);
                 expect(nativeMode.hasAttribute(token)).toBe(false);
             });
@@ -77,7 +76,7 @@ describe('static content when stylesheets change', () => {
                 const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
                 expect(classList).toEqual([
                     'foo',
-                    process.env.API_VERSION <= 58 ? 'x-multipleStyles_b' : 'lwc-6fpm08fjoch',
+                    LOWERCASE_SCOPE_TOKENS ? 'lwc-6fpm08fjoch' : 'x-multipleStyles_b',
                 ]);
 
                 expect(() => {

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -113,14 +113,14 @@ export function isAPIFeatureEnabled(
         case APIFeature.LOWERCASE_SCOPE_TOKENS:
         case APIFeature.TREAT_ALL_PARSE5_ERRORS_AS_ERRORS:
             return apiVersion >= APIVersion.V59_246_WINTER_24;
-        case APIFeature.USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS:
         case APIFeature.DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION:
         case APIFeature.SKIP_UNNECESSARY_REGISTER_DECORATORS:
         case APIFeature.USE_COMMENTS_FOR_FRAGMENT_BOOKENDS:
+        case APIFeature.USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS:
             return apiVersion >= APIVersion.V60_248_SPRING_24;
-        case APIFeature.USE_LIGHT_DOM_SLOT_FORWARDING:
-        case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
         case APIFeature.ENABLE_ELEMENT_INTERNALS:
+        case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
+        case APIFeature.USE_LIGHT_DOM_SLOT_FORWARDING:
             return apiVersion >= APIVersion.V61_250_SUMMER_24;
     }
 }


### PR DESCRIPTION
## Details

This is just a refactor of the test code to organize how we test API versioning.

I find it easier to think about when the Karma tests explicitly say `if (someApiVersionFeature)` rather than `if (process.env.API_VERSION >= 59)`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
