### PR TITLE
test: add production-mode hydration tests

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -179,6 +179,7 @@ jobs:
             - run: NODE_ENV_FOR_TEST=production DISABLE_SYNTHETIC=1 yarn sauce:ci
             - run: yarn hydration:sauce:ci
             - run: ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION=1 yarn hydration:sauce:ci
+            - run: NODE_ENV_FOR_TEST=production yarn hydration:sauce:ci
 
             - name: Upload coverage results
               uses: actions/upload-artifact@v4

--- a/packages/@lwc/integration-karma/.eslintrc
+++ b/packages/@lwc/integration-karma/.eslintrc
@@ -2,7 +2,8 @@
     "globals": {
         "process": true,
         "LWC": true,
-        "spyOnAllFunctions": true
+        "spyOnAllFunctions": true,
+        "TestUtils": true
     },
 
     "env": {

--- a/packages/@lwc/integration-karma/scripts/karma-configs/hydration/base.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/hydration/base.js
@@ -14,7 +14,7 @@ const { ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION } = require('../../shared/options')
 const karmaPluginHydrationTests = require('../../karma-plugins/hydration-tests');
 const karmaPluginEnv = require('../../karma-plugins/env');
 const karmaPluginTransformFramework = require('../../karma-plugins/transform-framework.js');
-const { GREP, COVERAGE } = require('../../shared/options');
+const { GREP, COVERAGE, COVERAGE_DIR_FOR_OPTIONS } = require('../../shared/options');
 const { createPattern } = require('../utils');
 
 const BASE_DIR = path.resolve(__dirname, '../../../test-hydration');
@@ -98,7 +98,7 @@ module.exports = (config) => {
         config.plugins.push('karma-coverage');
 
         config.coverageReporter = {
-            dir: path.resolve(COVERAGE_DIR, 'hydration'),
+            dir: path.resolve(COVERAGE_DIR, 'hydration', COVERAGE_DIR_FOR_OPTIONS),
             reporters: [{ type: 'html' }, { type: 'json' }],
         };
     }

--- a/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/attributes/falsy-mismatch/index.spec.js
@@ -28,14 +28,13 @@ export default {
             expect(divs[i].getAttribute('data-foo')).toEqual(expectedAttrValues[i]);
         }
 
-        expect(consoleCalls.warn).toHaveSize(0);
-        expect(consoleCalls.error).toHaveSize(3);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "undefined" but found null'
-        );
-        expect(consoleCalls.error[1][0].message).toContain(
-            'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "null" but found null'
-        );
-        expect(consoleCalls.error[2][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [],
+            error: [
+                'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "undefined" but found null',
+                'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "null" but found null',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/errors/already-hydrated/index.spec.js
@@ -5,8 +5,9 @@ export default {
         hydrateComponent(target, Component, {});
 
         const consoleCalls = consoleSpy.calls;
-        const expectedMessage = '"hydrateComponent" expects an element that is not hydrated.';
-        expect(consoleCalls.warn).toHaveSize(1);
-        expect(consoleCalls.warn[0][0]).toContain(expectedMessage);
+
+        TestUtils.expectConsoleCalls(consoleCalls, {
+            warn: ['"hydrateComponent" expects an element that is not hydrated.'],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/attrs-compatibility/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/attrs-compatibility/index.spec.js
@@ -18,13 +18,12 @@ export default {
         expect(p.getAttribute('data-same')).toBe('same-value');
         expect(p.getAttribute('data-another-diff')).toBe('client-val');
 
-        expect(consoleCalls.error).toHaveSize(3);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "title" has different values, expected "client-title" but found "ssr-title"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "data-another-diff" has different values, expected "client-val" but found "ssr-val"'
-        );
-        expect(consoleCalls.error[2][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "title" has different values, expected "client-title" but found "ssr-title"',
+                'Mismatch hydrating element <p>: attribute "data-another-diff" has different values, expected "client-val" but found "ssr-val"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/attrs-expression/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/attrs-expression/index.spec.js
@@ -17,10 +17,11 @@ export default {
         expect(div.getAttribute('data-foo')).toBe('client');
         expect(div.getAttribute('data-static')).toBe('same-value');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "client" but found "server"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <div>: attribute "data-foo" has different values, expected "client" but found "server"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-different/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-different/index.spec.js
@@ -18,10 +18,11 @@ export default {
         expect(p).not.toBe(snapshots.p);
         expect(p.className).not.toBe(snapshots.classes);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c2 c3 c4" but found "c1 c2 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c2 c3 c4" but found "c1 c2 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-empty-in-ssr-null-string-in-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-empty-in-ssr-null-string-in-client/index.spec.js
@@ -21,11 +21,12 @@ export default {
         expect(p).not.toBe(snapshots.p);
         expect(p.className).not.toBe(snapshots.className);
 
-        expect(consoleCalls.warn).toHaveSize(0);
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "null" but found null'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [],
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "null" but found null',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-null-string-in-ssr-empty-in-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-null-string-in-ssr-empty-in-client/index.spec.js
@@ -21,11 +21,12 @@ export default {
         expect(p).not.toBe(snapshots.p);
         expect(p.className).not.toBe(snapshots.className);
 
-        expect(consoleCalls.warn).toHaveSize(0);
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "" but found "null"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [],
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "" but found "null"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-same-different-order-throws/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/dynamic-same-different-order-throws/index.spec.js
@@ -18,10 +18,11 @@ export default {
         expect(p).not.toBe(snapshots.p);
         expect(p.className).not.toBe(snapshots.classes);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c3 c2 c1" but found "c1 c2 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c3 c2 c1" but found "c1 c2 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/only-present-in-ssr/index.spec.js
@@ -10,12 +10,12 @@ export default {
 
         hydrateComponent(target, Component, {});
 
-        expect(consoleSpy.calls.error).toHaveSize(2);
-        expect(consoleSpy.calls.error[0][0].message).toEqual(
-            '[LWC error]: Mismatch hydrating element <x-child>: attribute "class" has different values, expected "" but found "foo"\n'
-        );
-        expect(consoleSpy.calls.error[1][0].message).toEqual(
-            '[LWC error]: Hydration completed with errors.\n'
-        );
+        const consoleCalls = consoleSpy.calls;
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <x-child>: attribute "class" has different values, expected "" but found "foo"\n',
+                '[LWC error]: Hydration completed with errors.\n',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-extra-class-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-extra-class-from-client/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.className).not.toBe(snapshots.classes);
         expect(p.className).toBe('c1 c2 c3');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c1 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c1 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-extra-class-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-extra-class-from-server/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.className).not.toBe(snapshots.classes);
         expect(p.className).toBe('c1 c3');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c3" but found "c1 c2 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c3" but found "c1 c2 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-same-different-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-same-different-order/index.spec.js
@@ -18,10 +18,11 @@ export default {
         expect(p).not.toBe(snapshots.p);
         expect(p.className).toBe('c1 c2 c3');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c3 c2 c1"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c3 c2 c1"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-client/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.className).not.toBe(snapshots.classes);
         expect(p.className).toBe('c1 c2 c3');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c1 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c2 c3" but found "c1 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/static-unoptimized-extra-class-from-server/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.className).not.toBe(snapshots.classes);
         expect(p.className).toBe('c1 c3');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c3" but found "c1 c2 c3"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "c1 c3" but found "c1 c2 c3"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/comment-instead-of-text/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/comment-instead-of-text/index.spec.js
@@ -17,10 +17,11 @@ export default {
         expect(comment.nodeType).toBe(Node.COMMENT_NODE);
         expect(comment.nodeValue).toBe(snapshots.text.nodeValue);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Hydration mismatch: incorrect node type received'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Hydration mismatch: incorrect node type received',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/different-lwc-inner-html/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/different-lwc-inner-html/index.spec.js
@@ -21,10 +21,11 @@ export default {
         expect(p).not.toBe(snapshot.p);
         expect(p.textContent).toBe('different-content');
 
-        expect(consoleCalls.warn).toHaveSize(1);
-        expect(consoleCalls.warn[0][0].message).toContain(
-            'Mismatch hydrating element <div>: innerHTML values do not match for element, will recover from the difference'
-        );
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Mismatch hydrating element <div>: innerHTML values do not match for element, will recover from the difference',
+            ],
+        });
 
         target.content = '<p>another-content</p>';
 

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/display-errors-attrs-class-style/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/display-errors-attrs-class-style/index.spec.js
@@ -23,16 +23,13 @@ export default {
         expect(p.getAttribute('style')).toBe('background-color: blue;');
         expect(p.getAttribute('data-attrs')).toBe('client-attrs');
 
-        expect(consoleCalls.error).toHaveSize(4);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "data-attrs" has different values, expected "client-attrs" but found "ssr-attrs"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: blue;" but found "background-color: red;"'
-        );
-        expect(consoleCalls.error[2][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "class" has different values, expected "client-class" but found "ssr-class"'
-        );
-        expect(consoleCalls.error[3][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "data-attrs" has different values, expected "client-attrs" but found "ssr-attrs"',
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: blue;" but found "background-color: red;"',
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "client-class" but found "ssr-class"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/dynamic-component/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/dynamic-component/index.spec.js
@@ -16,10 +16,12 @@ export default {
         expect(snapshots.tagName).toBe('x-server');
         // Client side constructor
         expect(target.shadowRoot.querySelector('x-client')).not.toBeNull();
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: expecting element with tag "x-client" but found "x-server".'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Hydration mismatch: expecting element with tag "x-client" but found "x-server".',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/element-instead-of-textNode/index.spec.js
@@ -19,10 +19,11 @@ export default {
 
         expect(text.nodeType).toBe(Node.TEXT_NODE);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: incorrect node type received'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Hydration mismatch: incorrect node type received',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/favors-client-side-comment/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/favors-client-side-comment/index.spec.js
@@ -18,9 +18,10 @@ export default {
         expect(comment.nodeValue).not.toBe(snapshots.commentText);
         expect(comment.nodeValue).toBe('second');
 
-        expect(consoleCalls.warn).toHaveSize(1);
-        expect(consoleCalls.warn[0][0].message).toContain(
-            'Hydration mismatch: comment values do not match, will recover from the difference'
-        );
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Hydration mismatch: comment values do not match, will recover from the difference',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/favors-client-side-text/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/favors-client-side-text/index.spec.js
@@ -18,9 +18,10 @@ export default {
         expect(p.firstChild).toBe(snapshots.text);
         expect(p.textContent).toBe('bye!');
 
-        expect(consoleCalls.warn).toHaveSize(1);
-        expect(consoleCalls.warn[0][0].message).toContain(
-            'Hydration mismatch: text values do not match, will recover from the difference'
-        );
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Hydration mismatch: text values do not match, will recover from the difference',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/foreach/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/foreach/index.spec.js
@@ -15,10 +15,11 @@ export default {
 
         expect(hydratedSnapshot.text).not.toBe(snapshots.text);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Server rendered more nodes than the client.'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Server rendered more nodes than the client.',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/if-true/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/invalid-number-of-nodes/if-true/index.spec.js
@@ -15,10 +15,11 @@ export default {
 
         expect(hydratedSnapshot.text).not.toBe(snapshots.text);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Server rendered more nodes than the client.'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Server rendered more nodes than the client.',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/different-priority/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red !important;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red !important;" but found "background-color: red; border-color: red;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red !important;" but found "background-color: red; border-color: red;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/extra-from-client/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red; margin: 1px;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red; margin: 1px;" but found "background-color: red; border-color: red;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red; margin: 1px;" but found "background-color: red; border-color: red;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/extra-from-server/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.getAttribute('style')).not.toBe(snapshots.style);
         expect(p.getAttribute('style')).toBe('background-color: red; border-color: red;');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red;" but found "background-color: red; border-color: red; margin: 1px;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red;" but found "background-color: red; border-color: red; margin: 1px;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/same-different-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/computed/same-different-order/index.spec.js
@@ -20,10 +20,11 @@ export default {
             'margin: 1px; border-color: red; background-color: red;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "margin: 1px; border-color: red; background-color: red;" but found "background-color: red; border-color: red; margin: 1px;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "margin: 1px; border-color: red; background-color: red;" but found "background-color: red; border-color: red; margin: 1px;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/different-priority/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red !important;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red !important;" but found "background-color: red; border-color: red;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red !important;" but found "background-color: red; border-color: red;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/extra-from-client/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red; margin: 1px;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red; margin: 1px;" but found "background-color: red; border-color: red;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red; margin: 1px;" but found "background-color: red; border-color: red;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/extra-from-server/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.getAttribute('style')).not.toBe(snapshots.style);
         expect(p.getAttribute('style')).toBe('background-color: red; border-color: red;');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red;" but found "background-color: red; border-color: red; margin: 1px;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red;" but found "background-color: red; border-color: red; margin: 1px;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/same-different-order/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/same-different-order/index.spec.js
@@ -20,10 +20,11 @@ export default {
             'margin: 1px; border-color: red; background-color: red;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <p>: attribute "style" has different values, expected "margin: 1px; border-color: red; background-color: red;" but found "background-color: red; border-color: red; margin: 1px;"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "margin: 1px; border-color: red; background-color: red;" but found "background-color: red; border-color: red; margin: 1px;"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red !important;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red important!" but found "background-color: red; border-color: red"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red important!" but found "background-color: red; border-color: red"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
@@ -21,10 +21,11 @@ export default {
             'background-color: red; border-color: red; margin: 1px;'
         );
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
@@ -19,10 +19,11 @@ export default {
         expect(p.getAttribute('style')).not.toBe(snapshots.style);
         expect(p.getAttribute('style')).toBe('background-color: red; border-color: red;');
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px"'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px"',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/text-instead-of-comment/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/text-instead-of-comment/index.spec.js
@@ -17,10 +17,11 @@ export default {
         expect(text.nodeType).toBe(Node.TEXT_NODE);
         expect(text.nodeValue).toBe(snapshots.comment.nodeValue);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Hydration mismatch: incorrect node type received'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Hydration mismatch: incorrect node type received',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/textNode-instead-of-element/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/textNode-instead-of-element/index.spec.js
@@ -19,10 +19,11 @@ export default {
 
         expect(text.nodeType).toBe(Node.ELEMENT_NODE);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            '[LWC error]: Hydration mismatch: incorrect node type received'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                '[LWC error]: Hydration mismatch: incorrect node type received',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/class-mismatch-excluded/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/class-mismatch-excluded/index.spec.js
@@ -1,9 +1,10 @@
 export default {
     test(_target, _snapshots, consoleCalls) {
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Mismatch hydrating element <x-child>: attribute "class" has different values'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <x-child>: attribute "class" has different values',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/number-of-child-els/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/number-of-child-els/index.spec.js
@@ -14,10 +14,11 @@ export default {
         const hydratedSnapshot = this.snapshot(target);
         expect(hydratedSnapshot.childMarkup).not.toBe(snapshots.childMarkup);
 
-        expect(consoleCalls.error).toHaveSize(2);
-        expect(consoleCalls.error[0][0].message).toContain(
-            'Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.'
-        );
-        expect(consoleCalls.error[1][0].message).toContain('Hydration completed with errors.');
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Hydration mismatch: incorrect number of rendered nodes. Client produced more nodes than the server.',
+                'Hydration completed with errors.',
+            ],
+        });
     },
 };


### PR DESCRIPTION
## Details

Fixes #3253

Adds `NODE_ENV=production` tests for the hydration tests, and ensures coverage is calculated correctly.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
