### PR TITLE
chore(template-compiler): update acorn and fix its types

### DIFF
--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -42,10 +42,9 @@
         }
     },
     "dependencies": {
-        "//": "Acorn is pinned due to a breaking change in its types in 8.11: https://github.com/acornjs/acorn/issues/1260",
         "@lwc/errors": "6.5.0",
         "@lwc/shared": "6.5.0",
-        "acorn": "8.10.0",
+        "acorn": "~8.11.3",
         "astring": "~1.8.6",
         "estree-walker": "~2.0.2",
         "he": "~1.2.0"

--- a/packages/@lwc/template-compiler/src/typings/acorn.d.ts
+++ b/packages/@lwc/template-compiler/src/typings/acorn.d.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import type { Expression, Options } from 'acorn';
+
+// Acorn shipped a breaking change in its types: https://github.com/acornjs/acorn/issues/1260
+// This is a workaround based on Svelte's solution: https://github.com/sveltejs/svelte/pull/10301
+declare module 'acorn' {
+    export function isIdentifierStart(code: number, astral?: boolean): boolean;
+    export function isIdentifierChar(code: number, astral?: boolean): boolean;
+    export function parseExpressionAt(input: string, pos: number, options: Options): Expression;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,12 +2599,7 @@ acorn-walk@^8.0.2:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
   integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
 
-acorn@8.10.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
-
-acorn@^8.1.0, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.1.0, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9.0, acorn@~8.11.3:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==


### PR DESCRIPTION
## Details

Acorn shipped a breaking change in its types: https://github.com/acornjs/acorn/issues/1260
This is a workaround based on Svelte's solution: https://github.com/sveltejs/svelte/pull/10301

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
