### PR TITLE
perf: optimize initial render for nullish class

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -744,7 +744,13 @@ function shc(content: unknown): string {
  * This implementation is borrowed from Vue:
  * https://github.com/vuejs/core/blob/e790e1bdd7df7be39e14780529db86e4da47a3db/packages/shared/src/normalizeProp.ts#L63-L82
  */
-function ncls(value: unknown): string {
+function ncls(value: unknown): string | undefined {
+    if (isUndefined(value) || isNull(value)) {
+        // Returning undefined here improves initial render cost, because the old vnode's class will be considered
+        // undefined in the `patchClassAttribute` routine, so `oldClass === newClass` will be true so we return early
+        return undefined;
+    }
+
     let res = '';
 
     if (isString(value)) {


### PR DESCRIPTION
## Details

From looking at our Best benchmarks, I realized we had actually regressed recently in `dom-table-hydrate-1k` due to https://github.com/salesforce/lwc/pull/3950:

![Screenshot 2024-07-10 at 11 10 54 AM](https://github.com/salesforce/lwc/assets/283842/0941bef9-ad7e-4735-8d2e-615ddd355ec7)

Tachometer confirmed it (comparing current master to the 250 release, i.e. [v6.4.5](https://github.com/salesforce/lwc/releases/v6.4.5)):

![Screenshot 2024-07-10 at 12 36 49 PM](https://github.com/salesforce/lwc/assets/283842/0f7e17b4-7801-4491-b71e-70976093f772)

The reason is actually unrelated to hydration – it's because the components used in this benchmark set a `class` to `row.className` which is actually undefined:

https://github.com/salesforce/lwc/blob/c1f4a2bce0883d3d8bd9c1dce0cedd6295b36335/packages/%40lwc/perf-benchmarks-components/src/benchmark/table/table.html#L11

After https://github.com/salesforce/lwc/pull/3950, the `ncls` utility is converting `undefined` into an empty string:

https://github.com/salesforce/lwc/blob/c1f4a2bce0883d3d8bd9c1dce0cedd6295b36335/packages/%40lwc/engine-core/src/framework/api.ts#L747-L748

https://github.com/salesforce/lwc/blob/c1f4a2bce0883d3d8bd9c1dce0cedd6295b36335/packages/%40lwc/engine-core/src/framework/api.ts#L770

This means we don't hit the early-return condition when patching the class attribute:

https://github.com/salesforce/lwc/blob/c1f4a2bce0883d3d8bd9c1dce0cedd6295b36335/packages/%40lwc/engine-core/src/framework/modules/computed-class-attr.ts#L70-L73

This PR fixes this, by converting `undefined` and `null` into `undefined` within `ncls`, which means we hit the early-return when patching classes. This fixes the perf regression in the benchmark (comparing this PR to `master`):

![Screenshot 2024-07-10 at 12 36 40 PM](https://github.com/salesforce/lwc/assets/283842/c28e697d-e749-45e5-996c-4fe96eb0045b)

There are probably more optimizations we can do to `ncls` (e.g. treating `''` the same as `undefined`, avoiding the `StringTrim` call), but this PR is at least a start.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

The engine ultimately treats a `null`, `undefined`, or `""` class exactly the same at runtime, so there are no observable changes.

<!-- If yes, please describe the anticipated observable changes. -->
