### PR TITLE
fix: do not error if abort controller for stylesheet does not exist @W-16189944

### DIFF
--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -364,9 +364,8 @@ export function unrenderStylesheet(stylesheet: Stylesheet) {
     }
     for (const cssContent of cssContents) {
         const abortController = cssContentToAbortControllers.get(cssContent);
-        /* istanbul ignore if */
         if (isUndefined(abortController)) {
-            // Two stylesheets with the same content will share a abort controller, in which case only its needs to be called only once.
+            // Two stylesheets with the same content will share an abort controller, in which case it only needs to be called once.
             continue;
         }
         abortController.abort();

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -366,7 +366,8 @@ export function unrenderStylesheet(stylesheet: Stylesheet) {
         const abortController = cssContentToAbortControllers.get(cssContent);
         /* istanbul ignore if */
         if (isUndefined(abortController)) {
-            throw new Error('Cannot find AbortController for CSS content');
+            // Two stylesheets with the same content will share a abort controller, in which case only its needs to be called only once.
+            continue;
         }
         abortController.abort();
         // remove association with AbortController in case stylesheet is rendered again

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -238,7 +238,7 @@ if (process.env.NODE_ENV !== 'production') {
             expect(() => {
                 implicitTemplate.stylesheets = style;
             }).toLogWarningDev(/Mutating the "stylesheets" property on a template/);
-            // reswap the tempalte to implicit template
+            // reswap the template to implicit template
             swapTemplate(newTemplate, implicitTemplate);
             await Promise.resolve();
 

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement, swapStyle } from 'lwc';
+import { createElement, swapStyle, swapTemplate } from 'lwc';
 import { extractDataIds } from 'test-utils';
 import ShadowUsesStaticStylesheets from 'shadow/usesStaticStylesheets';
 import LightUsesStaticStylesheets from 'light/usesStaticStylesheets';
@@ -13,6 +13,8 @@ import LibraryUserA from 'x/libraryUserA';
 import LibraryUserB from 'x/libraryUserB';
 import libraryStyle from 'x/library';
 import libraryStyleV2 from 'x/libraryV2';
+import IdenticalStylesheets from 'shadow/identicalStylesheets';
+import IdenticalStylesheetsContainer from 'shadow/identicalStylesheetsContainer';
 
 function expectStyles(elm, styles) {
     const computed = getComputedStyle(elm);
@@ -209,6 +211,45 @@ if (process.env.NODE_ENV !== 'production') {
                         display: 'none',
                     });
                 });
+            });
+        });
+
+        it('should be able to swap stylesheets that produce identical content', async () => {
+            const { style, identicalStyle, newStyle, implicitTemplate, newTemplate } =
+                IdenticalStylesheets;
+            const elm = createElement(`identical-stylesheets`, {
+                is: IdenticalStylesheetsContainer,
+            });
+            document.body.appendChild(elm);
+
+            // Step 1: wait for first render
+            // implicitTemplate is associated with identicalStyle
+            await Promise.resolve();
+            expectStyles(extractDataIds(elm).paragraph, {
+                display: 'inline',
+            });
+
+            // Step 2: swap template with a new template to trigger rehydration
+            swapTemplate(implicitTemplate, newTemplate);
+            await Promise.resolve();
+
+            // Step 3: Associate an identical stylesheet with the same template(or a template with the same shadow token)
+            // associate identical stylesheet with the original template
+            expect(() => {
+                implicitTemplate.stylesheets = style;
+            }).toLogWarningDev(/Mutating the "stylesheets" property on a template/);
+            // reswap the tempalte to implicit template
+            swapTemplate(newTemplate, implicitTemplate);
+            await Promise.resolve();
+
+            // Act to trigger the unrender of the identical stylesheets
+            swapStyle(style[0], newStyle[0]);
+            swapStyle(identicalStyle[0], newStyle[0]);
+            await Promise.resolve();
+
+            // Assert that the swap is successful
+            expectStyles(extractDataIds(elm).paragraph, {
+                display: 'none',
             });
         });
 

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.css
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.css
@@ -1,0 +1,3 @@
+.identical {
+    display: inline;
+}

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.html
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.html
@@ -1,0 +1,3 @@
+<template>
+    <p data-id="paragraph" class="identical" data-mutate={prop}>identical style</p>
+</template>

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/identicalStylesheets.js
@@ -1,0 +1,14 @@
+import { LightningElement } from 'lwc';
+import style from './style.css';
+import identicalStyle from './identicalStylesheets.css';
+import newStyle from './newStyle.css';
+import implicitTemplate from './identicalStylesheets.html';
+import newTemplate from './newTemplate.html';
+
+export default class IdenticalStylesheet extends LightningElement {
+    static style = style;
+    static identicalStyle = identicalStyle;
+    static newStyle = newStyle;
+    static implicitTemplate = implicitTemplate;
+    static newTemplate = newTemplate;
+}

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/newStyle.css
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/newStyle.css
@@ -1,0 +1,3 @@
+.identical {
+    display: none;
+}

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/newTemplate.html
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/newTemplate.html
@@ -1,0 +1,3 @@
+<template>
+    <div>new template</div>
+</template>

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/style.css
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheets/style.css
@@ -1,0 +1,3 @@
+.identical {
+    display: inline;
+}

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheetsContainer/identicalStylesheetsContainer.html
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheetsContainer/identicalStylesheetsContainer.html
@@ -1,0 +1,3 @@
+<template>
+    <shadow-identical-stylesheets></shadow-identical-stylesheets>
+</template>

--- a/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheetsContainer/identicalStylesheetsContainer.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/shadow/identicalStylesheetsContainer/identicalStylesheetsContainer.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Container extends LightningElement {}


### PR DESCRIPTION
## Details
The main root cause of the issue is that AbortController look up is based on the stylesheet content(a string) rather than the stylesheet function. There is a possibility that two stylesheets produce the same exact stylesheet content and when they both need to be unrendered at the same time, the AbortController look up will fail for the second stylesheet.

The scenario where the abort controller has a conflict is the following:
1. A component has been rendered
2. Modify a css files for that component and we only call swapStyle() to swap the style sheet.
    - Note that the new style module is associated with the vm instance and will have a callback registered for style hmr
3. Now modify the js files and we call swapComponent() to swap the component. Note that for js file changes we bundle the entire component
    - Note that the style did not change, hence the new component has a reference to the same style sheet "content" although a different stylesheet function instance.
    - The new component module will have a callback registered for the style hmr
With this, we have a situation where there are two stylesheet functions with the same content but different instance. Both have a hmr accept callback.

When a new style hot module comes in, swapStyle() will invoke the accept callback for both the modules. It will get the abort controller based on the style content(a string) and invoke the abort controller for the content. However, for the second accept callback, it will fail because the style content has already been un-rendered and the abort controller removed.

Note: I have tried to automate this but it is difficult to simulate with our karma setup. May be I was only trying with synthetic shadow and native or light shadow might have better luck. Open for suggestions.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-16189944
