### PR TITLE
chore: fix type errors in test files during dev

### DIFF
--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -22,6 +22,8 @@ interface CustomMatchers<R = unknown> {
     toBeInRange: (range: { min: number; max: number }, key: string) => R;
 }
 
+import 'vitest';
+
 declare module 'vitest' {
     interface Assertion<T = any> extends CustomMatchers<T> {}
     interface AsymmetricMatchersContaining extends CustomMatchers {}

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -60,6 +60,7 @@ function sharedPlugins() {
     return [
         typescript({
             tsconfig: path.join(packageRoot, 'tsconfig.json'),
+            exclude: ['**/__tests__/**'],
             noEmitOnError: !watchMode, // in watch mode, do not exit with an error if typechecking fails
             ...(watchMode && {
                 incremental: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
         "noEmit": true
     },
 
-    "exclude": ["**/__tests__"]
+    "exclude": []
 }


### PR DESCRIPTION
This makes sure vscode picks up vitest/globals.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
