### PR TITLE
perf(engine-core): optimize `patchClassAttribute`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -78,7 +78,7 @@ export function patchClassAttribute(
     if (oldClassMap === newClassMap) {
         // These objects are cached by className string (`classNameToClassMap`), so we can only get here if there is
         // a key collision due to types, e.g. oldClass is `undefined` and newClass is `""` (empty string), or oldClass
-        // className is `1` (number) and newClass is `"1"` (string).
+        // is `1` (number) and newClass is `"1"` (string).
         return;
     }
 

--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -21,8 +21,7 @@ import { VBaseElement, VStaticPart } from '../vnodes';
 const classNameToClassMap = create(null);
 
 export function getMapFromClassName(className: string | undefined): Record<string, boolean> {
-    // Intentionally using == to match undefined and null values from computed style attribute
-    if (className == null) {
+    if (isUndefined(className) || isNull(className) || className === '') {
         return EmptyObject;
     }
     // computed class names must be string
@@ -73,10 +72,18 @@ export function patchClassAttribute(
         return;
     }
 
-    const { getClassList } = renderer;
-    const classList = getClassList(elm!);
     const newClassMap = getMapFromClassName(newClass);
     const oldClassMap = getMapFromClassName(oldClass);
+
+    if (oldClassMap === newClassMap) {
+        // These objects are cached by className string, so at this point we can only get here if there is a key
+        // collision due to types, e.g. one string is `undefined` and the other is `""` (empty string), or one
+        // string is `1` (number) and the other is `"1"` (string).
+        return;
+    }
+
+    const { getClassList } = renderer;
+    const classList = getClassList(elm!);
 
     let name: string;
     for (name in oldClassMap) {

--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -76,9 +76,9 @@ export function patchClassAttribute(
     const oldClassMap = getMapFromClassName(oldClass);
 
     if (oldClassMap === newClassMap) {
-        // These objects are cached by className string, so at this point we can only get here if there is a key
-        // collision due to types, e.g. one string is `undefined` and the other is `""` (empty string), or one
-        // string is `1` (number) and the other is `"1"` (string).
+        // These objects are cached by className string (`classNameToClassMap`), so we can only get here if there is
+        // a key collision due to types, e.g. oldClass is `undefined` and newClass is `""` (empty string), or oldClass
+        // className is `1` (number) and newClass is `"1"` (string).
         return;
     }
 


### PR DESCRIPTION
## Details

This optimizes `patchClassAttribute`, specifically the case where the old class name is `undefined` and the new one is `""` (the empty string). This is exercised by the `js-framework-benchmark` component here:

https://github.com/salesforce/lwc/blob/3665f31e94ee8b990036c7caaa4be4d4496d77ca/packages/%40lwc/perf-benchmarks-components/src/benchmark/jsFrameworkBenchmarkTable/jsFrameworkBenchmarkTable.js#L134-L136

Here is the perf improvement (relative to #4099):

<img width="1101" alt="Screenshot 2024-03-26 at 4 39 39 PM" src="https://github.com/salesforce/lwc/assets/283842/a93fc35a-5eac-43ae-8205-e580a02b9a87">


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
