### PR TITLE
chore: filter `@lwc/engine-server` fixture test warnings for `lwc:dynamic` only

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -44,6 +44,9 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
         ],
         onwarn(warning) {
             if (warning.message.includes('LWC1187')) {
+                // TODO [#3331]: The existing lwc:dynamic fixture test will generate warnings that can be safely suppressed.
+                // The warning message is expected and appears when the compiler detects usage of the directive.
+                // We plan to remove the directive in a future release, see #3331 for details.
                 warnings.push(warning);
             }
         },

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -43,7 +43,9 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
             }),
         ],
         onwarn(warning) {
-            warnings.push(warning);
+            if (warning.message.includes('LWC1187')) {
+                warnings.push(warning);
+            }
         },
     });
 


### PR DESCRIPTION
## Details
In #3381 the `@lwc/engine-server` fixture test warnings were suppressed.

The intention here was to only supress the warnings generated for `lwc:dynamic` [usage](https://github.com/salesforce/lwc/tree/jtu/enable-engine-server-warnings/packages/%40lwc/engine-server/src/__tests__/fixtures/lwc-dynamic).

Supressing all warnings in `@lwc/engine-server` hid an issue with the fixture tests in #4055.

Filtering the warnings to specifically look for `lwc:dynamic` warning messages.

## Does this pull request introduce a breaking change?

-   😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

