### PR TITLE
fix: add signals as dependency

### DIFF
--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -43,10 +43,10 @@
     },
     "dependencies": {
         "@lwc/features": "6.3.4",
-        "@lwc/shared": "6.3.4"
+        "@lwc/shared": "6.3.4",
+        "@lwc/signals": "6.3.4"
     },
     "devDependencies": {
-        "observable-membrane": "2.0.0",
-        "@lwc/signals": "6.3.4"
+        "observable-membrane": "2.0.0"
     }
 }

--- a/packages/@lwc/engine-core/src/libs/signal-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/signal-tracker/index.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isFalse, isFunction, isUndefined } from '@lwc/shared';
-import { Signal } from '@lwc/signals';
 import { logWarnOnce } from '../../shared/logger';
+import type { Signal } from '@lwc/signals';
 
 /**
  * This map keeps track of objects to signals. There is an assumption that the signal is strongly referenced

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -31,7 +31,6 @@
         "@lwc/module-resolver": "6.3.4",
         "@lwc/rollup-plugin": "6.3.4",
         "@lwc/shared": "6.3.4",
-        "@lwc/signals": "6.3.4",
         "@lwc/style-compiler": "6.3.4",
         "@lwc/synthetic-shadow": "6.3.4",
         "@lwc/template-compiler": "6.3.4",

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -31,6 +31,7 @@
         "@lwc/module-resolver": "6.3.4",
         "@lwc/rollup-plugin": "6.3.4",
         "@lwc/shared": "6.3.4",
+        "@lwc/signals": "6.3.4",
         "@lwc/style-compiler": "6.3.4",
         "@lwc/synthetic-shadow": "6.3.4",
         "@lwc/template-compiler": "6.3.4",


### PR DESCRIPTION
## Details

Not sure why this hasn't broken sooner but the `@lwc/signals` package is causing breakages in our nucleus down streams.

The reason is because the the `SignalTracker` imports the `Signal` type from `@lwc/signals` and because it hasn't been added as a dependency it causes breakages.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-15276750
