### PR TITLE
fix(rollup-plugin): allow any implicit HTML import from any kind of script file @W-15941938

### DIFF
--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -126,6 +126,8 @@ function transformFile(
         case '.jsx':
         case '.ts':
         case '.js':
+        case '.mts':
+        case '.mjs':
             transformer = options.targetSSR ? compileComponentForSSR : scriptTransformer;
             break;
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/lwc.config.json
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/lwc.config.json
@@ -1,0 +1,5 @@
+{
+    "modules": [
+        { "dir" : "src/modules" }
+    ]
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/package.json
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "inherited-template-tests",
+    "private": true,
+    "version": "0.0.1"
+}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/javascript.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/javascript.js
@@ -1,0 +1,1 @@
+import Extension from 'x/ext-js'

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/base/base.html
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/base/base.html
@@ -1,0 +1,3 @@
+<template>
+  all your base
+</template>

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/base/base.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/base/base.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/ext-js/ext-js.js
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/ext-js/ext-js.js
@@ -1,0 +1,3 @@
+import Base from "x/base";
+
+export default class extends Base {}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/ext-ts/ext-ts.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/modules/x/ext-ts/ext-ts.ts
@@ -1,0 +1,3 @@
+import Base from "x/base";
+
+export default class extends Base {}

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/typescript.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/typescript.ts
@@ -1,0 +1,1 @@
+import Extension from 'x/ext-ts'

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -231,4 +231,32 @@ describe('resolver', () => {
         // Alias name
         expect(code).not.toContain(`sel: "foo-bar"`);
     });
+
+    it('should resolve inherited template for JavaScript component [#4233]', async () => {
+        const bundle = await rollup({
+            input: path.resolve(__dirname, 'fixtures/inherited-templates/src/javascript.js'),
+            plugins: [lwc()],
+        });
+
+        const result = await bundle.generate({
+            format: 'esm',
+        });
+        const { code } = result.output[0];
+
+        expect(code).toContain('all your base');
+    });
+
+    it('should resolve inherited template for TypeScript component [#4233]', async () => {
+        const bundle = await rollup({
+            input: path.resolve(__dirname, 'fixtures/inherited-templates/src/typescript.ts'),
+            plugins: [lwc()],
+        });
+
+        const result = await bundle.generate({
+            format: 'esm',
+        });
+        const { code } = result.output[0];
+
+        expect(code).toContain('all your base');
+    });
 });

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -65,13 +65,15 @@ const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
 const EMPTY_IMPLICIT_CSS_CONTENT = '';
+/** Matches all permutations of CJS/ESM, JS/TS, JS/JSX. */
+const SCRIPT_FILE_EXTENSION_REGEX = /^\.[cm]?[jt]sx?$/i;
 
-function isImplicitHTMLImport(importee: string, importer: string): boolean {
+function isImplicitHTMLImport(importee: string, importer: string, importerExt: string): boolean {
     return (
-        path.extname(importer) === '.js' &&
+        SCRIPT_FILE_EXTENSION_REGEX.test(importerExt) &&
         path.extname(importee) === '.html' &&
         path.dirname(importer) === path.dirname(importee) &&
-        path.basename(importer, '.js') === path.basename(importee, '.html')
+        path.basename(importer, importerExt) === path.basename(importee, '.html')
     );
 }
 
@@ -227,7 +229,11 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                         parseDescriptorFromFilePath(importeeAbsPath);
 
                     if (
-                        isImplicitHTMLImport(importeeNormalizedFilename, importerFilename) &&
+                        isImplicitHTMLImport(
+                            importeeNormalizedFilename,
+                            importerFilename,
+                            importerExt
+                        ) &&
                         !fs.existsSync(importeeNormalizedFilename)
                     ) {
                         return IMPLICIT_DEFAULT_HTML_PATH;

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -65,12 +65,11 @@ const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
 const EMPTY_IMPLICIT_CSS_CONTENT = '';
-/** Matches all permutations of CJS/ESM, JS/TS, JS/JSX. */
-const SCRIPT_FILE_EXTENSION_REGEX = /^\.[cm]?[jt]sx?$/i;
+const SCRIPT_FILE_EXTENSIONS = ['.js', '.mjs', '.jsx', '.ts', '.mts', '.tsx'];
 
 function isImplicitHTMLImport(importee: string, importer: string, importerExt: string): boolean {
     return (
-        SCRIPT_FILE_EXTENSION_REGEX.test(importerExt) &&
+        SCRIPT_FILE_EXTENSIONS.includes(importerExt) &&
         path.extname(importee) === '.html' &&
         path.dirname(importer) === path.dirname(importee) &&
         path.basename(importer, importerExt) === path.basename(importee, '.html')


### PR DESCRIPTION
To detect whether a component is using an implicit HTML import, we check that it's a `.js` file. But that's not the only kind of script file that can be used! This PR adds support for all flavors of JS/TS/JSX that we might expect to encounter.

Fixes #4233.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
W-15941938
