### PR TITLE
fix: fix iframe onload with static content optimization

### DIFF
--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -304,8 +304,8 @@ function mountStatic(
 
     // slotAssignments can only apply to the top level element, never to a static part.
     patchSlotAssignment(null, vnode, renderer);
-    insertNode(elm, parent, anchor, renderer);
     mountStaticParts(elm, vnode, renderer);
+    insertNode(elm, parent, anchor, renderer);
 }
 
 function mountCustomElement(

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -488,7 +488,9 @@ describe('iframe onload event listener', () => {
     it('works with iframe onload listener', async () => {
         const elm = createElement('x-iframe-onload', { is: IframeOnload });
         document.body.appendChild(elm);
-        await Promise.resolve();
+        // Oddly Firefox requires two macrotasks before the load event fires. Chrome/Safari only require a microtask.
+        await new Promise((resolve) => setTimeout(resolve));
+        await new Promise((resolve) => setTimeout(resolve));
         expect(elm.loaded).toBeTrue();
     });
 });

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -18,6 +18,7 @@ import Comments from 'x/comments';
 import PreserveComments from 'x/preserveComments';
 import AttributeExpression from 'x/attributeExpression';
 import DeepAttributeExpression from 'x/deepAttributeExpression';
+import IframeOnload from 'x/iframeOnload';
 
 if (!process.env.NATIVE_SHADOW) {
     describe('Mixed mode for static content', () => {
@@ -480,5 +481,14 @@ describe('static optimization with attributes', () => {
         expect(nodes['deep3nested'].getAttribute('data-dynamic')).toEqual('3');
         expect(nodes['deep4'].getAttribute('data-dynamic')).toEqual('4');
         expect(nodes['deep4nested'].getAttribute('data-dynamic')).toEqual('4');
+    });
+});
+
+describe('iframe onload event listener', () => {
+    it('works with iframe onload listener', async () => {
+        const elm = createElement('x-iframe-onload', { is: IframeOnload });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+        expect(elm.loaded).toBeTrue();
     });
 });

--- a/packages/@lwc/integration-karma/test/static-content/x/iframeOnload/iframeOnload.html
+++ b/packages/@lwc/integration-karma/test/static-content/x/iframeOnload/iframeOnload.html
@@ -1,0 +1,4 @@
+<template>
+    <!-- this onload will fire instantly when the element is inserted into the DOM -->
+    <iframe onload={loadHandler}></iframe>
+</template>

--- a/packages/@lwc/integration-karma/test/static-content/x/iframeOnload/iframeOnload.js
+++ b/packages/@lwc/integration-karma/test/static-content/x/iframeOnload/iframeOnload.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api loaded = false;
+
+    loadHandler() {
+        this.loaded = true;
+    }
+}


### PR DESCRIPTION
## Details

Fixes #4081

This is just a matter of inserting the static nodes after applying their event listeners, as originally discovered by @jmsjtu.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

Well unless you consider the fact that `iframe` `onload` works correctly now. 😅 

<!-- If yes, please describe the anticipated observable changes. -->
