### PR TITLE
test(integration-karma): add listener memoization tests

### DIFF
--- a/packages/@lwc/integration-karma/test/events/memoization/index.spec.js
+++ b/packages/@lwc/integration-karma/test/events/memoization/index.spec.js
@@ -31,6 +31,7 @@ describe('deep listener', () => {
 
     // In this case, the click listener is re-bound on every render, because the referenced
     // listener is scoped inside a <template for:each>
+    // TODO [#4467]: consider optimizing locally-scoped listeners
     it('does redefine the onClick for a list of deep click listeners', async () => {
         const elm = createElement('x-list', { is: List });
         document.body.appendChild(elm);

--- a/packages/@lwc/integration-karma/test/events/memoization/index.spec.js
+++ b/packages/@lwc/integration-karma/test/events/memoization/index.spec.js
@@ -1,0 +1,48 @@
+import { createElement } from 'lwc';
+import Deep from 'x/deep';
+import List from 'x/list';
+
+describe('deep listener', () => {
+    beforeEach(() => {
+        window.clickBuffer = [];
+    });
+
+    afterEach(() => {
+        delete window.clickBuffer;
+    });
+
+    // In this case, `logger.onClick` is never re-bound because the `logger` is
+    // scoped to the component, so the event listener memoization optimization causes
+    // the listener to be bound once and never redefined
+    it('does not redefine the onClick for a single deep listener', async () => {
+        const elm = createElement('x-deep', { is: Deep });
+        document.body.appendChild(elm);
+
+        elm.logger = { onClick: () => window.clickBuffer.push(1) }; // never called
+        await Promise.resolve();
+        elm.shadowRoot.querySelector('button').click();
+        expect(window.clickBuffer).toEqual([0]);
+
+        elm.logger = { onClick: () => window.clickBuffer.push(2) }; // never called
+        await Promise.resolve();
+        elm.shadowRoot.querySelector('button').click();
+        expect(window.clickBuffer).toEqual([0, 0]);
+    });
+
+    // In this case, the click listener is re-bound on every render, because the referenced
+    // listener is scoped inside a <template for:each>
+    it('does redefine the onClick for a list of deep click listeners', async () => {
+        const elm = createElement('x-list', { is: List });
+        document.body.appendChild(elm);
+
+        elm.loggers = [{ id: 1, onClick: () => window.clickBuffer.push(1) }];
+        await Promise.resolve();
+        elm.shadowRoot.querySelector('button').click();
+        expect(window.clickBuffer).toEqual([1]);
+
+        elm.loggers = [{ id: 2, onClick: () => window.clickBuffer.push(2) }];
+        await Promise.resolve();
+        elm.shadowRoot.querySelector('button').click();
+        expect(window.clickBuffer).toEqual([1, 2]);
+    });
+});

--- a/packages/@lwc/integration-karma/test/events/memoization/x/deep/deep.html
+++ b/packages/@lwc/integration-karma/test/events/memoization/x/deep/deep.html
@@ -1,0 +1,3 @@
+<template>
+    <button onclick={logger.onClick}></button>
+</template>

--- a/packages/@lwc/integration-karma/test/events/memoization/x/deep/deep.js
+++ b/packages/@lwc/integration-karma/test/events/memoization/x/deep/deep.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api logger = {
+        onClick() {
+            window.clickBuffer.push(0);
+        },
+    };
+}

--- a/packages/@lwc/integration-karma/test/events/memoization/x/list/list.html
+++ b/packages/@lwc/integration-karma/test/events/memoization/x/list/list.html
@@ -1,0 +1,5 @@
+<template>
+    <template for:each={loggers} for:item="logger">
+        <button key={logger.id} onclick={logger.onClick}></button>
+    </template>
+</template>

--- a/packages/@lwc/integration-karma/test/events/memoization/x/list/list.js
+++ b/packages/@lwc/integration-karma/test/events/memoization/x/list/list.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api loggers = [];
+}


### PR DESCRIPTION
## Details

This adds Karma tests for event listener memoization, which came up when I was reviewing #4468.

This behavior is a little subtle, and previously we were only really testing it in the template-compiler snapshot tests here:

https://github.com/salesforce/lwc/blob/39af4df1fd18d2d4835fcc532795b9b65e1ba23b/packages/%40lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/actual.html#L4-L9

Adding the test ensures we don't regress the current functionality.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
