### PR TITLE
feat: add flag to disable synthetic shadow

### DIFF
--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -511,6 +511,8 @@ function computeShadowMode(
         // on, but components running in actual native shadow mode
         (process.env.NODE_ENV === 'test-karma-lwc' &&
             process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST) ||
+        // If synthetic shadow is explicitly disabled, use pure-native
+        lwcRuntimeFlags.DISABLE_SYNTHETIC_SHADOW ||
         // hydration only supports native shadow
         isTrue(hydrated)
     ) {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -19,6 +19,7 @@ const features: FeatureFlagMap = {
     ENABLE_LEGACY_SCOPE_TOKENS: null,
     ENABLE_FORCE_SHADOW_MIGRATE_MODE: null,
     ENABLE_EXPERIMENTAL_SIGNALS: null,
+    DISABLE_SYNTHETIC_SHADOW: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -69,6 +69,12 @@ export interface FeatureFlagMap {
      * If true, allows the engine to expose reactivity to signals as describe in @lwc/signals.
      */
     ENABLE_EXPERIMENTAL_SIGNALS: FeatureFlagValue;
+
+    /**
+     * If true, ignore `@lwc/synthetic-shadow` even if it's loaded on the page. Instead, run all components in
+     * native shadow mode.
+     */
+    DISABLE_SYNTHETIC_SHADOW: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/index.spec.js
@@ -1,0 +1,31 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import { IS_SYNTHETIC_SHADOW_LOADED, isSyntheticShadowRootInstance } from 'test-utils';
+import Component from 'x/component';
+
+if (IS_SYNTHETIC_SHADOW_LOADED && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST) {
+    describe('DISABLE_SYNTHETIC_SHADOW', () => {
+        describe('flag disabled', () => {
+            it('renders synthetic shadow', () => {
+                const elm = createElement('x-component', { is: Component });
+                document.body.appendChild(elm);
+                expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(true);
+            });
+        });
+
+        describe('flag enabled', () => {
+            beforeEach(() => {
+                setFeatureFlagForTest('DISABLE_SYNTHETIC_SHADOW', true);
+            });
+
+            afterEach(() => {
+                setFeatureFlagForTest('DISABLE_SYNTHETIC_SHADOW', false);
+            });
+
+            it('renders native shadow', () => {
+                const elm = createElement('x-component', { is: Component });
+                document.body.appendChild(elm);
+                expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(false);
+            });
+        });
+    });
+}

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -27,8 +27,8 @@ const { ROLLUP_WATCH: watchMode } = process.env;
 const formats = ['es', 'cjs'];
 
 if (packageName === '@lwc/synthetic-shadow') {
-    // Here we wrap all of synthetic shadow in a check for lwcRuntimeFlags.ENABLE_FORCE_SHADOW_MIGRATE_MODE, so
-    // that synthetic shadow is not loaded at all if the flag is in effect.
+    // Here we wrap all of synthetic shadow in a check for lwcRuntimeFlags.ENABLE_FORCE_SHADOW_MIGRATE_MODE and
+    // lwcRuntimeFlags.DISABLE_SYNTHETIC_SHADOW, so that synthetic shadow is not loaded if either flag is set.
     // Note that lwcRuntimeFlags must be referenced as a pure global, or else string replacement in ESBuild
     // will not work. But we also have to check to make sure that lwcRuntimeFlags is defined, so this
     // `Object.defineProperty` code is copied from @lwc/features itself.
@@ -36,7 +36,7 @@ if (packageName === '@lwc/synthetic-shadow') {
     if (!globalThis.lwcRuntimeFlags) {
       Object.defineProperty(globalThis, 'lwcRuntimeFlags', { value: Object.create(null) });
     }
-    if (!lwcRuntimeFlags.ENABLE_FORCE_SHADOW_MIGRATE_MODE) {
+    if (!lwcRuntimeFlags.ENABLE_FORCE_SHADOW_MIGRATE_MODE && !lwcRuntimeFlags.DISABLE_SYNTHETIC_SHADOW) {
     `
         .replaceAll(/\n {4}/g, '\n')
         .trimEnd();


### PR DESCRIPTION
## Details

Today, you can simply not import `@lwc/synthetic-shadow` and you'll run in pure-native-shadow mode. However, if `@lwc/synthetic-shadow` is loaded, then there's no way to switch back to a pure-native-shadow mode.

In some environments though (notably core), it would be convenient to have a runtime flag that can toggle this behavior on-demand, regardless of whether `@lwc/synthetic-shadow` was previously loaded or not. This PR accomplishes that via a new `lwcRuntimeFlags` prop.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
