### PR TITLE
feat: exports HMR stubs from engine-server

### DIFF
--- a/packages/@lwc/engine-server/src/apis/hot-swaps.ts
+++ b/packages/@lwc/engine-server/src/apis/hot-swaps.ts
@@ -13,8 +13,12 @@
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapComponent(): never {
-    throw new Error('swapComponent is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+export function swapComponent(): void {
+    if (process.env.NODE_ENV !== 'production') {
+        throw new Error(
+            'swapComponent is not supported in @lwc/engine-server, only @lwc/engine-dom.'
+        );
+    }
 }
 
 /**
@@ -25,8 +29,10 @@ export function swapComponent(): never {
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapStyle(): never {
-    throw new Error('swapStyle is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+export function swapStyle(): void {
+    if (process.env.NODE_ENV !== 'production') {
+        throw new Error('swapStyle is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+    }
 }
 
 /**
@@ -37,6 +43,20 @@ export function swapStyle(): never {
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapTemplate(): never {
-    throw new Error('swapTemplate is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+export function swapTemplate(): void {
+    if (process.env.NODE_ENV !== 'production') {
+        throw new Error(
+            'swapTemplate is not supported in @lwc/engine-server, only @lwc/engine-dom.'
+        );
+    }
 }
+
+/**
+ * The hot API is used to orchestrate hot swapping in client rendered components.
+ * It doesn't do anything on the server side, however, you may import it.
+ *
+ * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
+ * an error being thrown by the import itself.
+ * @returns undefined
+ */
+export const hot = void 0;

--- a/packages/@lwc/engine-server/src/apis/hot-swaps.ts
+++ b/packages/@lwc/engine-server/src/apis/hot-swaps.ts
@@ -57,6 +57,5 @@ export function swapTemplate(): void {
  *
  * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
  * an error being thrown by the import itself.
- * @returns undefined
  */
 export const hot = void 0;

--- a/packages/@lwc/engine-server/src/apis/hot-swaps.ts
+++ b/packages/@lwc/engine-server/src/apis/hot-swaps.ts
@@ -13,12 +13,8 @@
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapComponent(): void {
-    if (process.env.NODE_ENV !== 'production') {
-        throw new Error(
-            'swapComponent is not supported in @lwc/engine-server, only @lwc/engine-dom.'
-        );
-    }
+export function swapComponent(): never {
+    throw new Error('swapComponent is not supported in @lwc/engine-server, only @lwc/engine-dom.');
 }
 
 /**
@@ -29,10 +25,8 @@ export function swapComponent(): void {
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapStyle(): void {
-    if (process.env.NODE_ENV !== 'production') {
-        throw new Error('swapStyle is not supported in @lwc/engine-server, only @lwc/engine-dom.');
-    }
+export function swapStyle(): never {
+    throw new Error('swapStyle is not supported in @lwc/engine-server, only @lwc/engine-dom.');
 }
 
 /**
@@ -43,12 +37,8 @@ export function swapStyle(): void {
  * an error being thrown by the import itself.
  * @throws Always throws, as it should not be used.
  */
-export function swapTemplate(): void {
-    if (process.env.NODE_ENV !== 'production') {
-        throw new Error(
-            'swapTemplate is not supported in @lwc/engine-server, only @lwc/engine-dom.'
-        );
-    }
+export function swapTemplate(): never {
+    throw new Error('swapTemplate is not supported in @lwc/engine-server, only @lwc/engine-dom.');
 }
 
 /**
@@ -58,4 +48,4 @@ export function swapTemplate(): void {
  * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
  * an error being thrown by the import itself.
  */
-export const hot = void 0;
+export const hot = undefined;

--- a/packages/@lwc/engine-server/src/apis/hot-swaps.ts
+++ b/packages/@lwc/engine-server/src/apis/hot-swaps.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * These swapComponent is equivalent to the { swapComponent } functions exposed by @lwc/engine-dom. It doesn't do anything on
+ * the server side, however, you may import it.
+ *
+ * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
+ * an error being thrown by the import itself.
+ * @throws Always throws, as it should not be used.
+ */
+export function swapComponent(): never {
+    throw new Error('swapComponent is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+}
+
+/**
+ * These swapStyle API is equivalent to the { swapStyle } functions exposed by @lwc/engine-dom. It doesn't do anything on
+ * the server side, however, you may import it.
+ *
+ * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
+ * an error being thrown by the import itself.
+ * @throws Always throws, as it should not be used.
+ */
+export function swapStyle(): never {
+    throw new Error('swapStyle is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+}
+
+/**
+ * These swapTemplate API are equivalent to the { swapTemplate } functions exposed by @lwc/engine-dom. It doesn't do anything on
+ * the server side, however, you may import it.
+ *
+ * The whole point of defining this and exporting it is so that you can import it in isomorphic code without
+ * an error being thrown by the import itself.
+ * @throws Always throws, as it should not be used.
+ */
+export function swapTemplate(): never {
+    throw new Error('swapTemplate is not supported in @lwc/engine-server, only @lwc/engine-dom.');
+}

--- a/packages/@lwc/engine-server/src/index.ts
+++ b/packages/@lwc/engine-server/src/index.ts
@@ -37,3 +37,4 @@ export { LightningElement } from './apis/lightning-element';
 export { renderer } from './renderer';
 export { createElement } from './apis/create-element';
 export { createContextProvider } from './context';
+export { swapComponent, swapStyle, swapTemplate } from './apis/hot-swaps';

--- a/packages/@lwc/engine-server/src/index.ts
+++ b/packages/@lwc/engine-server/src/index.ts
@@ -37,4 +37,4 @@ export { LightningElement } from './apis/lightning-element';
 export { renderer } from './renderer';
 export { createElement } from './apis/create-element';
 export { createContextProvider } from './context';
-export { swapComponent, swapStyle, swapTemplate } from './apis/hot-swaps';
+export { hot, swapComponent, swapStyle, swapTemplate } from './apis/hot-swaps';


### PR DESCRIPTION
## Details
This exposes stubs for HMR APIs from `@lwc/engine-server`, so that the modules with HMR hooks are valid but these APIs are a no-op.
## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
W-15369047