### PR TITLE
test: add html coverage reporter

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -41,7 +41,14 @@ export default defineConfig({
                 lines: 95,
                 statements: 95,
             },
-            reporter: ['clover', 'json', 'lcov', 'text', ['text', { file: 'coverage.txt' }]],
+            reporter: [
+                'clover',
+                'html',
+                'json',
+                'lcov',
+                'text',
+                ['text', { file: 'coverage.txt' }],
+            ],
         },
     },
 });


### PR DESCRIPTION
## Details

Enables the HTML reporter. This allows coverage to be reported when running `yarn test --ui --coverage`:

![Screenshot 2024-07-29 at 3 12 01 PM](https://github.com/user-attachments/assets/75034fe8-9a5d-43ce-bada-86c63fcf923d)


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
