### PR TITLE
chore(dependabot): add groups, remove outdated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,22 @@ updates:
       schedule:
           interval: 'weekly'
       groups:
+          babel:
+              patterns:
+                  - '@babel/*'
+          best:
+              patterns:
+                  - '@best/*'
+          rollup:
+              patterns:
+                  - 'rollup'
+                  - '@rollup/*'
+          webdriverio:
+              patterns:
+                  - '@wdio/*'
           # Non-major version bumps hopefully shouldn't break anything,
           # so let's group them together into a single PR!
           theoretically-non-breaking:
               update-types:
                   - 'minor'
                   - 'patch'
-      ignore:
-          # We are pinned to Tachometer 0.5.10 due to a breaking change in 0.6.0.
-          # See: https://github.com/google/tachometer/issues/244
-          - dependency-name: 'tachometer'
-          # TODO [#4386]: Stop ignoring when we've done the upgrade ourselves
-          - dependency-name: 'prettier'
-            versions: '>= 3'
-          - dependency-name: '@types/prettier'
-            versions: '>= 3'


### PR DESCRIPTION
## Details

Deps that are similar like Best and WebdriverIO should be updated together. Also Tachometer and Prettier don't need to be pinned anymore.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
