### PR TITLE
test(hydration): add `.only` support

### DIFF
--- a/packages/@lwc/integration-karma/README.md
+++ b/packages/@lwc/integration-karma/README.md
@@ -73,6 +73,12 @@ This will connect to Sauce Labs, start the browser, and run the tests.
 
 You can also pass in `--log-level=debug` to `karma` for debug logging.
 
+## Running specific tests
+
+In the main test suite, you can use `fdescribe()` instead of `describe()` or `fit()` instead of `it()` to only run certain tests.
+
+In the hydration tests, you can create an empty `.only` file alongside an `index.spec.js` file to run just that test.
+
 ## Contributing
 
 -   The test suite uses jasmine for test runner. You can find more details about jasmine here: https://jasmine.github.io/api/3.3/global


### PR DESCRIPTION
## Details

Adds support for the `.only` convention we use in our Jest tests to the hydration tests. This makes it a lot easier to test individual hydration tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
