### PR TITLE
test: reproduce timing issue with renderedCallback

### DIFF
--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -8,6 +8,10 @@ import ParentProp from 'x/parentProp';
 import Container from 'invocationorder/container';
 import LightContainer from 'invocationorder/lightContainer';
 import DispatchEvents from 'x/dispatchEvents';
+import TimingParent from 'timing/parent';
+import TimingParentLight from 'timing/parentLight';
+import ReorderingList from 'reordering/list';
+import ReorderingListLight from 'reordering/listLight';
 
 function resetTimingBuffer() {
     window.timingBuffer = [];
@@ -264,6 +268,106 @@ describe('invocation order', () => {
                 ];
 
                 expect(window.timingBuffer).toEqual(expected);
+            });
+        });
+    });
+});
+
+describe('connectedCallback/renderedCallback timing when reconnected', () => {
+    const scenarios = [
+        {
+            testName: 'shadow',
+            tagName: 'timing-parent',
+            Ctor: TimingParent,
+        },
+        {
+            testName: 'light',
+            tagName: 'timing-parent-light',
+            Ctor: TimingParentLight,
+        },
+    ];
+
+    scenarios.forEach(({ testName, Ctor, tagName }) => {
+        describe(testName, () => {
+            it('connect/disconnect/reconnect', async () => {
+                const elm = createElement(tagName, { is: Ctor });
+                document.body.appendChild(elm);
+                document.body.removeChild(elm);
+
+                await Promise.resolve();
+                resetTimingBuffer();
+
+                document.body.appendChild(elm);
+                // TODO [#4057]: the child's renderedCallback should probably fire here if the parent's does
+                expect(window.timingBuffer).toEqual(
+                    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                        ? [
+                              'parent:connectedCallback',
+                              'parent:renderedCallback',
+                              'child:connectedCallback',
+                          ]
+                        : ['parent:connectedCallback', 'parent:renderedCallback']
+                );
+            });
+
+            it('connect/mutate/disconnect/reconnect', async () => {
+                const elm = createElement(tagName, { is: Ctor });
+                document.body.appendChild(elm);
+                elm.value = 'baz';
+                document.body.removeChild(elm);
+
+                await Promise.resolve();
+                resetTimingBuffer();
+
+                document.body.appendChild(elm);
+                expect(window.timingBuffer).toEqual(
+                    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                        ? ['parent:connectedCallback', 'child:connectedCallback']
+                        : ['parent:connectedCallback']
+                );
+            });
+        });
+    });
+});
+
+describe('timing when reordering a list', () => {
+    const scenarios = [
+        {
+            testName: 'shadow',
+            tagName: 'reordering-list',
+            Ctor: ReorderingList,
+        },
+        {
+            testName: 'light',
+            tagName: 'reordering-list-light',
+            Ctor: ReorderingListLight,
+        },
+    ];
+    scenarios.forEach(({ testName, tagName, Ctor }) => {
+        describe(testName, () => {
+            it('invokes the expected callbacks when reordering', async () => {
+                const elm = createElement(tagName, { is: Ctor });
+                elm.uids = [1, 2];
+                document.body.appendChild(elm);
+
+                await Promise.resolve();
+                resetTimingBuffer();
+
+                elm.uids = [2, 1];
+                await Promise.resolve();
+
+                expect(window.timingBuffer).toEqual(
+                    // TODO [#4057]: the child's renderedCallback should probably fire here if the parent's does
+                    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                        ? [
+                              'item-wrapper-1:disconnectedCallback',
+                              'item-1:disconnectedCallback',
+                              'item-wrapper-1:connectedCallback',
+                              'item-wrapper-1:renderedCallback',
+                              'item-1:connectedCallback',
+                          ]
+                        : []
+                );
             });
         });
     });

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -287,7 +287,7 @@ describe('connectedCallback/renderedCallback timing when reconnected', () => {
         },
     ];
 
-    scenarios.forEach(({ testName, Ctor, tagName }) => {
+    scenarios.forEach(({ testName, tagName, Ctor }) => {
         describe(testName, () => {
             it('connect/disconnect/reconnect', async () => {
                 const elm = createElement(tagName, { is: Ctor });

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/item/item.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/item/item.html
@@ -1,0 +1,3 @@
+<template>
+    {uid}
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/item/item.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/item/item.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api uid;
+    connectedCallback() {
+        window.timingBuffer.push(`item-${this.uid}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`item-${this.uid}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`item-${this.uid}:disconnectedCallback`);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemLight/itemLight.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemLight/itemLight.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    {uid}
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemLight/itemLight.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemLight/itemLight.js
@@ -1,0 +1,19 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api uid;
+    connectedCallback() {
+        window.timingBuffer.push(`item-${this.uid}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`item-${this.uid}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`item-${this.uid}:disconnectedCallback`);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapper/itemWrapper.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapper/itemWrapper.html
@@ -1,0 +1,3 @@
+<template>
+    <reordering-item uid={uid}></reordering-item>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapper/itemWrapper.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapper/itemWrapper.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api uid;
+    connectedCallback() {
+        window.timingBuffer.push(`item-wrapper-${this.uid}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`item-wrapper-${this.uid}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`item-wrapper-${this.uid}:disconnectedCallback`);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapperLight/itemWrapperLight.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapperLight/itemWrapperLight.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <reordering-item-light uid={uid}></reordering-item-light>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapperLight/itemWrapperLight.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/itemWrapperLight/itemWrapperLight.js
@@ -1,0 +1,19 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api uid;
+    connectedCallback() {
+        window.timingBuffer.push(`item-wrapper-${this.uid}:connectedCallback`);
+    }
+    renderedCallback() {
+        window.timingBuffer.push(`item-wrapper-${this.uid}:renderedCallback`);
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push(`item-wrapper-${this.uid}:disconnectedCallback`);
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/list/list.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/list/list.html
@@ -1,0 +1,5 @@
+<template>
+    <template for:each={uids} for:item="uid">
+        <reordering-item-wrapper uid={uid} key={uid}></reordering-item-wrapper>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/list/list.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/list/list.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api uids = [];
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/listLight/listLight.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/listLight/listLight.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <template for:each={uids} for:item="uid">
+        <reordering-item-wrapper-light uid={uid} key={uid}></reordering-item-wrapper-light>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/listLight/listLight.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/reordering/listLight/listLight.js
@@ -1,0 +1,6 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api uids = [];
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/child/child.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/child/child.html
@@ -1,0 +1,3 @@
+<template>
+    {value}
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/child/child.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/child/child.js
@@ -1,0 +1,22 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api value = 'foo';
+    constructor() {
+        super();
+        window.timingBuffer.push('child:constructor');
+    }
+    connectedCallback() {
+        window.timingBuffer.push('child:connectedCallback');
+    }
+    renderedCallback() {
+        window.timingBuffer.push('child:renderedCallback');
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:disconnectedCallback');
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/childLight/childLight.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/childLight/childLight.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    {value}
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/childLight/childLight.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/childLight/childLight.js
@@ -1,0 +1,23 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api value = 'foo';
+    constructor() {
+        super();
+        window.timingBuffer.push('child:constructor');
+    }
+    connectedCallback() {
+        window.timingBuffer.push('child:connectedCallback');
+    }
+    renderedCallback() {
+        window.timingBuffer.push('child:renderedCallback');
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push('child:disconnectedCallback');
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parent/parent.html
@@ -1,0 +1,3 @@
+<template>
+    <timing-child value={value}></timing-child>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parent/parent.js
@@ -1,0 +1,22 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    @api value;
+    constructor() {
+        super();
+        window.timingBuffer.push('parent:constructor');
+    }
+    connectedCallback() {
+        window.timingBuffer.push('parent:connectedCallback');
+    }
+    renderedCallback() {
+        window.timingBuffer.push('parent:renderedCallback');
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:disconnectedCallback');
+        }
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parentLight/parentLight.html
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parentLight/parentLight.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <timing-child-light value={value}></timing-child-light>
+</template>

--- a/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parentLight/parentLight.js
+++ b/packages/@lwc/integration-karma/test/component/lifecycle-callbacks/timing/parentLight/parentLight.js
@@ -1,0 +1,23 @@
+import { api, LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api value;
+    constructor() {
+        super();
+        window.timingBuffer.push('parent:constructor');
+    }
+    connectedCallback() {
+        window.timingBuffer.push('parent:connectedCallback');
+    }
+    renderedCallback() {
+        window.timingBuffer.push('parent:renderedCallback');
+    }
+    disconnectedCallback() {
+        // This component could get disconnected by our Karma `test-setup.js` after `window.timingBuffer` has
+        // already been cleared; we don't care about the `disconnectedCallback`s in that case.
+        if (window.timingBuffer) {
+            window.timingBuffer.push('parent:disconnectedCallback');
+        }
+    }
+}


### PR DESCRIPTION
## Details

This reproduces the issue described in #4057 and merely asserts the current behavior.

We should probably fix it, but first I wanted to at least have a repro of the issue itself. I added `TODO` comments where applicable.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
