### PR TITLE
perf(synthetic-shadow): optimize recursivelySetShadowResolver

### DIFF
--- a/packages/@lwc/synthetic-shadow/src/env/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/node.ts
@@ -76,6 +76,11 @@ const childNodesGetter: (this: Node) => NodeListOf<Node & Element> = getOwnPrope
     'childNodes'
 )!.get!;
 
+const nextSiblingGetter: (this: Node) => ChildNode | null = getOwnPropertyDescriptor(
+    nodePrototype,
+    'nextSibling'
+)!.get!;
+
 const isConnected = hasOwnProperty.call(nodePrototype, 'isConnected')
     ? getOwnPropertyDescriptor(nodePrototype, 'isConnected')!.get!
     : function (this: Node): boolean {
@@ -109,6 +114,7 @@ export {
     firstChildGetter,
     lastChildGetter,
     textContentGetter,
+    nextSiblingGetter,
     // Node
     DOCUMENT_POSITION_CONTAINS,
     DOCUMENT_POSITION_CONTAINED_BY,


### PR DESCRIPTION
## Details

Optimizes the `recursivelySetShadowResolver` function to avoid calling `childNodes` and to use `firstChild`/`nextSibling` instead.

Browsers represent the DOM as a [linked list](https://viethung.space/blog/2020/09/01/Browser-from-Scratch-DOM-API/#Choosing-DOM-tree-data-structure) under the hood, so this is faster.

This improves the `dom-ss-slot-create-container-5k-this-change` benchmark by 4-9%, and possibly some other synthetic-shadow benchmarks as well.

![Screenshot 2024-03-20 at 1 36 58 PM](https://github.com/salesforce/lwc/assets/283842/c4e5cd45-5ae5-45a6-8187-58f91e179723)

The reason this is important is because we set `KEY__SHADOW_STATIC` on the top level of a static fragment, which then causes us to recurse through the entire DOM structure to set the `KEY__SHADOW_RESOLVER`. (This is used for the legacy `isNodeShadowed`/`isNodeFromTemplate` as well as for the patched `MutationObserver`.) If we have a lot of static fragments, or if they are very deep, then we can spend a lot of time recursing.

Long-term, we should probably try to avoid this recursion entirely and just do the lookup on-demand when MutationObserver/`isNodeShadowed` is called: #4089

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
