### PR TITLE
test(ssr): use `Document.parseHTMLUnsafe`

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,10 +34,10 @@ jobs:
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v121
+            - name: Setup chrome v126
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 121
+                  chrome-version: 126
               id: setup-chrome
 
             - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
             # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
             # See: https://github.com/google/tachometer#on-demand-dependencies
-            - name: Install chromedriver v121
-              run: yarn add -W chromedriver@^121
+            - name: Install chromedriver v126
+              run: yarn add -W chromedriver@^126
 
             - name: Check package.json integrity
               run: node ./scripts/tasks/check-and-rewrite-package-json.js --test

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
@@ -29,9 +29,7 @@ benchmark(`hydrate/table/hydrate/1k`, () => {
 
         const ssrHtml = renderComponent('benchmark-table', Table, props);
 
-        const fragment = new DOMParser().parseFromString(ssrHtml, 'text/html', {
-            includeShadowRoots: true,
-        });
+        const fragment = Document.parseHTMLUnsafe(ssrHtml);
 
         tableElement = fragment.querySelector('benchmark-table');
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
@@ -27,10 +27,7 @@ benchmark(`hydrate/table-component/hydrate/1k`, () => {
         };
 
         const ssrHtml = renderComponent('benchmark-table', Table, props);
-
-        const fragment = new DOMParser().parseFromString(ssrHtml, 'text/html', {
-            includeShadowRoots: true,
-        });
+        const fragment = Document.parseHTMLUnsafe(ssrHtml);
 
         tableElement = fragment.querySelector('benchmark-table');
 


### PR DESCRIPTION
## Details

Chrome is giving us a warning about using `includeShadowRoot`s in our tests:

![Screenshot 2024-07-03 at 3 41 49 PM](https://github.com/salesforce/lwc/assets/283842/8661ee03-0d14-4137-80e6-73cf22eefeea)

We can switch over to the new [`parseHTMLUnsafe`](https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) API instead. Although nothing is ever easy, so we have to polyfill for Firefox.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
