### PR TITLE
chore(eslint): remove jsdoc plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,12 +7,8 @@
         "project": true
     },
 
-    "plugins": ["jest", "@lwc/lwc-internal", "@typescript-eslint", "import", "header", "jsdoc"],
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended-type-checked",
-        "plugin:jsdoc/recommended-typescript"
-    ],
+    "plugins": ["jest", "@lwc/lwc-internal", "@typescript-eslint", "import", "header"],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended-type-checked"],
 
     "env": {
         "es6": true
@@ -163,24 +159,7 @@
         "@typescript-eslint/no-unsafe-return": "off",
         "@typescript-eslint/no-unsafe-argument": "off",
         // This rule returns false positives with ! assertions, even with strictNullChecks(https://github.com/typescript-eslint/typescript-eslint/issues/1618) on it was complaining
-        "@typescript-eslint/no-unnecessary-type-assertion": "off",
-
-        "jsdoc/require-jsdoc": ["warn", { "publicOnly": true }],
-        "jsdoc/check-indentation": "error",
-        "jsdoc/check-syntax": "error",
-        "jsdoc/informative-docs": "error",
-        "jsdoc/no-bad-blocks": [
-            "error",
-            { "ignore": ["__PURE__", "__PURE__@", "ts-expect-error", "ts-ignore"] }
-        ],
-        "jsdoc/no-blank-blocks": "error",
-        "jsdoc/no-defaults": "error",
-        "jsdoc/no-types": "error",
-        "jsdoc/require-description": "error",
-        "jsdoc/require-example": "error",
-        "jsdoc/require-hyphen-before-param-description": ["error", "never"],
-        "jsdoc/require-throws": "error",
-        "jsdoc/sort-tags": "error"
+        "@typescript-eslint/no-unnecessary-type-assertion": "off"
     },
 
     "overrides": [
@@ -281,73 +260,6 @@
             ],
             "rules": {
                 "header/header": "off"
-            }
-        },
-        {
-            // Don't complain about 3rd party JSDoc
-            "files": ["packages/@lwc/synthetic-shadow/src/3rdparty/**"],
-            "rules": {
-                "jsdoc/check-alignment": "off",
-                "jsdoc/check-indentation": "off",
-                "jsdoc/check-syntax": "off",
-                "jsdoc/check-values": "off",
-                "jsdoc/informative-docs": "off",
-                "jsdoc/no-bad-blocks": "off",
-                "jsdoc/no-blank-blocks": "off",
-                "jsdoc/no-defaults": "off",
-                "jsdoc/no-types": "off",
-                "jsdoc/require-description": "off",
-                "jsdoc/require-hyphen-before-param-description": "off",
-                "jsdoc/require-jsdoc": "off",
-                "jsdoc/require-param": "off",
-                "jsdoc/require-throws": "off",
-                "jsdoc/sort-tags": "off"
-            }
-        },
-        {
-            "files": [
-                // Private packages - documentation isn't required (but should still be good, if present)
-                "packages/@lwc/integration-karma/**",
-                "packages/@lwc/integration-tests/**",
-                "packages/@lwc/perf-benchmarks-components/**",
-                "packages/@lwc/perf-benchmarks/**",
-                // TODO [W-13278716]: All top-level exports should have JSDOC enforced
-                "packages/@lwc/engine-core/**",
-                // "packages/@lwc/engine-server/**",
-                // Package-level exports are documented, but not all file-level exports are, so we
-                // should keep these disabled for now
-                "packages/@lwc/babel-plugin-component/**",
-                "packages/@lwc/engine-dom/**",
-                "packages/@lwc/engine-server/**",
-                "packages/@lwc/module-resolver/**",
-                "packages/@lwc/shared/**",
-                "packages/@lwc/style-compiler/**",
-                "packages/@lwc/synthetic-shadow/**",
-                "packages/@lwc/template-compiler/**"
-            ],
-            "rules": {
-                "jsdoc/require-jsdoc": "off",
-                // TODO [W-13278716]: All JSDoc should fully describe functions
-                "jsdoc/require-description": "off",
-                "jsdoc/require-example": "off",
-                "jsdoc/require-param-description": "off",
-                "jsdoc/require-returns": "off",
-                "jsdoc/require-throws": "off"
-            }
-        },
-        // TODO [W-13278716]: Not everything *needs* an example, so I'll probably disable the rule
-        // when the ticket is complete, but for now I want to enable by default and disable as I go.
-        {
-            "files": [
-                "packages/@lwc/babel-plugin-component/**",
-                "packages/@lwc/compiler/**",
-                "packages/@lwc/errors/**",
-                "packages/@lwc/engine-dom/**",
-                "packages/@lwc/rollup-plugin/**",
-                "packages/@lwc/wire-service/**"
-            ],
-            "rules": {
-                "jsdoc/require-example": "off"
             }
         },
         {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^28.2.0",
-        "eslint-plugin-jsdoc": "^48.2.3",
         "glob": "^10.3.12",
         "husky": "^9.0.11",
         "isbinaryfile": "^5.0.2",

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -82,9 +82,6 @@ function monkeyPatchDomAPIs() {
     } as Pick<Node, 'appendChild' | 'insertBefore' | 'removeChild' | 'replaceChild'>);
 }
 
-// For some reason, JSDOC says "options.is" is a syntax error. And we can't disable the rule using
-// `eslint-disable-next-line` because that gets included in the JSDOC, so we need this workaround.
-/* eslint-disable jsdoc/valid-types */
 /**
  * EXPERIMENTAL: This function is almost identical to document.createElement with the slightly
  * difference that in the options, you can pass the `is` property set to a Constructor instead of
@@ -100,7 +97,6 @@ function monkeyPatchDomAPIs() {
  * const el = createElement('x-foo', { is: FooCtor });
  */
 export function createElement(
-    /* eslint-enable jsdoc/valid-types */
     sel: string,
     options: {
         is: typeof LightningElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,15 +898,6 @@
     buffer-crc32 "~0.2.3"
     fd-slicer2 "^1.2.0"
 
-"@es-joy/jsdoccomment@~0.42.0":
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.42.0.tgz#59e878708336aaee88c2b34c894f73dbf77ae2b0"
-  integrity sha512-R1w57YlVA6+YE01wch3GPYn6bCsrOV3YW/5oGGE2tmX6JcL9Nr+b5IikrjMPF+v9CV3ay+obImEdsDhovhJrzw==
-  dependencies:
-    comment-parser "1.4.1"
-    esquery "^1.5.0"
-    jsdoc-type-pratt-parser "~4.0.0"
-
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -2765,11 +2756,6 @@ archiver@^7.0.0:
     tar-stream "^3.0.0"
     zip-stream "^6.0.1"
 
-are-docs-informative@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
-  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
-
 are-we-there-yet@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd"
@@ -3810,11 +3796,6 @@ commander@^9.3.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
-
-comment-parser@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
-  integrity sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4920,21 +4901,6 @@ eslint-plugin-jest@^28.2.0:
   dependencies:
     "@typescript-eslint/utils" "^6.0.0"
 
-eslint-plugin-jsdoc@^48.2.3:
-  version "48.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.3.tgz#0188d17c7a4aa7185416556589e71a954b343ecd"
-  integrity sha512-r9DMAmFs66VNvNqRLLjHejdnJtILrt3xGi+Qx0op0oRfFGVpOR1Hb3BC++MacseHx93d8SKYPhyrC9BS7Os2QA==
-  dependencies:
-    "@es-joy/jsdoccomment" "~0.42.0"
-    are-docs-informative "^0.0.2"
-    comment-parser "1.4.1"
-    debug "^4.3.4"
-    escape-string-regexp "^4.0.0"
-    esquery "^1.5.0"
-    is-builtin-module "^3.2.1"
-    semver "^7.6.0"
-    spdx-expression-parse "^4.0.0"
-
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
@@ -5006,7 +4972,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.2, esquery@^1.5.0:
+esquery@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -7282,11 +7248,6 @@ jsbn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
   integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
-
-jsdoc-type-pratt-parser@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
-  integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
 
 jsdom@^20.0.0:
   version "20.0.3"
@@ -10504,14 +10465,6 @@ spdx-expression-parse@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-expression-parse@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz#a23af9f3132115465dac215c099303e4ceac5794"
-  integrity sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==
   dependencies:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"


### PR DESCRIPTION
We don't _really_ need it and it makes eslint take longer. This PR reduces the time it takes to run `yarn lint` on my machine from 50s to 43s.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
