### PR TITLE
fix(template-compiler): escape tag names

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
@@ -23,6 +23,7 @@ const {
     API_VERSION,
     DISABLE_SYNTHETIC,
     DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
+    DISABLE_STATIC_CONTENT_OPTIMIZATION,
 } = require('../shared/options');
 
 const DIST_DIR = path.resolve(__dirname, '../../dist');
@@ -39,6 +40,7 @@ function createEnvFile() {
         globalThis.process = {
             env: {
                 API_VERSION: ${JSON.stringify(API_VERSION)},
+                DISABLE_STATIC_CONTENT_OPTIMIZATION: ${DISABLE_STATIC_CONTENT_OPTIMIZATION},
                 ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL: ${ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL},
                 ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION: ${ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION},
                 FORCE_NATIVE_SHADOW_MODE_FOR_TEST: ${FORCE_NATIVE_SHADOW_MODE_FOR_TEST},

--- a/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
@@ -3,7 +3,7 @@ import { catchUnhandledRejectionsAndErrors } from 'test-utils';
 import Component from 'x/component';
 
 // Browsers treat tag names containing the \ (backslash) character differently
-// depending on whether the HTML is parsed or you call `setAttribute` directly.
+// depending on whether the HTML is parsed or you call `createElement` directly.
 //
 // Succeeds:
 //

--- a/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
@@ -1,0 +1,47 @@
+import { createElement } from 'lwc';
+import { catchUnhandledRejectionsAndErrors } from 'test-utils';
+import Component from 'x/component';
+
+// Browsers treat tag names containing the \ (backslash) character differently
+// depending on whether the HTML is parsed or you call `setAttribute` directly.
+//
+// Succeeds:
+//
+//     elm.innerHTML = '<s\ection></s\ection>'
+//
+// Fails with: Uncaught InvalidCharacterError: Failed to execute 'createElement' on 'Document': The tag name provided ('s\ection') is not a valid name.
+//
+//     document.createElement('s\\ection')
+//
+// Since the static content optimization only uses the first pattern and non-optimized only uses the second,
+// one case will work whereas the other will throw an error.
+//
+// Since using backslashes in attribute names is fairly useless, we do not attempt to smooth out this difference.
+
+let caughtError;
+
+catchUnhandledRejectionsAndErrors((error) => {
+    caughtError = error;
+});
+
+afterEach(() => {
+    caughtError = undefined;
+});
+
+it('should render tag names with proper escaping', async () => {
+    const elm = createElement('x-component', { is: Component });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    if (process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION) {
+        expect(elm.shadowRoot.children.length).toBe(0); // does not render
+        expect(caughtError).not.toBeUndefined();
+        expect(caughtError.message).toMatch(
+            /Failed to execute 'createElement'|Invalid qualified name|String contains an invalid character/
+        );
+    } else {
+        expect(elm.shadowRoot.children[0].tagName).toBe('S\\ECTION');
+        expect(caughtError).toBeUndefined();
+    }
+});

--- a/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-tag-name/index.spec.js
@@ -38,7 +38,7 @@ it('should render tag names with proper escaping', async () => {
         expect(elm.shadowRoot.children.length).toBe(0); // does not render
         expect(caughtError).not.toBeUndefined();
         expect(caughtError.message).toMatch(
-            /Failed to execute 'createElement'|Invalid qualified name|String contains an invalid character/
+            /Failed to execute 'createElement'|Invalid qualified name|String contains an invalid character|The string contains invalid characters/
         );
     } else {
         expect(elm.shadowRoot.children[0].tagName).toBe('S\\ECTION');

--- a/packages/@lwc/integration-karma/test/template/escape-tag-name/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/template/escape-tag-name/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <s\ection></s\ection>
+</template>

--- a/packages/@lwc/integration-karma/test/template/escape-tag-name/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/template/escape-tag-name/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/actual.html
@@ -1,0 +1,3 @@
+<template>
+    <s\ection></s\ection>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/ast.json
@@ -1,0 +1,66 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 12,
+            "start": 0,
+            "end": 48,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 3,
+                "startColumn": 1,
+                "endLine": 3,
+                "endColumn": 12,
+                "start": 37,
+                "end": 48
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Element",
+                "name": "s\\ection",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 26,
+                    "start": 15,
+                    "end": 36,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 15,
+                        "start": 15,
+                        "end": 25
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 15,
+                        "endLine": 2,
+                        "endColumn": 26,
+                        "start": 25,
+                        "end": 36
+                    }
+                },
+                "attributes": [],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/config.json
@@ -1,0 +1,3 @@
+{
+  "enableStaticContentOptimization": false
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/expected.js
@@ -1,0 +1,22 @@
+import _implicitStylesheets from "./non-optimized.css";
+import _implicitScopedStylesheets from "./non-optimized.scoped.css?scoped=true";
+import { freezeTemplate, registerTemplate } from "lwc";
+const stc0 = {
+  key: 0,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { h: api_element } = $api;
+  return [api_element("s\\ection", stc0)];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];
+tmpl.stylesheetToken = "lwc-71tdq7g4m0k";
+tmpl.legacyStylesheetToken = "x-non-optimized_non-optimized";
+if (_implicitStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+}
+if (_implicitScopedStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+}
+freezeTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1123,
+            "message": "LWC1123: Unknown html tag '<s\\ection>'. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element and https://developer.mozilla.org/en-US/docs/Web/SVG/Element",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 15,
+                "length": 21
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/actual.html
@@ -1,0 +1,3 @@
+<template>
+    <s\ection></s\ection>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/ast.json
@@ -1,0 +1,66 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 12,
+            "start": 0,
+            "end": 48,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 3,
+                "startColumn": 1,
+                "endLine": 3,
+                "endColumn": 12,
+                "start": 37,
+                "end": 48
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Element",
+                "name": "s\\ection",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 26,
+                    "start": 15,
+                    "end": 36,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 15,
+                        "start": 15,
+                        "end": 25
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 15,
+                        "endLine": 2,
+                        "endColumn": 26,
+                        "start": 25,
+                        "end": 36
+                    }
+                },
+                "attributes": [],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/config.json
@@ -1,0 +1,3 @@
+{
+  "enableStaticContentOptimization": true
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/expected.js
@@ -1,0 +1,20 @@
+import _implicitStylesheets from "./optimized.css";
+import _implicitScopedStylesheets from "./optimized.scoped.css?scoped=true";
+import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<s\\ection${3}></s\\ection>`;
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { st: api_static_fragment } = $api;
+  return [api_static_fragment($fragment1, 1)];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];
+tmpl.stylesheetToken = "lwc-6dfvqpqt2d0";
+tmpl.legacyStylesheetToken = "x-optimized_optimized";
+if (_implicitStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+}
+if (_implicitScopedStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+}
+freezeTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/metadata.json
@@ -1,0 +1,15 @@
+{
+    "warnings": [
+        {
+            "code": 1123,
+            "message": "LWC1123: Unknown html tag '<s\\ection>'. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element and https://developer.mozilla.org/en-US/docs/Web/SVG/Element",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 5,
+                "start": 15,
+                "length": 21
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -224,7 +224,10 @@ export function serializeStaticElement(element: StaticElement, codeGen: CodeGen)
     const isForeignElement = namespace !== HTML_NAMESPACE;
     const hasChildren = element.children.length > 0;
 
-    let html = `<${tagName}${serializeAttrs(element, codeGen)}`;
+    // See W-16469970
+    const escapedTagName = templateStringEscape(tagName);
+
+    let html = `<${escapedTagName}${serializeAttrs(element, codeGen)}`;
 
     if (isForeignElement && !hasChildren) {
         html += '/>';
@@ -237,7 +240,7 @@ export function serializeStaticElement(element: StaticElement, codeGen: CodeGen)
     html += serializeChildren(children, tagName, codeGen);
 
     if (!isVoidElement(tagName, namespace) || hasChildren) {
-        html += `</${tagName}>`;
+        html += `</${escapedTagName}>`;
     }
 
     return html;


### PR DESCRIPTION
## Details

Fixes an issue in the static content optimization where tag names are not properly escaped so may render invalid characters.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Only observable for odd characters like backslashes which are uncommonly (if ever) used.

<!-- If yes, please describe the anticipated observable changes. -->
