### PR TITLE
chore: release v6.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc-monorepo",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "private": true,
     "description": "Lightning Web Components",
     "repository": {

--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/aria-reflection",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "ARIA element reflection polyfill for strings",
     "keywords": [
         "aom",

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/babel-plugin-component",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Babel plugin to transform a LWC module",
     "keywords": [
         "lwc"
@@ -43,8 +43,8 @@
     },
     "dependencies": {
         "@babel/helper-module-imports": "7.22.15",
-        "@lwc/errors": "6.3.3",
-        "@lwc/shared": "6.3.3",
+        "@lwc/errors": "6.3.4",
+        "@lwc/shared": "6.3.4",
         "line-column": "~1.0.2"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/compiler",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "LWC compiler",
     "keywords": [
         "lwc"
@@ -48,10 +48,10 @@
         "@babel/plugin-proposal-object-rest-spread": "7.20.7",
         "@babel/plugin-transform-async-to-generator": "7.23.3",
         "@locker/babel-plugin-transform-unforgeables": "0.20.0",
-        "@lwc/babel-plugin-component": "6.3.3",
-        "@lwc/errors": "6.3.3",
-        "@lwc/shared": "6.3.3",
-        "@lwc/style-compiler": "6.3.3",
-        "@lwc/template-compiler": "6.3.3"
+        "@lwc/babel-plugin-component": "6.3.4",
+        "@lwc/errors": "6.3.4",
+        "@lwc/shared": "6.3.4",
+        "@lwc/style-compiler": "6.3.4",
+        "@lwc/template-compiler": "6.3.4"
     }
 }

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-core",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Core LWC engine APIs.",
     "keywords": [
         "lwc"
@@ -42,11 +42,11 @@
         }
     },
     "dependencies": {
-        "@lwc/features": "6.3.3",
-        "@lwc/shared": "6.3.3"
+        "@lwc/features": "6.3.4",
+        "@lwc/shared": "6.3.4"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0",
-        "@lwc/signals": "6.3.3"
+        "@lwc/signals": "6.3.4"
     }
 }

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-dom",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Renders LWC components in a DOM environment.",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "6.3.3",
-        "@lwc/shared": "6.3.3"
+        "@lwc/engine-core": "6.3.4",
+        "@lwc/shared": "6.3.4"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-server",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Renders LWC components in a server environment.",
     "keywords": [
         "lwc"
@@ -42,9 +42,9 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "6.3.3",
-        "@lwc/rollup-plugin": "6.3.3",
-        "@lwc/shared": "6.3.3",
+        "@lwc/engine-core": "6.3.4",
+        "@lwc/rollup-plugin": "6.3.4",
+        "@lwc/shared": "6.3.4",
         "@parse5/tools": "^0.4.0",
         "@rollup/plugin-virtual": "^3.0.1",
         "parse5": "^7.1.2"

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/errors",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "LWC Error Utilities",
     "keywords": [
         "lwc"

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/features",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "LWC Features Flags",
     "keywords": [
         "lwc"
@@ -42,6 +42,6 @@
         }
     },
     "dependencies": {
-        "@lwc/shared": "6.3.3"
+        "@lwc/shared": "6.3.4"
     }
 }

--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-karma",
     "private": true,
-    "version": "6.3.3",
+    "version": "6.3.4",
     "scripts": {
         "start": "KARMA_MODE=watch karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
@@ -17,11 +17,11 @@
         "karma-sauce-launcher-fix-firefox": "using a fork to work around https://github.com/karma-runner/karma-sauce-launcher/issues/275"
     },
     "devDependencies": {
-        "@lwc/compiler": "6.3.3",
-        "@lwc/engine-dom": "6.3.3",
-        "@lwc/engine-server": "6.3.3",
-        "@lwc/rollup-plugin": "6.3.3",
-        "@lwc/synthetic-shadow": "6.3.3",
+        "@lwc/compiler": "6.3.4",
+        "@lwc/engine-dom": "6.3.4",
+        "@lwc/engine-server": "6.3.4",
+        "@lwc/rollup-plugin": "6.3.4",
+        "@lwc/synthetic-shadow": "6.3.4",
         "chokidar": "^3.6.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-tests",
     "private": true,
-    "version": "6.3.3",
+    "version": "6.3.4",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -16,7 +16,7 @@
         "sauce:prod:ci": "MODE=prod yarn build:prod && MODE=prod ../../../scripts/ci/retry.sh wdio ./scripts/wdio.sauce.conf.js"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "6.3.3",
+        "@lwc/rollup-plugin": "6.3.4",
         "@wdio/cli": "^8.33.1",
         "@wdio/local-runner": "^8.33.1",
         "@wdio/mocha-framework": "^8.33.1",
@@ -25,7 +25,7 @@
         "@wdio/static-server-service": "^8.32.4",
         "deepmerge": "^4.3.0",
         "dotenv": "^16.4.5",
-        "lwc": "6.3.3",
+        "lwc": "6.3.4",
         "minimist": "^1.2.8",
         "webdriverio": "^8.33.1"
     }

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/module-resolver",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Resolves paths for LWC components",
     "keywords": [
         "lwc"

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lwc/perf-benchmarks-components",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c ./rollup.config.mjs"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "6.3.3"
+        "@lwc/rollup-plugin": "6.3.4"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/perf-benchmarks",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c  ./rollup.config.mjs && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -17,10 +17,10 @@
         "Also note that we use legacy versions of rollup-plugin-node-resolve and rollup-plugin-commonjs because Best uses an old version of Rollup."
     ],
     "dependencies": {
-        "@lwc/engine-dom": "6.3.3",
-        "@lwc/engine-server": "6.3.3",
-        "@lwc/perf-benchmarks-components": "6.3.3",
-        "@lwc/synthetic-shadow": "6.3.3"
+        "@lwc/engine-dom": "6.3.4",
+        "@lwc/engine-server": "6.3.4",
+        "@lwc/perf-benchmarks-components": "6.3.4",
+        "@lwc/synthetic-shadow": "6.3.4"
     },
     "devDependencies": {
         "@best/cli": "^11.0.0",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/rollup-plugin",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Rollup plugin to compile LWC",
     "keywords": [
         "lwc"
@@ -42,12 +42,12 @@
         }
     },
     "dependencies": {
-        "@lwc/compiler": "6.3.3",
-        "@lwc/module-resolver": "6.3.3",
+        "@lwc/compiler": "6.3.4",
+        "@lwc/module-resolver": "6.3.4",
         "@rollup/pluginutils": "~5.1.0"
     },
     "devDependencies": {
-        "@lwc/errors": "6.3.3"
+        "@lwc/errors": "6.3.4"
     },
     "peerDependencies": {
         "rollup": "^1.2.0||^2.0.0||^3.0.0||^4.0.0"

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/shared",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Utilities and methods that are shared across packages",
     "keywords": [
         "lwc"

--- a/packages/@lwc/signals/package.json
+++ b/packages/@lwc/signals/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/signals",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Provides the interface to interact with reactivity from outside the framework",
     "keywords": [
         "lwc"

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/style-compiler",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "keywords": [
         "lwc"
@@ -42,7 +42,7 @@
         }
     },
     "dependencies": {
-        "@lwc/shared": "6.3.3",
+        "@lwc/shared": "6.3.4",
         "postcss": "~8.4.35",
         "postcss-selector-parser": "~6.0.15",
         "postcss-value-parser": "~4.2.0"

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/synthetic-shadow",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Synthetic Shadow Root for LWC",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/features": "6.3.3",
-        "@lwc/shared": "6.3.3"
+        "@lwc/features": "6.3.4",
+        "@lwc/shared": "6.3.4"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/template-compiler",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Template compiler package",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "dependencies": {
-        "@lwc/errors": "6.3.3",
-        "@lwc/shared": "6.3.3",
+        "@lwc/errors": "6.3.4",
+        "@lwc/shared": "6.3.4",
         "acorn": "8.10.0",
         "astring": "~1.8.6",
         "estree-walker": "~2.0.2",

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/wire-service",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "@wire service",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "6.3.3",
-        "@lwc/shared": "6.3.3"
+        "@lwc/engine-core": "6.3.4",
+        "@lwc/shared": "6.3.4"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -20,21 +20,21 @@
         "*.d.ts"
     ],
     "dependencies": {
-        "@lwc/aria-reflection": "6.3.3",
-        "@lwc/babel-plugin-component": "6.3.3",
-        "@lwc/compiler": "6.3.3",
-        "@lwc/engine-core": "6.3.3",
-        "@lwc/engine-dom": "6.3.3",
-        "@lwc/engine-server": "6.3.3",
-        "@lwc/errors": "6.3.3",
-        "@lwc/features": "6.3.3",
-        "@lwc/module-resolver": "6.3.3",
-        "@lwc/rollup-plugin": "6.3.3",
-        "@lwc/shared": "6.3.3",
-        "@lwc/style-compiler": "6.3.3",
-        "@lwc/synthetic-shadow": "6.3.3",
-        "@lwc/template-compiler": "6.3.3",
-        "@lwc/wire-service": "6.3.3"
+        "@lwc/aria-reflection": "6.3.4",
+        "@lwc/babel-plugin-component": "6.3.4",
+        "@lwc/compiler": "6.3.4",
+        "@lwc/engine-core": "6.3.4",
+        "@lwc/engine-dom": "6.3.4",
+        "@lwc/engine-server": "6.3.4",
+        "@lwc/errors": "6.3.4",
+        "@lwc/features": "6.3.4",
+        "@lwc/module-resolver": "6.3.4",
+        "@lwc/rollup-plugin": "6.3.4",
+        "@lwc/shared": "6.3.4",
+        "@lwc/style-compiler": "6.3.4",
+        "@lwc/synthetic-shadow": "6.3.4",
+        "@lwc/template-compiler": "6.3.4",
+        "@lwc/wire-service": "6.3.4"
     },
     "lwc": {
         "modules": [

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@lwc/playground",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "type": "module",
     "description": "Playground project to experiment with LWC.",
     "scripts": {
@@ -9,9 +9,9 @@
         "build": "NODE_ENV=production rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "6.3.3",
+        "@lwc/rollup-plugin": "6.3.4",
         "@rollup/plugin-replace": "^5.0.5",
-        "lwc": "6.3.3",
+        "lwc": "6.3.4",
         "rollup": "^4.12.1",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^3.0.0"


### PR DESCRIPTION
## Details
First weekly release.

From https://github.com/salesforce/lwc/pull/4059:
> This is technically a breaking change, but it's only a breaking change for npm package users who have mismatched LWC versions. These users should use something like [Yarn resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) if necessary to force all their lwc and @lwc/* dependencies to the same version.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
