### PR TITLE
fix: add selector type to all vnodes

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -99,7 +99,7 @@ function st(
     const fragment = fragmentFactory(parts);
     const vnode: VStatic = {
         type: VNodeType.Static,
-        sel: undefined,
+        sel: '__static__',
         key,
         elm: undefined,
         fragment,
@@ -124,7 +124,7 @@ function fr(key: Key, children: VNodes, stable: 0 | 1): VFragment {
 
     return {
         type: VNodeType.Fragment,
-        sel: undefined,
+        sel: '__fragment__',
         key,
         elm: undefined,
         children: [leading, ...children, trailing],
@@ -494,10 +494,10 @@ function f(items: ReadonlyArray<VNodes> | VNodes): VNodes {
 
 // [t]ext node
 function t(text: string): VText {
-    let sel, key, elm;
+    let key, elm;
     return {
         type: VNodeType.Text,
-        sel,
+        sel: '__text__',
         text,
         elm,
         key,
@@ -507,13 +507,13 @@ function t(text: string): VText {
 
 // [co]mment node
 function co(text: string): VComment {
-    let sel, elm;
+    let elm, key;
     return {
         type: VNodeType.Comment,
-        sel,
+        sel: '__comment__',
         text,
         elm,
-        key: 'c',
+        key,
         owner: getVMBeingRendered()!,
     };
 }

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -83,7 +83,7 @@ function ssf(slotName: unknown, factory: (value: any, key: any) => VFragment): V
         factory,
         owner: getVMBeingRendered()!,
         elm: undefined,
-        sel: undefined,
+        sel: '__scoped_slot_fragment__',
         key: undefined,
         slotName,
     };

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -57,6 +57,7 @@ export interface VScopedSlotFragment extends BaseVNode {
     factory: (value: any, key: any) => VFragment;
     type: VNodeType.ScopedSlotFragment;
     slotName: unknown;
+    sel: '__scoped_slot_fragment__';
 }
 
 export interface VStaticPart {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -82,7 +82,7 @@ export type VStaticPartData = Pick<VElementData, 'on' | 'ref' | 'attrs' | 'style
 
 export interface VStatic extends BaseVNode {
     readonly type: VNodeType.Static;
-    readonly sel: undefined;
+    readonly sel: '__static__';
     readonly key: Key;
     readonly fragment: Element;
     readonly parts: VStaticPart[] | undefined;
@@ -95,7 +95,7 @@ export interface VFragment extends BaseVNode, BaseVParent {
     // In a fragment elm represents the last node of the fragment,
     // which is the end delimiter text node ([start, ...children, end]). Used in the updateStaticChildren routine.
     // elm: Node | undefined; (inherited from BaseVNode)
-    sel: undefined;
+    sel: '__fragment__';
     type: VNodeType.Fragment;
 
     // which diffing strategy to use.
@@ -108,16 +108,16 @@ export interface VFragment extends BaseVNode, BaseVParent {
 
 export interface VText extends BaseVNode {
     type: VNodeType.Text;
-    sel: undefined;
+    sel: '__text__';
     text: string;
     key: undefined;
 }
 
 export interface VComment extends BaseVNode {
     type: VNodeType.Comment;
-    sel: undefined;
+    sel: '__comment__';
     text: string;
-    key: 'c';
+    key: undefined;
 }
 
 export interface VBaseElement extends BaseVNode, BaseVParent {

--- a/packages/@lwc/engine-core/src/framework/vnodes.ts
+++ b/packages/@lwc/engine-core/src/framework/vnodes.ts
@@ -48,7 +48,7 @@ export interface BaseVParent {
 export interface BaseVNode {
     type: VNodeType;
     elm: Node | undefined;
-    sel: string | undefined;
+    sel: string;
     key: Key | undefined;
     owner: VM;
 }

--- a/packages/@lwc/integration-karma/test/regression/invalid-key/index.spec.js
+++ b/packages/@lwc/integration-karma/test/regression/invalid-key/index.spec.js
@@ -1,0 +1,28 @@
+import { createElement } from 'lwc';
+import { extractDataIds, spyConsole } from 'test-utils';
+import ConditionalList from 'x/conditionalList';
+
+it('W-15885661 - renders list when key is invalid (preserve backwards compat)', async () => {
+    const elm = createElement('x-conditional-list', { is: ConditionalList });
+    document.body.appendChild(elm);
+    await Promise.resolve();
+
+    const { ul } = extractDataIds(elm);
+    // Empty fragment
+    expect(ul.children.length).toBe(0);
+
+    const spy = spyConsole();
+    elm.items = [{ value: 1 }];
+    await Promise.resolve();
+
+    const {
+        calls: { error },
+    } = spy;
+    expect(error.length).toBe(2);
+    error.forEach((error) =>
+        expect(error).toMatch(/(Invalid key value.*|Invalid "key" attribute.*)/)
+    );
+    spy.reset();
+
+    expect(ul.children.length).toBe(1);
+});

--- a/packages/@lwc/integration-karma/test/regression/invalid-key/index.spec.js
+++ b/packages/@lwc/integration-karma/test/regression/invalid-key/index.spec.js
@@ -18,11 +18,13 @@ it('W-15885661 - renders list when key is invalid (preserve backwards compat)', 
     const {
         calls: { error },
     } = spy;
-    expect(error.length).toBe(2);
+    expect(error.length).toBe(process.env.NODE_ENV === 'production' ? 0 : 2);
     error.forEach((error) =>
         expect(error).toMatch(/(Invalid key value.*|Invalid "key" attribute.*)/)
     );
+
     spy.reset();
 
+    // Still renders list with invalid keys
     expect(ul.children.length).toBe(1);
 });

--- a/packages/@lwc/integration-karma/test/regression/invalid-key/x/conditionalList/conditionalList.html
+++ b/packages/@lwc/integration-karma/test/regression/invalid-key/x/conditionalList/conditionalList.html
@@ -1,0 +1,10 @@
+<template>
+    <!-- Note lwc:if is necessary to diff empty fragment against a list -->
+    <ul data-id="ul">
+        <template lwc:if={show}>
+            <template for:each={items} for:item="item">
+                <li key={item}>{item.value}</li>
+            </template>
+        </template>
+    </ul>
+</template>

--- a/packages/@lwc/integration-karma/test/regression/invalid-key/x/conditionalList/conditionalList.js
+++ b/packages/@lwc/integration-karma/test/regression/invalid-key/x/conditionalList/conditionalList.js
@@ -1,0 +1,6 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    show = true;
+    @api items = [];
+}


### PR DESCRIPTION
## Details

By expanding static content optimization to more nodes we've revealed a bug with the existing diffing algo.

In special circumstances when a text vnode is compared against a static vnode they will be considered the same vnode because we use the `sel` and `key` to determine vnode equality.

Since both text and static vnodes have an `undefined` `key` and `sel` values they are incorrectly evaluated.

This PR updates the values of `sel` to distinguish these vnodes and prevent future false positives.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
