### PR TITLE
chore(dependabot): add bare package names, nx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
               patterns:
                   - 'best'
                   - '@best/*'
+          nx:
+              patterns:
+                  - 'nx'
+                  - '@nx/*'
           rollup:
               patterns:
                   - 'rollup'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
                   - '@babel/*'
           best:
               patterns:
+                  - 'best'
                   - '@best/*'
           rollup:
               patterns:
@@ -20,6 +21,7 @@ updates:
                   - '@rollup/*'
           webdriverio:
               patterns:
+                  - 'webdriverio'
                   - '@wdio/*'
           # Non-major version bumps hopefully shouldn't break anything,
           # so let's group them together into a single PR!


### PR DESCRIPTION
## Details

Missed this in #4466. `webdriverio` in particular needs to be included with `@wdio/*`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
