### PR TITLE
fix: require Node v18+

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '20.12.2'
+                  node-version: '18.0.0'
                   cache: 'yarn'
 
             - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '20.12.2'
+                  node-version: '18.0.0'
                   cache: 'yarn'
 
             # Needed for local browser integration tests

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -22,7 +22,7 @@ env:
     PUPPETEER_SKIP_DOWNLOAD: 'true' # only needed for @best/runner-local, unused here
     GITHUB_RUN_ID: ${{github.run_id}}
     COVERAGE: '1'
-    NODE_VERSION: '20.12.2'
+    NODE_VERSION: '18.0.0'
 
 jobs:
     run-karma-tests-group-1:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '20.12.2'
+                  node-version: '18.0.0'
                   cache: 'yarn'
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)

--- a/package.json
+++ b/package.json
@@ -87,11 +87,8 @@
         "packages/lwc",
         "playground"
     ],
-    "engines": {
-        "node": ">=10"
-    },
     "volta": {
-        "node": "20.12.2",
+        "node": "22.7.0",
         "yarn": "1.22.22"
     },
     "resolutions": {

--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -26,6 +26,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/signals/package.json
+++ b/packages/@lwc/signals/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -24,6 +24,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/ssr-runtime/package.json
+++ b/packages/@lwc/ssr-runtime/package.json
@@ -24,6 +24,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/@lwc/types/package.json
+++ b/packages/@lwc/types/package.json
@@ -24,6 +24,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "types": "index.d.ts",
     "files": [
         "*.d.ts"

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -22,6 +22,9 @@
     "publishConfig": {
         "access": "public"
     },
+    "engines": {
+        "node": ">=18"
+    },
     "main": "dist/index.cjs.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/scripts/tasks/check-and-rewrite-package-json.js
+++ b/scripts/tasks/check-and-rewrite-package-json.js
@@ -106,6 +106,9 @@ for (const dir of globSync('./packages/@lwc/*')) {
         bugs: { url: 'https://github.com/salesforce/lwc/issues' },
         license: 'MIT',
         publishConfig: { access: 'public' },
+        engines: {
+            node: '>=18',
+        },
         ...buildProps,
         dependencies,
         devDependencies,


### PR DESCRIPTION
## Details

BREAKING CHANGE: require Node v18+.

Node 18 will be [supported](https://nodejs.org/en/about/previous-releases) until April 2025.

This also updates our CI tests to test in the earliest version of Node that we can possibly support.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
