### PR TITLE
chore(dependabot): pin tachometer version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    groups:
-      # Non-major version bumps hopefully shouldn't break anything,
-      # so let's group them together into a single PR!
-      theoretically-non-breaking:
-        update-types:
-          - "minor"
-          - "patch"
+    - package-ecosystem: 'npm' # See documentation for possible values
+      directory: '/' # Location of package manifests
+      schedule:
+          interval: 'weekly'
+      groups:
+          # Non-major version bumps hopefully shouldn't break anything,
+          # so let's group them together into a single PR!
+          theoretically-non-breaking:
+              update-types:
+                  - 'minor'
+                  - 'patch'
+      ignore:
+          # We are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0.
+          # See: https://github.com/google/tachometer/issues/244
+          - dependency-name: 'tachometer'

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -13,8 +13,7 @@
     "//": [
         "Note it's important for Tachometer that any deps it needs to swap out are dependencies, not devDependencies.",
         "Also note we are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0.",
-        "Breaking change: https://github.com/google/tachometer/issues/244",
-        "Also note that we use legacy versions of rollup-plugin-node-resolve and rollup-plugin-commonjs because Best uses an old version of Rollup."
+        "Breaking change: https://github.com/google/tachometer/issues/244"
     ],
     "dependencies": {
         "@lwc/engine-dom": "6.5.0",


### PR DESCRIPTION
## Details

We can't update `tachometer` due to a breaking change that hasn't been resolved yet.

For now we need to tell Dependabot not to try to update this dependency.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
