### PR TITLE
feat: add ability to use skip/only with test fixtures @W-15228939

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ node_modules/
 dist/
 lib/
 coverage/
-fixtures/
 public/
 __benchmarks_results__/
 playground/

--- a/.eslintrc
+++ b/.eslintrc
@@ -185,6 +185,8 @@
 
     "overrides": [
         {
+            // The main tsconfig used for this repo excludes tests/scripts, so we must use a second
+            // tsconfig to enable typed linting of those files.
             "files": [
                 "**/__tests__/**",
                 "packages/@lwc/*/scripts/**",
@@ -230,6 +232,7 @@
             }
         },
         {
+            // Add jest-specific rules only to test files
             "files": ["**/__tests__/**", "**/__mocks__/**", "packages/@lwc/integration-karma/**"],
 
             "env": {
@@ -274,6 +277,7 @@
             }
         },
         {
+            // Test files aren't exported, so don't need headers
             "files": [
                 "packages/@lwc/integration-tests/src/**/!(*.spec.js)",
                 "packages/@lwc/integration-karma/test/**",
@@ -281,6 +285,22 @@
             ],
             "rules": {
                 "header/header": "off"
+            }
+        },
+        {
+            // Test fixtures aren't real code, so don't need all the rules
+            "files": ["packages/@lwc/*/src/__tests__/**/fixtures/**"],
+            "rules": {
+                "@typescript-eslint/no-unused-vars": "off",
+                "@typescript-eslint/restrict-plus-operands": "off",
+                "header/header": "off",
+                "import/order": "off",
+                "no-console": "off",
+                // This has a lot of false positives for getters/setters
+                "no-dupe-class-members": "off",
+                "no-prototype-builtins": "off",
+                "no-undef": "off",
+                "prefer-const": "off"
             }
         },
         {

--- a/.eslintrc
+++ b/.eslintrc
@@ -243,7 +243,8 @@
             "rules": {
                 "jest/no-focused-tests": "error",
                 "jest/valid-expect": "error",
-                "jest/valid-expect-in-promise": "error"
+                "jest/valid-expect-in-promise": "error",
+                "@lwc/lwc-internal/no-lwc-test-directive": "error"
             }
         },
         {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/actual.js
@@ -2,7 +2,9 @@ import { api, LightningElement } from "lwc";
 export default class Test extends LightningElement {
   @api
   set first(value) {}
-  get first() {}
+  get first() {
+    return undefined
+  }
 
   @api
   get second() {

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/@api-setter-on-one-class-member-should-not-conflict-with-@api-getter-on-another/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Test extends LightningElement {
   set first(value) {}
-  get first() {}
+  get first() {
+    return undefined;
+  }
   get second() {
     return this.s;
   }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/does-not-allow-computed-api-getters-and-setters/actual.js
@@ -2,5 +2,7 @@ import { LightningElement, api } from "lwc";
 export default class ComputedAPIProp extends LightningElement {
   @api
   set [x](value) {}
-  get [x]() {}
+  get [x]() {
+    return undefined
+  }
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/actual.js
@@ -3,11 +3,13 @@ export default class Text extends LightningElement {
   @api publicProp;
   privateProp;
 
-  @api get aloneGet() {}
-  @api get myget() {}
-  set myget(x) {
-    return 1;
+  @api get aloneGet() {
+    return undefined
   }
+  @api get myget() {
+    return undefined
+  }
+  set myget(x) {}
   @api m1() {}
   m2() {}
   static ctor = "ctor";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/transform-complex-attributes/expected.js
@@ -3,11 +3,13 @@ import _tmpl from "./test.html";
 class Text extends LightningElement {
   publicProp;
   privateProp;
-  get aloneGet() {}
-  get myget() {}
-  set myget(x) {
-    return 1;
+  get aloneGet() {
+    return undefined;
   }
+  get myget() {
+    return undefined;
+  }
+  set myget(x) {}
   m1() {}
   m2() {}
   static ctor = "ctor";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/actual.js
@@ -3,6 +3,8 @@ export default class Text extends LightningElement {
   foo = 1;
 
   @api
-  get foo() {}
+  get foo() {
+    return undefined
+  }
   set foo(value) {}
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-getter-setter-with-duplicate-property/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Text extends LightningElement {
   foo = 1;
-  get foo() {}
+  get foo() {
+    return undefined;
+  }
   set foo(value) {}
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/actual.js
@@ -2,6 +2,8 @@ import { api, LightningElement } from "lwc";
 export default class Text extends LightningElement {
   @api foo = 1;
 
-  get foo() {}
+  get foo() {
+    return undefined
+  }
   set foo(value) {}
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/api-decorator/w-9927596-public-property-with-duplicate-getter-setter/expected.js
@@ -2,7 +2,9 @@ import { registerDecorators as _registerDecorators, registerComponent as _regist
 import _tmpl from "./test.html";
 class Text extends LightningElement {
   foo = 1;
-  get foo() {}
+  get foo() {
+    return undefined;
+  }
   set foo(value) {}
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/actual.js
@@ -1,6 +1,5 @@
 import lwc, {LightningElement} from 'lwc'
 
-// eslint-disable-next-line no-console
 console.log(lwc)
 
 export default class extends LightningElement {}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default-and-named/expected.js
@@ -1,6 +1,5 @@
 import _tmpl from "./test.html";
 import lwc, { registerComponent as _registerComponent, LightningElement } from "lwc";
-// eslint-disable-next-line no-console
 console.log(lwc);
 export default _registerComponent(class extends LightningElement {
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/actual.js
@@ -1,4 +1,3 @@
 import lwc from 'lwc'
 
-// eslint-disable-next-line no-console
 console.log(lwc)

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/import-engine-default/expected.js
@@ -1,4 +1,2 @@
 import lwc from 'lwc';
-
-// eslint-disable-next-line no-console
 console.log(lwc);

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/actual.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-computed-key */
 import { wire, LightningElement } from "lwc";
 import { getFoo, getBar } from "data-service";
 

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/transforms-computed-properties/expected.js
@@ -1,5 +1,6 @@
 import { registerDecorators as _registerDecorators, registerComponent as _registerComponent, LightningElement } from "lwc";
 import _tmpl from "./test.html";
+/* eslint-disable no-useless-computed-key */
 import { getFoo, getBar } from "data-service";
 const symbol = Symbol.for("key");
 class Test extends LightningElement {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-dynamic-with-scoped-css/modules/x/attribute-dynamic-with-scoped-css/attribute-dynamic-with-scoped-css.js
@@ -2,4 +2,4 @@ import { LightningElement } from 'lwc';
 
 export default class AttributeDynamicWithScopedCss extends LightningElement {
   dynamicClass = 'kree'
-};
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/modules/x/rehydration/rehydration.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/rehydration/modules/x/rehydration/rehydration.js
@@ -5,6 +5,7 @@ export default class Rehydration extends LightningElement {
     @track reactive = 0;
 
     connectedCallback() {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => {
             this.reactive = 1;
         });

--- a/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/fixtures/lightningWebSecurityTransforms/lightningWebSecurityTransforms.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/fixtures/lightningWebSecurityTransforms/lightningWebSecurityTransforms.js
@@ -10,6 +10,7 @@ export default class extends LightningElement {
             break;
         }
     }
+    // eslint-disable-next-line @typescript-eslint/require-await
     async * baz() {
         yield 1;
         yield 2;

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/non-component-class/src/x/app/app.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/non-component-class/src/x/app/app.js
@@ -9,7 +9,6 @@ class AlsoNotALightningElement {
 
 export default class App extends LightningElement {
     renderedCallback() {
-        // eslint-disable-next-line no-console
         console.log(NotALightningElement, AlsoNotALightningElement)
     }
 }

--- a/scripts/eslint-plugin/index.js
+++ b/scripts/eslint-plugin/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -10,6 +10,7 @@ module.exports = {
         'no-extend-global-constructor': require('./rules/no-extend-global-constructor'),
         'no-global-node': require('./rules/no-global-node'),
         'no-invalid-todo': require('./rules/no-invalid-todo'),
+        'no-lwc-test-directive': require('./rules/no-lwc-test-directive'),
         'no-production-assert': require('./rules/no-production-assert'),
     },
 };

--- a/scripts/eslint-plugin/rules/no-lwc-test-directive.js
+++ b/scripts/eslint-plugin/rules/no-lwc-test-directive.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+/**
+ * This eslint rule checks that there are no "LWC test" directives, which are only intended for local use
+ */
+const LWC_TEST_REGEX = /\bLWC test /i;
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow LWC test directives in comments.',
+        },
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+        return {
+            Program() {
+                for (const comment of sourceCode.getAllComments()) {
+                    if (LWC_TEST_REGEX.test(comment.value)) {
+                        context.report({
+                            node: comment,
+                            message: 'Unexpected LWC test directive; remove before committing.',
+                        });
+                    }
+                }
+            },
+        };
+    },
+};


### PR DESCRIPTION
## Details

Let's say you want to make a change to the template compiler and you need to update the [attribute-allow](https://github.com/salesforce/lwc/tree/09f7b4c6f5756b034129fd8e7e79a8878f7e672b/packages/%40lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow) test fixture. You need to debug something, so you throw a breakpoint in the [test function](https://github.com/salesforce/lwc/blob/09f7b4c6f5756b034129fd8e7e79a8878f7e672b/packages/%40lwc/template-compiler/src/__tests__/fixtures.spec.ts#L22). Do you know how many times you need to click ▶️ Continue to get to that specific test? **461**! And this may be a controversial opinion, but I think that's a lot of clicking.

In regular jest tests, you can easily change `test(...)` to `test.only(...)` or `test.skip(...)`. You can't do that with tests that are run by the `testFixtureDir` helper. Until now! This PR introduces two new comment directives, `LWC test only` and `LWC test skip`. When detected in a comment at the start of a fixture file, the helper function uses `test.only` and `test.skip`, respectively.

As an example, when you add `<!-- LWC test only -->` to the start of [attribute-allow/actual.html](https://github.com/salesforce/lwc/blob/09f7b4c6f5756b034129fd8e7e79a8878f7e672b/packages/%40lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/actual.html), you no longer need to click through the debugger hundreds of times, because all the other tests in that test fixture directory are skipped.

```
Test Suites: 40 passed, 40 total
Tests:       461 skipped, 783 passed, 1244 total
Snapshots:   5 passed, 5 total
Time:        19.364 s
Ran all test suites in 15 projects.
```

One minor foot gun to be wary of is accidentally making a commit that uses these directives. However, we can avoid this for JavaScript files, at least, using a new eslint rule that I've created.

![Screenshot of JS code using with a comment `// LWC test skip`. The comment is highlighted as an eslint error, and a popover showing the error states "Unexpected LWC test directive; remove before committing."](https://github.com/salesforce/lwc/assets/62956339/d13d2f94-6769-4358-b9a3-a07b97d3fb66)


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-15228939
