### PR TITLE
fix(rollup-plugin): add `@lwc/shared` dep

### DIFF
--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
         "@lwc/compiler": "7.2.0",
         "@lwc/module-resolver": "7.2.0",
+        "@lwc/shared": "7.2.0",
         "@rollup/pluginutils": "~5.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## Details

Somehow, we managed to miss the fact that `@lwc/rollup-plugin` has an implicit dep on `@lwc/shared`:

https://github.com/salesforce/lwc/blob/58ac746ec5cb8052acca84c0f3f04972c92d39cf/packages/%40lwc/rollup-plugin/src/index.ts#L15

This fixes that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
