### PR TITLE
fix: allow lazy-disabling native lifecycle

### DIFF
--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -1,36 +1,38 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import { attachReportingControlDispatcher, detachReportingControlDispatcher } from 'test-utils';
 
 import Component from 'x/component';
 import Parent from 'x/parent';
+import LogsWhenConnected from 'x/logsWhenConnected';
+
+let logger;
+let dispatcher;
+
+beforeEach(() => {
+    dispatcher = jasmine.createSpy();
+    attachReportingControlDispatcher(dispatcher, ['ConnectedCallbackWhileDisconnected']);
+    logger = spyOn(console, 'warn');
+});
+
+afterEach(() => {
+    detachReportingControlDispatcher();
+});
+
+const expectLogs = (regexes) => {
+    if (process.env.NODE_ENV === 'production') {
+        expect(logger).not.toHaveBeenCalled();
+    } else {
+        const args = logger.calls.allArgs();
+        expect(args.length).toBe(regexes.length);
+        for (let i = 0; i < args.length; i++) {
+            expect(args[i][0]).toMatch(regexes[i]);
+        }
+    }
+};
 
 if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
+    // synthetic lifecycle mode
     describe('ConnectedCallbackWhileDisconnected reporting', () => {
-        let logger;
-        let dispatcher;
-
-        beforeEach(() => {
-            dispatcher = jasmine.createSpy();
-            attachReportingControlDispatcher(dispatcher, ['ConnectedCallbackWhileDisconnected']);
-            logger = spyOn(console, 'warn');
-        });
-
-        afterEach(() => {
-            detachReportingControlDispatcher();
-        });
-
-        function expectLogs(regexes) {
-            if (process.env.NODE_ENV === 'production') {
-                expect(logger).not.toHaveBeenCalled();
-            } else {
-                const args = logger.calls.allArgs();
-                expect(args.length).toBe(regexes.length);
-                for (let i = 0; i < args.length; i++) {
-                    expect(args[i][0]).toMatch(regexes[i]);
-                }
-            }
-        }
-
         it('disconnected DOM', () => {
             const div = document.createElement('div');
             const elm = createElement('x-component', { is: Component });
@@ -58,6 +60,33 @@ if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
             expect(dispatcher.calls.allArgs()).toEqual([
                 ['ConnectedCallbackWhileDisconnected', { tagName: 'x-parent' }],
                 ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
+            ]);
+        });
+    });
+} else {
+    // native lifecycle mode
+    describe('Lazily setting lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE to true', () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE', true);
+            window.timingBuffer = [];
+        });
+        afterEach(() => {
+            setFeatureFlagForTest('DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE', false);
+            delete window.timingBuffer;
+        });
+
+        it('component runs in synthetic lifecycle after flag is lazily set', () => {
+            const div = document.createElement('div');
+            const elm = createElement('x-logs-when-connected', { is: LogsWhenConnected });
+
+            div.appendChild(elm);
+
+            expect(window.timingBuffer).toEqual(['<x-logs-when-connected>: connectedCallback']);
+            expectLogs([
+                /Element <x-logs-when-connected> fired a `connectedCallback` and rendered, but was not connected to the DOM/,
+            ]);
+            expect(dispatcher.calls.allArgs()).toEqual([
+                ['ConnectedCallbackWhileDisconnected', { tagName: 'x-logs-when-connected' }],
             ]);
         });
     });

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/logsWhenConnected/logsWhenConnected.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/x/logsWhenConnected/logsWhenConnected.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    connectedCallback() {
+        window.timingBuffer.push('<x-logs-when-connected>: connectedCallback');
+    }
+}


### PR DESCRIPTION
## Details

In some environments, the `lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE` flag is _lazily_ set to `true`, after the engine has initialized but before a component has rendered. This worked okay in LWC v6 through LWC v7.0.0, but broke in LWC v7.0.1 due to #4316, which caused all DOM monkey-patching to only occur at initialization time. 

So lazily-setting the flag effectively puts you in a broken state, where the component is trying to run in synthetic lifecycle mode, but `connectedCallback`/`disconnectedCallback` never fires because the monkey-patching is never put in place.

This PR restores the previous behavior, where the monkey-patching can occur dynamically at the time the component is rendered.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Yeah but it's observable in a way that restores the previous (250-like) behavior.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

[W-16153421](https://gus.lightning.force.com/a07EE00001vpCITYA2)
