### PR TITLE
chore(nucleus): bump memory limit

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -37,6 +37,13 @@ branches:
         pull-request:
             <<: *branch-definition
             workflow: build-and-test # the default workflow is release, and we just want build+tests
+jobs:
+    build-and-test:
+        memory-limit: 16
+    create-canary-release:
+        memory-limit: 16
+    build-dependency:
+        memory-limit: 16
 steps:
     node-conformance:
         run:


### PR DESCRIPTION
## Details

I noticed that some of our `yarn lint` jobs are causing Nucleus to crash with an OOM since ESLint is apparently a hungry boy. I stole this Nucleus config from [LBC here](https://github.com/salesforce-experience-platform-emu/lightning-components/blob/f809bde3a8dc9400126710246b211a2b1705fdfe/.nucleus.yaml#L13-L22) and it should bump us up to 16GB on these instances.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
