### PR TITLE
chore(integration-karma): add @types/jasmine

### DIFF
--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -22,6 +22,7 @@
         "@lwc/engine-server": "7.2.2",
         "@lwc/rollup-plugin": "7.2.2",
         "@lwc/synthetic-shadow": "7.2.2",
+        "@types/jasmine": "^5.1.4",
         "chokidar": "^3.6.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,6 +2971,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jasmine@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-5.1.4.tgz#0de3f6ca753e10d1600ce1864ae42cfd47cf9924"
+  integrity sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"


### PR DESCRIPTION
## Details

I noticed there was no autocompletion or hover information for jasmine's expect, spyOn, etc, which makes it harder for someone unfamiliar with jasmine like myself.

This PR just adds the @type/jasmine dev dependency to @lwc/integration-karma. It doesn't seem to affect tests in other packages, but I recommend giving it a try before merging.

I understand karma is to be replaced at some point, but in the meanwhile it's nice to have this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
