### PR TITLE
fix(lwc): use real exports from @lwc/engine-dom

### DIFF
--- a/packages/lwc/index.d.ts
+++ b/packages/lwc/index.d.ts
@@ -1,11 +1,19 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import type { FormRestoreReason, FormRestoreState } from '@lwc/engine-core';
+export * from '@lwc/engine-dom';
+
+// ---------------------------------------------------------------------------------------------- //
+// In the JavaScript code (./index.js), we just re-export @lwc/engine-dom. Everything below this
+// line does not exist in that package. It's mostly types that aren't actually used, plus a fake
+// class `HTMLElementTheGoodPart` and an additional signature for the wire decorator. Those two
+// anomalies should be remedied in a major version bump. The types should probably go, too, but
+// less urgently, as they're not really hurting anything.
+// ---------------------------------------------------------------------------------------------- //
 
 /**
  * Lightning Web Components core module
@@ -17,6 +25,14 @@ declare module 'lwc' {
         composed: boolean;
     }
 
+    /**
+     * **DO NOT USE**: This is a former implementation detail for `LightningElement`. It is solely
+     * exported as a type, and does not exist in the JavaScript code. If you think you need it, use
+     * `LightningElement` instead, or the full [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)
+     * interface.
+     * @private
+     * @deprecated
+     */
     class HTMLElementTheGoodPart {
         dispatchEvent(evt: Event): boolean;
         addEventListener(
@@ -150,83 +166,6 @@ declare module 'lwc' {
         querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
     }
 
-    /**
-     * Base class for the Lightning Web Component JavaScript class
-     */
-    export class LightningElement extends HTMLElementTheGoodPart {
-        /**
-         * This static getter builds a Web Component class from a LWC constructor so it can be registered
-         * as a new element via customElements.define() at any given time. For example:
-         *
-         * ```
-         * import XComponent from 'namespace/element';
-         * customElements.define('x-component', XComponent.CustomElementConstructor);
-         * const elm = document.createElement('x-component');
-         * ```
-         */
-        static get CustomElementConstructor(): typeof HTMLElement;
-
-        /**
-         * Set to true to designate this component as a Form-Associated Custom Element (FACE).
-         * @see https://web.dev/articles/more-capable-form-controls#form-associated_custom_elements
-         */
-        static formAssociated?: boolean;
-        /**
-         * Called when the element is inserted in a document
-         */
-        connectedCallback(): void;
-        /**
-         * Called when the element is removed from a document
-         */
-        disconnectedCallback(): void;
-        /**
-         * Called after every render of the component
-         */
-        renderedCallback(): void;
-        /**
-         * Called when a descendant component throws an error in one of its lifecycle hooks
-         */
-        errorCallback(error: Error, stack: string): void;
-        /**
-         * Called when a Form-Associated Custom Element (FACE) is associated with an HTMLFormElement.
-         * @param form HTMLFormElement - the associated form element
-         * @see https://web.dev/articles/more-capable-form-controls#void_formassociatedcallbackform
-         */
-        formAssociatedCallback(form: HTMLFormElement | null): void;
-        /**
-         * Called when a Form-Associated Custom Element (FACE) has a disabled state that has changed.
-         * @param disabled boolean - the new disabled state
-         * @see https://web.dev/articles/more-capable-form-controls#void_formdisabledcallbackdisabled
-         */
-        formDisabledCallback(disabled: boolean): void;
-        /**
-         * Called when a Form-Associated Custom Element (FACE) has an associated form that is reset.
-         * @see https://web.dev/articles/more-capable-form-controls#void_formresetcallback
-         */
-        formResetCallback(): void;
-        /**
-         * Called when a Form-Associated Custom Element (FACE) has an associated form that is restored.
-         * @param state FormRestoreState - the state of the form during restoration
-         * @param reason FormRestoreReason - the reason the form was restored
-         * @see https://web.dev/articles/more-capable-form-controls#void_formstaterestorecallbackstate_mode
-         */
-        formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason): void;
-
-        readonly template: ShadowRootTheGoodPart;
-        readonly shadowRoot: null;
-        readonly refs: { [key: string]: Element | LightningElement };
-    }
-
-    /**
-     * Decorator to mark public reactive properties
-     */
-    export const api: PropertyDecorator;
-
-    /**
-     * Decorator to mark private reactive properties
-     */
-    export const track: PropertyDecorator;
-
     type StringKeyedRecord = Record<string, any>;
     /**
      * Decorator factory to wire a property or method to a wire adapter data source
@@ -298,9 +237,4 @@ declare module 'lwc' {
         elm: EventTarget,
         options: ContextProviderOptions<Context>
     ) => void;
-    export function createContextProvider<
-        Config extends StringKeyedRecord,
-        Value,
-        Context extends StringKeyedRecord = StringKeyedRecord
-    >(config: WireAdapterConstructor<Config, Value, Context>): Contextualizer<Context>;
 }


### PR DESCRIPTION
The code in `lwc/index.js` is just `export * from '@lwc/engine-dom';` The types in `lwc/index.d.ts` don't match. That's weird, and going to cause complaints once we move to full TypeScript support. The good news, though, is that fixing the oddities is mostly non-breaking!

| `lwc` Export | 💬 Comment
| - | -
| `HTMLElementTheGoodPart` | 🫠 Doesn't exist in `@lwc/engine-dom`, although there is a `HTMLElementTheGoodParts` (plural) interface, but it's not exported. It's weird to have a type for a class that doesn't exist, but we'll just keep it for now.
| `LightningElement` | ❗️ In `@lwc/engine-dom`, `connectedCallback` is optional, rather than required, and the class inherits more from `HTMLElement`. Neither of these should be breaking changes.
| `createContextProvider` | ✅ No issues
| `@api` |  ✅ No issues
| `@track` | ✅ No issues
| `@wire` | ❗️ `lwc` accepts a `LegacyWireAdapterConstructor` that `@lwc/engine-dom` does not. Probably nobody uses the legacy constructor, since it's not supported by the JS, but removing it is technically breaking.
| types | 🤷 `@lwc/engine-dom` does not export any types. Weird to export these extra types, but I guess it's not hurting anyone?

The only thing that gives me pause is `@wire`, but it feels like it's probably an okay change?

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
