### PR TITLE
chore: update engines.node version to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "playground"
     ],
     "engines": {
-        "node": ">=18.18.0"
+        "node": ">=16"
     },
     "volta": {
         "node": "20.12.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "playground"
     ],
     "engines": {
-        "node": ">=10"
+        "node": ">=18.18.0"
     },
     "volta": {
         "node": "20.12.2",


### PR DESCRIPTION
## Details

<strike>v18.18.0 seems like a reasonable minimum supported node version considering our project doesn't build successfully using anything below that.</strike>

Conservatively update to v16 since our internal systems are still in the process of migrating to v18/v20. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

## GUS work item

[W-15647787](https://gus.lightning.force.com/a07EE00001qNH9pYAG)