### PR TITLE
chore: add flag to disable `isNodeFromTemplate`

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
+++ b/packages/@lwc/engine-dom/src/apis/is-node-from-template.ts
@@ -26,6 +26,11 @@ const _Node = Node;
  * @example isNodeShadowed(document.querySelector('my-component'))
  */
 function isNodeShadowed(node: Node): boolean {
+    if (lwcRuntimeFlags.DISABLE_IS_NODE_FROM_TEMPLATE) {
+        throw new Error(
+            'isNodeFromTemplate/isNodeShadowed is a deprecated API and is no longer supported'
+        );
+    }
     if (isFalse(node instanceof _Node)) {
         return false;
     }

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -19,6 +19,7 @@ const features: FeatureFlagMap = {
     ENABLE_LEGACY_SCOPE_TOKENS: null,
     ENABLE_FORCE_SHADOW_MIGRATE_MODE: null,
     ENABLE_EXPERIMENTAL_SIGNALS: null,
+    DISABLE_IS_NODE_FROM_TEMPLATE: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -69,6 +69,11 @@ export interface FeatureFlagMap {
      * If true, allows the engine to expose reactivity to signals as describe in @lwc/signals.
      */
     ENABLE_EXPERIMENTAL_SIGNALS: FeatureFlagValue;
+    /**
+     * Causes the legacy `isNodeFromTemplate`/`isNodeShadowed` API to throw an error. Intend to be used as a first
+     * step toward deleting this API.
+     */
+    DISABLE_IS_NODE_FROM_TEMPLATE: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, isNodeFromTemplate } from 'lwc';
+import { createElement, isNodeFromTemplate, setFeatureFlagForTest } from 'lwc';
 import Test from 'x/test';
 
 function testNonNodes(type, obj) {
@@ -76,3 +76,19 @@ if (!process.env.NATIVE_SHADOW) {
         });
     });
 }
+
+describe('DISABLE_IS_NODE_FROM_TEMPLATE flag', () => {
+    beforeEach(() => {
+        setFeatureFlagForTest('DISABLE_IS_NODE_FROM_TEMPLATE', true);
+    });
+
+    afterEach(() => {
+        setFeatureFlagForTest('DISABLE_IS_NODE_FROM_TEMPLATE', false);
+    });
+
+    it('should throw an error when the flag is enabled', () => {
+        expect(isNodeFromTemplate).toThrowError(
+            /isNodeFromTemplate\/isNodeShadowed is a deprecated API and is no longer supported/
+        );
+    });
+});


### PR DESCRIPTION
## Details

I'm looking into our entire `shadowResolver`/`isNodeFromTemplate` system since it's a perf tax when running synthetic shadow. As such, I came across #1252 which says `isNodeFromTemplate` is deprecated and should be removed eventually. It's also [not available externally](https://github.com/salesforce/eslint-plugin-lwc/blob/addfa3d28a6cff3eb911e212cf5b2ebe59804101/lib/rules/no-disallowed-lwc-imports.js#L11-L35).

I couldn't actually find any usages of this API internally, so I'd like to add a flag to test what happens if we just have it throw an error. Presumably we can flip this flag on and see if anybody yelps. This would be step 1 towards just removing it entirely.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

Not yet!

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
