### PR TITLE
fix: improve error for null/undefined iter values

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -399,7 +399,7 @@ function i(
             logError(
                 `Invalid template iteration for value \`${toString(
                     iterable
-                )}\` in ${vmBeingRendered}. It must be an array-like object and not \`null\` nor \`undefined\`.`,
+                )}\` in ${vmBeingRendered}. It must be an array-like object.`,
                 vmBeingRendered!
             );
         }

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -394,12 +394,12 @@ function i(
     // TODO [#1276]: compiler should give us some sort of indicator when a vnodes collection is dynamic
     sc(list);
     const vmBeingRendered = getVMBeingRendered()!;
-    if (isUndefined(iterable) || iterable === null) {
+    if (isUndefined(iterable) || isNull(iterable)) {
         if (process.env.NODE_ENV !== 'production') {
             logError(
-                `Invalid template iteration for value "${toString(
+                `Invalid template iteration for value \`${toString(
                     iterable
-                )}" in ${vmBeingRendered}. It must be an Array or an iterable Object.`,
+                )}\` in ${vmBeingRendered}. It must be an array-like object and not \`null\` nor \`undefined\`.`,
                 vmBeingRendered!
             );
         }

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -411,7 +411,7 @@ function i(
             isUndefined(iterable[SymbolIterator]),
             `Invalid template iteration for value \`${toString(
                 iterable
-            )}\` in ${vmBeingRendered}. It must be an array-like object and not \`null\` nor \`undefined\`.`
+            )}\` in ${vmBeingRendered}. It must be an array-like object.`
         );
     }
     const iterator = iterable[SymbolIterator]();

--- a/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
@@ -67,7 +67,7 @@ it('should throw an error when the passing a non iterable', () => {
 
     // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
     expect(() => document.body.appendChild(elm)).toThrowCallbackReactionError(
-        /Invalid template iteration for value `\[object (ProxyObject|Object)]` in \[object:vm Test \(\d+\)]\. It must be an array-like object and not `null` nor `undefined`\.|is not a function/
+        /Invalid template iteration for value `\[object (ProxyObject|Object)]` in \[object:vm Test \(\d+\)]\. It must be an array-like object\.|is not a function/
     );
 });
 
@@ -97,9 +97,7 @@ describe('null/undefined values', () => {
             } else {
                 expect(spy.calls.error.length).toBe(1);
                 // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
-                expect(spy.calls.error[0]).toMatch(
-                    /It must be an array-like object and not `null` nor `undefined`/
-                );
+                expect(spy.calls.error[0]).toMatch(/It must be an array-like object/);
             }
         });
     });

--- a/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-for-each/index.spec.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { spyConsole } from 'test-utils';
 import XTest from 'x/test';
 import XTestStatic from 'x/testStatic';
 import XTestCustomElement from 'x/testCustomElement';
@@ -68,6 +69,40 @@ it('should throw an error when the passing a non iterable', () => {
     expect(() => document.body.appendChild(elm)).toThrowCallbackReactionError(
         /Invalid template iteration for value `\[object (ProxyObject|Object)]` in \[object:vm Test \(\d+\)]\. It must be an array-like object and not `null` nor `undefined`\.|is not a function/
     );
+});
+
+describe('null/undefined values', () => {
+    let spy;
+
+    beforeEach(() => {
+        spy = spyConsole();
+    });
+
+    afterEach(() => {
+        spy.reset();
+    });
+
+    [undefined, null].forEach((value) => {
+        it(`should log an error when passing in ${value}`, async () => {
+            const elm = createElement('x-test', { is: XTest });
+            elm.items = null;
+
+            document.body.appendChild(elm);
+            await Promise.resolve();
+
+            expect(elm.shadowRoot.querySelector('ul').children.length).toBe(0);
+
+            if (process.env.NODE_ENV === 'production') {
+                expect(spy.calls.error.length).toBe(0);
+            } else {
+                expect(spy.calls.error.length).toBe(1);
+                // TODO [#1283]: Improve this error message. The vm should not be exposed and the message is not helpful.
+                expect(spy.calls.error[0]).toMatch(
+                    /It must be an array-like object and not `null` nor `undefined`/
+                );
+            }
+        });
+    });
 });
 
 it('should render an array of objects with null prototype', () => {


### PR DESCRIPTION
## Details

I noticed that this bit of code in the `i` (iterator) function was not being tested. This adds tests, and also improves the error message a bit by making it the same as the one below it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
