### PR TITLE
fix(engine-dom): allow FACE in synthetic lifecycle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -263,6 +263,14 @@
             }
         },
         {
+            "files": [
+                "packages/@lwc/integration-karma/**"
+            ],
+            "globals": {
+                "lwcRuntimeFlags": true
+            }
+        },
+        {
             // These files aren't JS files, but are directives used to selectively run test fixtures.
             // We use eslint to break CI if they are accidentally committed. Note that lint-staged
             // uses a different config to prevent them from being committed.

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -56,6 +56,8 @@ jobs:
             - run: DISABLE_SYNTHETIC=1 yarn sauce:ci
             - run: LEGACY_BROWSERS=1 yarn sauce:ci
             - run: FORCE_NATIVE_SHADOW_MODE_FOR_TEST=1 yarn sauce:ci
+            - run: DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE=1 yarn sauce:ci
+            - run: DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE=1 DISABLE_SYNTHETIC=1 yarn sauce:ci
             - run: API_VERSION=58 yarn sauce:ci
             - run: API_VERSION=58 DISABLE_SYNTHETIC=1 yarn sauce:ci
 

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -53,34 +53,33 @@ function createBaseUpgradableConstructor() {
         }
 
         connectedCallback() {
+            // native `connectedCallback`/`disconnectedCallback` are only enabled in native lifecycle mode
             if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
                 connectRootElement(this);
             }
         }
+
         disconnectedCallback() {
+            // native `connectedCallback`/`disconnectedCallback` are only enabled in native lifecycle mode
             if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
                 disconnectRootElement(this);
             }
         }
+
         formAssociatedCallback(form: HTMLFormElement | null) {
-            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-                runFormAssociatedCallback(this, form);
-            }
+            runFormAssociatedCallback(this, form);
         }
+
         formDisabledCallback(disabled: boolean) {
-            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-                runFormDisabledCallback(this, disabled);
-            }
+            runFormDisabledCallback(this, disabled);
         }
+
         formResetCallback() {
-            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-                runFormResetCallback(this);
-            }
+            runFormResetCallback(this);
         }
+
         formStateRestoreCallback(state: FormRestoreState | null, reason: FormRestoreReason) {
-            if (isTrue(nativeLifecycleElementsToUpgradedByLWC.get(this))) {
-                runFormStateRestoreCallback(this, state, reason);
-            }
+            runFormStateRestoreCallback(this, state, reason);
         }
     };
     BaseHTMLElement = HTMLElement; // cache to track if it changes
@@ -97,6 +96,7 @@ const createUpgradableConstructor = (isFormAssociated: boolean) => {
     // Using a BaseUpgradableConstructor superclass here is a perf optimization to avoid
     // re-defining the same logic (connectedCallback, disconnectedCallback, etc.) over and over.
     class UpgradableConstructor extends (BaseUpgradableConstructor!) {}
+
     if (isFormAssociated) {
         // Perf optimization - the vast majority of components have formAssociated=false,
         // so we can skip the setter in those cases, since undefined works the same as false.

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -572,7 +572,9 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         USE_FRAGMENTS_FOR_LIGHT_DOM_SLOTS: process.env.API_VERSION >= 60,
         DISABLE_OBJECT_REST_SPREAD_TRANSFORMATION: process.env.API_VERSION >= 60,
         ENABLE_ELEMENT_INTERNALS_AND_FACE: process.env.API_VERSION >= 61,
-        ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: process.env.API_VERSION >= 61,
+        ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
+            process.env.API_VERSION >= 61 &&
+            !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
         USE_LIGHT_DOM_SLOT_FORWARDING: process.env.API_VERSION >= 61,
     };
 

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
@@ -22,6 +22,7 @@ const {
     NODE_ENV_FOR_TEST,
     API_VERSION,
     DISABLE_SYNTHETIC,
+    DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
 } = require('../shared/options');
 
 const DIST_DIR = path.resolve(__dirname, '../../dist');
@@ -35,7 +36,7 @@ function createEnvFile() {
     fs.writeFileSync(
         ENV_FILENAME,
         `
-        window.process = {
+        globalThis.process = {
             env: {
                 API_VERSION: ${JSON.stringify(API_VERSION)},
                 ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL: ${ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL},
@@ -45,6 +46,9 @@ function createEnvFile() {
                 NATIVE_SHADOW: ${DISABLE_SYNTHETIC || FORCE_NATIVE_SHADOW_MODE_FOR_TEST},
                 NODE_ENV: ${JSON.stringify(NODE_ENV_FOR_TEST || 'development')},
             }
+        };
+        globalThis.lwcRuntimeFlags = {
+          DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE: ${DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE}
         };
     `
     );

--- a/packages/@lwc/integration-karma/scripts/shared/options.js
+++ b/packages/@lwc/integration-karma/scripts/shared/options.js
@@ -33,6 +33,9 @@ const NODE_ENV_FOR_TEST = process.env.NODE_ENV_FOR_TEST;
 const API_VERSION = process.env.API_VERSION
     ? parseInt(process.env.API_VERSION, 10)
     : HIGHEST_API_VERSION;
+const DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE = Boolean(
+    process.env.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+);
 
 const baseOptions = {
     API_VERSION,
@@ -44,6 +47,7 @@ const baseOptions = {
     FORCE_NATIVE_SHADOW_MODE_FOR_TEST,
     LEGACY_BROWSERS,
     NODE_ENV_FOR_TEST,
+    DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
 };
 
 /** Unique directory name that encodes the flags that the tests were executed with. */

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -1,8 +1,5 @@
 import { createElement } from 'lwc';
-import {
-    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
-    ENABLE_ELEMENT_INTERNALS_AND_FACE,
-} from 'test-utils';
+import { ENABLE_ELEMENT_INTERNALS_AND_FACE } from 'test-utils';
 
 import Container from 'face/container';
 import FormAssociated from 'face/formAssociated';
@@ -79,6 +76,7 @@ const faceSanityTest = (tagName, ctor) => {
 
         it('is associated with the correct form', () => {
             const form2 = document.createElement('form');
+            document.body.appendChild(form2);
             form2.setAttribute('class', 'form2');
             const face2 = createElement('face-form-associated-2', { is: ctor });
             form2.appendChild(face2);
@@ -148,9 +146,9 @@ const testFaceLifecycleMethodsNotCallable = (createFace) => {
 };
 
 if (typeof ElementInternals !== 'undefined') {
-    if (ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+    if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         // native lifecycle enabled
-        describe('native lifecycle', () => {
+        describe('ElementInternals/FACE enabled', () => {
             if (process.env.NATIVE_SHADOW) {
                 describe('native shadow', () => {
                     faceSanityTest('native-shadow', FormAssociated);
@@ -162,7 +160,9 @@ if (typeof ElementInternals !== 'undefined') {
                         it('cannot be used and throws an error', () => {
                             const face = createFace();
                             const form = createFormElement();
-                            expect(() => form.appendChild(face)).toThrowCallbackReactionError(
+                            expect(() =>
+                                form.appendChild(face)
+                            ).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
                                 'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
                             );
                         });
@@ -175,7 +175,7 @@ if (typeof ElementInternals !== 'undefined') {
             });
         });
     } else {
-        describe('synthetic lifecycle', () => {
+        describe('ElementInternals/FACE disabled', () => {
             [
                 { name: 'shadow DOM', tagName: 'synthetic-lifecycle-shadow', ctor: FormAssociated },
                 {

--- a/packages/@lwc/integration-karma/test/custom-elements-registry/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements-registry/index.spec.js
@@ -14,8 +14,8 @@ function getEngineCode() {
         getCode(document.querySelector('script[src*="synthetic-shadow"]').src);
 
     const scripts = [
-        `window.process = { env: { NODE_ENV: "production" } };`,
-        `window.lwcRuntimeFlags = ${JSON.stringify(window.lwcRuntimeFlags)};`, // copy runtime flags to iframe
+        `globalThis.process = { env: { NODE_ENV: "production" } };`,
+        `globalThis.lwcRuntimeFlags = ${JSON.stringify(lwcRuntimeFlags)};`, // copy runtime flags to iframe
         syntheticShadowSrc,
         getCode(engineDomSrc),
     ].filter(Boolean);

--- a/packages/@lwc/integration-karma/test/light-dom/lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/lifecycle/index.spec.js
@@ -1,5 +1,9 @@
 import { createElement } from 'lwc';
-import { extractDataIds, USE_LIGHT_DOM_SLOT_FORWARDING } from 'test-utils';
+import {
+    extractDataIds,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
+} from 'test-utils';
 
 import SlotForwarding from 'x/slotForwarding';
 import DynamicSlotForwarding from 'x/dynamicSlotForwarding';
@@ -159,14 +163,24 @@ if (USE_LIGHT_DOM_SLOT_FORWARDING) {
             elm.showTop = false;
             await Promise.resolve();
 
-            expect(window.timingBuffer).toEqual([
-                '10:connectedCallback',
-                '11:connectedCallback',
-                '12:connectedCallback',
-                '4:disconnectedCallback',
-                '9:disconnectedCallback',
-                '8:disconnectedCallback',
-            ]);
+            // Synthetic custom element lifecycle does not fire disconnectedCallback correctly
+            expect(window.timingBuffer).toEqual(
+                ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                    ? [
+                          '10:connectedCallback',
+                          '11:connectedCallback',
+                          '12:connectedCallback',
+                          '4:disconnectedCallback',
+                          '9:disconnectedCallback',
+                          '8:disconnectedCallback',
+                      ]
+                    : [
+                          '10:connectedCallback',
+                          '11:connectedCallback',
+                          '12:connectedCallback',
+                          '4:disconnectedCallback',
+                      ]
+            );
         });
     });
 }

--- a/packages/@lwc/integration-karma/test/regression/lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/regression/lifecycle/index.spec.js
@@ -19,7 +19,9 @@ describe('W-15904769', () => {
         );
     };
 
-    if (!process.env.NATIVE_SHADOW) {
+    // If `lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE` is true, then components no longer run in a
+    // "mixed" lifecycle mode, so this bug cannot repro.
+    if (!process.env.NATIVE_SHADOW && !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
         it('native sloter + synthetic slotee disconnects root and subtree components but does not reconnect synthetic subtree', async () => {
             const elm = createElement('x-native-sloter-synthetic-slotee', {
                 is: NativeSloterSyntheticSlotee,


### PR DESCRIPTION
## Details

Fixes #4251. Allows components to use FACE (Form Associated Custom Element) callbacks even when running in synthetic lifecycle mode.

This also adds tests for the `DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE` flag just to make sure everything works correctly even when that flag is enabled.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
