### PR TITLE
fix: support arguments for FACE callbacks

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -57,6 +57,7 @@ export type {
     WireContextSubscriptionPayload,
     WireContextSubscriptionCallback,
 } from './wiring';
+export type { FormRestoreState, FormRestoreReason } from './vm';
 
 // Public APIs -------------------------------------------------------------------------------------
 export { LightningElement } from './base-lightning-element';

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -940,7 +940,7 @@ export function forceRehydration(vm: VM) {
     }
 }
 
-export function runFormAssociatedCustomElementCallback(vm: VM, faceCb: () => void) {
+export function runFormAssociatedCustomElementCallback(vm: VM, faceCb: () => void, args?: any[]) {
     const { renderMode, shadowMode } = vm;
 
     if (shadowMode === ShadowMode.Synthetic && renderMode !== RenderMode.Light) {
@@ -949,24 +949,24 @@ export function runFormAssociatedCustomElementCallback(vm: VM, faceCb: () => voi
         );
     }
 
-    invokeComponentCallback(vm, faceCb);
+    invokeComponentCallback(vm, faceCb, args);
 }
 
-export function runFormAssociatedCallback(elm: HTMLElement) {
+export function runFormAssociatedCallback(elm: HTMLElement, form: HTMLFormElement | null) {
     const vm = getAssociatedVM(elm);
     const { formAssociatedCallback } = vm.def;
 
     if (!isUndefined(formAssociatedCallback)) {
-        runFormAssociatedCustomElementCallback(vm, formAssociatedCallback);
+        runFormAssociatedCustomElementCallback(vm, formAssociatedCallback, [form]);
     }
 }
 
-export function runFormDisabledCallback(elm: HTMLElement) {
+export function runFormDisabledCallback(elm: HTMLElement, disabled: boolean) {
     const vm = getAssociatedVM(elm);
     const { formDisabledCallback } = vm.def;
 
     if (!isUndefined(formDisabledCallback)) {
-        runFormAssociatedCustomElementCallback(vm, formDisabledCallback);
+        runFormAssociatedCustomElementCallback(vm, formDisabledCallback, [disabled]);
     }
 }
 
@@ -979,12 +979,21 @@ export function runFormResetCallback(elm: HTMLElement) {
     }
 }
 
-export function runFormStateRestoreCallback(elm: HTMLElement) {
+// These types are inspired by https://github.com/material-components/material-web/blob/ffc08d1/labs/behaviors/form-associated.ts
+export type FormRestoreState = File | string | Array<[string, FormDataEntryValue]>;
+
+export type FormRestoreReason = 'restore' | 'autocomplete';
+
+export function runFormStateRestoreCallback(
+    elm: HTMLElement,
+    state: FormRestoreState | null,
+    reason: FormRestoreReason
+) {
     const vm = getAssociatedVM(elm);
     const { formStateRestoreCallback } = vm.def;
 
     if (!isUndefined(formStateRestoreCallback)) {
-        runFormAssociatedCustomElementCallback(vm, formStateRestoreCallback);
+        runFormAssociatedCustomElementCallback(vm, formStateRestoreCallback, [state, reason]);
     }
 }
 

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -18,6 +18,8 @@ import {
     runFormDisabledCallback,
     runFormResetCallback,
     runFormStateRestoreCallback,
+    FormRestoreState,
+    FormRestoreReason,
 } from '@lwc/engine-core';
 import { isNull } from '@lwc/shared';
 import { renderer } from '../renderer';
@@ -124,20 +126,20 @@ export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLE
             attributeChangedCallback.call(this, name, oldValue, newValue);
         }
 
-        formAssociatedCallback() {
-            runFormAssociatedCallback(this);
+        formAssociatedCallback(form: HTMLFormElement | null) {
+            runFormAssociatedCallback(this, form);
         }
 
-        formDisabledCallback() {
-            runFormDisabledCallback(this);
+        formDisabledCallback(disabled: boolean) {
+            runFormDisabledCallback(this, disabled);
         }
 
         formResetCallback() {
             runFormResetCallback(this);
         }
 
-        formStateRestoreCallback() {
-            runFormStateRestoreCallback(this);
+        formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason) {
+            runFormStateRestoreCallback(this, state, reason);
         }
 
         static observedAttributes = observedAttributes;

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/face/formAssociated/formAssociated.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/face/formAssociated/formAssociated.js
@@ -13,6 +13,15 @@ export default class extends LightningElement {
     formResetCallbackHasBeenCalled = false;
 
     @api
+    formAssociatedCallbackHasBeenCalledWith;
+
+    @api
+    formDisabledCallbackHasBeenCalledWith;
+
+    @api
+    formResetCallbackHasBeenCalledWith;
+
+    @api
     get internals() {
         if (!this._internals) {
             this._internals = this.attachInternals();
@@ -20,15 +29,18 @@ export default class extends LightningElement {
         return this._internals;
     }
 
-    formAssociatedCallback() {
+    formAssociatedCallback(form) {
         this.formAssociatedCallbackHasBeenCalled = true;
+        this.formAssociatedCallbackHasBeenCalledWith = form;
     }
 
-    formDisabledCallback() {
+    formDisabledCallback(disabled) {
         this.formDisabledCallbackHasBeenCalled = true;
+        this.formDisabledCallbackHasBeenCalledWith = disabled;
     }
 
-    formResetCallback() {
+    formResetCallback(expectUndefinedHere) {
         this.formResetCallbackHasBeenCalled = true;
+        this.formResetCallbackHasBeenCalledWith = expectUndefinedHere;
     }
 }

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/face/lightDomFormAssociated/lightDomFormAssociated.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/face/lightDomFormAssociated/lightDomFormAssociated.js
@@ -14,6 +14,15 @@ export default class extends LightningElement {
     formResetCallbackHasBeenCalled = false;
 
     @api
+    formAssociatedCallbackHasBeenCalledWith;
+
+    @api
+    formDisabledCallbackHasBeenCalledWith;
+
+    @api
+    formResetCallbackHasBeenCalledWith;
+
+    @api
     get internals() {
         if (!this._internals) {
             this._internals = this.attachInternals();
@@ -21,15 +30,18 @@ export default class extends LightningElement {
         return this._internals;
     }
 
-    formAssociatedCallback() {
+    formAssociatedCallback(form) {
         this.formAssociatedCallbackHasBeenCalled = true;
+        this.formAssociatedCallbackHasBeenCalledWith = form;
     }
 
-    formDisabledCallback() {
+    formDisabledCallback(disabled) {
         this.formDisabledCallbackHasBeenCalled = true;
+        this.formDisabledCallbackHasBeenCalledWith = disabled;
     }
 
-    formResetCallback() {
+    formResetCallback(expectUndefinedHere) {
         this.formResetCallbackHasBeenCalled = true;
+        this.formResetCallbackHasBeenCalledWith = expectUndefinedHere;
     }
 }

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -100,14 +100,22 @@ const testFaceLifecycleMethodsCallable = (createFace) => {
 
     // formAssociatedCallback
     expect(face.formAssociatedCallbackHasBeenCalled).toBeTruthy();
+    expect(face.formAssociatedCallbackHasBeenCalledWith).toBe(form);
 
     // formDisabledCallback
-    face.setAttribute('disabled', true);
+    face.setAttribute('disabled', 'true');
     expect(face.formDisabledCallbackHasBeenCalled).toBeTruthy();
+    expect(face.formDisabledCallbackHasBeenCalledWith).toBe(true);
+
+    // formDisabledCallback - re-enable
+    face.removeAttribute('disabled');
+    expect(face.formDisabledCallbackHasBeenCalled).toBeTruthy();
+    expect(face.formDisabledCallbackHasBeenCalledWith).toBe(false);
 
     // formResetCallback
     form.reset();
     expect(face.formResetCallbackHasBeenCalled).toBeTruthy();
+    expect(face.formResetCallbackHasBeenCalledWith).toBeUndefined();
 
     // Note there is no good way to test formStateRestoreCallback in karma tests
 };

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import type { FormRestoreReason, FormRestoreState } from '@lwc/engine-core';
+
 /**
  * Lightning Web Components core module
  */
@@ -163,6 +165,12 @@ declare module 'lwc' {
          * ```
          */
         static get CustomElementConstructor(): typeof HTMLElement;
+
+        /**
+         * Set to true to designate this component as a Form-Associated Custom Element (FACE).
+         * @see https://web.dev/articles/more-capable-form-controls#form-associated_custom_elements
+         */
+        static formAssociated?: boolean;
         /**
          * Called when the element is inserted in a document
          */
@@ -179,6 +187,30 @@ declare module 'lwc' {
          * Called when a descendant component throws an error in one of its lifecycle hooks
          */
         errorCallback(error: Error, stack: string): void;
+        /**
+         * Called when a Form-Associated Custom Element (FACE) is associated with an HTMLFormElement.
+         * @param form HTMLFormElement
+         * @see https://web.dev/articles/more-capable-form-controls#void_formassociatedcallbackform
+         */
+        formAssociatedCallback(form: HTMLFormElement | null): void;
+        /**
+         * Called when a Form-Associated Custom Element (FACE) has a disabled state that has changed.
+         * @param disabled boolean
+         * @see https://web.dev/articles/more-capable-form-controls#void_formdisabledcallbackdisabled
+         */
+        formDisabledCallback(disabled: boolean): void;
+        /**
+         * Called when a Form-Associated Custom Element (FACE) has an associated form that is reset.
+         * @param state FormRestoreState
+         * @param reason FormRestoreReason
+         * @see https://web.dev/articles/more-capable-form-controls#void_formresetcallback
+         */
+        formResetCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
+        /**
+         * Called when a Form-Associated Custom Element (FACE) has an associated form that is restored.
+         * @see https://web.dev/articles/more-capable-form-controls#void_formstaterestorecallbackstate_mode
+         */
+        formStateRestoreCallback(): void;
 
         readonly template: ShadowRootTheGoodPart;
         readonly shadowRoot: null;

--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -189,28 +189,28 @@ declare module 'lwc' {
         errorCallback(error: Error, stack: string): void;
         /**
          * Called when a Form-Associated Custom Element (FACE) is associated with an HTMLFormElement.
-         * @param form HTMLFormElement
+         * @param form HTMLFormElement - the associated form element
          * @see https://web.dev/articles/more-capable-form-controls#void_formassociatedcallbackform
          */
         formAssociatedCallback(form: HTMLFormElement | null): void;
         /**
          * Called when a Form-Associated Custom Element (FACE) has a disabled state that has changed.
-         * @param disabled boolean
+         * @param disabled boolean - the new disabled state
          * @see https://web.dev/articles/more-capable-form-controls#void_formdisabledcallbackdisabled
          */
         formDisabledCallback(disabled: boolean): void;
         /**
          * Called when a Form-Associated Custom Element (FACE) has an associated form that is reset.
-         * @param state FormRestoreState
-         * @param reason FormRestoreReason
          * @see https://web.dev/articles/more-capable-form-controls#void_formresetcallback
          */
-        formResetCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
+        formResetCallback(): void;
         /**
          * Called when a Form-Associated Custom Element (FACE) has an associated form that is restored.
+         * @param state FormRestoreState - the state of the form during restoration
+         * @param reason FormRestoreReason - the reason the form was restored
          * @see https://web.dev/articles/more-capable-form-controls#void_formstaterestorecallbackstate_mode
          */
-        formStateRestoreCallback(): void;
+        formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
 
         readonly template: ShadowRootTheGoodPart;
         readonly shadowRoot: null;


### PR DESCRIPTION
## Details

Fixes #4093. Adds support for arguments in Form Associated Custom Element callbacks.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

The params for these callbacks work now. 🙂 

<!-- If yes, please describe the anticipated observable changes. -->
