### PR TITLE
perf(engine-core): avoid `Array#splice` in mutation tracking

### DIFF
--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
@@ -103,17 +103,16 @@ export class ReactiveObserver {
             for (let i = 0; i < len; i++) {
                 const set = listeners[i];
                 const setLength = set.length;
-                if (setLength === 1) {
-                    // Perf optimization for the common case - the length is usually 1, so avoid the indexOf+push.
-                    // If the length is 1, we can also be sure that `this` is the first item in the array.
-                    set.length = 0;
-                } else {
-                    // Slow case - swap with the last item and then remove.
+                // The length is usually 1, so avoid doing an indexOf when we know for certain
+                // that `this` is the first item in the array.
+                if (setLength > 1) {
+                    // Swap with the last item before removal.
                     // (Avoiding splice here is a perf optimization, and the order doesn't matter.)
                     const index = ArrayIndexOf.call(set, this);
                     set[index] = set[setLength - 1];
-                    ArrayPop.call(set);
                 }
+                // Remove the last item
+                ArrayPop.call(set);
             }
             listeners.length = 0;
         }

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.html
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.html
@@ -1,0 +1,19 @@
+<template>
+    <div>Depth: {depth}</div>
+    <div>Index: {index}</div>
+    <div>ID: {data.id}</div>
+    <template lwc:if={notLeaf}>
+        <template for:each={children} for:item="child">
+            <!-- The point of this component is to have multiple template functions that are
+             all observing the same data, hence why the data object is passed down -->
+            <benchmark-tree
+                    depth={depthMinusOne}
+                    breadth={breadth}
+                    data-id={data.id}
+                    data={data}
+                    key={child}
+                    index={child}
+            ></benchmark-tree>
+        </template>
+    </template>
+</template>

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.js
@@ -21,8 +21,6 @@ export default class extends LightningElement {
     }
 
     get children() {
-        return Array(this.breadth)
-            .fill()
-            .map((_, i) => i);
+        return Array.from({ length: this.breadth }, (_, i) => i);
     }
 }

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/tree/tree.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api data = { id: 'foo' };
+    @api depth = 0;
+    @api breadth = 0;
+    @api index = 0;
+
+    get depthMinusOne() {
+        return this.depth - 1;
+    }
+
+    get notLeaf() {
+        return this.depth > 0;
+    }
+
+    get children() {
+        return Array(this.breadth)
+            .fill()
+            .map((_, i) => i);
+    }
+}

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tree/tree-create-3k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tree/tree-create-3k.benchmark.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { createElement } from '@lwc/engine-dom';
+
+import Tree from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tree/tree.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+benchmark(`dom/tree/create/3k`, () => {
+    let treeElement;
+
+    before(() => {
+        treeElement = createElement('benchmark-tree', { is: Tree });
+        return insertComponent(treeElement);
+    });
+
+    run(() => {
+        // Not really 3k, but close enough: 5^5 = 3,125
+        treeElement.depth = 5;
+        treeElement.breadth = 5;
+    });
+
+    after(() => {
+        destroyComponent(treeElement);
+    });
+});

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tree/tree-remove-3k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-tree/tree-remove-3k.benchmark.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { createElement } from '@lwc/engine-dom';
+
+import Tree from '@lwc/perf-benchmarks-components/dist/dom/benchmark/tree/tree.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+// This test runs around 25ms on a 2019 MacBook Pro, so throttle a bit
+export const cpuThrottlingRate = 2;
+
+benchmark(`dom/tree/remove/5k`, () => {
+    let treeElement;
+
+    before(() => {
+        treeElement = createElement('benchmark-tree', { is: Tree });
+        // Not really 3k, but close enough: 5^5 = 3,125
+        treeElement.depth = 5;
+        treeElement.breadth = 5;
+        return insertComponent(treeElement);
+    });
+
+    run(() => {
+        treeElement.depth = 0;
+    });
+
+    after(() => {
+        destroyComponent(treeElement);
+    });
+});


### PR DESCRIPTION
## Details

Instead of doing an expensive `Array#splice` in this perf-sensitive mutation tracking code, we can

1) swap the target item with the last item
2) call `Array#pop` instead

I couldn't find an existing benchmark to repro the improvement in Chrome, so I wrote a new one. This new test builds a tree structure with recursive components. The reason it repros the improvement is that it has lots of component instances that are tracking mutations on a single getter (which is probably something that happens in the real world fairly frequently).

The improvement is 20-24%:

![Screenshot 2024-04-10 at 12 36 05 PM](https://github.com/salesforce/lwc/assets/283842/80022bb2-973d-4206-9e11-3189a6813031)

Here it is in a manual test to show the improvement to the `reset()` function:

![Screenshot 2024-04-10 at 12 50 30 PM](https://github.com/salesforce/lwc/assets/283842/6bbe5656-b96c-431a-93b7-13e67012f740)

FWIW I got this idea from Svelte [here](https://github.com/sveltejs/svelte/blob/3bb231197e7787b785cb463560f1b176323c119a/packages/svelte/src/internal/client/runtime.js#L334-L336).

(I assume that the reason the splice is slow is because it has to create an additional array under the hood, plus it has to shift a bunch of array items around.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

This is not an observable change because all the pending rehydration callbacks are queued up in a microtask, and then we sort the queue before running them:

https://github.com/salesforce/lwc/blob/6c46adb80c74c4e283deb2385a999349fa6e0731/packages/%40lwc/engine-core/src/framework/vm.ts#L667

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
