### PR TITLE
[DO NOT MERGE] Trigger CI for #4164: Fix: lwc compiler errors on .jsx/.tsx files

### DIFF
--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -121,6 +121,10 @@ function transformFile(
             transformer = styleTransform;
             break;
 
+        case '.tsx':
+        case '.jsx':
+            break;
+
         case '.ts':
         case '.js':
             transformer = scriptTransformer;

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -123,8 +123,6 @@ function transformFile(
 
         case '.tsx':
         case '.jsx':
-            break;
-
         case '.ts':
         case '.js':
             transformer = scriptTransformer;


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4164.