### PR TITLE
fix(engine-core): handle stylesheets not rendered yet

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hot-swaps.ts
+++ b/packages/@lwc/engine-core/src/framework/hot-swaps.ts
@@ -61,6 +61,9 @@ function rehydrateHotTemplate(tpl: Template): boolean {
 
 function rehydrateHotStyle(style: StylesheetFactory): boolean {
     const activeVMs = activeStyles.get(style);
+    if (!activeVMs.size) {
+        return true;
+    }
     unrenderStylesheet(style);
     for (const vm of activeVMs) {
         // if a style definition is swapped, we must reset

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -201,7 +201,7 @@ if (process.env.NODE_ENV !== 'production') {
                     expectStyles(extractDataIds(elm).paragraph, {
                         display: 'block',
                     });
-                    // Swap blockStyle to inlineStyle, which transitively be swapped to noneStyle
+                    // Swap blockStyle to inlineStyle, which will transitively be swapped to noneStyle
                     swapStyle(blockStyle[0], inlineStyle[0]);
 
                     await Promise.resolve();

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -183,6 +183,32 @@ if (process.env.NODE_ENV !== 'production') {
                         fontStyle: 'italic',
                     });
                 });
+
+                it('should be able to swap a style that will be used in future', async () => {
+                    const { blockStyle, inlineStyle, noneStyle } = Simple;
+                    const elm = createElement(`${testName}-simple`, { is: Simple });
+                    document.body.appendChild(elm);
+
+                    await Promise.resolve();
+                    expectStyles(extractDataIds(elm).paragraph, {
+                        display: 'block',
+                    });
+                    // Swap inlineStyle that hasn't been rendered yet
+                    swapStyle(inlineStyle[0], noneStyle[0]);
+
+                    await Promise.resolve();
+                    // Verify that rendered content did not change
+                    expectStyles(extractDataIds(elm).paragraph, {
+                        display: 'block',
+                    });
+                    // Swap blockStyle to inlineStyle, which transitively be swapped to noneStyle
+                    swapStyle(blockStyle[0], inlineStyle[0]);
+
+                    await Promise.resolve();
+                    expectStyles(extractDataIds(elm).paragraph, {
+                        display: 'none',
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
## Details
swapStyle() can be called on stylesheets that are yet to be rendered. This is valid especially in the case of salesforce platform where component definitions are (pre-)loaded and can be instantiated in the future, for example dynamic components.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-15890472
