### PR TITLE
fix: move `UpgradableConstructor` back into `createUpgradableConstructor`

### DIFF
--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -22,59 +22,6 @@ const nativeLifecycleElementsToUpgradedByLWC = new WeakMap<HTMLElement, boolean>
 
 let elementBeingUpgradedByLWC = false;
 
-// TODO [#2972]: this class should expose observedAttributes as necessary
-class BaseUpgradableConstructor extends HTMLElement {
-    constructor(upgradeCallback: LifecycleCallback, useNativeLifecycle: boolean) {
-        super();
-
-        if (useNativeLifecycle) {
-            // When in native lifecycle mode, we need to keep track of instances that were created outside LWC
-            // (i.e. not created by `lwc.createElement()`). If the element uses synthetic lifecycle, then we don't
-            // need to track this.
-            nativeLifecycleElementsToUpgradedByLWC.set(this, elementBeingUpgradedByLWC);
-        }
-
-        // If the element is not created using lwc.createElement(), e.g. `document.createElement('x-foo')`,
-        // then elementBeingUpgradedByLWC will be false
-        if (elementBeingUpgradedByLWC) {
-            upgradeCallback(this);
-        }
-        // TODO [#2970]: LWC elements cannot be upgraded via new Ctor()
-        // Do we want to support this? Throw an error? Currently for backwards compat it's a no-op.
-    }
-
-    connectedCallback() {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            connectRootElement(this);
-        }
-    }
-    disconnectedCallback() {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            disconnectRootElement(this);
-        }
-    }
-    formAssociatedCallback(form: HTMLFormElement | null) {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            runFormAssociatedCallback(this, form);
-        }
-    }
-    formDisabledCallback(disabled: boolean) {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            runFormDisabledCallback(this, disabled);
-        }
-    }
-    formResetCallback() {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            runFormResetCallback(this);
-        }
-    }
-    formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason) {
-        if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-            runFormStateRestoreCallback(this, state, reason);
-        }
-    }
-}
-
 // Creates a constructor that is intended to be used directly as a custom element, except that the upgradeCallback is
 // passed in to the constructor so LWC can reuse the same custom element constructor for multiple components.
 // Another benefit is that only LWC can create components that actually do anything – if you do
@@ -84,7 +31,59 @@ const createUpgradableConstructor = (isFormAssociated: boolean) => {
     // Note that every class passed into `customElements.define(...)` must be unique, so we can never return
     // the BaseUpgradableConstructor directly.
     // https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#exceptions
-    class UpgradableConstructor extends BaseUpgradableConstructor {}
+    // TODO [#2972]: this class should expose observedAttributes as necessary
+    class UpgradableConstructor extends HTMLElement {
+        constructor(upgradeCallback: LifecycleCallback, useNativeLifecycle: boolean) {
+            super();
+
+            if (useNativeLifecycle) {
+                // When in native lifecycle mode, we need to keep track of instances that were created outside LWC
+                // (i.e. not created by `lwc.createElement()`). If the element uses synthetic lifecycle, then we don't
+                // need to track this.
+                nativeLifecycleElementsToUpgradedByLWC.set(this, elementBeingUpgradedByLWC);
+            }
+
+            // If the element is not created using lwc.createElement(), e.g. `document.createElement('x-foo')`,
+            // then elementBeingUpgradedByLWC will be false
+            if (elementBeingUpgradedByLWC) {
+                upgradeCallback(this);
+            }
+            // TODO [#2970]: LWC elements cannot be upgraded via new Ctor()
+            // Do we want to support this? Throw an error? Currently for backwards compat it's a no-op.
+        }
+
+        connectedCallback() {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                connectRootElement(this);
+            }
+        }
+        disconnectedCallback() {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                disconnectRootElement(this);
+            }
+        }
+        formAssociatedCallback(form: HTMLFormElement | null) {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                runFormAssociatedCallback(this, form);
+            }
+        }
+        formDisabledCallback(disabled: boolean) {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                runFormDisabledCallback(this, disabled);
+            }
+        }
+        formResetCallback() {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                runFormResetCallback(this);
+            }
+        }
+        formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason) {
+            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
+                runFormStateRestoreCallback(this, state, reason);
+            }
+        }
+    }
+
     if (isFormAssociated) {
         // Perf optimization - the vast majority of components have formAssociated=false,
         // so we can skip the setter in those cases, since undefined works the same as false.

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -28,9 +28,6 @@ let elementBeingUpgradedByLWC = false;
 // `customElements.define('x-foo')`, then you don't have access to the upgradeCallback, so it's a dummy custom element.
 // This class should be created once per tag name.
 const createUpgradableConstructor = (isFormAssociated: boolean) => {
-    // Note that every class passed into `customElements.define(...)` must be unique, so we can never return
-    // the BaseUpgradableConstructor directly.
-    // https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#exceptions
     // TODO [#2972]: this class should expose observedAttributes as necessary
     class UpgradableConstructor extends HTMLElement {
         constructor(upgradeCallback: LifecycleCallback, useNativeLifecycle: boolean) {


### PR DESCRIPTION
## Details
The optimization introduced in #4092 to hoist the `UpgradableConstructor` seems to be causing issues without downstream teams.

The current suspicion is that the `BaseUpgradableConstructor` falls out of scope and causes an `Illegal Constructor` failure.

Can't do a straight revert because #4094 builds on top of #4092 so I'm creating a new PR to move it back into `createUpgradableConstructor`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-15276750

