### PR TITLE
perf: add throttling to tachometer benchmarks

### DIFF
--- a/packages/@lwc/perf-benchmarks/README.md
+++ b/packages/@lwc/perf-benchmarks/README.md
@@ -56,9 +56,12 @@ You can also use these environment variables to adjust the default benchmark set
 BENCHMARK_SAMPLE_SIZE=50
 BENCHMARK_AUTO_SAMPLE_CONDITIONS=25%
 BENCHMARK_TIMEOUT=5
+BENCHMARK_CPU_THROTTLING_RATE=4
 ```
 
 See the [Tachometer documentation](https://github.com/Polymer/tachometer) for details on what these mean.
+
+For `BENCHMARK_CPU_THROTTLING_RATE`, some tests have a built-in `cpuThrottlingRate` which is exported as a `const`. The environment variable will override this.
 
 You can run a smoke test (to confirm the benchmark tests are working) using:
 

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -55,6 +55,9 @@
                     },
                     {
                         "env": "BENCHMARK_SMOKE_TEST"
+                    },
+                    {
+                        "env": "BENCHMARK_CPU_THROTTLING_RATE"
                     }
                 ]
             },

--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -133,7 +133,7 @@ async function extractCpuThrottlingRate(benchmarkFile) {
     // Rollup transforms this into `const cpuThrottlingRate = 2; [...] export { cpuThrottlingRate };`,
     // so we just look for the const, not the export.
     // We could do a more sophisticated thing than a regex, but the regex works fine.
-    const match = contents.match(/const cpuThrottlingRate = (\d+)/);
+    const match = contents.match(/const cpuThrottlingRate\s*=\s*(\d+)/);
     return match && parseInt(match[1], 10);
 }
 

--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -9,13 +9,10 @@
  * Builds the HTML and tachometer.json files necessary to run the benchmarks.
  */
 
-const path = require('path');
-const fs = require('fs');
-const { promisify } = require('util');
+const path = require('node:path');
+const { readFile, writeFile } = require('node:fs/promises');
 const { glob } = require('glob');
 const { hashElement } = require('folder-hash');
-
-const writeFile = promisify(fs.writeFile);
 
 const {
     BENCHMARK_SMOKE_TEST,
@@ -27,6 +24,7 @@ const {
 let {
     BENCHMARK_SAMPLE_SIZE = 100, // minimum number of samples to run
     BENCHMARK_TIMEOUT = 15, // timeout in minutes during auto-sampling (after the minimum samples). If 0, no auto-sampling
+    BENCHMARK_CPU_THROTTLING_RATE, // CPU throttling factor, typically 2 or 4
 } = process.env;
 
 const toInt = (num) => (typeof num === 'number' ? num : parseInt(num, 10));
@@ -35,6 +33,8 @@ const toInt = (num) => (typeof num === 'number' ? num : parseInt(num, 10));
 BENCHMARK_SAMPLE_SIZE = BENCHMARK_SMOKE_TEST ? 2 : toInt(BENCHMARK_SAMPLE_SIZE);
 // Timeout of 0 means don't auto-sample at all
 BENCHMARK_TIMEOUT = BENCHMARK_SMOKE_TEST ? 0 : toInt(BENCHMARK_TIMEOUT);
+BENCHMARK_CPU_THROTTLING_RATE =
+    BENCHMARK_CPU_THROTTLING_RATE && toInt(BENCHMARK_CPU_THROTTLING_RATE);
 
 const benchmarkComponentsDir = path.join(__dirname, '../../../@lwc/perf-benchmarks-components');
 
@@ -66,7 +66,7 @@ function createHtml(benchmarkFile) {
   `.trim();
 }
 
-function createTachometerJson(htmlFilename, benchmarkName, directoryHash) {
+function createTachometerJson(htmlFilename, benchmarkName, directoryHash, cpuThrottlingRate) {
     return {
         $schema: 'https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json',
         sampleSize: BENCHMARK_SAMPLE_SIZE,
@@ -80,6 +80,7 @@ function createTachometerJson(htmlFilename, benchmarkName, directoryHash) {
                     name: 'chrome',
                     headless: true,
                     ...(CHROME_BINARY && { binary: CHROME_BINARY }),
+                    ...(typeof cpuThrottlingRate === 'number' && { cpuThrottlingRate }),
                 },
                 measurement: {
                     mode: 'performance',
@@ -126,6 +127,16 @@ function createTachometerJson(htmlFilename, benchmarkName, directoryHash) {
     };
 }
 
+// Given a *.benchmark.js file, extract the exported `cpuThrottlingRate`.
+async function extractCpuThrottlingRate(benchmarkFile) {
+    const contents = await readFile(benchmarkFile, 'utf-8');
+    // Rollup transforms this into `const cpuThrottlingRate = 2; [...] export { cpuThrottlingRate };`,
+    // so we just look for the const, not the export.
+    // We could do a more sophisticated thing than a regex, but the regex works fine.
+    const match = contents.match(/const cpuThrottlingRate = (\d+)/);
+    return match && parseInt(match[1], 10);
+}
+
 // Given a benchmark source file, create the necessary HTML file and Tachometer JSON
 // file for running it.
 async function processBenchmarkFile(benchmarkFile, directoryHash) {
@@ -141,7 +152,16 @@ async function processBenchmarkFile(benchmarkFile, directoryHash) {
     async function writeTachometerJsonFile() {
         const engineType = benchmarkFile.includes('/engine-server/') ? 'server' : 'dom';
         const benchmarkName = `${engineType}-${benchmarkFileBasename.split('.')[0]}`;
-        const tachometerJson = createTachometerJson(htmlFilename, benchmarkName, directoryHash);
+        const cpuThrottlingRate =
+            typeof BENCHMARK_CPU_THROTTLING_RATE === 'number'
+                ? BENCHMARK_CPU_THROTTLING_RATE
+                : await extractCpuThrottlingRate(benchmarkFile);
+        const tachometerJson = createTachometerJson(
+            htmlFilename,
+            benchmarkName,
+            directoryHash,
+            cpuThrottlingRate
+        );
         const jsonFilename = path.join(
             targetDir,
             `${benchmarkFileBasename.split('.')[0]}.tachometer.json`

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-expression/expression.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-expression/expression.benchmark.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -10,6 +10,9 @@ import { createElement } from '@lwc/engine-dom';
 import Expression from '@lwc/perf-benchmarks-components/dist/dom/benchmark/expression/expression.js';
 import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
 import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+// Throttling because otherwise this benchmark completes in <~5ms on a MacBook Pro
+export const cpuThrottlingRate = 4;
 
 benchmark(`dom/expressions`, () => {
     let expressionElement;

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/clear-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/clear-rows-1k.benchmark.js
@@ -6,6 +6,9 @@
  */
 import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
 
+// Throttling per https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html
+export const cpuThrottlingRate = 4;
+
 // Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
 // See `benchClear()`
 runJsFrameworkBenchmark(

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/partial-update-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/partial-update-1k.benchmark.js
@@ -6,6 +6,9 @@
  */
 import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
 
+// Throttling per https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html
+export const cpuThrottlingRate = 4;
+
 // Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
 // See `benchUpdate()`
 runJsFrameworkBenchmark(

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/remove-row-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/remove-row-1k.benchmark.js
@@ -6,6 +6,9 @@
  */
 import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
 
+// Throttling per https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html
+export const cpuThrottlingRate = 2;
+
 const rowsToSkip = 4;
 
 // Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/select-row-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/select-row-1k.benchmark.js
@@ -6,6 +6,9 @@
  */
 import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
 
+// Throttling per https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html
+export const cpuThrottlingRate = 4;
+
 // Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
 // See `benchSelect()`
 runJsFrameworkBenchmark(

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/swap-rows-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/js-framework-benchmark/swap-rows-1k.benchmark.js
@@ -6,6 +6,9 @@
  */
 import { runJsFrameworkBenchmark, WARMUP_COUNT } from '../../../utils/runJsFrameworkBenchmark.js';
 
+// Throttling per https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html
+export const cpuThrottlingRate = 4;
+
 // Based on https://github.com/krausest/js-framework-benchmark/blob/6c9f43f/webdriver-ts/src/benchmarksPuppeteer.ts
 // See `benchSwapRows()`
 runJsFrameworkBenchmark(


### PR DESCRIPTION
## Details

(This PR is on top of #4069 to avoid bitrotting myself.)

The `js-framework-benchmark` actually throttles some of its benchmarks in its [reported results](https://krausest.github.io/js-framework-benchmark/2024/table_chrome_122.0.6261.69.html). We should mimic this behavior to try to approximate what they're doing.

Plus, some of our existing benchmarks also execute fairly quickly, so throttling them could help reduce variance.

This adds CPU throttling to certain benchmarks (matching the `js-framework-benchmark` behavior), as well as adding a global `BENCHMARK_CPU_THROTTLING_RATE` that can be set on the command line and which overrides the per-benchmark defaults.

Note that this only affects Tachometer, not Best. Best has no CPU throttling currently.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
