### PR TITLE
chore(nucleus): bump memory for release job

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -44,6 +44,8 @@ jobs:
         memory-limit: 16
     build-dependency:
         memory-limit: 16
+    release:
+        memory-limit: 16
 steps:
     node-conformance:
         run:


### PR DESCRIPTION
## Details

See [docs](https://confluence.internal.salesforce.com/display/UIPENGSYS/Jobs) and [release failure](https://nucleus.uipengsys-public.buildndeliver-s.aws-esvc1-useast2.aws.sfdc.cl/workflows/221455#job=997848&step=node-conformance). `yarn lint` is running up against memory limits, preventing a release.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
