### PR TITLE
fix(class): avoid enumerable prototype for class object binding @W-16109991@

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -24,6 +24,7 @@ import {
     StringReplace,
     StringTrim,
     toString,
+    keys as ObjectKeys,
 } from '@lwc/shared';
 
 import { logError } from '../shared/logger';
@@ -755,9 +756,9 @@ function ncls(value: unknown): string {
                 res += normalized + ' ';
             }
         }
-    } else if (isObject(value) && value !== null) {
+    } else if (isObject(value) && !isNull(value)) {
         // Iterate own enumerable keys of the object
-        const keys = Object.keys(value);
+        const keys = ObjectKeys(value);
         for (let i = 0; i < keys.length; i += 1) {
             const key = keys[i];
             if ((value as Record<string, unknown>)[key]) {

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -755,9 +755,12 @@ function ncls(value: unknown): string {
                 res += normalized + ' ';
             }
         }
-    } else if (isObject(value)) {
-        for (const key in value) {
-            if ((value as any)[key]) {
+    } else if (isObject(value) && value !== null) {
+        // Iterate own enumerable keys of the object
+        const keys = Object.keys(value);
+        for (let i = 0; i < keys.length; i += 1) {
+            const key = keys[i];
+            if ((value as Record<string, unknown>)[key]) {
                 res += key + ' ';
             }
         }

--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -42,7 +42,12 @@ function classSet(props) {
     const proto = {
         add() {},
         invert() {},
-        toString() {},
+        toString() {
+            return Object.entries(props)
+                .filter(([, val]) => val)
+                .map(([key]) => key)
+                .join(' ');
+        },
     };
     return Object.assign(Object.create(proto), props);
 }

--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -88,7 +88,6 @@ if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
 
         testClassNameValue('symbols keys', { [Symbol('foo')]: true }, '');
         testClassNameValue('null proto', Object.create(null), '');
-        testClassNameValue('enumerable proto', classSet({ foo: true }), 'foo');
     });
 
     describe('array class value', () => {

--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -37,6 +37,16 @@ function testReactiveClassNameValue(name, setupFn, updateFn, expected) {
     });
 }
 
+/** Stub of LBC's `classSet`. Has enumerable keys on the prototype. */
+function classSet(props) {
+    const proto = {
+        add() {},
+        invert() {},
+        toString() {},
+    };
+    return Object.assign(Object.create(proto), props);
+}
+
 describe('type coercion', () => {
     testClassNameValue('object', {}, TEMPLATE_CLASS_NAME_OBJECT_BINDING ? '' : '[object Object]');
     testClassNameValue('true', true, TEMPLATE_CLASS_NAME_OBJECT_BINDING ? '' : 'true');
@@ -50,6 +60,7 @@ describe('type coercion', () => {
         function () {},
         TEMPLATE_CLASS_NAME_OBJECT_BINDING ? '' : 'function () {}'
     );
+    testClassNameValue('enumerable proto', classSet({ foo: true }), 'foo');
 
     // Passing a symbol as a class name prior to API v61 would throw an error.
     if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
@@ -77,6 +88,7 @@ if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
 
         testClassNameValue('symbols keys', { [Symbol('foo')]: true }, '');
         testClassNameValue('null proto', Object.create(null), '');
+        testClassNameValue('enumerable proto', classSet({ foo: true }), 'foo');
     });
 
     describe('array class value', () => {


### PR DESCRIPTION
## Details

We currently iterate over _all_ enumerable properties on an object, not just _own_ enumerable properties. This breaks anything using LBC's `classSet` utility, because that has enumerable props on the prototype. Anything using that helper will see `add invert toString` added to their class. Oops!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

Technically, but it's a bug fix!

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-16109991
