### PR TITLE
fix: use latest chrome version in saucelabs

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
@@ -9,10 +9,7 @@ exports.STANDARD_SAUCE_BROWSERS = [
     {
         label: 'sl_chrome_latest',
         browserName: 'chrome',
-        // Hydration tests are broken on Chrome 121 due to changes with shadowRoot, but fixed on Chrome 122.
-        // Pinning Chrome version to unblock tests.
-        // TODO [#3987]: Should be removed once Chrome 122 becomes latest.
-        browserVersion: '120',
+        browserVersion: 'latest',
     },
     {
         label: 'sl_firefox_latest',


### PR DESCRIPTION
## Details
Resolves https://github.com/salesforce/lwc/issues/3987 to use latest chrome version in saucelabs.
## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
W-15377039