### PR TITLE
fix(perf-benchmarks): add `parseHTMLUnsafe` polyfill

### DIFF
--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/table-hydrate-1k.benchmark.js
@@ -29,7 +29,12 @@ benchmark(`hydrate/table/hydrate/1k`, () => {
 
         const ssrHtml = renderComponent('benchmark-table', Table, props);
 
-        const fragment = Document.parseHTMLUnsafe(ssrHtml);
+        // parseHTMLUnsafe landed in Chrome 124 https://caniuse.com/mdn-api_document_parsehtmlunsafe_static
+        const fragment = Document.parseHTMLUnsafe
+            ? Document.parseHTMLUnsafe(ssrHtml)
+            : new DOMParser().parseFromString(ssrHtml, 'text/html', {
+                  includeShadowRoots: true,
+              });
 
         tableElement = fragment.querySelector('benchmark-table');
 

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-hydrate/tablecmp-hydrate-1k.benchmark.js
@@ -27,7 +27,13 @@ benchmark(`hydrate/table-component/hydrate/1k`, () => {
         };
 
         const ssrHtml = renderComponent('benchmark-table', Table, props);
-        const fragment = Document.parseHTMLUnsafe(ssrHtml);
+
+        // parseHTMLUnsafe landed in Chrome 124 https://caniuse.com/mdn-api_document_parsehtmlunsafe_static
+        const fragment = Document.parseHTMLUnsafe
+            ? Document.parseHTMLUnsafe(ssrHtml)
+            : new DOMParser().parseFromString(ssrHtml, 'text/html', {
+                  includeShadowRoots: true,
+              });
 
         tableElement = fragment.querySelector('benchmark-table');
 


### PR DESCRIPTION
## Details

Apparently Best is running Chrome v123, because it's failing with

```
Document.parseHTMLUnsafe is not a function
```

which was caused by #4357.

This introduces a polyfill to temporarily fix it. Not we only care about Chrome for Best tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
