### PR TITLE
chore(git): run CI checks on push @W-15999315@

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+node ./scripts/tasks/check-and-rewrite-package-json.js --test
+node ./scripts/tasks/generate-license-files.js --test
+node ./scripts/tasks/verify-treeshakable.js ./packages/@lwc/shared/dist/index.js
+node ./scripts/tasks/check-imports-are-declared-dependencies.js
+yarn run format
+yarn run bundlesize

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,5 +4,3 @@ node ./scripts/tasks/check-and-rewrite-package-json.js --test
 node ./scripts/tasks/generate-license-files.js --test
 node ./scripts/tasks/verify-treeshakable.js ./packages/@lwc/shared/dist/index.js
 node ./scripts/tasks/check-imports-are-declared-dependencies.js
-yarn run format
-yarn run bundlesize

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,9 @@ types/
 
 __benchmarks_results__/
 
+.nx/
+.nx-cache/
+
 # HTML files are used by tests and may include deliberately invalid/ugly HTML
 # e.g. <input> without self-closing tag, extra leading/trailing whitespace, etc.
 *.html


### PR DESCRIPTION
## Details

It's annoying when I push and go do something else while I wait for CI to run, then I come back later and CI failed after 30 seconds because of something trivial.

This PR adds a git hook to run CI checks locally that are quick and not covered by the pre-commit hook.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-15999315