### PR TITLE
[DO NOT MERGE] Trigger CI for #4359: Fix 4319: Ensure insertBefore throws an error - Updated with logWarnOnce and added a test

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -22,7 +22,6 @@ import {
     shouldBeFormAssociated,
 } from '@lwc/engine-core';
 import { renderer } from '../renderer';
-import { logWarnOnce } from '../../../engine-core/src/shared/logger';
 
 // TODO [#2472]: Remove this workaround when appropriate.
 // eslint-disable-next-line @lwc/lwc-internal/no-global-node

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -22,6 +22,7 @@ import {
     shouldBeFormAssociated,
 } from '@lwc/engine-core';
 import { renderer } from '../renderer';
+import { logWarnOnce } from '../../../engine-core/src/shared/logger';
 
 // TODO [#2472]: Remove this workaround when appropriate.
 // eslint-disable-next-line @lwc/lwc-internal/no-global-node
@@ -63,6 +64,9 @@ function monkeyPatchDomAPIs() {
             return callNodeSlot(appendedNode, ConnectingSlot);
         },
         insertBefore(newChild, referenceNode) {
+            if (arguments.length < 2) {
+                logWarnOnce('insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported.');
+            }
             const insertedNode = insertBefore.call(this, newChild, referenceNode);
             return callNodeSlot(insertedNode, ConnectingSlot);
         },

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -64,7 +64,7 @@ function monkeyPatchDomAPIs() {
             return callNodeSlot(appendedNode, ConnectingSlot);
         },
         insertBefore(newChild, referenceNode) {
-            if (arguments.length < 2) {
+            if (process.env.NODE_ENV !== 'production' && arguments.length < 2) {
                 console.warn('insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported.');
             }
             const insertedNode = insertBefore.call(this, newChild, referenceNode);

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -65,7 +65,7 @@ function monkeyPatchDomAPIs() {
         },
         insertBefore(newChild, referenceNode) {
             if (arguments.length < 2) {
-                logWarnOnce('insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported.');
+                console.warn('insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported.');
             }
             const insertedNode = insertBefore.call(this, newChild, referenceNode);
             return callNodeSlot(insertedNode, ConnectingSlot);

--- a/packages/@lwc/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/createElement/index.spec.js
@@ -111,3 +111,12 @@ describe('locker integration', () => {
         expect(elm instanceof HTMLElement).toBe(true);
     });
 });
+
+it('should log a warning when insertBefore is called with fewer than 2 arguments', () => {
+    const div = document.createElement('div');
+    const span = document.createElement('span');
+
+    expect(() => {
+        div.insertBefore(span)
+    }).toLogWarningDev(/insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported./);
+});


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4359.