### PR TITLE
fix: event listener not being invoked for native web components

### DIFF
--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/index.spec.js
@@ -1,0 +1,44 @@
+import { createElement } from 'lwc';
+import Test from 'x/test';
+
+describe('event.composedPath() of event dispatched from closed shadow root', () => {
+    it('should have shadowed elements when invoked inside the shadow root', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            elm.clickShadowedButton();
+
+            expect(elm.getShadowedComposedPath()).toEqual([
+                jasmine.any(HTMLElement), // button
+                jasmine.any(Object), // #shadow-root(closed)
+                elm.child,
+                elm.shadowRoot,
+                elm,
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ]);
+        });
+    });
+
+    it('should not have shadowed elements when invoked outside the shadow root', () => {
+        const elm = createElement('x-test', { is: Test });
+        document.body.appendChild(elm);
+
+        return Promise.resolve().then(() => {
+            elm.clickShadowedButton();
+
+            expect(elm.getComposedPath()).toEqual([
+                elm.child,
+                elm.shadowRoot,
+                elm,
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ]);
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/component.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/component.js
@@ -1,0 +1,18 @@
+customElements.define(
+    'x-mixed-shadow-mode-composed-path',
+    class extends HTMLElement {
+        constructor() {
+            super();
+            this._shadowRoot = this.attachShadow({ mode: 'closed' });
+            this._button = document.createElement('button');
+            this._button.addEventListener('click', (event) => {
+                this.composedPath = event.composedPath();
+            });
+            this._shadowRoot.appendChild(this._button);
+        }
+
+        click() {
+            this._button.click();
+        }
+    }
+);

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/test.html
@@ -1,0 +1,3 @@
+<template>
+    <x-mixed-shadow-mode-composed-path lwc:external lwc:ref="child" onclick={handleClick}></x-mixed-shadow-mode-composed-path>
+</template>

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/test.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/composed-path/x/test/test.js
@@ -1,0 +1,30 @@
+import { LightningElement, api } from 'lwc';
+import './component.js';
+
+export default class Parent extends LightningElement {
+    composedPath;
+
+    @api
+    get child() {
+        return this.refs.child;
+    }
+
+    @api
+    getShadowedComposedPath() {
+        return this.child.composedPath;
+    }
+
+    @api
+    getComposedPath() {
+        return this.composedPath;
+    }
+
+    @api
+    clickShadowedButton() {
+        this.child.click();
+    }
+
+    handleClick(event) {
+        this.composedPath = event.composedPath();
+    }
+}

--- a/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/event-target/polyfill.ts
@@ -10,6 +10,8 @@ import {
     eventTargetPrototype,
     removeEventListener as nativeRemoveEventListener,
 } from '../../env/event-target';
+import { Node } from '../../env/node';
+import { isInstanceOfNativeShadowRoot } from '../../env/shadow-root';
 import {
     addCustomElementEventListener,
     removeCustomElementEventListener,
@@ -28,6 +30,13 @@ function patchedAddEventListener(
         // @ts-ignore type-mismatch
         return addCustomElementEventListener.apply(this, arguments);
     }
+
+    if (this instanceof Node && isInstanceOfNativeShadowRoot(this.getRootNode())) {
+        // Typescript does not like it when you treat the `arguments` object as an array
+        // @ts-expect-error type-mismatch
+        return nativeAddEventListener.apply(this, arguments);
+    }
+
     if (arguments.length < 2) {
         // Slow path, unlikely to be called frequently. We expect modern browsers to throw:
         // https://googlechrome.github.io/samples/event-listeners-mandatory-arguments/


### PR DESCRIPTION
## Details

Backport for #4012 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

## GUS work item

W-15126229