### PR TITLE
test(engine-server): assert HMR not supported

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/unsupported-apis.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/unsupported-apis.spec.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { swapComponent, swapStyle, swapTemplate } from '../index';
+
+it('throws error for swapComponent', () => {
+    expect(swapComponent).toThrow(
+        /swapComponent is not supported in @lwc\/engine-server, only @lwc\/engine-dom/
+    );
+});
+
+it('throws error for swapStyle', () => {
+    expect(swapStyle).toThrow(
+        /swapStyle is not supported in @lwc\/engine-server, only @lwc\/engine-dom/
+    );
+});
+
+it('throws error for swapTemplate', () => {
+    expect(swapTemplate).toThrow(
+        /swapTemplate is not supported in @lwc\/engine-server, only @lwc\/engine-dom/
+    );
+});


### PR DESCRIPTION
## Details

Improves our test coverage on `@lwc/engine-server`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

