### PR TITLE
test(ncls): test own non-enumerable props @W-16109991@

### DIFF
--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -65,7 +65,7 @@ describe('type coercion', () => {
         function () {},
         TEMPLATE_CLASS_NAME_OBJECT_BINDING ? '' : 'function () {}'
     );
-    testClassNameValue('enumerable proto', classSet({ foo: true }), 'foo');
+    testClassNameValue('object with enumerable prototype props', classSet({ foo: true }), 'foo');
 
     // Passing a symbol as a class name prior to API v61 would throw an error.
     if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
@@ -93,6 +93,18 @@ if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
 
         testClassNameValue('symbols keys', { [Symbol('foo')]: true }, '');
         testClassNameValue('null proto', Object.create(null), '');
+
+        testClassNameValue(
+            'non-enumerable property',
+            Object.defineProperties(
+                {},
+                {
+                    enumerable: { enumerable: true, value: true },
+                    hidden: { value: true },
+                }
+            ),
+            'enumerable'
+        );
     });
 
     describe('array class value', () => {


### PR DESCRIPTION
## Details

I committed and pushed and merged #4337. But I hadn't staged the file I had wanted to commit! So now we have a second PR to add one dinky little test. 🤦 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
