### PR TITLE
chore(prettier): format `.eslintrc` on commit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -263,9 +263,7 @@
             }
         },
         {
-            "files": [
-                "packages/@lwc/integration-karma/**"
-            ],
+            "files": ["packages/@lwc/integration-karma/**"],
             "globals": {
                 "lwcRuntimeFlags": true
             }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     },
     "lint-staged": {
         "*.{js,mjs,ts}": "eslint",
-        "*.{css,js,json,md,mjs,ts,yaml,yml}": "prettier --write",
+        "*.{css,js,json,md,mjs,ts,yaml,yml,eslintrc}": "prettier --write",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js",
         "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js",
         "*.{only,skip}": "eslint --no-eslintrc --plugin '@lwc/eslint-plugin-lwc-internal' --rule '@lwc/lwc-internal/forbidden-filename: error'"


### PR DESCRIPTION
## Details

I noticed that `yarn format` was formatting `.eslinrc`, but not on `git commit`. This fixes that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
