### PR TITLE
test(integration-karma): test bare decorator APIs

### DIFF
--- a/packages/@lwc/integration-karma/test/api/decorators/facade.js
+++ b/packages/@lwc/integration-karma/test/api/decorators/facade.js
@@ -1,0 +1,1 @@
+export { api, track, wire } from 'lwc';

--- a/packages/@lwc/integration-karma/test/api/decorators/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/decorators/index.spec.js
@@ -1,0 +1,38 @@
+// This facade is used because the compiler will throw `IS_NOT_DECORATOR` if it detects a decorator
+// imported from 'lwc' used as a non-decorator. But it can't detect when those same functions are
+// re-exported from a facade!
+import { api, track, wire } from './facade.js';
+
+describe('decorator APIs used as non-decorators', () => {
+    it('api() throws error', () => {
+        expect(api).toThrowError(/@api decorator can only be used as a decorator function/);
+    });
+
+    it('wire() throws error', () => {
+        expect(wire).toThrowError(/@wire\(adapter, config\?\) may only be used as a decorator/);
+    });
+
+    it('track() throws error when passed arguments !== 1', () => {
+        const funcs = [
+            () => track(),
+            () => track('foo', 'bar'),
+            () => track('foo', undefined),
+            () => track('foo', 'bar', 'baz'),
+            () => track('foo', undefined, 'baz'),
+        ];
+
+        for (const func of funcs) {
+            expect(func).toThrowError(
+                /@track decorator can only be used with one argument to return a trackable object, or as a decorator function/
+            );
+        }
+    });
+
+    it('track() returns reactive proxy when passed exactly 1 arg', () => {
+        const obj = { foo: 'bar' };
+        const proxy = track(obj);
+
+        expect(proxy.foo).toBe('bar');
+        expect(proxy).not.toBe(obj);
+    });
+});


### PR DESCRIPTION
## Details

Tests using the `api`/`track`/`wire` APIs directly, not as decorators.

I'm not sure who in their right mind would do this, and it requires elaborate workarounds, but the point of this PR is to add test coverage to assert the API surface that we are effectively declaring.

See discussion in https://github.com/salesforce/lwc/pull/4429/files#r1702349234

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
