### PR TITLE
fix: inline style parsing for "! important"

### DIFF
--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
@@ -8,7 +8,7 @@ describe('important styling and style override', () => {
 
         await Promise.resolve();
 
-        for (const div of elm.shadowRoot.querySelectorAll('.imporant')) {
+        for (const div of elm.shadowRoot.querySelectorAll('.important')) {
             expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(255, 0, 0)');
             expect(div.style.getPropertyPriority('color')).toBe('important');
         }

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
@@ -1,0 +1,39 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+describe('important styling and style override', () => {
+    it('should render !important styles correctly', async () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        for (const div of elm.shadowRoot.querySelectorAll('.imporant')) {
+            expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(255, 0, 0)');
+            expect(div.style.getPropertyPriority('color')).toBe('important');
+        }
+    });
+
+    it('should render inline styles correctly', async () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        for (const div of elm.shadowRoot.querySelectorAll('.inline')) {
+            expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(255, 0, 0)');
+            expect(div.style.getPropertyPriority('color')).not.toBe('important');
+        }
+    });
+
+    it('should render untouched styles correctly', async () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        for (const div of elm.shadowRoot.querySelectorAll('.untouched')) {
+            expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(0, 0, 255)');
+        }
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/index.spec.js
@@ -7,8 +7,9 @@ describe('important styling and style override', () => {
         document.body.appendChild(elm);
 
         await Promise.resolve();
-
-        for (const div of elm.shadowRoot.querySelectorAll('.important')) {
+        const importantDivs = elm.shadowRoot.querySelectorAll('.important');
+        expect(importantDivs.length).toBeGreaterThan(0);
+        for (const div of importantDivs) {
             expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(255, 0, 0)');
             expect(div.style.getPropertyPriority('color')).toBe('important');
         }
@@ -19,8 +20,9 @@ describe('important styling and style override', () => {
         document.body.appendChild(elm);
 
         await Promise.resolve();
-
-        for (const div of elm.shadowRoot.querySelectorAll('.inline')) {
+        const inlineDivs = elm.shadowRoot.querySelectorAll('.inline');
+        expect(inlineDivs.length).toBeGreaterThan(0);
+        for (const div of inlineDivs) {
             expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(255, 0, 0)');
             expect(div.style.getPropertyPriority('color')).not.toBe('important');
         }
@@ -31,8 +33,9 @@ describe('important styling and style override', () => {
         document.body.appendChild(elm);
 
         await Promise.resolve();
-
-        for (const div of elm.shadowRoot.querySelectorAll('.untouched')) {
+        const untouchedDivs = elm.shadowRoot.querySelectorAll('.untouched');
+        expect(untouchedDivs.length).toBeGreaterThan(0);
+        for (const div of untouchedDivs) {
             expect(getComputedStyle(div).getPropertyValue('color')).toBe('rgb(0, 0, 255)');
         }
     });

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.css
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.css
@@ -1,0 +1,3 @@
+div {
+    color: blue;
+}

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.html
@@ -1,0 +1,23 @@
+<template>
+    <div class="imporant" style="color: red !important "></div>
+    <div class="imporant" style="color: red !important ;"></div>
+    <div class="imporant" style="color: red  !important "></div>
+    <div class="imporant" style="color: red  !important ;"></div>
+    <div class="imporant" style="color: red ! important;"></div>
+    <div class="imporant" style="color: red ! important"></div>
+    <div class="imporant" style="  color  :  red  !  important  ;  "></div>
+    <div class="inline" style="color: red"></div>
+    <div class="inline" style="color: red;"></div>
+    <div class="inline" style="color: red"></div>
+    <div class="inline" style="color: red"></div>
+    <div class="inline" style="color: red"></div>
+    <div class="inline" style="color: red"></div>
+    <div class="inline" style="  color  :  red;  "></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+    <div class="untouched"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.html
@@ -1,11 +1,18 @@
 <template>
-    <div class="imporant" style="color: red !important "></div>
-    <div class="imporant" style="color: red !important ;"></div>
-    <div class="imporant" style="color: red  !important "></div>
-    <div class="imporant" style="color: red  !important ;"></div>
-    <div class="imporant" style="color: red ! important;"></div>
-    <div class="imporant" style="color: red ! important"></div>
-    <div class="imporant" style="  color  :  red  !  important  ;  "></div>
+    <div class="important" style="color: red !important "></div>
+    <div class="important" style="color: red !important ;"></div>
+    <div class="important" style="color: red  !important "></div>
+    <div class="important" style="color: red  !important ;"></div>
+    <div class="important" style="color: red ! important;"></div>
+    <div class="important" style="color: red ! important"></div>
+    <div class="important" style="color: red !IMPORTANT "></div>
+    <div class="important" style="color: red !IMPORTANT ;"></div>
+    <div class="important" style="color: red  !IMPORTANT "></div>
+    <div class="important" style="color: red  !IMPORTANT ;"></div>
+    <div class="important" style="color: red ! IMPORTANT;"></div>
+    <div class="important" style="color: red ! IMPORTANT"></div>
+    <div class="important" style="  color  :  red  !  IMPORTANT  ;  "></div>
+    <div class="important" style="  color  :  red  !  IMPORTAnt  ;  "></div>
     <div class="inline" style="color: red"></div>
     <div class="inline" style="color: red;"></div>
     <div class="inline" style="color: red"></div>

--- a/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/rendering/style-specificity-important/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -273,10 +273,10 @@ export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t
     const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
         styleMap
     ).map(([key, value]) => {
-        const important = value.endsWith('!important');
+        const importantRegex = /\s*!\s*important\s*$/;
+        const important = importantRegex.test(value);
         if (important) {
-            // trim off the trailing "!important" (10 chars)
-            value = value.substring(0, value.length - 10).trim();
+            value = value.replace(importantRegex, '').trim();
         }
         return [key, value, important];
     });

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -273,7 +273,7 @@ export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t
     const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
         styleMap
     ).map(([key, value]) => {
-        const importantRegex = /\s*!\s*important\s*$/;
+        const importantRegex = /\s*!\s*important\s*$/i;
         const important = importantRegex.test(value);
         if (important) {
             value = value.replace(importantRegex, '').trim();

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -266,6 +266,8 @@ export function parseStyleText(cssText: string): { [name: string]: string } {
     return styleMap;
 }
 
+const IMPORTANT_FLAG = /\s*!\s*important\s*$/i;
+
 // Given a map of CSS property keys to values, return an array AST like:
 // ['color', 'blue', false]    // { color: 'blue' }
 // ['background', 'red', true] // { background: 'red !important' }
@@ -273,10 +275,9 @@ export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t
     const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
         styleMap
     ).map(([key, value]) => {
-        const importantRegex = /\s*!\s*important\s*$/i;
-        const important = importantRegex.test(value);
+        const important = IMPORTANT_FLAG.test(value);
         if (important) {
-            value = value.replace(importantRegex, '').trim();
+            value = value.replace(IMPORTANT_FLAG, '').trim();
         }
         return [key, value, important];
     });


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

-   😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

-   🔬 Yes, it does include an observable change.

If DISABLE_STATIC_CONTENT_OPTIMIZATION=1 "! important" will now be parsed correctly.
This approach uses Regex to find the !important tag at the end of the string, it is generous in that it allows for abitrary amounts of  white space.
Happy to update to only look for the one scenario outlined in the original issue.

## GUS work item
