### PR TITLE
[DO NOT MERGE] Trigger CI for #4216: refactor: version mismatch warning on patch version difference

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -39,9 +39,7 @@ export function checkVersionMismatch(
     const versionMatcher = func.toString().match(LWC_VERSION_COMMENT_REGEX);
     if (!isNull(versionMatcher) && !warned) {
         const version = versionMatcher[1];
-        const [major, minor] = version.split('.');
-        const [expectedMajor, expectedMinor] = LWC_VERSION.split('.');
-        if (major !== expectedMajor || minor !== expectedMinor || version !== LWC_VERSION) {
+        if (version !== LWC_VERSION) {
             warned = true; // only warn once to avoid flooding the console
             // stylesheets and templates do not have user-meaningful names, but components do
             const friendlyName = type === 'component' ? `${type} ${func.name}` : type;

--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -41,7 +41,7 @@ export function checkVersionMismatch(
         const version = versionMatcher[1];
         const [major, minor] = version.split('.');
         const [expectedMajor, expectedMinor] = LWC_VERSION.split('.');
-        if (major !== expectedMajor || minor !== expectedMinor) {
+        if (major !== expectedMajor || minor !== expectedMinor || version !== LWC_VERSION) {
             warned = true; // only warn once to avoid flooding the console
             // stylesheets and templates do not have user-meaningful names, but components do
             const friendlyName = type === 'component' ? `${type} ${func.name}` : type;


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4216.