### PR TITLE
fix: move style validation to style compiler

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -95,6 +95,8 @@ jobs:
 
             - run: API_VERSION=60 yarn sauce:ci
             - run: API_VERSION=60 DISABLE_SYNTHETIC=1 yarn sauce:ci
+            - run: API_VERSION=61 yarn sauce:ci
+            - run: API_VERSION=61 DISABLE_SYNTHETIC=1 yarn sauce:ci
             - run: ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL=1 yarn sauce:ci
             - run: ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL=1 DISABLE_SYNTHETIC=1 yarn sauce:ci
             - run: DISABLE_SYNTHETIC_SHADOW_SUPPORT_IN_COMPILER=1 DISABLE_SYNTHETIC=1 yarn sauce:ci

--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -37,6 +37,14 @@ branches:
         pull-request:
             <<: *branch-definition
             workflow: build-and-test # the default workflow is release, and we just want build+tests
+jobs:
+    build-and-test:
+        memory-limit: 16
+    create-canary-release:
+        memory-limit: 16
+    build-dependency:
+        memory-limit: 16
+
 steps:
     node-conformance:
         run:

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -45,7 +45,6 @@
         "@lwc/engine-core": "6.4.1",
         "@lwc/rollup-plugin": "6.4.1",
         "@lwc/shared": "6.4.1",
-        "@parse5/tools": "^0.4.0",
         "@rollup/plugin-virtual": "^3.0.1",
         "parse5": "^7.1.2"
     }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -23,7 +23,15 @@ interface FixtureModule {
 
 jest.setTimeout(10_000 /* 10 seconds */);
 
-async function compileFixture({ input, dirname }: { input: string; dirname: string }) {
+async function compileFixture({
+    input,
+    dirname,
+    apiVersion,
+}: {
+    input: string;
+    dirname: string;
+    apiVersion?: number;
+}) {
     const modulesDir = path.resolve(dirname, './modules');
     const outputFile = path.resolve(dirname, './dist/compiled.js');
     // TODO [#3331]: this is only needed to silence warnings on lwc:dynamic, remove in 246.
@@ -40,6 +48,7 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
                         dir: modulesDir,
                     },
                 ],
+                ...(typeof apiVersion !== 'undefined' && { apiVersion }),
             }),
         ],
         onwarn(warning, warn) {
@@ -161,6 +170,7 @@ function testFixtures() {
             const compiledFixturePath = await compileFixture({
                 input: filename,
                 dirname,
+                ...('apiVersion' in config && { apiVersion: config.apiVersion }),
             });
 
             // The LWC engine holds global state like the current VM index, which has an impact on

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-multiple-levels/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-multiple-levels/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-multiple-levels/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-multiple-levels/error.txt
@@ -1,1 +1,1 @@
-CSS contains unsafe characters and cannot be serialized inside a style element
+CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-close-tag/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-close-tag/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-close-tag/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-close-tag/error.txt
@@ -1,1 +1,1 @@
-CSS contains unsafe characters and cannot be serialized inside a style element
+CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-open-tag/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-open-tag/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-open-tag/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-trailing-open-tag/error.txt
@@ -1,1 +1,1 @@
-CSS contains unsafe characters and cannot be serialized inside a style element
+CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-unclosed-open-tag/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-unclosed-open-tag/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-unclosed-open-tag/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-invalid-unclosed-open-tag/error.txt
@@ -1,1 +1,1 @@
-CSS contains unsafe characters and cannot be serialized inside a style element
+CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-unsafe/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-unsafe/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-unsafe/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/styles-escaping-unsafe/error.txt
@@ -1,1 +1,1 @@
-CSS contains unsafe characters and cannot be serialized inside a style element
+CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content.

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { createVM, connectRootElement, LightningElement } from '@lwc/engine-core';
+import {
+    createVM,
+    connectRootElement,
+    LightningElement,
+    getComponentAPIVersion,
+} from '@lwc/engine-core';
 import { isString, isFunction, isObject, isNull, HTML_NAMESPACE } from '@lwc/shared';
 
 import { renderer } from '../renderer';
@@ -82,5 +87,7 @@ export function renderComponent(
 
     connectRootElement(element);
 
-    return serializeElement(element);
+    const apiVersion = getComponentAPIVersion(Ctor);
+
+    return serializeElement(element, apiVersion);
 }

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -5,22 +5,29 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { htmlEscape, HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
-
 import {
-    HostElement,
-    HostShadowRoot,
+    APIFeature,
+    APIVersion,
+    HTML_NAMESPACE,
+    htmlEscape,
+    isAPIFeatureEnabled,
+    isVoidElement,
+    validateStyleTextContents,
+} from '@lwc/shared';
+import { parseFragment } from 'parse5';
+import {
     HostAttribute,
-    HostChildNode,
-    HostNodeType,
-    HostTypeKey,
-    HostNamespaceKey,
-    HostShadowRootKey,
     HostAttributesKey,
+    HostChildNode,
     HostChildrenKey,
+    HostElement,
+    HostNamespaceKey,
+    HostNodeType,
+    HostShadowRoot,
+    HostShadowRootKey,
+    HostTypeKey,
     HostValueKey,
 } from './types';
-import { validateStyleTextContents } from './utils/validate-style-text-contents';
 
 // Note that for statically optimized content the expression serialization is done in
 // buildParseFragmentFn in @lwc/engine-core. It takes the same logic used here.
@@ -32,24 +39,28 @@ function serializeAttributes(attributes: HostAttribute[]): string {
         .join(' ');
 }
 
-function serializeChildNodes(children: HostChildNode[], tagName?: string): string {
+function serializeChildNodes(
+    children: HostChildNode[],
+    apiVersion: APIVersion,
+    tagName?: string
+): string {
     return children
         .map((child): string => {
             switch (child[HostTypeKey]) {
                 case HostNodeType.Text:
-                    return serializeTextContent(child[HostValueKey], tagName);
+                    return serializeTextContent(child[HostValueKey], apiVersion, tagName);
                 case HostNodeType.Comment:
                     return `<!--${htmlEscape(child[HostValueKey])}-->`;
                 case HostNodeType.Raw:
                     return child[HostValueKey];
                 case HostNodeType.Element:
-                    return serializeElement(child);
+                    return serializeElement(child, apiVersion);
             }
         })
         .join('');
 }
 
-function serializeShadowRoot(shadowRoot: HostShadowRoot): string {
+function serializeShadowRoot(shadowRoot: HostShadowRoot, apiVersion: APIVersion): string {
     const attrs = [`shadowrootmode="${shadowRoot.mode}"`];
 
     if (shadowRoot.delegatesFocus) {
@@ -57,16 +68,18 @@ function serializeShadowRoot(shadowRoot: HostShadowRoot): string {
     }
 
     return `<template ${attrs.join(' ')}>${serializeChildNodes(
-        shadowRoot[HostChildrenKey]
+        shadowRoot[HostChildrenKey],
+        apiVersion
     )}</template>`;
 }
 
 /**
  * Serializes an element into a string
  * @param element The element to serialize
+ * @param apiVersion The API version associated with the component for this element
  * @returns A string representation of the element
  */
-export function serializeElement(element: HostElement): string {
+export function serializeElement(element: HostElement, apiVersion: APIVersion): string {
     let output = '';
 
     const tagName = element.tagName;
@@ -89,10 +102,10 @@ export function serializeElement(element: HostElement): string {
     output += '>';
 
     if (element[HostShadowRootKey]) {
-        output += serializeShadowRoot(element[HostShadowRootKey]);
+        output += serializeShadowRoot(element[HostShadowRootKey], apiVersion);
     }
 
-    output += serializeChildNodes(element[HostChildrenKey], tagName);
+    output += serializeChildNodes(element[HostChildrenKey], apiVersion, tagName);
 
     if (!isVoidElement(tagName, namespace) || hasChildren) {
         output += `</${tagName}>`;
@@ -101,15 +114,17 @@ export function serializeElement(element: HostElement): string {
     return output;
 }
 
-function serializeTextContent(contents: string, tagName?: string) {
+function serializeTextContent(contents: string, apiVersion: APIVersion, tagName?: string) {
     if (contents === '') {
         return '\u200D'; // Special serialization for empty text nodes
     }
     if (tagName === 'style') {
         // Special validation for <style> tags since their content must be served unescaped, and we need to validate
         // that the contents are safe to serialize unescaped.
-        // TODO [#3454]: move this validation to compilation
-        validateStyleTextContents(contents);
+        // This only occurs in older API versions; in newer versions; it's handled by the @lwc/style-compiler.
+        if (!isAPIFeatureEnabled(APIFeature.VALIDATE_CSS_CONTENT_IN_STYLE_COMPILER, apiVersion)) {
+            validateStyleTextContents(contents, parseFragment);
+        }
         // If we haven't thrown an error during validation, then the content is safe to serialize unescaped
         return contents;
     }

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -40,5 +40,9 @@
                 ]
             }
         }
+    },
+    "devDependencies": {
+        "@parse5/tools": "^0.4.0",
+        "parse5": "^7.1.2"
     }
 }

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -12,21 +12,23 @@ export const enum APIVersion {
     V59_246_WINTER_24 = 59,
     V60_248_SPRING_24 = 60,
     V61_250_SUMMER_24 = 61,
+    V62_252_WINTER_25 = 62,
 }
 
 // These must be updated when the enum is updated.
 // It's a bit annoying to do have to do this manually, but this makes the file tree-shakeable,
 // passing the `verify-treeshakeable.js` test.
 
-export const LOWEST_API_VERSION = APIVersion.V58_244_SUMMER_23;
-export const HIGHEST_API_VERSION = APIVersion.V61_250_SUMMER_24;
 const allVersions = [
     APIVersion.V58_244_SUMMER_23,
     APIVersion.V59_246_WINTER_24,
     APIVersion.V60_248_SPRING_24,
     APIVersion.V61_250_SUMMER_24,
+    APIVersion.V62_252_WINTER_25,
 ];
 const allVersionsSet = /*@__PURE__@*/ new Set(allVersions);
+export const LOWEST_API_VERSION = allVersions[0];
+export const HIGHEST_API_VERSION = allVersions[allVersions.length - 1];
 
 /**
  *
@@ -99,6 +101,11 @@ export const enum APIFeature {
      * Form-Associated Custom Elements (FACE).
      */
     ENABLE_ELEMENT_INTERNALS_AND_FACE,
+    /**
+     * If enabled, we check for invalid CSS content (such as CSS that includes HTML tags) in `@lwc/style-compiler`
+     * rather than during SSR serialization.
+     */
+    VALIDATE_CSS_CONTENT_IN_STYLE_COMPILER,
 }
 
 /**
@@ -123,5 +130,7 @@ export function isAPIFeatureEnabled(
         case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
         case APIFeature.USE_LIGHT_DOM_SLOT_FORWARDING:
             return apiVersion >= APIVersion.V61_250_SUMMER_24;
+        case APIFeature.VALIDATE_CSS_CONTENT_IN_STYLE_COMPILER:
+            return apiVersion >= APIVersion.V62_252_WINTER_25;
     }
 }

--- a/packages/@lwc/shared/src/index.ts
+++ b/packages/@lwc/shared/src/index.ts
@@ -16,5 +16,6 @@ export * from './html-escape';
 export * from './namespaces';
 export * from './meta';
 export * from './static-part-tokens';
+export * from './validate-style-text-contents';
 
 export { assert };

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -46,5 +46,8 @@
         "postcss": "~8.4.37",
         "postcss-selector-parser": "~6.0.15",
         "postcss-value-parser": "~4.2.0"
+    },
+    "devDependencies": {
+        "parse5": "^7.1.2"
     }
 }

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/actual.css
@@ -1,0 +1,3 @@
+[data-foo="</style><script>alert('pwned!')</script>"] {
+    color: red;
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/config.json
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/config.json
@@ -1,0 +1,3 @@
+{
+  "apiVersion": 61
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-61/expected.js
@@ -1,0 +1,8 @@
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
+  var shadowSelector = token ? ("[" + token + "]") : "";
+  var hostSelector = token ? ("[" + token + "-host]") : "";
+  var suffixToken = token ? ("-" + token) : "";
+  return "[data-foo=\"</style><script>alert('pwned!')</script>\"]" + shadowSelector + " {color: red;}";
+  /*LWC compiler vX.X.X*/
+}
+export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-latest/actual.css
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-latest/actual.css
@@ -1,0 +1,3 @@
+[data-foo="</style><script>alert('pwned!')</script>"] {
+    color: red;
+}

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-latest/error.json
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/invalid-xss-api-version-latest/error.json
@@ -1,0 +1,4 @@
+{
+    "name": "Error",
+    "message": "CSS contains unsafe characters and cannot be serialized inside a style element. Ensure that your CSS does not contain any HTML content."
+}

--- a/packages/@lwc/style-compiler/src/transform.ts
+++ b/packages/@lwc/style-compiler/src/transform.ts
@@ -5,7 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import postcss from 'postcss';
-import { getAPIVersionFromNumber } from '@lwc/shared';
+import { parseFragment } from 'parse5';
+import {
+    APIFeature,
+    getAPIVersionFromNumber,
+    isAPIFeatureEnabled,
+    validateStyleTextContents,
+} from '@lwc/shared';
 
 import serialize from './serialize';
 import postcssLwc from './postcss-lwc-plugin';
@@ -58,5 +64,11 @@ export function transform(src: string, id: string, config: Config = {}): { code:
 
     const result = postcss(plugins).process(src, { from: id }).sync();
 
-    return { code: serialize(result, config) };
+    const code = serialize(result, config);
+
+    if (isAPIFeatureEnabled(APIFeature.VALIDATE_CSS_CONTENT_IN_STYLE_COMPILER, apiVersion)) {
+        validateStyleTextContents(code, parseFragment);
+    }
+
+    return { code };
 }


### PR DESCRIPTION
## Details

Fixes #3454

This moves style content validation from `@lwc/engine-server` into `@lwc/style-compiler`, but only for components with API version 62+. This avoids a breaking change.

The main purpose of this validation is to avoid XSS in CSS during SSR, e.g.:

```css
[data-foo="</style><script>alert('pwned!')</script>"] {
    color: red;
}
```

However, this is technically a breaking change, and the vast majority of existing components don't care about this because they don't support SSR.

However, it's a perf tax to do this validation during SSR serialization (especially for large stylesheets), so ideally we'd want to do it during compilation instead. This PR achieves that without breaking backwards compat.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

Yes, for OSS package authors, who don't use API versioning, this is technically a breaking change. This will require a major version bump.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

See above

<!-- If yes, please describe the anticipated observable changes. -->
