### PR TITLE
perf: avoid using a stack in `traverseAndSetElements`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -63,7 +63,7 @@ export function traverseAndSetElements(
     // This is very slightly faster than a TreeWalker (~0.5% on js-framework-benchmark create-10k), but basically
     // the same idea.
     let node: Element | Text | null = root;
-    mainloop: while (!isNull(node)) {
+    while (!isNull(node)) {
         // visit node
         partId++;
         const part = partIdsToParts.get(partId);
@@ -81,9 +81,12 @@ export function traverseAndSetElements(
         } else {
             let sibling: Element | Text | null;
             while (isNull((sibling = nextSibling(node)))) {
-                if (node === root) {
-                    // reached the root - don't walk up further
-                    break mainloop;
+                if (process.env.NODE_ENV !== 'production') {
+                    // We should never traverse up to the root. We should exit early due to numFoundParts === numParts.
+                    assert.isFalse(
+                        node === root,
+                        `Reached the root without finding all parts. Found ${numFoundParts}, needed ${numParts}.`
+                    );
                 }
                 // walk up
                 node = getParentNode(node);

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -69,7 +69,8 @@ export function traverseAndSetElements(
         const part = partIdsToParts.get(partId);
         if (!isUndefined(part)) {
             part.elm = node;
-            if (++numFoundParts === numParts) {
+            numFoundParts++;
+            if (numFoundParts === numParts) {
                 return; // perf optimization - stop traversing once we've found everything we need
             }
         }

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -97,6 +97,7 @@ export function traverseAndSetElements(
         }
     }
 
+    /* istanbul ignore next */
     if (process.env.NODE_ENV !== 'production') {
         assert.isTrue(
             numFoundParts === numParts,

--- a/packages/@lwc/engine-core/src/framework/renderer.ts
+++ b/packages/@lwc/engine-core/src/framework/renderer.ts
@@ -25,6 +25,7 @@ export interface RendererAPI {
     createComment: (content: string) => N;
     nextSibling: (node: N) => N | null;
     previousSibling: (node: N) => N | null;
+    getParentNode: (node: N) => N | null;
     attachShadow: (element: E, options: ShadowRootInit) => N;
     getProperty: (node: N, key: string) => any;
     setProperty: (node: N, key: string, value: any) => void;

--- a/packages/@lwc/engine-dom/src/renderer/index.ts
+++ b/packages/@lwc/engine-dom/src/renderer/index.ts
@@ -48,6 +48,10 @@ function previousSibling(node: Node): Node | null {
     return node.previousSibling;
 }
 
+function getParentNode(node: Node): Node | null {
+    return node.parentNode;
+}
+
 function attachShadow(element: Element, options: ShadowRootInit): ShadowRoot {
     // `shadowRoot` will be non-null in two cases:
     //   1. upon initial load with an SSR-generated DOM, while in Shadow render mode
@@ -251,4 +255,5 @@ export {
     assertInstanceOfHTMLElement,
     ownerDocument,
     attachInternals,
+    getParentNode,
 };

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -138,6 +138,10 @@ function previousSibling(node: N) {
     return getSibling(node, -1);
 }
 
+function getParentNode(node: N) {
+    return node[HostParentKey];
+}
+
 function attachShadow(element: E, config: ShadowRootInit) {
     element[HostShadowRootKey] = {
         [HostTypeKey]: HostNodeType.ShadowRoot,
@@ -481,4 +485,5 @@ export const renderer = {
     registerContextConsumer,
     attachInternals,
     defineCustomElement: getUpgradableElement,
+    getParentNode,
 };


### PR DESCRIPTION
## Details

This improves the `js-framework-benchmark`'s `create-10k` test by 8-10% in Chrome/Firefox and 4-9% in Safari. It does so by avoiding either recursion or a stack (array) by using a loop with `firstChild`/`nextSibling`/`parentNode`.

<details><summary>Click to see benchmark results</summary>

![Screenshot 2024-04-26 at 1 58 36 PM](https://github.com/salesforce/lwc/assets/283842/68c72d49-3727-45bb-af2f-6fb3705c5624)
![Screenshot 2024-04-26 at 3 23 24 PM](https://github.com/salesforce/lwc/assets/283842/04b0c5b2-20db-409b-b93c-9029925c6f83)
![Screenshot 2024-04-26 at 3 19 08 PM](https://github.com/salesforce/lwc/assets/283842/fd2416a7-d319-4562-bf67-6d31bdbe4661)
</details>

I was kind of concerned that adding `parentNode` would cause a perf regression in synthetic shadow (due to patches), but I tested manually in synthetic shadow (https://github.com/nolanlawson/lwc-1/commit/4536c23ffeed0bb2a08de47217ef07eb7755504b), and it's faster there as well:

<details><summary>Click to see</summary>

![Screenshot 2024-04-26 at 1 46 29 PM](https://github.com/salesforce/lwc/assets/283842/1eeb07f9-f208-4e58-b60e-efee3a349596)

</details>

I also tried using a `TreeWalker` (https://github.com/nolanlawson/lwc-1/commit/303e7b7a796437a1ba42aa2499ba47ab8d2ed610), since [this is what Lit does](https://github.com/lit/lit/blob/56cb2ca4a86f2c7f6af757c612f05e50d1966615/packages/lit-html/src/lit-html.ts#L938). However, I found that the `TreeWalker` is ~0.5% slower than the loop:

<details><summary>Click to see</summary>

![Screenshot 2024-04-26 at 3 09 55 PM](https://github.com/salesforce/lwc/assets/283842/14fd007c-7015-4cfa-b165-8b0ecfbd93ea)

(TreeWalker is this-change, loop is tip-of-tree)

</details>

We may still want to consider the `TreeWalker` someday, due to the possible benefits in synthetic shadow (which does not patch `TreeWalker` at all), and because it's slightly less code.

One major downside, though, is that we'd need to implement a `TreeWalker` shim for `@lwc/engine-server`. For that reason, and because this is the optimal solution for `js-framework-benchmark`, I'm proposing this for now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->