### PR TITLE
fix: children and childNodes not returning top-level slotted children

### DIFF
--- a/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/root/index.spec.js
@@ -78,5 +78,7 @@ describe('root light element', () => {
         expect(nodes['x-list'].querySelector('button')).toEqual(nodes.button);
         expect(nodes['x-list'].getElementsByTagName('button')[0]).toEqual(nodes.button);
         expect(nodes['x-list'].getElementsByClassName('button')[0]).toEqual(nodes.button);
+        expect(nodes['x-list'].childNodes[0]).toEqual(nodes.button);
+        expect(nodes['x-list'].children[0]).toEqual(nodes.button);
     });
 });

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -92,7 +92,7 @@ function shadowRootGetterPatched(this: Element): ShadowRoot | null {
 
 function childrenGetterPatched(this: Element): HTMLCollectionOf<Element> {
     const owner = getNodeOwner(this);
-    const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));
+    const childNodes = getAllMatches(owner, getFilteredChildNodes(this));
     return createStaticHTMLCollection(
         ArrayFilter.call(childNodes, (node: Node | Element) => node instanceof Element)
     );

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -92,7 +92,11 @@ function shadowRootGetterPatched(this: Element): ShadowRoot | null {
 
 function childrenGetterPatched(this: Element): HTMLCollectionOf<Element> {
     const owner = getNodeOwner(this);
-    const childNodes = getAllMatches(owner, getFilteredChildNodes(this));
+    const filteredChildNodes = getFilteredChildNodes(this);
+    // no need to filter nodes by owner in case of light DOM
+    const childNodes = isNull(owner)
+        ? filteredChildNodes
+        : getAllMatches(owner, filteredChildNodes);
     return createStaticHTMLCollection(
         ArrayFilter.call(childNodes, (node: Node | Element) => node instanceof Element)
     );

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/element.ts
@@ -93,7 +93,7 @@ function shadowRootGetterPatched(this: Element): ShadowRoot | null {
 function childrenGetterPatched(this: Element): HTMLCollectionOf<Element> {
     const owner = getNodeOwner(this);
     const filteredChildNodes = getFilteredChildNodes(this);
-    // no need to filter nodes by owner in case of light DOM
+    // No need to filter by owner for non-shadowed nodes
     const childNodes = isNull(owner)
         ? filteredChildNodes
         : getAllMatches(owner, filteredChildNodes);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -174,7 +174,7 @@ function childNodesGetterPatched(this: Node): NodeListOf<Node> {
     if (isSyntheticShadowHost(this)) {
         const owner = getNodeOwner(this);
         const filteredChildNodes = getFilteredChildNodes(this);
-        // no need to filter nodes by owner in case of light DOM
+        // No need to filter by owner for non-shadowed nodes
         const childNodes = isNull(owner)
             ? filteredChildNodes
             : getAllMatches(owner, filteredChildNodes);

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -173,7 +173,7 @@ function cloneNodePatched(this: Node, deep?: boolean): Node {
 function childNodesGetterPatched(this: Node): NodeListOf<Node> {
     if (isSyntheticShadowHost(this)) {
         const owner = getNodeOwner(this);
-        const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));
+        const childNodes = getAllMatches(owner, getFilteredChildNodes(this));
         return createStaticNodeList(childNodes);
     }
     // nothing to do here since this does not have a synthetic shadow attached to it

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/node.ts
@@ -173,7 +173,11 @@ function cloneNodePatched(this: Node, deep?: boolean): Node {
 function childNodesGetterPatched(this: Node): NodeListOf<Node> {
     if (isSyntheticShadowHost(this)) {
         const owner = getNodeOwner(this);
-        const childNodes = getAllMatches(owner, getFilteredChildNodes(this));
+        const filteredChildNodes = getFilteredChildNodes(this);
+        // no need to filter nodes by owner in case of light DOM
+        const childNodes = isNull(owner)
+            ? filteredChildNodes
+            : getAllMatches(owner, filteredChildNodes);
         return createStaticNodeList(childNodes);
     }
     // nothing to do here since this does not have a synthetic shadow attached to it

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -134,25 +134,15 @@ export function isSlotElement(node: Node): node is HTMLSlotElement {
     return node instanceof HTMLSlotElement;
 }
 
-export function isNodeOwnedBy(owner: Element | null, node: Node): boolean {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!(node instanceof Node)) {
-            // eslint-disable-next-line no-console
-            console.error(`isNodeOwnedBy() should be called with a node as the second argument`);
-        }
-    }
-
-    // owner can be null if all the parents are in the light DOM
-    // ownerKey is undefined for such nodes
-    const ownerKey = getNodeNearestOwnerKey(node);
-    if (isNull(owner)) {
-        return isUndefined(ownerKey);
-    }
-
+export function isNodeOwnedBy(owner: Element, node: Node): boolean {
     if (process.env.NODE_ENV !== 'production') {
         if (!(owner instanceof HTMLElement)) {
             // eslint-disable-next-line no-console
             console.error(`isNodeOwnedBy() should be called with an element as the first argument`);
+        }
+        if (!(node instanceof Node)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeOwnedBy() should be called with a node as the second argument`);
         }
         if (!(compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS)) {
             // eslint-disable-next-line no-console
@@ -161,6 +151,7 @@ export function isNodeOwnedBy(owner: Element | null, node: Node): boolean {
             );
         }
     }
+    const ownerKey = getNodeNearestOwnerKey(node);
 
     if (isUndefined(ownerKey)) {
         // in case of root level light DOM element slotting into a synthetic shadow
@@ -205,7 +196,7 @@ export function getFirstSlottedMatch(host: Element, nodeList: Element[]): Elemen
     return null;
 }
 
-export function getAllMatches<T extends Node>(owner: Element | null, nodeList: Node[]): T[] {
+export function getAllMatches<T extends Node>(owner: Element, nodeList: Node[]): T[] {
     const filteredAndPatched: T[] = [];
     for (let i = 0, len = nodeList.length; i < len; i += 1) {
         const node = nodeList[i];

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/traverse.ts
@@ -134,15 +134,25 @@ export function isSlotElement(node: Node): node is HTMLSlotElement {
     return node instanceof HTMLSlotElement;
 }
 
-export function isNodeOwnedBy(owner: Element, node: Node): boolean {
+export function isNodeOwnedBy(owner: Element | null, node: Node): boolean {
+    if (process.env.NODE_ENV !== 'production') {
+        if (!(node instanceof Node)) {
+            // eslint-disable-next-line no-console
+            console.error(`isNodeOwnedBy() should be called with a node as the second argument`);
+        }
+    }
+
+    // owner can be null if all the parents are in the light DOM
+    // ownerKey is undefined for such nodes
+    const ownerKey = getNodeNearestOwnerKey(node);
+    if (isNull(owner)) {
+        return isUndefined(ownerKey);
+    }
+
     if (process.env.NODE_ENV !== 'production') {
         if (!(owner instanceof HTMLElement)) {
             // eslint-disable-next-line no-console
             console.error(`isNodeOwnedBy() should be called with an element as the first argument`);
-        }
-        if (!(node instanceof Node)) {
-            // eslint-disable-next-line no-console
-            console.error(`isNodeOwnedBy() should be called with a node as the second argument`);
         }
         if (!(compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS)) {
             // eslint-disable-next-line no-console
@@ -151,7 +161,6 @@ export function isNodeOwnedBy(owner: Element, node: Node): boolean {
             );
         }
     }
-    const ownerKey = getNodeNearestOwnerKey(node);
 
     if (isUndefined(ownerKey)) {
         // in case of root level light DOM element slotting into a synthetic shadow
@@ -196,7 +205,7 @@ export function getFirstSlottedMatch(host: Element, nodeList: Element[]): Elemen
     return null;
 }
 
-export function getAllMatches<T extends Node>(owner: Element, nodeList: Node[]): T[] {
+export function getAllMatches<T extends Node>(owner: Element | null, nodeList: Node[]): T[] {
     const filteredAndPatched: T[] = [];
     for (let i = 0, len = nodeList.length; i < len; i += 1) {
         const node = nodeList[i];

--- a/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
+++ b/packages/@lwc/synthetic-shadow/src/shared/node-ownership.ts
@@ -58,6 +58,8 @@ export function getNodeNearestOwnerKey(node: Node): number | undefined {
         }
         host = parentNodeGetter.call(host) as ShadowedNode | null;
 
+        // Elements slotted from top level light DOM into synthetic shadow
+        // reach the slot tag from the shadow element first
         if (!isNull(host) && isSyntheticSlotElement(host)) {
             return undefined;
         }


### PR DESCRIPTION
## Details
Fixes #4076
Light DOM nodes aren't owned by any shadow root. We change `isNodeOwedBy` to account for `owner` being null.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
