### PR TITLE
Fix: lwc compiler errors on .jsx/.tsx files

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -270,32 +270,20 @@ describe('sourcemaps', () => {
     });
 });
 
-describe('transformFile function', () => {
-    it('should be tranform Typescript file with ext (.tsx)', () => {
-        const src = `
-            import { LightningElement } from 'lwc';
-            export default class Foo extends LightningElement {}
-        `;
-        const fileName = 'app.tsx';
-        const options = { namespace: 'c', name: 'app' };
-        const result = transformSync(src, fileName, options);
-        expect(result.code).toBeDefined();
-        expect(result.map).toBeDefined();
-        expect(result.warnings).toBeUndefined();
-        expect(result.cssScopeTokens).toBeUndefined();
-    });
-
-    it('should be tranform Javascript file with ext (.jsx)', () => {
-        const src = `
-            import { LightningElement } from 'lwc';
-            export default class Foo extends LightningElement {}
-        `;
-        const fileName = 'app.jsx';
-        const options = { namespace: 'c', name: 'app' };
-        const result = transformSync(src, fileName, options);
-        expect(result.code).toBeDefined();
-        expect(result.map).toBeDefined();
-        expect(result.warnings).toBeUndefined();
-        expect(result.cssScopeTokens).toBeUndefined();
-    });
+describe('file extension support', () => {
+    function testFileExtensionSupport(ext: string) {
+        it(`should support ${ext} file extension`, () => {
+            const src = `
+                import { LightningElement } from 'lwc';
+                export default class Foo extends LightningElement {}
+            `;
+            const options = { namespace: 'c', name: 'foo' };
+            const result = transformSync(src, `foo${ext}`, options);
+            expect(result.code).toBeDefined();
+            expect(result.map).toBeDefined();
+            expect(result.warnings).toBeUndefined();
+            expect(result.cssScopeTokens).toBeUndefined();
+        });
+    }
+    ['.js', '.jsx', '.ts', '.tsx'].forEach(testFileExtensionSupport);
 });

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -269,3 +269,33 @@ describe('sourcemaps', () => {
         });
     });
 });
+
+describe('transformFile function', () => {
+    it('should be tranform Typescript file with ext (.tsx)', () => {
+        const src = `
+            import { LightningElement } from 'lwc';
+            export default class Foo extends LightningElement {}
+        `;
+        const fileName = 'app.tsx';
+        const options = { namespace: 'c', name: 'app' };
+        const result = transformSync(src, fileName, options);
+        expect(result.code).toBeDefined();
+        expect(result.map).toBeDefined();
+        expect(result.warnings).toBeUndefined();
+        expect(result.cssScopeTokens).toBeUndefined();
+    });
+
+    it('should be tranform Javascript file with ext (.jsx)', () => {
+        const src = `
+            import { LightningElement } from 'lwc';
+            export default class Foo extends LightningElement {}
+        `;
+        const fileName = 'app.jsx';
+        const options = { namespace: 'c', name: 'app' };
+        const result = transformSync(src, fileName, options);
+        expect(result.code).toBeDefined();
+        expect(result.map).toBeDefined();
+        expect(result.warnings).toBeUndefined();
+        expect(result.cssScopeTokens).toBeUndefined();
+    });
+});

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -121,6 +121,8 @@ function transformFile(
             transformer = styleTransform;
             break;
 
+        case '.tsx':
+        case '.jsx':
         case '.ts':
         case '.js':
             transformer = scriptTransformer;


### PR DESCRIPTION
## Details
Fix: LWC compiler errors on .jsx/.tsx files #4122. 
(Treating .jsx/.tsx  file extensions the same as .js & .ts.) 

## Does this pull request introduce a breaking change?
-   😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?
-   🤞 No, it does not introduce an observable change.