### PR TITLE
chore: lint test fixtures @W-15228939

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ node_modules/
 dist/
 lib/
 coverage/
-fixtures/
 public/
 __benchmarks_results__/
 playground/

--- a/.eslintrc
+++ b/.eslintrc
@@ -185,6 +185,8 @@
 
     "overrides": [
         {
+            // The main tsconfig used for this repo excludes tests/scripts, so we must use a second
+            // tsconfig to enable typed linting of those files.
             "files": [
                 "**/__tests__/**",
                 "packages/@lwc/*/scripts/**",
@@ -230,6 +232,7 @@
             }
         },
         {
+            // Add jest-specific rules only to test files
             "files": ["**/__tests__/**", "**/__mocks__/**", "packages/@lwc/integration-karma/**"],
 
             "env": {
@@ -274,6 +277,7 @@
             }
         },
         {
+            // Test files aren't exported, so don't need headers
             "files": [
                 "packages/@lwc/integration-tests/src/**/!(*.spec.js)",
                 "packages/@lwc/integration-karma/test/**",
@@ -281,6 +285,22 @@
             ],
             "rules": {
                 "header/header": "off"
+            }
+        },
+        {
+            // Test fixtures aren't real code, so don't need all the rules
+            "files": ["packages/@lwc/*/src/__tests__/**/fixtures/**"],
+            "rules": {
+                "@typescript-eslint/no-unused-vars": "off",
+                "@typescript-eslint/restrict-plus-operands": "off",
+                "header/header": "off",
+                "import/order": "off",
+                "no-console": "off",
+                // This has a lot of false positives for getters/setters
+                "no-dupe-class-members": "off",
+                "no-prototype-builtins": "off",
+                "no-undef": "off",
+                "prefer-const": "off"
             }
         },
         {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/actual.js
@@ -2,7 +2,9 @@ import { api, LightningElement } from "lwc";
 export default class Test extends LightningElement {
   @api
   set first(value) {}
-  get first() {}
+  get first() {
+    return undefined
+  }
 
   @api
   get second() {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Test extends LightningElement {
   set first(value) {}
-  get first() {}
+  get first() {
+    return undefined;
+  }
   get second() {
     return this.s;
   }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/actual.js
@@ -2,5 +2,7 @@ import { LightningElement, api } from "lwc";
 export default class ComputedAPIProp extends LightningElement {
   @api
   set [x](value) {}
-  get [x]() {}
+  get [x]() {
+    return undefined
+  }
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/actual.js
@@ -3,11 +3,13 @@ export default class Text extends LightningElement {
   @api publicProp;
   privateProp;
 
-  @api get aloneGet() {}
-  @api get myget() {}
-  set myget(x) {
-    return 1;
+  @api get aloneGet() {
+    return undefined
   }
+  @api get myget() {
+    return undefined
+  }
+  set myget(x) {}
   @api m1() {}
   m2() {}
   static ctor = "ctor";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/expected.js
@@ -3,11 +3,13 @@ import _tmpl from "./test.html";
 class Text extends LightningElement {
   publicProp;
   privateProp;
-  get aloneGet() {}
-  get myget() {}
-  set myget(x) {
-    return 1;
+  get aloneGet() {
+    return undefined;
   }
+  get myget() {
+    return undefined;
+  }
+  set myget(x) {}
   m1() {}
   m2() {}
   static ctor = "ctor";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/actual.js
@@ -3,6 +3,8 @@ export default class Text extends LightningElement {
   foo = 1;
 
   @api
-  get foo() {}
+  get foo() {
+    return undefined
+  }
   set foo(value) {}
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Text extends LightningElement {
   foo = 1;
-  get foo() {}
+  get foo() {
+    return undefined;
+  }
   set foo(value) {}
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/actual.js
@@ -2,6 +2,8 @@ import { api, LightningElement } from "lwc";
 export default class Text extends LightningElement {
   @api foo = 1;
 
-  get foo() {}
+  get foo() {
+    return undefined
+  }
   set foo(value) {}
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Text extends LightningElement {
   foo = 1;
-  get foo() {}
+  get foo() {
+    return undefined;
+  }
   set foo(value) {}
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
@@ -1,6 +1,5 @@
 import lwc, {LightningElement} from 'lwc'
 
-// eslint-disable-next-line no-console
 console.log(lwc)
 
 export default class extends LightningElement {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
@@ -1,6 +1,5 @@
 import _tmpl from "./test.html";
 import lwc, { registerComponent as _registerComponent, LightningElement } from "lwc";
-// eslint-disable-next-line no-console
 console.log(lwc);
 export default _registerComponent(class extends LightningElement {
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
@@ -1,4 +1,3 @@
 import lwc from 'lwc'
 
-// eslint-disable-next-line no-console
 console.log(lwc)

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
@@ -1,4 +1,2 @@
 import lwc from 'lwc';
-
-// eslint-disable-next-line no-console
 console.log(lwc);

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/actual.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-computed-key */
 import { wire, LightningElement } from "lwc";
 import { getFoo, getBar } from "data-service";
 

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/expected.js
@@ -1,5 +1,6 @@
 import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
 import _tmpl from "./test.html";
+/* eslint-disable no-useless-computed-key */
 import { getFoo, getBar } from "data-service";
 const symbol = Symbol.for("key");
 class Test extends LightningElement {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
@@ -2,4 +2,4 @@ import { LightningElement } from 'lwc';
 
 export default class AttributeDynamicWithScopedCss extends LightningElement {
   dynamicClass = 'kree'
-};
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/modules/x/rehydration/rehydration.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/modules/x/rehydration/rehydration.js
@@ -5,6 +5,7 @@ export default class Rehydration extends LightningElement {
     @track reactive = 0;
 
     connectedCallback() {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => {
             this.reactive = 1;
         });

--- a/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/fixtures/lightningWebSecurityTransforms/lightningWebSecurityTransforms.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/fixtures/lightningWebSecurityTransforms/lightningWebSecurityTransforms.js
@@ -10,6 +10,7 @@ export default class extends LightningElement {
             break;
         }
     }
+    // eslint-disable-next-line @typescript-eslint/require-await
     async * baz() {
         yield 1;
         yield 2;

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/non-component-class/src/x/app/app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/non-component-class/src/x/app/app.js
@@ -9,7 +9,6 @@ class AlsoNotALightningElement {
 
 export default class App extends LightningElement {
     renderedCallback() {
-        // eslint-disable-next-line no-console
         console.log(NotALightningElement, AlsoNotALightningElement)
     }
 }


### PR DESCRIPTION
## Details

I plan on adding a feature to enable using jest's `skip`/`only` in test fixtures executed by `testFixtureDir`. My implementation uses code comment directives (similar to `/* eslint-disable rule */`) to accomplish this. This feature is intended to be for local development only, and should not be included in committed code. To enforce that, I created a new eslint rule (similar to [jest/no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/v27.9.0/docs/rules/no-focused-tests.md)). However, that only works if we actually lint the fixtures! Hence, this PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.
    
    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list. 
-->
* ✅ No, it does not introduce a breaking change.
<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers. 
    Such changes don't qualify as breaking changes because they don't impact any publicly defined 
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list. 
-->
* ✅ No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
<!-- Work ID in text, if applicable. -->
W-15228939