### PR TITLE
fix: put `this.hostElement` behind API version 62

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -576,6 +576,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
             process.env.API_VERSION >= 61 &&
             !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
         USE_LIGHT_DOM_SLOT_FORWARDING: process.env.API_VERSION >= 61,
+        ENABLE_THIS_DOT_HOST_ELEMENT: process.env.API_VERSION >= 62,
     };
 
     return {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.hostElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.hostElement/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { ENABLE_THIS_DOT_HOST_ELEMENT } from 'test-utils';
 
 import Wrapper from 'x/wrapper';
 
@@ -8,32 +9,48 @@ function createWrapper() {
     return elm;
 }
 
-it('should provide the root element for light rendering', () => {
-    const elm = createWrapper();
+if (ENABLE_THIS_DOT_HOST_ELEMENT) {
+    it('should provide the root element for light rendering', () => {
+        const elm = createWrapper();
 
-    const divElement = elm.getDivElement();
-    const lightElement = elm.getLightElement();
-    const hostElement = lightElement.getHostElement();
+        const divElement = elm.getDivElement();
+        const lightElement = elm.getLightElement();
+        const hostElement = lightElement.getHostElement();
 
-    expect(hostElement).toBeTruthy();
-    expect(hostElement.tagName).toEqual('X-LIGHT');
-    expect(hostElement.dataset.name).toEqual('lightElement');
+        expect(hostElement).toBeTruthy();
+        expect(hostElement.tagName).toEqual('X-LIGHT');
+        expect(hostElement.dataset.name).toEqual('lightElement');
 
-    expect(hostElement).toEqual(lightElement);
-    expect(hostElement.parentElement).toEqual(divElement);
-});
+        expect(hostElement).toEqual(lightElement);
+        expect(hostElement.parentElement).toEqual(divElement);
+    });
 
-it('should provide the root element for shadow rendering', () => {
-    const elm = createWrapper();
+    it('should provide the root element for shadow rendering', () => {
+        const elm = createWrapper();
 
-    const divElement = elm.getDivElement();
-    const shadowElement = elm.getShadowElement();
-    const hostElement = shadowElement.getHostElement();
+        const divElement = elm.getDivElement();
+        const shadowElement = elm.getShadowElement();
+        const hostElement = shadowElement.getHostElement();
 
-    expect(hostElement).toBeTruthy();
-    expect(hostElement.tagName).toEqual('X-SHADOW');
-    expect(hostElement.dataset.name).toEqual('shadowElement');
+        expect(hostElement).toBeTruthy();
+        expect(hostElement.tagName).toEqual('X-SHADOW');
+        expect(hostElement.dataset.name).toEqual('shadowElement');
 
-    expect(hostElement).toEqual(shadowElement);
-    expect(hostElement.parentElement).toEqual(divElement);
-});
+        expect(hostElement).toEqual(shadowElement);
+        expect(hostElement.parentElement).toEqual(divElement);
+    });
+} else {
+    // this.hostElement unsupported
+    it('this.hostElement unsupported in older API versions', () => {
+        const elm = createWrapper();
+
+        const shadowElement = elm.getShadowElement();
+
+        let hostElement;
+        expect(() => {
+            hostElement = shadowElement.getHostElement();
+        }).toLogWarningDev(/Increase the API version to use it/);
+
+        expect(hostElement).toBeUndefined();
+    });
+}

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -102,8 +102,7 @@ export const enum APIFeature {
      */
     ENABLE_ELEMENT_INTERNALS_AND_FACE,
     /**
-     * If enabled, allow `this.style` within a `LightningElement` to return the `CSSStyleDeclaration`
-     * for that element.
+     * If enabled, allow `this.hostElement` within a `LightningElement` to return the host element.
      */
     ENABLE_THIS_DOT_HOST_ELEMENT,
 }

--- a/packages/@lwc/shared/src/api-version.ts
+++ b/packages/@lwc/shared/src/api-version.ts
@@ -101,6 +101,11 @@ export const enum APIFeature {
      * Form-Associated Custom Elements (FACE).
      */
     ENABLE_ELEMENT_INTERNALS_AND_FACE,
+    /**
+     * If enabled, allow `this.style` within a `LightningElement` to return the `CSSStyleDeclaration`
+     * for that element.
+     */
+    ENABLE_THIS_DOT_HOST_ELEMENT,
 }
 
 /**
@@ -125,5 +130,7 @@ export function isAPIFeatureEnabled(
         case APIFeature.ENABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE:
         case APIFeature.USE_LIGHT_DOM_SLOT_FORWARDING:
             return apiVersion >= APIVersion.V61_250_SUMMER_24;
+        case APIFeature.ENABLE_THIS_DOT_HOST_ELEMENT:
+            return apiVersion >= APIVersion.V62_252_WINTER_25;
     }
 }


### PR DESCRIPTION
## Details

It occurred to me that it's kind of strange for the release notes to say "`this.style` is only available in API version 62 due to possible breaking changes, but `this.hostElement` is available regardless." It's more consistent to just put both of them behind API versioning.

Plus, this way we don't have to worry about potential breaking changes on the off-change that someone has already squatted `this.hostElement`.

Related: #4259 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

No, we haven't released `this.hostElement` yet.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
