### PR TITLE
chore(scripts): remove `--all` from build script to enable using `--project`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "lint": "eslint packages/ scripts/ --ext=js,mjs,ts,only,skip",
         "format": "prettier --write .",
         "bundlesize": "node scripts/bundlesize/bundlesize.mjs",
-        "build": "nx run-many --target=build --all --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests,lwc",
+        "build": "nx run-many --target=build --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests,lwc",
         "build:performance": "yarn build:performance:components && yarn build:performance:benchmarks",
         "build:performance:components": "nx build @lwc/perf-benchmarks-components",
         "build:performance:benchmarks": "nx build @lwc/perf-benchmarks",


### PR DESCRIPTION
Follow up to #4191 because I forgot to delete a word. Per the [`nx` docs](https://nx.dev/nx-api/nx/documents/run-many#all), specifying `--all` is no longer required. The command is the same without the flag, and removing it allows us to use `--project` to build only specific projects.