### PR TITLE
chore(dependabot): ignore prettier v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           # We are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0.
           # See: https://github.com/google/tachometer/issues/244
           - dependency-name: 'tachometer'
-          # TODO [#]:
+          # TODO [#4386]: Stop ignoring when we've done the upgrade ourselves
           - dependency-name: 'prettier'
             versions: '>= 3'
           - dependency-name: '@types/prettier'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
           # We are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0.
           # See: https://github.com/google/tachometer/issues/244
           - dependency-name: 'tachometer'
+          # TODO [#]:
+          - dependency-name: 'prettier'
+            versions: '>= 3'
+          - dependency-name: '@types/prettier'
+            versions: '>= 3'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
     "printWidth": 100,
     "singleQuote": true,
-    "tabWidth": 4
+    "tabWidth": 4,
+    "trailingComma": "es5"
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
@@ -38,6 +38,7 @@ describe('fixtures', () => {
             );
 
             return {
+                // TODO [#4386]: Prettier v3 returns a promise - add an `await` here
                 'expected.js': prettier.format(code, { parser: 'babel' }),
                 'ast.json': JSON.stringify({ root }, null, 4),
                 'metadata.json': JSON.stringify({ warnings }, null, 4),

--- a/scripts/tasks/generate-license-files.js
+++ b/scripts/tasks/generate-license-files.js
@@ -60,6 +60,7 @@ async function main() {
             '\n'
         )}`.trim() + '\n';
 
+    // TODO [#4386]: Prettier v3 returns a promise - add an `await` here
     const formattedLicense = prettier.format(newLicense, {
         parser: 'markdown',
     });


### PR DESCRIPTION
## Details

We can't update to prettier v3 (see #4386), so we should tell dependabot to stop trying. I also added notes for the changes that we'll need to make when we do the upgrade, and I explicitly set `trailingComma` in the prettier config because the default value changes in v3 (not a big deal, but keeping the v2 value means a smaller diff in the upgrade).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
