### PR TITLE
feat(wire): ensure prop type matches adapter value @W-16314799@

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,3 @@
-#!/usr/bin/env sh
 set -e
 node ./scripts/tasks/check-and-rewrite-package-json.js --test
 node ./scripts/tasks/generate-license-files.js --test

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -5,11 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert } from '@lwc/shared';
-import { LightningElement } from '../base-lightning-element';
 import { componentValueObserved } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
-import { WireAdapterConstructor } from '../wiring';
 import { updateComponentValue } from '../update-component-value';
+import type { LightningElement } from '../base-lightning-element';
+import type { ConfigValue, ContextValue, WireAdapterConstructor, WireDecorator } from '../wiring';
 
 /**
  * Decorator factory to wire a property or method to a wire adapter data source.
@@ -22,12 +22,16 @@ import { updateComponentValue } from '../update-component-value';
  *   \@wire(getBook, { id: '$bookId'}) book;
  * }
  */
-export default function wire(
+export default function wire<
+    Config extends ConfigValue = ConfigValue,
+    Value = any,
+    Context extends ContextValue = ContextValue
+>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    adapter: WireAdapterConstructor,
+    adapter: WireAdapterConstructor<Config, Value, Context>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    config?: Record<string, any>
-): (value: unknown, context: ClassMemberDecoratorContext | string | symbol) => void {
+    config?: Config
+): WireDecorator<Value> {
     if (process.env.NODE_ENV !== 'production') {
         assert.fail('@wire(adapter, config?) may only be used as a decorator.');
     }

--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -9,7 +9,13 @@ import { componentValueObserved } from '../mutation-tracker';
 import { getAssociatedVM } from '../vm';
 import { updateComponentValue } from '../update-component-value';
 import type { LightningElement } from '../base-lightning-element';
-import type { ConfigValue, ContextValue, WireAdapterConstructor, WireDecorator } from '../wiring';
+import type {
+    ConfigValue,
+    ContextValue,
+    ReplaceReactiveValues,
+    WireAdapterConstructor,
+    WireDecorator,
+} from '../wiring';
 
 /**
  * Decorator factory to wire a property or method to a wire adapter data source.
@@ -23,14 +29,14 @@ import type { ConfigValue, ContextValue, WireAdapterConstructor, WireDecorator }
  * }
  */
 export default function wire<
-    Config extends ConfigValue = ConfigValue,
+    ReactiveConfig extends ConfigValue = ConfigValue,
     Value = any,
     Context extends ContextValue = ContextValue
 >(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    adapter: WireAdapterConstructor<Config, Value, Context>,
+    adapter: WireAdapterConstructor<ReplaceReactiveValues<ReactiveConfig>, Value, Context>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    config?: Config
+    config?: ReactiveConfig
 ): WireDecorator<Value> {
     if (process.env.NODE_ENV !== 'production') {
         assert.fail('@wire(adapter, config?) may only be used as a decorator.');

--- a/packages/@lwc/engine-core/src/framework/wiring/index.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/index.ts
@@ -14,6 +14,7 @@ export {
     ContextProvider,
     ContextValue,
     DataCallback,
+    ReplaceReactiveValues,
     WireAdapter,
     WireAdapterConstructor,
     WireAdapterSchemaValue,

--- a/packages/@lwc/engine-core/src/framework/wiring/index.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/index.ts
@@ -19,6 +19,7 @@ export {
     WireAdapterSchemaValue,
     WireContextSubscriptionPayload,
     WireContextSubscriptionCallback,
+    WireDecorator,
 } from './types';
 
 export {

--- a/packages/@lwc/engine-core/src/framework/wiring/types.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/types.ts
@@ -125,3 +125,12 @@ export type RegisterContextProviderFn = (
     adapterContextToken: string,
     onContextSubscription: WireContextSubscriptionCallback
 ) => void;
+
+/**
+ * String values starting with "$" are reactive; they get replaced by values from the component.
+ * We don't have access to the component, and we don't expect all reactive strings to be typed as
+ * literals, so we just replace all strings with `any`.
+ */
+export type ReplaceReactiveValues<T> = {
+    [K in keyof T]: T[K] extends string ? any : T[K];
+};

--- a/packages/@lwc/integration-types/src/decorators.ts
+++ b/packages/@lwc/integration-types/src/decorators.ts
@@ -24,18 +24,34 @@ const FakeWireAdapter = class FakeWireAdapter implements WireAdapter<WireConfig,
     disconnect() {}
 } satisfies WireAdapterConstructor<WireConfig, WireValue, WireContext>;
 
-export default class extends LightningElement {
+export default class Decorators extends LightningElement {
+    plainProp = 'config' as const;
+    otherProp = 123;
+
     // Valid cases
     @api apiProp?: string;
     @track trackedProp?: Record<string, unknown>;
-    @wire(FakeWireAdapter, { config: 'config' }) validWireProp!: WireValue;
-    @wire(FakeWireAdapter) validWireMethod(_value: WireValue) {}
+    @wire(FakeWireAdapter, { config: 'config' }) baseConfigProp!: WireValue;
+    @wire(FakeWireAdapter, { config: '$plainProp' }) reactiveConfigProp!: WireValue;
+    @wire(FakeWireAdapter, { config: 'config' } as const) baseConstConfigProp!: WireValue;
+    @wire(FakeWireAdapter, { config: '$plainProp' } as const)
+    reactiveConstConfigProp!: WireValue;
+    // Possibly shouldn't be valid?
+    @wire(FakeWireAdapter) noConfigProp!: WireValue;
+    @wire(FakeWireAdapter, { config: 'config' }) baseConfigMethod(_: WireValue) {}
+    @wire(FakeWireAdapter, { config: '$plainProp' }) reactiveConfigMethod(_: WireValue) {}
+    @wire(FakeWireAdapter, { config: 'config' } as const) baseConstConfigMethod(_: WireValue) {}
+    @wire(FakeWireAdapter, { config: '$plainProp' } as const) reactiveConstConfigMethod(
+        _: WireValue
+    ) {}
+    // Possibly shouldn't be valid?
+    @wire(FakeWireAdapter) noConfigMethod(_value: WireValue) {}
 
     // Invalid cases
-    // @ts-expect-error prop type is `string` but the adapter needs `WireValue`
+    // @ts-expect-error because prop type is `string` but the adapter needs `WireValue`
     @wire(FakeWireAdapter, { config: 'config' }) wireWrongPropType!: 'wrong type';
-    // @ts-expect-error config type is `{wrong: string}` but the adapter needs `WireConfig`
+    // @ts-expect-error because config type is `{wrong: string}` but the adapter needs `WireConfig`
     @wire(FakeWireAdapter, { wrong: 'type' }) wireWrongConfig!: WireValue;
-    // @ts-expect-error prop type is `string` but the adapter needs `WireValue`
+    // @ts-expect-error because prop type is `string` but the adapter needs `WireValue`
     @wire(FakeWireAdapter, { config: 'config' }) wireWrongMethodSignature(_value: 'wrong type') {}
 }

--- a/packages/@lwc/integration-types/src/decorators.ts
+++ b/packages/@lwc/integration-types/src/decorators.ts
@@ -10,16 +10,32 @@
  * `true` and `false`, to validate that the method signatures work in both cases.
  */
 
-import { LightningElement, api, track, wire } from 'lwc';
+import { WireAdapter } from '@lwc/engine-core';
+import { LightningElement, WireAdapterConstructor, api, track, wire } from 'lwc';
 
-class FakeWireAdapter {
-    update() {}
+type WireConfig = { config: 'config' };
+type WireValue = { value: 'value' };
+type WireContext = { context: 'context' };
+
+const FakeWireAdapter = class FakeWireAdapter implements WireAdapter<WireConfig, WireContext> {
+    constructor(private cb: (value: WireValue) => void) {}
+    update(_cfg: WireConfig, _ctx: WireContext) {}
     connect() {}
     disconnect() {}
-}
+} satisfies WireAdapterConstructor<WireConfig, WireValue, WireContext>;
 
 export default class extends LightningElement {
+    // Valid cases
     @api apiProp?: string;
-    @wire(FakeWireAdapter, {}) wireProp?: number;
     @track trackedProp?: Record<string, unknown>;
+    @wire(FakeWireAdapter, { config: 'config' }) validWireProp!: WireValue;
+    @wire(FakeWireAdapter) validWireMethod(_value: WireValue) {}
+
+    // Invalid cases
+    // @ts-expect-error prop type is `string` but the adapter needs `WireValue`
+    @wire(FakeWireAdapter, { config: 'config' }) wireWrongPropType!: 'wrong type';
+    // @ts-expect-error config type is `{wrong: string}` but the adapter needs `WireConfig`
+    @wire(FakeWireAdapter, { wrong: 'type' }) wireWrongConfig!: WireValue;
+    // @ts-expect-error prop type is `string` but the adapter needs `WireValue`
+    @wire(FakeWireAdapter, { config: 'config' }) wireWrongMethodSignature(_value: 'wrong type') {}
 }


### PR DESCRIPTION
## Details

When using a wire adapter (e.g. `@wire(getData) data: Type`), the type of the decorator returned by `@wire()` does not include any type information from the adapter provided, and therefore no type checking can be done to ensure that the adapter is providing the type that the prop expects. For example, `@wire(getString) prop: number` would not result in a type error, even though it should. This PR fixes that.

This also provides limited type checking that the config passed to `@wire` matches the config expected by the adapter. If the value of a prop is a string (e.g. `@wire(getData, {val: '$prop'})`), we know that the value used by the adapter is a value from the component, so we opt out of type checking strings.<sup>1</sup> But all other values work as expected.

### Known limitations

* Due to the way TypeScript works, the type of the prop cannot be inferred from the decorator (it's the other way around - the decorator type is derived from the prop).
* TypeScript doesn't know about the LWC component lifecycle. It expects all properties to be initialized in the constructor or with a default value, unless `undefined` is a valid type. In practice, this means that all `@wire`-decorated properties will need to use a non-null assertion (e.g. `@wire(getData) data!: Type`), mark the property as optional, or assign a default value that gets overwritten.

<sup>1</sup> If we decide to drop support for experimental decorators, modern decorators have access to the component type, so we _could_ resolve reactive props to the correct type from the component.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

If you're using `@wire` incorrectly in a TypeScript project, you'll now see a type error.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-16314799