### PR TITLE
feat: create script to facilitate accepting external contributions @W-15482802

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "build:performance:components": "nx build @lwc/perf-benchmarks-components",
         "build:performance:benchmarks": "nx build @lwc/perf-benchmarks",
         "dev": "nx run-many --target=dev --all --parallel=999 --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests,lwc",
+        "external-contributor-ci-workaround": "./scripts/tasks/unsafe-external-contributor-ci-workaround.sh",
         "test": "jest --config ./scripts/jest/root.config.js",
         "test:debug": "node --inspect node_modules/.bin/jest --config ./scripts/jest/root.config.js --runInBand --watch",
         "test:ci": "yarn test --no-cache --coverage --runInBand",

--- a/scripts/tasks/unsafe-external-contributor-ci-workaround.sh
+++ b/scripts/tasks/unsafe-external-contributor-ci-workaround.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# CI fails for external contributors because they do not have access to the secrets necessary to run
+# all jobs (namely, Sauce Labs). This script is a workaround to copy the branch from the external
+# contributor's fork and push it to the main repo. This causes CI to be executed by the internal
+# maintainer, and therefore have full access to all the secrets.
+# WARNING: This is not safe! Review all code changes in the PR before granting access to secrets.
+#
+# Usage: yarn external-contributor-ci-workaround <PR number> [remote=origin]
+
+set -e
+
+PR_INPUT="$1" # Technically can be any input `gh pr` accepts
+REMOTE="${2:-origin}"
+
+# Avoid accidentally committing unrelated files
+if [[ -n `git status --porcelain` ]]; then
+  echo -e '\033[1mPlease stash your work before continuing.\n\033[0m'
+  git status
+  exit 1
+fi
+
+# Enforce required tooling
+if [[ -z `which gh` ]]; then
+  echo 'Please install the GitHub CLI (gh): https://cli.github.com/'
+  exit 1
+fi
+
+# Enforce required input
+if [[ -z "$PR_INPUT" ]]; then
+  echo 'Please provide a pull request number or branch name.'
+  exit 1
+fi
+
+# Enforce valid remote
+if ! git remote get-url "$REMOTE" 1>/dev/null; then
+  LIST=`git remote`
+  echo "Please specify a known remote: ${LIST//$'\n'/, }"
+  exit 1
+fi
+
+# Query GitHub for PR data
+PR_DATA=`gh pr view "$PR_INPUT" --json author,baseRefName,isCrossRepository,number,title`
+AUTHOR=`echo $PR_DATA | jq -r .author.login`
+BASE=`echo $PR_DATA | jq -r .baseRefName`
+IS_FORK=`echo $PR_DATA | jq -r .isCrossRepository`
+NUMBER=`echo $PR_DATA | jq -r .number`
+TITLE=`echo $PR_DATA | jq -r .title`
+
+# Sanity check: Is this the right PR?
+if [[ "$IS_FORK" != 'true' ]]; then
+  echo "PR #$NUMBER: $TITLE (by $AUTHOR) is not external. This script is not necessary."
+  exit 1
+fi
+
+# Sanity check: did you review?
+echo -e 'This will run CI \033[1mwith secrets\033[0m using your account!'
+echo "You are about to clone PR #$NUMBER: $TITLE (by $AUTHOR)."
+read -p 'Did you review the PR first? (y/N) ' CONFIRM
+if [[ ! $CONFIRM =~ ^[yY] ]]; then
+  echo "Go review it now!"
+  sleep 1
+  gh pr view "$NUMBER" --web
+  exit 1
+fi
+
+# Copy and push the branch, then immediately delete it
+INTERNAL_BRANCH="external-contributor-ci-workaround/pr-$NUMBER"
+gh pr checkout "$NUMBER" --branch "$INTERNAL_BRANCH"
+git push -u "$REMOTE" "$INTERNAL_BRANCH"
+gh pr create \
+  --base "$BASE" \
+  --head "$INTERNAL_BRANCH" \
+  --title "[DO NOT MERGE] Trigger CI for #$NUMBER: $TITLE" \
+  --body "External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #$NUMBER."
+git switch -
+gh pr close "$INTERNAL_BRANCH" --delete-branch
+# Open the original PR in browser to validate that CI is running correctly
+gh pr view --web "$NUMBER"


### PR DESCRIPTION
External contributors don't have access to secrets in CI, but our current CI workflow requires secrets to succeed. As a workaround, we can clone the branch from the external fork, push it to our repo, and create a PR. This causes CI to be executed as the internal user who opened the workaround PR, thereby granting access to secrets. Because the commits in the workaround PR are identical to those in the original PR, the checks are shared by both PRs, and the original PR is unblocked.

**Usage**
* `yarn external-contributor-ci-workaround <PR number> [remote=origin]`.
* PR number is required.
* Remote is optional and defaults to origin.
* Any internal user can execute the script locally, from any branch.
* Requires the GitHub CLI.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
W-15482802