### PR TITLE
perf(engine-server): faster `<style>` validation

### DIFF
--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -108,7 +108,6 @@ function serializeTextContent(contents: string, tagName?: string) {
     if (tagName === 'style') {
         // Special validation for <style> tags since their content must be served unescaped, and we need to validate
         // that the contents are safe to serialize unescaped.
-        // TODO [#3454]: move this validation to compilation
         validateStyleTextContents(contents);
         // If we haven't thrown an error during validation, then the content is safe to serialize unescaped
         return contents;


### PR DESCRIPTION
## Details

Fixes #3454

Rather than doing an expensive full-parse with `parse5`, I think we can just [follow the HTML spec](https://html.spec.whatwg.org/multipage/syntax.html#raw-text-elements) on how `<style>` contents should be parsed. 

This amounts to a basic regex search for disallowed character sequences (namely `</style>`). So we can do the same thing that `parse5` was doing, but without the perf hit, so we can continue doing the validation in `@lwc/engine-server` rather than in `@lwc/style-compiler` (where it would impact compilation time, and would also affect every component regardless of whether it is SSR-able or not).

This PR also has no breaking changes, which is nice.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
