### PR TITLE
fix(template-compiler): add complex template expression binding support for computed properties

### DIFF
--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
@@ -1,3 +1,3 @@
 <template>
-    <section onclick={bar.arr[baz]}>{bar.arr[baz]}</section>
+    <section onclick={bar.arr[baz]}>{bar.arr[baz]} {bar.baz.arr[quux]} {bar.arr[baz.quux]}</section>
 </template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
@@ -1,3 +1,3 @@
 <template>
-    <section foo={bar.arr[baz]}>{bar.arr[baz]}</section>
+    <section onclick={bar.arr[baz]}>{bar.arr[baz]}</section>
 </template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/actual.html
@@ -1,0 +1,3 @@
+<template>
+    <section foo={bar.arr[baz]}>{bar.arr[baz]}</section>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
@@ -7,7 +7,7 @@
             "endLine": 3,
             "endColumn": 12,
             "start": 0,
-            "end": 83,
+            "end": 123,
             "startTag": {
                 "startLine": 1,
                 "startColumn": 1,
@@ -21,8 +21,8 @@
                 "startColumn": 1,
                 "endLine": 3,
                 "endColumn": 12,
-                "start": 72,
-                "end": 83
+                "start": 112,
+                "end": 123
             }
         },
         "directives": [],
@@ -35,9 +35,9 @@
                     "startLine": 2,
                     "startColumn": 5,
                     "endLine": 2,
-                    "endColumn": 61,
+                    "endColumn": 101,
                     "start": 15,
-                    "end": 71,
+                    "end": 111,
                     "startTag": {
                         "startLine": 2,
                         "startColumn": 5,
@@ -48,11 +48,11 @@
                     },
                     "endTag": {
                         "startLine": 2,
-                        "startColumn": 51,
+                        "startColumn": 91,
                         "endLine": 2,
-                        "endColumn": 61,
-                        "start": 61,
-                        "end": 71
+                        "endColumn": 101,
+                        "start": 101,
+                        "end": 111
                     }
                 },
                 "attributes": [],
@@ -233,6 +233,364 @@
                             "endColumn": 51,
                             "start": 47,
                             "end": 61
+                        }
+                    },
+                    {
+                        "type": "Text",
+                        "raw": " ",
+                        "value": {
+                            "type": "Literal",
+                            "value": " "
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 51,
+                            "endLine": 2,
+                            "endColumn": 52,
+                            "start": 61,
+                            "end": 62
+                        }
+                    },
+                    {
+                        "type": "Text",
+                        "raw": "{bar.baz.arr[quux]}",
+                        "value": {
+                            "type": "MemberExpression",
+                            "start": 63,
+                            "end": 80,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 52
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 69
+                                }
+                            },
+                            "range": [
+                                63,
+                                80
+                            ],
+                            "object": {
+                                "type": "MemberExpression",
+                                "start": 63,
+                                "end": 74,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 52
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 63
+                                    }
+                                },
+                                "range": [
+                                    63,
+                                    74
+                                ],
+                                "object": {
+                                    "type": "MemberExpression",
+                                    "start": 63,
+                                    "end": 70,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 52
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 59
+                                        }
+                                    },
+                                    "range": [
+                                        63,
+                                        70
+                                    ],
+                                    "object": {
+                                        "type": "Identifier",
+                                        "start": 63,
+                                        "end": 66,
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 52
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 55
+                                            }
+                                        },
+                                        "range": [
+                                            63,
+                                            66
+                                        ],
+                                        "name": "bar"
+                                    },
+                                    "property": {
+                                        "type": "Identifier",
+                                        "start": 67,
+                                        "end": 70,
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 56
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 59
+                                            }
+                                        },
+                                        "range": [
+                                            67,
+                                            70
+                                        ],
+                                        "name": "baz"
+                                    },
+                                    "computed": false,
+                                    "optional": false
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 71,
+                                    "end": 74,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 60
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 63
+                                        }
+                                    },
+                                    "range": [
+                                        71,
+                                        74
+                                    ],
+                                    "name": "arr"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "property": {
+                                "type": "Identifier",
+                                "start": 75,
+                                "end": 79,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 64
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 68
+                                    }
+                                },
+                                "range": [
+                                    75,
+                                    79
+                                ],
+                                "name": "quux"
+                            },
+                            "computed": true,
+                            "optional": false,
+                            "location": {
+                                "startLine": 2,
+                                "startColumn": 52,
+                                "endLine": 2,
+                                "endColumn": 71,
+                                "start": 62,
+                                "end": 81
+                            }
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 52,
+                            "endLine": 2,
+                            "endColumn": 71,
+                            "start": 62,
+                            "end": 81
+                        }
+                    },
+                    {
+                        "type": "Text",
+                        "raw": " ",
+                        "value": {
+                            "type": "Literal",
+                            "value": " "
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 71,
+                            "endLine": 2,
+                            "endColumn": 72,
+                            "start": 81,
+                            "end": 82
+                        }
+                    },
+                    {
+                        "type": "Text",
+                        "raw": "{bar.arr[baz.quux]}",
+                        "value": {
+                            "type": "MemberExpression",
+                            "start": 83,
+                            "end": 100,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 72
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 89
+                                }
+                            },
+                            "range": [
+                                83,
+                                100
+                            ],
+                            "object": {
+                                "type": "MemberExpression",
+                                "start": 83,
+                                "end": 90,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 72
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 79
+                                    }
+                                },
+                                "range": [
+                                    83,
+                                    90
+                                ],
+                                "object": {
+                                    "type": "Identifier",
+                                    "start": 83,
+                                    "end": 86,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 72
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 75
+                                        }
+                                    },
+                                    "range": [
+                                        83,
+                                        86
+                                    ],
+                                    "name": "bar"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 87,
+                                    "end": 90,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 76
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 79
+                                        }
+                                    },
+                                    "range": [
+                                        87,
+                                        90
+                                    ],
+                                    "name": "arr"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "property": {
+                                "type": "MemberExpression",
+                                "start": 91,
+                                "end": 99,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 80
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 88
+                                    }
+                                },
+                                "range": [
+                                    91,
+                                    99
+                                ],
+                                "object": {
+                                    "type": "Identifier",
+                                    "start": 91,
+                                    "end": 94,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 80
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 83
+                                        }
+                                    },
+                                    "range": [
+                                        91,
+                                        94
+                                    ],
+                                    "name": "baz"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 95,
+                                    "end": 99,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 84
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 88
+                                        }
+                                    },
+                                    "range": [
+                                        95,
+                                        99
+                                    ],
+                                    "name": "quux"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "computed": true,
+                            "optional": false,
+                            "location": {
+                                "startLine": 2,
+                                "startColumn": 72,
+                                "endLine": 2,
+                                "endColumn": 91,
+                                "start": 82,
+                                "end": 101
+                            }
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 72,
+                            "endLine": 2,
+                            "endColumn": 91,
+                            "start": 82,
+                            "end": 101
                         }
                     }
                 ]

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
@@ -7,7 +7,7 @@
             "endLine": 3,
             "endColumn": 12,
             "start": 0,
-            "end": 79,
+            "end": 83,
             "startTag": {
                 "startLine": 1,
                 "startColumn": 1,
@@ -21,8 +21,8 @@
                 "startColumn": 1,
                 "endLine": 3,
                 "endColumn": 12,
-                "start": 68,
-                "end": 79
+                "start": 72,
+                "end": 83
             }
         },
         "directives": [],
@@ -35,31 +35,34 @@
                     "startLine": 2,
                     "startColumn": 5,
                     "endLine": 2,
-                    "endColumn": 57,
+                    "endColumn": 61,
                     "start": 15,
-                    "end": 67,
+                    "end": 71,
                     "startTag": {
                         "startLine": 2,
                         "startColumn": 5,
                         "endLine": 2,
-                        "endColumn": 33,
+                        "endColumn": 37,
                         "start": 15,
-                        "end": 43
+                        "end": 47
                     },
                     "endTag": {
                         "startLine": 2,
-                        "startColumn": 47,
+                        "startColumn": 51,
                         "endLine": 2,
-                        "endColumn": 57,
-                        "start": 57,
-                        "end": 67
+                        "endColumn": 61,
+                        "start": 61,
+                        "end": 71
                     }
                 },
-                "attributes": [
+                "attributes": [],
+                "properties": [],
+                "directives": [],
+                "listeners": [
                     {
-                        "type": "Attribute",
-                        "name": "foo",
-                        "value": {
+                        "type": "EventListener",
+                        "name": "click",
+                        "handler": {
                             "type": "MemberExpression",
                             "start": 1,
                             "end": 13,
@@ -94,85 +97,62 @@
                                 "startLine": 2,
                                 "startColumn": 14,
                                 "endLine": 2,
-                                "endColumn": 32,
+                                "endColumn": 36,
                                 "start": 24,
-                                "end": 42
+                                "end": 46
                             }
                         },
                         "location": {
                             "startLine": 2,
                             "startColumn": 14,
                             "endLine": 2,
-                            "endColumn": 32,
+                            "endColumn": 36,
                             "start": 24,
-                            "end": 42
+                            "end": 46
                         }
                     }
                 ],
-                "properties": [],
-                "directives": [],
-                "listeners": [],
                 "children": [
                     {
                         "type": "Text",
                         "raw": "{bar.arr[baz]}",
                         "value": {
                             "type": "MemberExpression",
-                            "start": 44,
-                            "end": 56,
+                            "start": 48,
+                            "end": 60,
                             "loc": {
                                 "start": {
                                     "line": 2,
-                                    "column": 33
+                                    "column": 37
                                 },
                                 "end": {
                                     "line": 2,
-                                    "column": 45
+                                    "column": 49
                                 }
                             },
                             "range": [
-                                44,
-                                56
+                                48,
+                                60
                             ],
                             "object": {
                                 "type": "MemberExpression",
-                                "start": 44,
-                                "end": 51,
+                                "start": 48,
+                                "end": 55,
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 33
+                                        "column": 37
                                     },
                                     "end": {
                                         "line": 2,
-                                        "column": 40
+                                        "column": 44
                                     }
                                 },
                                 "range": [
-                                    44,
-                                    51
+                                    48,
+                                    55
                                 ],
                                 "object": {
-                                    "type": "Identifier",
-                                    "start": 44,
-                                    "end": 47,
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 33
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 36
-                                        }
-                                    },
-                                    "range": [
-                                        44,
-                                        47
-                                    ],
-                                    "name": "bar"
-                                },
-                                "property": {
                                     "type": "Identifier",
                                     "start": 48,
                                     "end": 51,
@@ -190,6 +170,26 @@
                                         48,
                                         51
                                     ],
+                                    "name": "bar"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 52,
+                                    "end": 55,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 41
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 44
+                                        }
+                                    },
+                                    "range": [
+                                        52,
+                                        55
+                                    ],
                                     "name": "arr"
                                 },
                                 "computed": false,
@@ -197,21 +197,21 @@
                             },
                             "property": {
                                 "type": "Identifier",
-                                "start": 52,
-                                "end": 55,
+                                "start": 56,
+                                "end": 59,
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 41
+                                        "column": 45
                                     },
                                     "end": {
                                         "line": 2,
-                                        "column": 44
+                                        "column": 48
                                     }
                                 },
                                 "range": [
-                                    52,
-                                    55
+                                    56,
+                                    59
                                 ],
                                 "name": "baz"
                             },
@@ -219,20 +219,20 @@
                             "optional": false,
                             "location": {
                                 "startLine": 2,
-                                "startColumn": 33,
+                                "startColumn": 37,
                                 "endLine": 2,
-                                "endColumn": 47,
-                                "start": 43,
-                                "end": 57
+                                "endColumn": 51,
+                                "start": 47,
+                                "end": 61
                             }
                         },
                         "location": {
                             "startLine": 2,
-                            "startColumn": 33,
+                            "startColumn": 37,
                             "endLine": 2,
-                            "endColumn": 47,
-                            "start": 43,
-                            "end": 57
+                            "endColumn": 51,
+                            "start": 47,
+                            "end": 61
                         }
                     }
                 ]

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/ast.json
@@ -1,0 +1,242 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 12,
+            "start": 0,
+            "end": 79,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 3,
+                "startColumn": 1,
+                "endLine": 3,
+                "endColumn": 12,
+                "start": 68,
+                "end": 79
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Element",
+                "name": "section",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 57,
+                    "start": 15,
+                    "end": 67,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 33,
+                        "start": 15,
+                        "end": 43
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 47,
+                        "endLine": 2,
+                        "endColumn": 57,
+                        "start": 57,
+                        "end": 67
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "foo",
+                        "value": {
+                            "type": "MemberExpression",
+                            "start": 1,
+                            "end": 13,
+                            "object": {
+                                "type": "MemberExpression",
+                                "start": 1,
+                                "end": 8,
+                                "object": {
+                                    "type": "Identifier",
+                                    "start": 1,
+                                    "end": 4,
+                                    "name": "bar"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 5,
+                                    "end": 8,
+                                    "name": "arr"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "property": {
+                                "type": "Identifier",
+                                "start": 9,
+                                "end": 12,
+                                "name": "baz"
+                            },
+                            "computed": true,
+                            "optional": false,
+                            "location": {
+                                "startLine": 2,
+                                "startColumn": 14,
+                                "endLine": 2,
+                                "endColumn": 32,
+                                "start": 24,
+                                "end": 42
+                            }
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 14,
+                            "endLine": 2,
+                            "endColumn": 32,
+                            "start": 24,
+                            "end": 42
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": [
+                    {
+                        "type": "Text",
+                        "raw": "{bar.arr[baz]}",
+                        "value": {
+                            "type": "MemberExpression",
+                            "start": 44,
+                            "end": 56,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 33
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 45
+                                }
+                            },
+                            "range": [
+                                44,
+                                56
+                            ],
+                            "object": {
+                                "type": "MemberExpression",
+                                "start": 44,
+                                "end": 51,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 33
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 40
+                                    }
+                                },
+                                "range": [
+                                    44,
+                                    51
+                                ],
+                                "object": {
+                                    "type": "Identifier",
+                                    "start": 44,
+                                    "end": 47,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 33
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 36
+                                        }
+                                    },
+                                    "range": [
+                                        44,
+                                        47
+                                    ],
+                                    "name": "bar"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "start": 48,
+                                    "end": 51,
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 37
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 40
+                                        }
+                                    },
+                                    "range": [
+                                        48,
+                                        51
+                                    ],
+                                    "name": "arr"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "property": {
+                                "type": "Identifier",
+                                "start": 52,
+                                "end": 55,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 41
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 44
+                                    }
+                                },
+                                "range": [
+                                    52,
+                                    55
+                                ],
+                                "name": "baz"
+                            },
+                            "computed": true,
+                            "optional": false,
+                            "location": {
+                                "startLine": 2,
+                                "startColumn": 33,
+                                "endLine": 2,
+                                "endColumn": 47,
+                                "start": 43,
+                                "end": 57
+                            }
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 33,
+                            "endLine": 2,
+                            "endColumn": 47,
+                            "start": 43,
+                            "end": 57
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/config.json
@@ -1,0 +1,3 @@
+{
+	"experimentalComplexExpressions": true
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
@@ -1,0 +1,19 @@
+import { registerTemplate } from "lwc";
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+  return [
+    api_element(
+      "section",
+      {
+        attrs: {
+          foo: $cmp.bar.arr[$cmp.baz],
+        },
+        key: 0,
+      },
+      [api_text(api_dynamic_text($cmp.bar.arr[$cmp.baz]))]
+    ),
+  ];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
@@ -16,7 +16,15 @@ function tmpl($api, $cmp, $slotset, $ctx) {
           click: _m0 || ($ctx._m0 = api_bind($cmp.bar.arr[$cmp.baz])),
         },
       },
-      [api_text(api_dynamic_text($cmp.bar.arr[$cmp.baz]))]
+      [
+        api_text(
+          api_dynamic_text($cmp.bar.arr[$cmp.baz]) +
+            " " +
+            api_dynamic_text($cmp.bar.baz.arr[$cmp.quux]) +
+            " " +
+            api_dynamic_text($cmp.bar.arr[$cmp.baz.quux])
+        ),
+      ]
     ),
   ];
   /*LWC compiler vX.X.X*/

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
@@ -1,14 +1,20 @@
 import { registerTemplate } from "lwc";
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { d: api_dynamic_text, t: api_text, h: api_element } = $api;
+  const {
+    b: api_bind,
+    d: api_dynamic_text,
+    t: api_text,
+    h: api_element,
+  } = $api;
+  const { _m0 } = $ctx;
   return [
     api_element(
       "section",
       {
-        attrs: {
-          foo: $cmp.bar.arr[$cmp.baz],
-        },
         key: 0,
+        on: {
+          click: _m0 || ($ctx._m0 = api_bind($cmp.bar.arr[$cmp.baz])),
+        },
       },
       [api_text(api_dynamic_text($cmp.bar.arr[$cmp.baz]))]
     ),

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/metadata.json
@@ -1,15 +1,3 @@
 {
-    "warnings": [
-        {
-            "code": 1057,
-            "message": "LWC1057: foo is not valid attribute for section. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section",
-            "level": 2,
-            "location": {
-                "line": 2,
-                "column": 14,
-                "start": 24,
-                "length": 18
-            }
-        }
-    ]
+    "warnings": []
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1057,
+            "message": "LWC1057: foo is not valid attribute for section. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 14,
+                "start": 24,
+                "length": 18
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/codegen/expression.ts
+++ b/packages/@lwc/template-compiler/src/codegen/expression.ts
@@ -53,13 +53,14 @@ export function bindComplexExpression(
 
         leave(node, parent) {
             if (t.isArrowFunctionExpression(node)) {
-                expressionScopes.exitScope(node);
-            } else if (
+                return expressionScopes.exitScope(node);
+            }
+            // Acorn parses `undefined` as an Identifier.
+            const isIdentifier = t.isIdentifier(node) && node.name !== 'undefined';
+            if (
                 parent !== null &&
-                t.isIdentifier(node) &&
-                // Acorn parses `undefined` as an Identifier.
-                node.name !== 'undefined' &&
-                !(t.isMemberExpression(parent) && parent.property === node) &&
+                isIdentifier &&
+                !(t.isMemberExpression(parent) && parent.property === node && !parent.computed) &&
                 !(t.isProperty(parent) && parent.key === node) &&
                 !codeGen.isLocalIdentifier(node) &&
                 !expressionScopes.isScopedToExpression(node)


### PR DESCRIPTION
## Details

`arr[baz]` and `arr.baz` are both considered member expressions, with the difference being whether the property is computed or not. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

## GUS work item

W-14631155