### PR TITLE
fix: error accessing tagName on fragment

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -23,7 +23,6 @@ import {
     isUndefined,
     StringReplace,
     toString,
-    StringToLowerCase,
 } from '@lwc/shared';
 
 import { logError } from '../shared/logger';
@@ -437,11 +436,7 @@ function i(
                 if (!isNull(childVnode) && (isVBaseElement(childVnode) || isVStatic(childVnode))) {
                     const { key } = childVnode;
                     // In @lwc/engine-server the fragment doesn't have a tagName, default to the VM's tagName.
-                    const tagName =
-                        childVnode.sel ??
-                        StringToLowerCase.call(
-                            childVnode.fragment.tagName ?? vmBeingRendered.tagName
-                        );
+                    const { tagName } = vmBeingRendered;
                     if (isString(key) || isNumber(key)) {
                         if (keyMap[key] === 1 && isUndefined(iterationError)) {
                             iterationError = `Duplicated "key" attribute value for "<${tagName}>" in ${vmBeingRendered} for item number ${j}. A key with value "${childVnode.key}" appears more than once in the iteration. Key values must be unique numbers or strings.`;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -439,11 +439,11 @@ function i(
                     const { tagName } = vmBeingRendered;
                     if (isString(key) || isNumber(key)) {
                         if (keyMap[key] === 1 && isUndefined(iterationError)) {
-                            iterationError = `Duplicated "key" attribute value for "<${tagName}>" in ${vmBeingRendered} for item number ${j}. A key with value "${childVnode.key}" appears more than once in the iteration. Key values must be unique numbers or strings.`;
+                            iterationError = `Duplicated "key" attribute value in "<${tagName}>" for item number ${j}. A key with value "${key}" appears more than once in the iteration. Key values must be unique numbers or strings.`;
                         }
                         keyMap[key] = 1;
                     } else if (isUndefined(iterationError)) {
-                        iterationError = `Invalid "key" attribute value in "<${tagName}>" in ${vmBeingRendered} for item number ${j}. Set a unique "key" value on all iterated child elements.`;
+                        iterationError = `Invalid "key" attribute value in "<${tagName}>" for item number ${j}. Set a unique "key" value on all iterated child elements.`;
                     }
                 }
             });

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -22,7 +22,6 @@ import {
     isTrue,
     isUndefined,
     StringReplace,
-    StringToLowerCase,
     toString,
 } from '@lwc/shared';
 
@@ -378,7 +377,7 @@ function i(
     const list: VNodes = [];
     // TODO [#1276]: compiler should give us some sort of indicator when a vnodes collection is dynamic
     sc(list);
-    const vmBeingRendered = getVMBeingRendered();
+    const vmBeingRendered = getVMBeingRendered()!;
     if (isUndefined(iterable) || iterable === null) {
         if (process.env.NODE_ENV !== 'production') {
             logError(
@@ -436,8 +435,11 @@ function i(
                 // Check that the child vnode is either an element or VStatic
                 if (!isNull(childVnode) && (isVBaseElement(childVnode) || isVStatic(childVnode))) {
                     const { key } = childVnode;
+                    // In @lwc/engine-server the fragment doesn't have a tagName, default to the VM's tagName.
                     const tagName =
-                        childVnode.sel ?? StringToLowerCase.call(childVnode.fragment.tagName);
+                        childVnode.sel ??
+                        childVnode.fragment.tagName?.toLowerCase() ??
+                        vmBeingRendered.tagName;
                     if (isString(key) || isNumber(key)) {
                         if (keyMap[key] === 1 && isUndefined(iterationError)) {
                             iterationError = `Duplicated "key" attribute value for "<${tagName}>" in ${vmBeingRendered} for item number ${j}. A key with value "${childVnode.key}" appears more than once in the iteration. Key values must be unique numbers or strings.`;

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -23,6 +23,7 @@ import {
     isUndefined,
     StringReplace,
     toString,
+    StringToLowerCase,
 } from '@lwc/shared';
 
 import { logError } from '../shared/logger';
@@ -438,8 +439,9 @@ function i(
                     // In @lwc/engine-server the fragment doesn't have a tagName, default to the VM's tagName.
                     const tagName =
                         childVnode.sel ??
-                        childVnode.fragment.tagName?.toLowerCase() ??
-                        vmBeingRendered.tagName;
+                        StringToLowerCase.call(
+                            childVnode.fragment.tagName ?? vmBeingRendered.tagName
+                        );
                     if (isString(key) || isNumber(key)) {
                         if (keyMap[key] === 1 && isUndefined(iterationError)) {
                             iterationError = `Duplicated "key" attribute value for "<${tagName}>" in ${vmBeingRendered} for item number ${j}. A key with value "${childVnode.key}" appears more than once in the iteration. Key values must be unique numbers or strings.`;

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/expected.html
@@ -10,6 +10,15 @@
       <li>
         render
       </li>
+      <li>
+        static text
+      </li>
+      <li>
+        static text
+      </li>
+      <li>
+        static text
+      </li>
     </ul>
   </template>
 </x-lifecycle-hooks>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/modules/x/lifecycle-hooks/lifecycle-hooks.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lifecycle-hooks/modules/x/lifecycle-hooks/lifecycle-hooks.html
@@ -1,5 +1,6 @@
 <template>
     <ul>
         <li for:each={hooks} for:item="hook" key={hook}>{hook}</li>
+        <li for:each={hooks} for:item="hook" key={hook}>static text</li>
     </ul>
 </template>

--- a/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
@@ -103,7 +103,7 @@ scenarios.forEach(({ testName, Ctor, tagName }) => {
             // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
             expect(() => document.body.appendChild(elm)).toLogErrorDev([
                 /Invalid key value "null" in \[object:vm (TestStatic|TestCustomElement|Test) \(\d+\)]. Key must be a string or number\./,
-                /Invalid "key" attribute value in "<(li|x-custom)>"/,
+                /Invalid "key" attribute value in "<(x-test|x-test-static|x-test-custom-element)>"/,
             ]);
         });
 
@@ -116,7 +116,7 @@ scenarios.forEach(({ testName, Ctor, tagName }) => {
 
             // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
             expect(() => document.body.appendChild(elm)).toLogErrorDev(
-                /Duplicated "key" attribute value for "<(li|x-custom)>" in \[object:vm (TestStatic|TestCustomElement|Test) \(\d+\)] for item number 1\. A key with value "\d:xyz" appears more than once in the iteration\. Key values must be unique numbers or strings\./
+                /Duplicated "key" attribute value in "<(x-test|x-test-static|x-test-custom-element)>" for item number 1\. A key with value "\d:xyz" appears more than once in the iteration\. Key values must be unique numbers or strings\./
             );
         });
     });


### PR DESCRIPTION
## Details
There's an edge case not covered in our existing tests with the fix introduced in #4097.

On the server, it looks like [`VStatic.fragment` does not have a `tagName`](https://github.com/salesforce/lwc/blob/master/packages/%40lwc/engine-server/src/renderer.ts#L98-L104).

This PR fixes the issue but defaulting to the VM's tag name since there is no better alternative on the server.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
