### PR TITLE
[DO NOT MERGE] Trigger CI for #4435: test: remove remaining vestiges of jest types 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ yarn dev
 
 ### Unit Testing LWC
 
-When developing LWC, utilize [jest](https://jestjs.io/en/) unit testing to provide test coverage for new functionality. To run the jest tests use the following command from the root directory:
+When developing LWC, utilize [vitest](https://vitest.dev/) unit testing to provide test coverage for new functionality. To run the vitest tests use the following command from the root directory:
 
 ```bash
 yarn test
@@ -84,11 +84,11 @@ If you want to debug these tests, you can do as follow:
 3. Click on "Open dedicated DevTools for Node"
 4. In your terminal, type the following command: `yarn test:debug <path_to_test>`
 
-Your test should now be running in the Chrome debugger which you can use to poke around and explore. Now simply hit Enter in the terminal running your Jest process anytime you want to re-run your currently selected specs. You'll be dropped right back into the Chrome debugger.
+Your test should now be running in the Chrome debugger which you can use to poke around and explore. Now simply hit Enter in the terminal running your Vitest process anytime you want to re-run your currently selected specs. You'll be dropped right back into the Chrome debugger.
 
 ### Debugging Test Fixtures LWC
 
-Test fixtures are file-based tests that are executed using a helper called [`testFixtureDir`](./scripts/jest/utils/test-fixture-dir.ts). Because this helper does not list tests individually, jest's [`test.only`](https://jestjs.io/docs/api#testonlyname-fn-timeout) and [`test.skip`](https://jestjs.io/docs/api#testskipname-fn) cannot be used. Instead, to achieve the same behavior, "directive" files can be added to individual test fixtures. If a file called `.only` is found in a test fixture, that test will use `test.only`. Similarly, if a file called `.skip` is found, `test.skip` will be used.
+Test fixtures are file-based tests that are executed using a helper called [`testFixtureDir`](./scripts/test-utils/test-fixture-dir.ts). Because this helper does not list tests individually, vitest's [`test.only`](https://vitest.dev/api/#test-only) and [`test.skip`](https://vitest.dev/api/#test-skip) cannot be used. Instead, to achieve the same behavior, "directive" files can be added to individual test fixtures. If a file called `.only` is found in a test fixture, that test will use `test.only`. Similarly, if a file called `.skip` is found, `test.skip` will be used.
 
 ### Integration Testing LWC
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "release:version": "./scripts/release/version.js"
     },
     "//": {
-        "prettier": "v3 requires ESM, and we use prettier in our Jest tests. Jest does not support ESM yet."
+        "prettier": "Outdated since Jest has been replaced with vitest: v3 requires ESM, and we use prettier in our Jest tests. Jest does not support ESM yet."
     },
     "devDependencies": {
         "@commitlint/cli": "^19.3.0",

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -32,7 +32,7 @@ function log(method: 'warn' | 'error', message: string, vm: VM | undefined, once
         alreadyLoggedMessages.add(msg);
     }
 
-    // In Jest tests, reduce the warning and error verbosity by not printing the callstack
+    // In Vitest tests, reduce the warning and error verbosity by not printing the callstack
     if (process.env.NODE_ENV === 'test') {
         /* eslint-disable-next-line no-console */
         console[method](msg);

--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
+import { it } from 'vitest';
 import { renderComponent, LightningElement } from '../index';
 
 class Test extends LightningElement {}

--- a/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
+++ b/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it } from 'vitest';
 import * as errorInfo from '../error-info';
-
 // All exported objects are maps of label/error info, except for GENERIC_COMPILER_ERROR,
 // which is a top-level error info object
 const { GENERIC_COMPILER_ERROR, ...errors } = errorInfo;

--- a/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
+++ b/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
@@ -14,7 +14,7 @@ const errorInfoMatcher = {
     code: expect.any(Number),
     message: expect.any(String),
     url: expect.any(String),
-    // Technically not *any* number, but jest doesn't have oneOf
+    // Technically not *any* number, but vitest doesn't have oneOf
     level: expect.any(Number),
 };
 

--- a/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-code.ts
+++ b/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-code.ts
@@ -5,11 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import diff from 'jest-diff';
-import MatcherUtils = jest.MatcherUtils;
+import diff from '@vitest/utils/diff';
+import type { MatcherState } from '@vitest/expect';
 
 export function toThrowErrorWithCode(
-    this: MatcherUtils,
+    this: MatcherState,
     received: any,
     code: string,
     message?: string

--- a/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-type.ts
+++ b/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-type.ts
@@ -5,11 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import diff from 'jest-diff';
-import MatcherUtils = jest.MatcherUtils;
+import diff from '@vitest/utils/diff';
+import type { MatcherState } from '@vitest/expect';
 
 export function toThrowErrorWithType(
-    this: MatcherUtils,
+    this: MatcherState,
     received: any,
     ctor: any,
     message?: string

--- a/packages/@lwc/module-resolver/scripts/test/types.ts
+++ b/packages/@lwc/module-resolver/scripts/test/types.ts
@@ -4,15 +4,16 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export {}; // required to have a module with just `declare global` in it
+// export {}; // required to have a module with just `declare vitest` in it
 
-declare global {
-    // eslint-disable-next-line @typescript-eslint/no-namespace
-    namespace jest {
-        interface Matchers<R> {
-            __type: R; // unused, but makes TypeScript happy
-            toThrowErrorWithCode(received: any, ctor: any, message?: string): CustomMatcherResult;
-            toThrowErrorWithType(received: any, ctor: any, message?: string): CustomMatcherResult;
-        }
-    }
+import 'vitest';
+
+interface CustomMatchers<R = unknown> {
+    toThrowErrorWithCode: (received: any, ctor: any, message?: string) => R;
+    toThrowErrorWithType: (received: any, ctor: any, message?: string) => R;
+}
+
+declare module 'vitest' {
+    interface Assertion<T = any> extends CustomMatchers<T> {}
+    interface AsymmetricMatchersContaining extends CustomMatchers {}
 }

--- a/packages/@lwc/module-resolver/scripts/test/types.ts
+++ b/packages/@lwc/module-resolver/scripts/test/types.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-// export {}; // required to have a module with just `declare vitest` in it
-
+/// <reference types="vitest/globals" />
 import 'vitest';
 
 interface CustomMatchers<R = unknown> {

--- a/packages/@lwc/shared/src/__tests__/html-attributes.spec.ts
+++ b/packages/@lwc/shared/src/__tests__/html-attributes.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { test } from 'vitest';
 import { htmlPropertyToAttribute, kebabCaseToCamelCase } from '../html-attributes';
 
 type StringPair = [prop: string, attr: string];

--- a/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
@@ -25,7 +25,7 @@ describe('customRendererConfig normalization', () => {
             },
         });
         expect(normalizedConfig.apiVersion).toBe(HIGHEST_API_VERSION);
-        normalizedConfig.apiVersion = -1; // avoid testing in inline snapshot so that Jest can easily update it
+        normalizedConfig.apiVersion = -1; // avoid testing in inline snapshot so that vitest can easily update it
 
         expect(normalizedConfig).toMatchInlineSnapshot(`
             {

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -21,6 +21,7 @@ const expectExportDefaultFromPackageInFile = (pkgName: string, ext: string) => {
 };
 
 /*
+ * This comment needs to be updated:
  * Jest uses CommonJS, which means that packages with no explicit export statements actually export
  * the default `module.exports` empty object. That export is an empty object with the prototype set
  * to an empty object with null prototype.
@@ -60,6 +61,7 @@ describe('default exports are not forgotten', () => {
             'dist/index.js'
         );
         const realModule = await import(pathToEsmDistFile);
+        // The commend below needs to be updated:
         // When jest properly supports ESM, this will be a lot simpler
         // const aliasedModule = await import(`lwc/${pkg}`);
         // expect(aliasedModule.default).toBe(realModule.default);

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -6,6 +6,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { test } from 'vitest';
 
 const PACKAGE_ROOT = path.join(__dirname, '..');
 

--- a/packages/lwc/__tests__/package-exports.spec.ts
+++ b/packages/lwc/__tests__/package-exports.spec.ts
@@ -6,6 +6,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { test } from 'vitest';
 
 /** Packages that only contain type definitions, no JavaScript. */
 const tsPackages = ['@lwc/types'];

--- a/scripts/test-utils/index.ts
+++ b/scripts/test-utils/index.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import './matchers'; // File has no exports, but registers jest matchers
+import './matchers'; // File has no exports, but registers vitest matchers
 export * from './test-fixture-dir';
 export * from './format-html';

--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -13,13 +13,13 @@ const { globSync } = glob;
 type TestFixtureOutput = { [filename: string]: unknown };
 
 /**
- * Facilitates the use of jest's `test.only`/`test.skip` in fixture files.
+ * Facilitates the use of vitest's `test.only`/`test.skip` in fixture files.
  * @param dirname fixture directory to check for "directive" files
  * @returns `test.only` if `.only` exists, `test.skip` if `.skip` exists, otherwise `test`
  * @throws if you have both `.only` and `.skip` in the directory
  * @example getTestFunc('/fixtures/some-test')
  */
-function getTestFunc(dirname: string): jest.It {
+function getTestFunc(dirname: string) {
     const isOnly = fs.existsSync(path.join(dirname, '.only'));
     const isSkip = fs.existsSync(path.join(dirname, '.skip'));
     if (isOnly && isSkip) {


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4435.