### PR TITLE
test: consistent fixture tests for disallowed `@api` props

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/class/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/class/actual.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc'
+
+export default class extends LightningElement {
+  @api class
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/class/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/class/error.json
@@ -1,0 +1,10 @@
+{
+    "message": "LWC1110: Invalid property name \"class\". \"class\" is a reserved attribute.",
+    "loc": {
+        "line": 4,
+        "column": 2,
+        "start": 95,
+        "length": 10
+    },
+    "filename": "test.js"
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/is/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/is/actual.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc'
+
+export default class extends LightningElement {
+  @api is
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/is/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/is/error.json
@@ -1,10 +1,10 @@
 {
     "message": "LWC1110: Invalid property name \"is\". \"is\" is a reserved attribute.",
     "loc": {
-        "line": 3,
+        "line": 4,
         "column": 2,
-        "start": 100,
-        "length": 8
+        "start": 95,
+        "length": 7
     },
     "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/slot/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/slot/actual.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc'
+
+export default class extends LightningElement {
+  @api slot
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/slot/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/slot/error.json
@@ -1,10 +1,10 @@
 {
     "message": "LWC1110: Invalid property name \"slot\". \"slot\" is a reserved attribute.",
     "loc": {
-        "line": 3,
+        "line": 4,
         "column": 2,
-        "start": 100,
-        "length": 10
+        "start": 95,
+        "length": 9
     },
     "filename": "test.js"
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/style/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/style/actual.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc'
+
+export default class extends LightningElement {
+  @api style
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/style/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/disallowed-props/style/error.json
@@ -1,0 +1,10 @@
+{
+    "message": "LWC1110: Invalid property name \"style\". \"style\" is a reserved attribute.",
+    "loc": {
+        "line": 4,
+        "column": 2,
+        "start": 95,
+        "length": 10
+    },
+    "filename": "test.js"
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-conflicts-with-disallowed-global-html-attribute-name/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-conflicts-with-disallowed-global-html-attribute-name/actual.js
@@ -1,4 +1,0 @@
-import { api, LightningElement } from "lwc";
-export default class Test extends LightningElement {
-  @api slot;
-}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-is/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/throws-error-if-property-name-is-is/actual.js
@@ -1,4 +1,0 @@
-import { api, LightningElement } from "lwc";
-export default class Test extends LightningElement {
-  @api is;
-}


### PR DESCRIPTION
## Details

This is extracted out of #4044 since it's not strictly related to that PR.

This just adds tests to confirm the behavior of disallowed `@api` properties defined here:

https://github.com/salesforce/lwc/blob/ccd0253991b6e5b806369d4e021833ab14c505e5/packages/%40lwc/babel-plugin-component/src/constants.ts#L23-L26

Previously, only some of these props were tested. Now, they are all tested.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
