### PR TITLE
perf: add js-framework-benchmark tests

### DIFF
--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.html
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.html
@@ -1,0 +1,60 @@
+<!--
+Copyright (c) 2024, Salesforce, Inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<!--
+  This should be kept in sync with
+  https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/keyed/lwc/src/bench/app/app.js
+-->
+<template lwc:render-mode="light">
+    <div class="jumbotron">
+        <div class="row">
+            <div class="col-md-6">
+                <h1>LWC</h1>
+            </div>
+            <div class="col-md-6">
+                <div class="row">
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="run" onclick={run}>Create 1,000 rows</button>
+                    </div>
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="runlots" onclick={runLots}>Create 10,000 rows</button>
+                    </div>
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="add" onclick={add}>Append 1,000 rows</button>
+                    </div>
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="update" onclick={update}>Update every 10th row</button>
+                    </div>
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="clear" onclick={clear}>Clear</button>
+                    </div>
+                    <div class="col-sm-6 smallpad">
+                        <button type="button" class="btn btn-primary btn-block" id="swaprows" onclick={swapRows}>Swap Rows</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <table class="table table-hover table-striped test-data">
+        <tbody>
+        <template for:each={rows} for:item="row">
+            <tr key={row.id} class={row.className} data-id={row.id} onclick={handleRowClick}>
+                <td class="col-md-1">{row.id}</td>
+                <td class="col-md-4" data-interaction="select">
+                    <a data-interaction="select">{row.label}</a>
+                </td>
+                <td class="col-md-1">
+                    <a data-interaction="remove">
+                        <span data-interaction="remove" class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    </a>
+                </td>
+                <td class="col-md-6"></td>
+            </tr>
+        </template>
+        </tbody>
+    </table>
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+</template>

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// This should be kept in sync with
+// https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/keyed/lwc/src/bench/app/app.js
+import { LightningElement, track } from 'lwc';
+
+let id = 1;
+
+function _random(max) {
+    return Math.round(Math.random() * 1000) % max;
+}
+
+export default class App extends LightningElement {
+    static renderMode = 'light';
+    @track rows = [];
+    selected;
+
+    run() {
+        this.rows = this.buildData();
+        this.selected = undefined;
+    }
+    runLots() {
+        this.rows = this.buildData(10000);
+        this.selected = undefined;
+    }
+    delete(id) {
+        const idx = this.rows.findIndex((row) => row.id === id);
+        this.rows.splice(idx, 1);
+    }
+    add() {
+        this.rows.push(...this.buildData(1000));
+    }
+    update() {
+        for (let i = 0, len = this.rows.length; i < len; i += 10) {
+            this.rows[i].label += ' !!!';
+        }
+    }
+    select(id) {
+        this.selected = id;
+    }
+    clear() {
+        this.rows.length = 0;
+        this.selected = undefined;
+    }
+    swapRows() {
+        if (this.rows.length > 998) {
+            const row = this.rows[1];
+            this.rows[1] = this.rows[998];
+            this.rows[998] = row;
+        }
+    }
+    handleRowClick(evt) {
+        const { target, currentTarget } = evt;
+        const { interaction } = target.dataset;
+        const { id } = currentTarget.dataset;
+
+        if (interaction === 'select') {
+            this.select(parseInt(id, 10));
+        } else if (interaction === 'remove') {
+            this.delete(parseInt(id, 10));
+        }
+    }
+    buildData(count = 1000) {
+        const adjectives = [
+            'pretty',
+            'large',
+            'big',
+            'small',
+            'tall',
+            'short',
+            'long',
+            'handsome',
+            'plain',
+            'quaint',
+            'clean',
+            'elegant',
+            'easy',
+            'angry',
+            'crazy',
+            'helpful',
+            'mushy',
+            'odd',
+            'unsightly',
+            'adorable',
+            'important',
+            'inexpensive',
+            'cheap',
+            'expensive',
+            'fancy',
+        ];
+        const colours = [
+            'red',
+            'yellow',
+            'blue',
+            'green',
+            'pink',
+            'brown',
+            'purple',
+            'brown',
+            'white',
+            'black',
+            'orange',
+        ];
+        const nouns = [
+            'table',
+            'chair',
+            'house',
+            'bbq',
+            'desk',
+            'car',
+            'pony',
+            'cookie',
+            'sandwich',
+            'burger',
+            'pizza',
+            'mouse',
+            'keyboard',
+        ];
+        const data = [];
+        const component = this; // eslint-disable-line @typescript-eslint/no-this-alias
+        for (let i = 0; i < count; i++) {
+            data.push({
+                id: id++,
+                label:
+                    adjectives[_random(adjectives.length)] +
+                    ' ' +
+                    colours[_random(colours.length)] +
+                    ' ' +
+                    nouns[_random(nouns.length)],
+                get className() {
+                    return this.id === component.selected ? 'danger' : '';
+                },
+            });
+        }
+        return data;
+    }
+}

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/append-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/append-rows-1k.benchmark.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchAppendToManyRows()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/append-rows/10k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, clear }) {
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await run();
+                await clear();
+            }
+            await run();
+        },
+        async execute({ add }) {
+            await add();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/clear-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/clear-rows-1k.benchmark.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchClear()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/clear-rows/10k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, clear }) {
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await run();
+                await clear();
+            }
+            await run();
+        },
+        async execute({ clear }) {
+            await clear();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/create-rows-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/create-rows-10k.benchmark.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchRunBig()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/create-rows/10k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ runLots, clear }) {
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await runLots();
+                await clear();
+            }
+        },
+        async execute({ runLots }) {
+            await runLots();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/create-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/create-rows-1k.benchmark.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchRun()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/create-rows/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, clear }) {
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await run();
+                await clear();
+            }
+        },
+        async execute({ run }) {
+            await run();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/partial-update-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/partial-update-1k.benchmark.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchUpdate()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/partial-update/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, update }) {
+            await run();
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await update();
+            }
+        },
+        async execute({ update }) {
+            await update();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/remove-row-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/remove-row-1k.benchmark.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+const rowsToSkip = 4;
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchRemove()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/remove-row/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, remove }) {
+            await run();
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                const rowToClick = WARMUP_COUNT - i + rowsToSkip;
+                await remove(rowToClick);
+            }
+        },
+        async execute({ remove }) {
+            await remove(rowsToSkip);
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/replace-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/replace-rows-1k.benchmark.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchReplaceAll()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/replace-rows/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run }) {
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await run();
+            }
+        },
+        async execute({ run }) {
+            await run();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/select-row-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/select-row-1k.benchmark.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchSelect()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/select-row/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, select }) {
+            await run();
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await select(i + 5);
+            }
+        },
+        async execute({ select }) {
+            await select(2);
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/swap-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/swap-rows-1k.benchmark.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
+
+// Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
+// See `benchSwapRows()`
+runJsFrameworkBenchmark(
+    `dom/js-framework-benchmark/swap-rows/1k`,
+    { benchmark, before, run, after },
+    {
+        async warmup({ run, swapRows }) {
+            await run();
+            for (let i = 0; i < WARMUP_COUNT; i++) {
+                await swapRows();
+            }
+        },
+        async execute({ swapRows }) {
+            await swapRows();
+        },
+    }
+);

--- a/packages/@lwc/perf-benchmarks/src/utils/runJsFrameworkBenchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/utils/runJsFrameworkBenchmark.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from '@lwc/engine-dom';
+import JsFrameworkBenchmarkTable from '@lwc/perf-benchmarks-components/dist/dom/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.js';
+import { destroyComponent, insertComponent } from './utils.js';
+
+const actionsToElementIds = {
+    run: '#run',
+    runLots: '#runlots',
+    add: '#add',
+    update: '#update',
+    clear: '#clear',
+    swapRows: '#swaprows',
+};
+
+export const WARMUP_COUNT = 5;
+
+// This is an abstraction of the various operations that js-framework-benchmark does.
+// Most of these revolve around clicking an element with a given id (#run, #runlots, etc.), but sometimes
+// it involves clicking a particular element inside a row (e.g. to remove the row or select it).
+export function runJsFrameworkBenchmark(
+    name,
+    { benchmark, before, run, after },
+    { warmup, execute }
+) {
+    benchmark(name, () => {
+        let elm;
+        let controller;
+
+        before(async () => {
+            elm = createElement('benchmark-js-framework-benchmark-table', {
+                is: JsFrameworkBenchmarkTable,
+            });
+            await insertComponent(elm);
+
+            controller = {
+                // actions that only require clicking a given element ID
+                ...Object.fromEntries(
+                    Object.entries(actionsToElementIds).map(([action, id]) => {
+                        return [
+                            action,
+                            async () => {
+                                elm.querySelector(id).click();
+                                await Promise.resolve(); // wait for LWC to render
+                            },
+                        ];
+                    })
+                ),
+                // actions that require clicking inside a particular row
+                select: async (rowToClick) => {
+                    elm.querySelector(
+                        `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(2)>a`
+                    ).click();
+                    await Promise.resolve(); // wait for LWC to render
+                },
+                remove: async (rowToClick) => {
+                    elm.querySelector(
+                        `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(3)>a>span:nth-of-type(1)`
+                    ).click();
+                    await Promise.resolve(); // wait for LWC to render
+                },
+            };
+
+            await warmup(controller);
+        });
+
+        run(async () => {
+            await execute(controller);
+        });
+
+        after(() => {
+            destroyComponent(elm);
+        });
+    });
+}


### PR DESCRIPTION
## Details

As we track our progress with fine-grained reactivity (#3624), I think it would be helpful to have the actual `js-framework-benchmark` benchmarks in our local benchmarks. Otherwise, it's kind of a pain to set up `js-framework-benchmark` itself, link it to LWC, and run it to see the results.

This PR is my attempt to replicate as closely as possible what `js-framework-benchmark` is doing. A few limitations:

- There is some overlap here with existing benchmarks, which were clearly also inspired by `js-framework-benchmark` but are slightly different.
- Some of the benchmarks execute quite quickly (<5ms), which is not great for Tachometer since it tends to lead to lots of variance. _(**Update**: opened #4070 to resolve this.)_

Despite these limitations, I still think this is worth doing, at least to see our historical trend over time as we try to improve these benchmark results.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
