### PR TITLE
[DO NOT MERGE] Trigger CI for #4329: fix: inline style parsing for "! important"

### DIFF
--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -273,10 +273,10 @@ export function styleMapToStyleDeclsAST(styleMap: { [name: string]: string }): t
     const styles: Array<[string, string] | [string, string, boolean]> = Object.entries(
         styleMap
     ).map(([key, value]) => {
-        const important = value.endsWith('!important');
+        const importantRegex = /\s*!\s*important\s*$/;
+        const important = importantRegex.test(value);
         if (important) {
-            // trim off the trailing "!important" (10 chars)
-            value = value.substring(0, value.length - 10).trim();
+            value = value.replace(importantRegex, '').trim();
         }
         return [key, value, important];
     });


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4329.