### PR TITLE
chore(integration-karma): fix iframe sandbox warning

### DIFF
--- a/packages/@lwc/integration-karma/test/custom-elements-registry/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements-registry/index.spec.js
@@ -100,7 +100,6 @@ describe('custom elements registry', () => {
 
     beforeEach(() => {
         iframe = document.createElement('iframe');
-        iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts');
         document.body.appendChild(iframe);
 
         if (window.__coverage__) {


### PR DESCRIPTION
## Details

This fixes an annoying Chrome warning when running the tests:

![Screenshot 2024-06-13 at 2 15 32 PM](https://github.com/salesforce/lwc/assets/283842/a166ad3d-ba2b-4d9f-a289-7e7b7787d4d3)

Apparently if you use `sandbox="allow-same-origin allow-scripts"` then you may as well not have `sandbox` at all.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
