### PR TITLE
chore: restore `release:version` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test:performance:best": "nx test:best @lwc/perf-benchmarks",
         "test:performance:best:ci": "nx test:best:ci @lwc/perf-benchmarks",
         "test:types": "nx test @lwc/integration-types",
-        "release:version": "nx release version",
+        "release:version": "node ./scripts/release/version.js",
         "release:publish": "nx release publish --registry https://registry.npmjs.org"
     },
     "devDependencies": {

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,12 @@
+# Release Scripts
+
+## `yarn release:version`
+
+This script is used to generate a release commit that updates the version of all packages in this
+monorepo. The version number should be specified through the interactive prompt.
+
+The release commit is generated locally, along with a git tag.
+
+:rotating_light: Please avoid pushing prerelease git tags such as `alpha`. These tags usually
+point to commits that are not guaranteed to exist at a later time due to squashed merges or
+deleted branches.

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+const { globSync } = require('glob');
+
+(async () => {
+    const newVersion = await promptVersion();
+    updatePackages(newVersion);
+})().catch(console.error);
+
+async function promptVersion() {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    try {
+        const answer = await new Promise((resolve) =>
+            rl.question('Enter a new LWC version: ', resolve)
+        );
+        return answer;
+    } catch (error) {
+        console.error(error);
+        process.exit(1);
+    } finally {
+        rl.close();
+    }
+}
+
+function updatePackages(newVersion) {
+    try {
+        const packagesToUpdate = getPackagesToUpdate();
+        const workspacesPackageJson = new Set(
+            packagesToUpdate.map(({ packageJson }) => packageJson.name)
+        );
+
+        for (const { packageJson } of packagesToUpdate) {
+            packageJson.version = newVersion;
+            // Look for different types of dependencies
+            // ex: dependencies, devDependencies, peerDependencies
+            const pkgDependencyTypes = Object.keys(packageJson).filter((key) =>
+                key.match(/.*[dD]ependencies/)
+            );
+            // Update dependencies in package.json
+            for (const pkgDependencyType of pkgDependencyTypes) {
+                for (const pkgDepName of Object.keys(packageJson[pkgDependencyType])) {
+                    if (workspacesPackageJson.has(pkgDepName)) {
+                        // ex: packageJson[devDependencies][@lwc/template-compiler]
+                        packageJson[pkgDependencyType][pkgDepName] = newVersion;
+                    }
+                }
+            }
+        }
+
+        // Update package.json files and print updated packges
+        for (const { originalVersion, packageJson, packageJsonPath } of packagesToUpdate) {
+            fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4) + '\n');
+            console.log(
+                `Updated ${packageJson.name} from ${originalVersion} to ${packageJson.version}`
+            );
+        }
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+function getPackagesToUpdate() {
+    const rootPath = path.resolve(__dirname, '../../');
+    const rootPackageJsonPath = `${rootPath}/package.json`;
+    const rootPackageJson = JSON.parse(fs.readFileSync(rootPackageJsonPath, 'utf-8'));
+    const packagesToUpdate = [];
+
+    const workspacePkgs = rootPackageJson.workspaces.reduce(
+        (accWorkspacePkgs, workspace) => {
+            const workspacePkg = globSync(`${workspace}/package.json`);
+            return [...accWorkspacePkgs, ...workspacePkg];
+        },
+        [rootPackageJsonPath]
+    );
+
+    for (const pkgName of workspacePkgs) {
+        const packageJsonPath = path.resolve(rootPath, pkgName);
+        if (fs.existsSync(packageJsonPath)) {
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+            packagesToUpdate.push({
+                originalVersion: packageJson.version,
+                packageJsonPath,
+                packageJson,
+            });
+        }
+    }
+
+    return packagesToUpdate;
+}


### PR DESCRIPTION
## Details

Unfortunately, it turns out that #4445 regressed the `release:version` script. It no longer updates the version in the root (monorepo) `package.json`, and more importantly, doesn't bump the versions in private packages like `@lwc/integration-tests`. I opened a discussion on NX about this: https://github.com/nrwl/nx/discussions/27566

In the meantime, we should revert to the old `release:version` script. Otherwise our tests will be running against old versions pulled from npm rather than the local versions of the code!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
