### PR TITLE
fix: disable form association entirely on older API versions

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -488,7 +488,9 @@ function warnIfInvokedDuringConstruction(vm: VM, methodOrPropName: string) {
 
         if (!isAPIFeatureEnabled(APIFeature.ENABLE_ELEMENT_INTERNALS_AND_FACE, apiVersion)) {
             throw new Error(
-                `The attachInternals API is only supported in API version 61 and above. To use this API please update the LWC component API version. https://lwc.dev/guide/versioning`
+                `The attachInternals API is only supported in API version 61 and above. ` +
+                    `The current version is ${apiVersion}. ` +
+                    `To use this API, update the LWC component API version. https://lwc.dev/guide/versioning`
             );
         }
 

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -486,9 +486,9 @@ function warnIfInvokedDuringConstruction(vm: VM, methodOrPropName: string) {
             renderer: { attachInternals },
         } = vm;
 
-        if (!isAPIFeatureEnabled(APIFeature.ENABLE_ELEMENT_INTERNALS, apiVersion)) {
+        if (!isAPIFeatureEnabled(APIFeature.ENABLE_ELEMENT_INTERNALS_AND_FACE, apiVersion)) {
             throw new Error(
-                `The attachInternals API is only supported in API version 61 and above. To use this API please update the LWC component API version.`
+                `The attachInternals API is only supported in API version 61 and above. To use this API please update the LWC component API version. https://lwc.dev/guide/versioning`
             );
         }
 

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -24,7 +24,7 @@ import {
 import { logError, logWarn } from '../shared/logger';
 
 import { RendererAPI } from './renderer';
-import { cloneAndOmitKey, parseStyleText } from './utils';
+import { cloneAndOmitKey, parseStyleText, shouldBeFormAssociated } from './utils';
 import { allocateChildren, mount, removeNode } from './rendering';
 import {
     createVM,
@@ -321,7 +321,8 @@ function hydrateCustomElement(
 
     const { sel, mode, ctor, owner } = vnode;
     const { defineCustomElement, getTagName } = renderer;
-    defineCustomElement(StringToLowerCase.call(getTagName(elm)), Boolean(ctor.formAssociated));
+    const isFormAssociated = shouldBeFormAssociated(ctor);
+    defineCustomElement(StringToLowerCase.call(getTagName(elm)), isFormAssociated);
 
     const vm = createVM(elm, ctor, renderer, {
         mode,

--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -26,7 +26,7 @@ export { parseFragment, parseSVGFragment } from './template';
 export { hydrateRoot } from './hydration';
 
 // Internal APIs used by compiled code -------------------------------------------------------------
-export { registerComponent, getComponentAPIVersion } from './component';
+export { registerComponent } from './component';
 export { registerTemplate } from './secure-template';
 export { registerDecorators } from './decorators/register';
 
@@ -39,6 +39,8 @@ export { reportingControl as __unstable__ReportingControl } from './reporting';
 export { swapTemplate, swapComponent, swapStyle } from './hot-swaps';
 export { setHooks } from './overridable-hooks';
 export { freezeTemplate } from './freeze-template';
+export { getComponentAPIVersion } from './component';
+export { shouldBeFormAssociated } from './utils';
 
 // Experimental or Internal APIs
 export { getComponentConstructor } from './get-component-constructor';

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -24,7 +24,7 @@ import {
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
 import { RendererAPI } from './renderer';
-import { EmptyArray, shouldUseNativeCustomElementLifecycle } from './utils';
+import { EmptyArray, shouldBeFormAssociated, shouldUseNativeCustomElementLifecycle } from './utils';
 import { markComponentAsDirty } from './component';
 import { getScopeTokenClass } from './stylesheet';
 import { lockDomMutation, patchElementWithRestrictions, unlockDomMutation } from './restrictions';
@@ -337,7 +337,7 @@ function mountCustomElement(
     const useNativeLifecycle = shouldUseNativeCustomElementLifecycle(
         ctor as LightningElementConstructor
     );
-    const isFormAssociated = Boolean(ctor.formAssociated);
+    const isFormAssociated = shouldBeFormAssociated(ctor);
     const elm = createCustomElement(
         normalizedTagname,
         upgradeCallback,

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -172,7 +172,7 @@ export function shouldBeFormAssociated(Ctor: LightningElementConstructor) {
         logWarnOnce(
             `Component <${tagName}> set static formAssociated to true, but form ` +
                 `association is not enabled because the API version is ${apiVersion}. To enable form association, ` +
-                `please update the LWC component API version. https://lwc.dev/guide/versioning`
+                `update the LWC component API version to 61 or above. https://lwc.dev/guide/versioning`
         );
     }
 

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -22,6 +22,7 @@ import {
     disconnectRootElement,
     LightningElement,
     getComponentAPIVersion,
+    shouldBeFormAssociated,
 } from '@lwc/engine-core';
 import { renderer } from '../renderer';
 
@@ -135,7 +136,7 @@ export function createElement(
         !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE &&
         isAPIFeatureEnabled(APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE, apiVersion);
 
-    const isFormAssociated = Boolean(Ctor.formAssociated);
+    const isFormAssociated = shouldBeFormAssociated(Ctor);
 
     // the custom element from the registry is expecting an upgrade callback
     /*

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -11,6 +11,7 @@ import {
     hydrateRoot,
     connectRootElement,
     getAssociatedVMIfPresent,
+    shouldBeFormAssociated,
 } from '@lwc/engine-core';
 import { StringToLowerCase, isFunction, isNull, isObject } from '@lwc/shared';
 import { renderer } from '../renderer';
@@ -89,10 +90,8 @@ export function hydrateComponent(
 
     try {
         const { defineCustomElement, getTagName } = renderer;
-        defineCustomElement(
-            StringToLowerCase.call(getTagName(element)),
-            Boolean(Ctor.formAssociated)
-        );
+        const isFormAssociated = shouldBeFormAssociated(Ctor);
+        defineCustomElement(StringToLowerCase.call(getTagName(element)), isFormAssociated);
         const vm = createVMWithProps(element, Ctor, props);
 
         hydrateRoot(vm);

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -339,6 +339,10 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
             customElementCallbackReactionErrorListener,
             true
         ),
+        toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode: errorMatcherFactory(
+            windowErrorListener,
+            true
+        ),
     };
 
     beforeAll(function () {

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -565,7 +565,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         USE_COMMENTS_FOR_FRAGMENT_BOOKENDS: process.env.API_VERSION >= 60,
         USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS: process.env.API_VERSION >= 60,
         DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION: process.env.API_VERSION >= 60,
-        ENABLE_ELEMENT_INTERNALS: process.env.API_VERSION >= 61,
+        ENABLE_ELEMENT_INTERNALS_AND_FACE: process.env.API_VERSION >= 61,
         ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: process.env.API_VERSION >= 61,
         USE_LIGHT_DOM_SLOT_FORWARDING: process.env.API_VERSION >= 61,
     };

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/lwc.js
@@ -38,12 +38,12 @@ function createPreprocessor(config, emitter, logger) {
 
         // Wrap all the tests into a describe block with the file structure name
         // This avoids needing to manually write `describe()` for every file.
-        // Also add a dummy test because otherwise Jasmine complains about empty describe()s:
+        // Also add an empty test because otherwise Jasmine complains about empty describe()s:
         // https://github.com/jasmine/jasmine/pull/1742
         const ancestorDirectories = path.relative(basePath, suiteDir).split(path.sep);
         const intro =
             ancestorDirectories.map((tag) => `describe("${tag}", function () {`).join('\n') +
-            `\nxit("dummy test", () => { /* empty */ });\n`;
+            `\nxit("empty test", () => { /* empty */ });\n`;
         const outro = ancestorDirectories.map(() => `});`).join('\n');
 
         // TODO [#3370]: remove experimental template expression flag

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -1,5 +1,8 @@
 import { createElement } from 'lwc';
-import { customElementCallbackReactionErrorListener, ENABLE_ELEMENT_INTERNALS } from 'test-utils';
+import {
+    customElementCallbackReactionErrorListener,
+    ENABLE_ELEMENT_INTERNALS_AND_FACE,
+} from 'test-utils';
 
 import ShadowDomCmp from 'ai/shadowDom';
 import LightDomCmp from 'ai/lightDom';
@@ -54,7 +57,7 @@ const attachInternalsSanityTest = (tagName, ctor) => {
     });
 };
 
-if (ENABLE_ELEMENT_INTERNALS) {
+if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
     if (typeof ElementInternals !== 'undefined') {
         // ElementInternals API is supported in the browser
         if (process.env.NATIVE_SHADOW) {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -84,7 +84,7 @@ if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         // Because of the order error messages are thrown, this error only appears when synthetic shadow
         // is disabled. Otherwise, 'attachInternals API is not supported in synthetic shadow.'
         // is thrown instead.
-        if (!process.env.SYNTHETIC_SHADOW_ENABLED) {
+        if (!process.env.NATIVE_SHADOW) {
             it('should throw an error when used with unsupported browser environments', () => {
                 createElementsThroughLwcAndCustomElementConstructor(
                     'unsupported-env-component',

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -84,7 +84,7 @@ if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         // Because of the order error messages are thrown, this error only appears when synthetic shadow
         // is disabled. Otherwise, 'attachInternals API is not supported in synthetic shadow.'
         // is thrown instead.
-        if (!process.env.NATIVE_SHADOW) {
+        if (!process.env.SYNTHETIC_SHADOW_ENABLED) {
             it('should throw an error when used with unsupported browser environments', () => {
                 createElementsThroughLwcAndCustomElementConstructor(
                     'unsupported-env-component',

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -104,7 +104,7 @@ if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         // Note CustomElementConstructor is not upgraded by LWC and inherits directly from HTMLElement which means it calls the native
         // attachInternals API.
         expect(() => document.body.appendChild(elm)).toThrowError(
-            /The attachInternals API is only supported in API version 61 and above. To use this API please update the LWC component API version./
+            /The attachInternals API is only supported in API version 61 and above/
         );
     });
 }

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -40,9 +40,7 @@ if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
     it('should log when attempting to use form association on an older API version', () => {
         // formAssociated = true
         expect(() => {
-            expect(() => {
-                createElement('x-form-associated', { is: FormAssociated });
-            }).toThrowError(
+            expect(() => createElement('x-form-associated', { is: FormAssociated })).toThrowError(
                 /The attachInternals API is only supported in API version 61 and above/
             );
         }).toLogWarningDev(
@@ -51,6 +49,8 @@ if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         // formAssociated = false
         createElement('x-form-associated-false', { is: FormAssociatedFalse });
         // formAssociated = undefined
-        createElement('x-not-form-associated', { is: NotFormAssociated });
+        expect(() =>
+            createElement('x-not-form-associated', { is: NotFormAssociated })
+        ).toThrowError(/The attachInternals API is only supported in API version 61 and above/);
     });
 }

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -39,46 +39,48 @@ if (
     });
 }
 
-const isFormAssociated = (elm) => {
-    const form = document.createElement('form');
-    document.body.appendChild(form);
-    form.appendChild(elm);
-    const result = elm.formAssociatedCallbackCalled;
-    document.body.removeChild(form); // cleanup
-    return result;
-};
-
-it('disallows form association on older API versions', () => {
-    let elm;
-
-    // formAssociated = true
-    const createFormAssociatedTrue = () => {
-        elm = createElement('x-form-associated-no-attach-internals', {
-            is: FormAssociatedNoAttachInternals,
-        });
+if (typeof ElementInternals !== 'undefined' && !process.env.SYNTHETIC_SHADOW_ENABLED) {
+    const isFormAssociated = (elm) => {
+        const form = document.createElement('form');
+        document.body.appendChild(form);
+        form.appendChild(elm);
+        const result = elm.formAssociatedCallbackCalled;
+        document.body.removeChild(form); // cleanup
+        return result;
     };
-    if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
-        createFormAssociatedTrue();
-        expect(isFormAssociated(elm)).toBe(true);
-    } else {
-        expect(createFormAssociatedTrue).toLogWarningDev(
-            /Component <x-form-associated-no-attach-internals> set static formAssociated to true, but form association is not enabled/
-        );
+
+    it('disallows form association on older API versions', () => {
+        let elm;
+
+        // formAssociated = true
+        const createFormAssociatedTrue = () => {
+            elm = createElement('x-form-associated-no-attach-internals', {
+                is: FormAssociatedNoAttachInternals,
+            });
+        };
+        if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
+            createFormAssociatedTrue();
+            expect(isFormAssociated(elm)).toBe(true);
+        } else {
+            expect(createFormAssociatedTrue).toLogWarningDev(
+                /Component <x-form-associated-no-attach-internals> set static formAssociated to true, but form association is not enabled/
+            );
+            expect(isFormAssociated(elm)).toBe(false);
+        }
+
+        // formAssociated = false
+        elm = createElement('x-form-associated-false-no-attach-internals', {
+            is: FormAssociatedFalseNoAttachInternals,
+        });
         expect(isFormAssociated(elm)).toBe(false);
-    }
 
-    // formAssociated = false
-    elm = createElement('x-form-associated-false-no-attach-internals', {
-        is: FormAssociatedFalseNoAttachInternals,
+        // formAssociated = undefined
+        elm = createElement('x-not-form-associated-no-attach-internals', {
+            is: NotFormAssociatedNoAttachInternals,
+        });
+        expect(isFormAssociated(elm)).toBe(false);
     });
-    expect(isFormAssociated(elm)).toBe(false);
-
-    // formAssociated = undefined
-    elm = createElement('x-not-form-associated-no-attach-internals', {
-        is: NotFormAssociatedNoAttachInternals,
-    });
-    expect(isFormAssociated(elm)).toBe(false);
-});
+}
 
 if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
     it('warns for attachInternals on older API versions', () => {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -1,12 +1,12 @@
 import { createElement } from 'lwc';
-import { ENABLE_ELEMENT_INTERNALS } from 'test-utils';
+import { ENABLE_ELEMENT_INTERNALS_AND_FACE } from 'test-utils';
 
 import NotFormAssociated from 'x/notFormAssociated';
 import FormAssociated from 'x/formAssociated';
 import FormAssociatedFalse from 'x/formAssociatedFalse';
 
 if (
-    ENABLE_ELEMENT_INTERNALS &&
+    ENABLE_ELEMENT_INTERNALS_AND_FACE &&
     typeof ElementInternals !== 'undefined' &&
     !process.env.SYNTHETIC_SHADOW_ENABLED
 ) {
@@ -33,5 +33,24 @@ if (
         expect(() =>
             createElement('x-not-form-associated', { is: NotFormAssociated })
         ).not.toThrow();
+    });
+}
+
+if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
+    it('should log when attempting to use form association on an older API version', () => {
+        // formAssociated = true
+        expect(() => {
+            expect(() => {
+                createElement('x-form-associated', { is: FormAssociated });
+            }).toThrowError(
+                /The attachInternals API is only supported in API version 61 and above/
+            );
+        }).toLogWarningDev(
+            /Component <x-form-associated> set static formAssociated to true, but form association is not enabled/
+        );
+        // formAssociated = false
+        createElement('x-form-associated-false', { is: FormAssociatedFalse });
+        // formAssociated = undefined
+        createElement('x-not-form-associated', { is: NotFormAssociated });
     });
 }

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -4,6 +4,9 @@ import { ENABLE_ELEMENT_INTERNALS_AND_FACE } from 'test-utils';
 import NotFormAssociated from 'x/notFormAssociated';
 import FormAssociated from 'x/formAssociated';
 import FormAssociatedFalse from 'x/formAssociatedFalse';
+import NotFormAssociatedNoAttachInternals from 'x/notFormAssociatedNoAttachInternals';
+import FormAssociatedNoAttachInternals from 'x/formAssociatedNoAttachInternals';
+import FormAssociatedFalseNoAttachInternals from 'x/formAssociatedFalseNoAttachInternals';
 
 if (
     ENABLE_ELEMENT_INTERNALS_AND_FACE &&
@@ -36,8 +39,48 @@ if (
     });
 }
 
+const isFormAssociated = (elm) => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    form.appendChild(elm);
+    const result = elm.formAssociatedCallbackCalled;
+    document.body.removeChild(form); // cleanup
+    return result;
+};
+
+it('disallows form association on older API versions', () => {
+    let elm;
+    // formAssociated = true
+    const createFormAssociatedTrue = () => {
+        elm = createElement('x-form-associated-no-attach-internals', {
+            is: FormAssociatedNoAttachInternals,
+        });
+    };
+    if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
+        createFormAssociatedTrue();
+    } else {
+        expect(createFormAssociatedTrue).toLogWarningDev(
+            /Component <x-form-associated-no-attach-internals> set static formAssociated to true, but form association is not enabled/
+        );
+    }
+
+    expect(isFormAssociated(elm)).toBe(!!ENABLE_ELEMENT_INTERNALS_AND_FACE);
+
+    // formAssociated = false
+    elm = createElement('x-form-associated-false-no-attach-internals', {
+        is: FormAssociatedFalseNoAttachInternals,
+    });
+    expect(isFormAssociated(elm)).toBe(false);
+
+    // formAssociated = undefined
+    elm = createElement('x-not-form-associated-no-attach-internals', {
+        is: NotFormAssociatedNoAttachInternals,
+    });
+    expect(isFormAssociated(elm)).toBe(false);
+});
+
 if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
-    it('should log when attempting to use form association on an older API version', () => {
+    it('warns for attachInternals on older API versions', () => {
         // formAssociated = true
         expect(() => {
             expect(() => createElement('x-form-associated', { is: FormAssociated })).toThrowError(
@@ -46,8 +89,12 @@ if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         }).toLogWarningDev(
             /Component <x-form-associated> set static formAssociated to true, but form association is not enabled/
         );
+
         // formAssociated = false
-        createElement('x-form-associated-false', { is: FormAssociatedFalse });
+        expect(() =>
+            createElement('x-form-associated-false', { is: FormAssociatedFalse })
+        ).toThrowError(/The attachInternals API is only supported in API version 61 and above/);
+
         // formAssociated = undefined
         expect(() =>
             createElement('x-not-form-associated', { is: NotFormAssociated })

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -50,6 +50,7 @@ const isFormAssociated = (elm) => {
 
 it('disallows form association on older API versions', () => {
     let elm;
+
     // formAssociated = true
     const createFormAssociatedTrue = () => {
         elm = createElement('x-form-associated-no-attach-internals', {
@@ -58,13 +59,13 @@ it('disallows form association on older API versions', () => {
     };
     if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         createFormAssociatedTrue();
+        expect(isFormAssociated(elm)).toBe(true);
     } else {
         expect(createFormAssociatedTrue).toLogWarningDev(
             /Component <x-form-associated-no-attach-internals> set static formAssociated to true, but form association is not enabled/
         );
+        expect(isFormAssociated(elm)).toBe(false);
     }
-
-    expect(isFormAssociated(elm)).toBe(!!ENABLE_ELEMENT_INTERNALS_AND_FACE);
 
     // formAssociated = false
     elm = createElement('x-form-associated-false-no-attach-internals', {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociated/formAssociated.html
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociated/formAssociated.html
@@ -1,1 +1,0 @@
-<template></template>

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedFalse/formAssociatedFalse.html
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedFalse/formAssociatedFalse.html
@@ -1,1 +1,0 @@
-<template></template>

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedFalseNoAttachInternals/formAssociatedFalseNoAttachInternals.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedFalseNoAttachInternals/formAssociatedFalseNoAttachInternals.js
@@ -4,10 +4,9 @@ export default class extends LightningElement {
     static formAssociated = false;
 
     @api
-    internals;
+    formAssociatedCallbackCalled = false;
 
-    constructor() {
-        super();
-        this.internals = this.attachInternals();
+    formAssociatedCallback() {
+        this.formAssociatedCallbackCalled = true;
     }
 }

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedNoAttachInternals/formAssociatedNoAttachInternals.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/formAssociatedNoAttachInternals/formAssociatedNoAttachInternals.js
@@ -1,0 +1,12 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static formAssociated = true;
+
+    @api
+    formAssociatedCallbackCalled = false;
+
+    formAssociatedCallback() {
+        this.formAssociatedCallbackCalled = true;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/notFormAssociated/notFormAssociated.html
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/notFormAssociated/notFormAssociated.html
@@ -1,1 +1,0 @@
-<template></template>

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/notFormAssociatedNoAttachInternals/notFormAssociatedNoAttachInternals.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/x/notFormAssociatedNoAttachInternals/notFormAssociatedNoAttachInternals.js
@@ -1,0 +1,10 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    formAssociatedCallbackCalled = false;
+
+    formAssociatedCallback() {
+        this.formAssociatedCallbackCalled = true;
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -1,10 +1,10 @@
 import { createElement } from 'lwc';
-import { ariaProperties, ariaAttributes, ENABLE_ELEMENT_INTERNALS } from 'test-utils';
+import { ariaProperties, ariaAttributes, ENABLE_ELEMENT_INTERNALS_AND_FACE } from 'test-utils';
 
 import ElementInternal from 'ei/component';
 
 if (
-    ENABLE_ELEMENT_INTERNALS &&
+    ENABLE_ELEMENT_INTERNALS_AND_FACE &&
     process.env.NATIVE_SHADOW &&
     typeof ElementInternals !== 'undefined'
 ) {

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -10,9 +10,6 @@ import NotFormAssociated from 'face/notFormAssociated';
 import LightDomFormAssociated from 'face/lightDomFormAssociated';
 import LightDomNotFormAssociated from 'face/lightDomNotFormAssociated';
 
-// set to true to indicate we're testing a light DOM component
-let isLightDom = false;
-
 const createFormElement = () => {
     const container = createElement('face-container', { is: Container });
     document.body.appendChild(container);
@@ -42,7 +39,7 @@ const createFaceUsingLwcCreateElement = (tagName, ctor) => {
     const doCreate = () => {
         elm = createElement(tagName, { is: ctor });
     };
-    if (ENABLE_ELEMENT_INTERNALS_AND_FACE && (!process.env.NATIVE_SHADOW || isLightDom)) {
+    if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         doCreate();
     } else {
         expect(doCreate).toLogWarningDev(
@@ -165,12 +162,6 @@ if (typeof ElementInternals !== 'undefined') {
                 });
             }
             describe('light DOM', () => {
-                beforeEach(() => {
-                    isLightDom = true;
-                });
-                afterEach(() => {
-                    isLightDom = false;
-                });
                 faceSanityTest('light-dom', LightDomFormAssociated);
                 notFormAssociatedSanityTest('light-dom', LightDomNotFormAssociated);
             });

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -10,6 +10,9 @@ import NotFormAssociated from 'face/notFormAssociated';
 import LightDomFormAssociated from 'face/lightDomFormAssociated';
 import LightDomNotFormAssociated from 'face/lightDomNotFormAssociated';
 
+// set to true to indicate we're testing a light DOM component
+let isLightDom = false;
+
 const createFormElement = () => {
     const container = createElement('face-container', { is: Container });
     document.body.appendChild(container);
@@ -39,7 +42,7 @@ const createFaceUsingLwcCreateElement = (tagName, ctor) => {
     const doCreate = () => {
         elm = createElement(tagName, { is: ctor });
     };
-    if (ENABLE_ELEMENT_INTERNALS_AND_FACE && process.env.NATIVE_SHADOW) {
+    if (ENABLE_ELEMENT_INTERNALS_AND_FACE && (!process.env.NATIVE_SHADOW || isLightDom)) {
         doCreate();
     } else {
         expect(doCreate).toLogWarningDev(
@@ -150,7 +153,7 @@ if (typeof ElementInternals !== 'undefined') {
                 });
             } else {
                 describe('synthetic shadow', () => {
-                    createFaceTests('synthetic-shadow', FormAssociated).forEach((createFace) => {
+                    createFaceTests('synthetic-shadow', FormAssociated, (createFace) => {
                         it('cannot be used and throws an error', () => {
                             const face = createFace();
                             const form = createFormElement();
@@ -162,6 +165,12 @@ if (typeof ElementInternals !== 'undefined') {
                 });
             }
             describe('light DOM', () => {
+                beforeEach(() => {
+                    isLightDom = true;
+                });
+                afterEach(() => {
+                    isLightDom = false;
+                });
                 faceSanityTest('light-dom', LightDomFormAssociated);
                 notFormAssociatedSanityTest('light-dom', LightDomNotFormAssociated);
             });

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -191,7 +191,16 @@ if (typeof ElementInternals !== 'undefined') {
                         } else {
                             // synthetic shadow mode
                             it(`${name} cannot call face lifecycle methods when using CustomElementConstructor`, () => {
-                                testFaceLifecycleMethodsNotCallable(createFace);
+                                // this is always a callback reaction error, even in "synthetic lifecycle" mode,
+                                // because synthetic lifecycle mode only includes connected/disconnected callbacks,
+                                // not the FACE callbacks
+                                expect(() => {
+                                    const face = createFace();
+                                    const form = createFormElement();
+                                    form.appendChild(face);
+                                }).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
+                                    'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
+                                );
                             });
                         }
                     }

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -188,6 +188,8 @@ if (typeof ElementInternals !== 'undefined') {
                                 // CustomElementConstructor is to be upgraded independently of LWC, it will always use native lifecycle
                                 testFaceLifecycleMethodsCallable(cecFace);
                             });
+                        } else {
+                            xit('empty test since jasmine demands every describe() has an it', () => {});
                         }
                     }
                 });

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -189,7 +189,10 @@ if (typeof ElementInternals !== 'undefined') {
                                 testFaceLifecycleMethodsCallable(createFace);
                             });
                         } else {
-                            xit('empty test since jasmine demands every describe() has an it', () => {});
+                            // synthetic shadow mode
+                            it(`${name} cannot call face lifecycle methods when using CustomElementConstructor`, () => {
+                                testFaceLifecycleMethodsNotCallable(createFace);
+                            });
                         }
                     }
                 });

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -95,9 +95,10 @@ export const enum APIFeature {
      */
     ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
     /**
-     * If enabled, allows usage of the `attachInternals` and `ElementInternals` API
+     * If enabled, allows usage of the `attachInternals` and `ElementInternals` APIs, as well as
+     * Form-Associated Custom Elements (FACE).
      */
-    ENABLE_ELEMENT_INTERNALS,
+    ENABLE_ELEMENT_INTERNALS_AND_FACE,
 }
 
 /**
@@ -118,7 +119,7 @@ export function isAPIFeatureEnabled(
         case APIFeature.USE_COMMENTS_FOR_FRAGMENT_BOOKENDS:
         case APIFeature.USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS:
             return apiVersion >= APIVersion.V60_248_SPRING_24;
-        case APIFeature.ENABLE_ELEMENT_INTERNALS:
+        case APIFeature.ENABLE_ELEMENT_INTERNALS_AND_FACE:
         case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
         case APIFeature.USE_LIGHT_DOM_SLOT_FORWARDING:
             return apiVersion >= APIVersion.V61_250_SUMMER_24;


### PR DESCRIPTION
## Details

Fixes #3929

Logs a warning when using synthetic custom element lifecycle and attempting to use `static formAssociated = true`. Also, ensures `formAssociated` is always false when the API version is <61.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ⚠️ Yes, it does include an observable change.

Technically someone could have been trying to use an older API version and setting formAssociated to true, but the FACE callbacks wouldn't have worked and older API versions are not used in OSS so I really doubt anyone took a dependency on this.

<!-- If yes, please describe the anticipated observable changes. -->
