### PR TITLE
fix(template-compiler): escape attribute names

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/env.js
@@ -23,6 +23,7 @@ const {
     API_VERSION,
     DISABLE_SYNTHETIC,
     DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE,
+    DISABLE_STATIC_CONTENT_OPTIMIZATION,
 } = require('../shared/options');
 
 const DIST_DIR = path.resolve(__dirname, '../../dist');
@@ -39,6 +40,7 @@ function createEnvFile() {
         globalThis.process = {
             env: {
                 API_VERSION: ${JSON.stringify(API_VERSION)},
+                DISABLE_STATIC_CONTENT_OPTIMIZATION: ${DISABLE_STATIC_CONTENT_OPTIMIZATION},
                 ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL: ${ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL},
                 ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION: ${ENABLE_SYNTHETIC_SHADOW_IN_HYDRATION},
                 FORCE_NATIVE_SHADOW_MODE_FOR_TEST: ${FORCE_NATIVE_SHADOW_MODE_FOR_TEST},

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
@@ -1,0 +1,66 @@
+import { createElement } from 'lwc';
+import { catchUnhandledRejectionsAndErrors } from 'test-utils';
+import BooleanValue from 'x/booleanValue';
+import StringValue from 'x/stringValue';
+
+// Browsers treat attribute names containing the ` (backtick) character differently
+// depending on whether the HTML is parsed or you call `setAttribute` directly.
+//
+// Succeeds:
+//
+//     elm.innerHTML = '<div a`b`c></div>'
+//
+// Fails with: Uncaught InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': 'a`b`c' is not a valid attribute name.
+//
+//     elm.setAttribute(theName, 'a`b`c')
+//
+// Since the static content optimization only uses the first pattern and non-optimized only uses the second,
+// one case will work whereas the other will throw an error.
+//
+// Since using backticks in attribute names is fairly useless, we do not attempt to smooth out this difference.
+
+let caughtError;
+
+catchUnhandledRejectionsAndErrors((error) => {
+    caughtError = error;
+});
+
+afterEach(() => {
+    caughtError = undefined;
+});
+
+const scenarios = [
+    {
+        name: 'boolean-true-value',
+        expectedValue: '',
+        Ctor: BooleanValue,
+        tagName: 'x-boolean-value',
+    },
+    {
+        name: 'string-value',
+        expectedValue: 'yolo',
+        Ctor: StringValue,
+        tagName: 'x-string-value',
+    },
+];
+
+scenarios.forEach(({ name, expectedValue, Ctor, tagName }) => {
+    describe(name, () => {
+        it('should render attr names with proper escaping', async () => {
+            const elm = createElement(tagName, { is: Ctor });
+            document.body.appendChild(elm);
+
+            await Promise.resolve();
+            if (process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION) {
+                expect(elm.shadowRoot.children.length).toBe(0); // does not render
+                expect(caughtError).not.toBeUndefined();
+                expect(caughtError.message).toMatch(
+                    /Failed to execute 'setAttribute' on 'Element'|Invalid qualified name|String contains an invalid character/
+                );
+            } else {
+                expect(elm.shadowRoot.children[0].getAttribute('a`b`c')).toBe(expectedValue);
+                expect(caughtError).toBeUndefined();
+            }
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
@@ -55,7 +55,7 @@ scenarios.forEach(({ name, expectedValue, Ctor, tagName }) => {
                 expect(elm.shadowRoot.children.length).toBe(0); // does not render
                 expect(caughtError).not.toBeUndefined();
                 expect(caughtError.message).toMatch(
-                    /Failed to execute 'setAttribute' on 'Element'|Invalid qualified name|The string contains invalid characters/
+                    /Failed to execute 'setAttribute' on 'Element'|Invalid qualified name|String contains an invalid character|The string contains invalid characters/
                 );
             } else {
                 expect(elm.shadowRoot.children[0].getAttribute('a`b`c')).toBe(expectedValue);

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/index.spec.js
@@ -55,7 +55,7 @@ scenarios.forEach(({ name, expectedValue, Ctor, tagName }) => {
                 expect(elm.shadowRoot.children.length).toBe(0); // does not render
                 expect(caughtError).not.toBeUndefined();
                 expect(caughtError.message).toMatch(
-                    /Failed to execute 'setAttribute' on 'Element'|Invalid qualified name|String contains an invalid character/
+                    /Failed to execute 'setAttribute' on 'Element'|Invalid qualified name|The string contains invalid characters/
                 );
             } else {
                 expect(elm.shadowRoot.children[0].getAttribute('a`b`c')).toBe(expectedValue);

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/x/booleanValue/booleanValue.html
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/x/booleanValue/booleanValue.html
@@ -1,0 +1,3 @@
+<template>
+    <div a`b`c></div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/x/booleanValue/booleanValue.js
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/x/booleanValue/booleanValue.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/x/stringValue/stringValue.html
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/x/stringValue/stringValue.html
@@ -1,0 +1,3 @@
+<template>
+    <div a`b`c="yolo"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/template/escape-attr-name/x/stringValue/stringValue.js
+++ b/packages/@lwc/integration-karma/test/template/escape-attr-name/x/stringValue/stringValue.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <div a`b`c></div>
+    <div a`b`c="yolo"></div>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/ast.json
@@ -1,0 +1,134 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 12,
+            "start": 0,
+            "end": 73,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 4,
+                "startColumn": 1,
+                "endLine": 4,
+                "endColumn": 12,
+                "start": 62,
+                "end": 73
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 22,
+                    "start": 15,
+                    "end": 32,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 16,
+                        "start": 15,
+                        "end": 26
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 16,
+                        "endLine": 2,
+                        "endColumn": 22,
+                        "start": 26,
+                        "end": 32
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "a`b`c",
+                        "value": {
+                            "type": "Literal",
+                            "value": true
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 10,
+                            "endLine": 2,
+                            "endColumn": 15,
+                            "start": 20,
+                            "end": 25
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            },
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 3,
+                    "startColumn": 5,
+                    "endLine": 3,
+                    "endColumn": 29,
+                    "start": 37,
+                    "end": 61,
+                    "startTag": {
+                        "startLine": 3,
+                        "startColumn": 5,
+                        "endLine": 3,
+                        "endColumn": 23,
+                        "start": 37,
+                        "end": 55
+                    },
+                    "endTag": {
+                        "startLine": 3,
+                        "startColumn": 23,
+                        "endLine": 3,
+                        "endColumn": 29,
+                        "start": 55,
+                        "end": 61
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "a`b`c",
+                        "value": {
+                            "type": "Literal",
+                            "value": "yolo"
+                        },
+                        "location": {
+                            "startLine": 3,
+                            "startColumn": 10,
+                            "endLine": 3,
+                            "endColumn": 22,
+                            "start": 42,
+                            "end": 54
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/config.json
@@ -1,0 +1,3 @@
+{
+  "enableStaticContentOptimization": false
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/expected.js
@@ -1,0 +1,31 @@
+import _implicitStylesheets from "./non-optimized.css";
+import _implicitScopedStylesheets from "./non-optimized.scoped.css?scoped=true";
+import { freezeTemplate, registerTemplate } from "lwc";
+const stc0 = {
+  attrs: {
+    "a`b`c": "",
+  },
+  key: 0,
+};
+const stc1 = {
+  attrs: {
+    "a`b`c": "yolo",
+  },
+  key: 1,
+};
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { h: api_element } = $api;
+  return [api_element("div", stc0), api_element("div", stc1)];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];
+tmpl.stylesheetToken = "lwc-71tdq7g4m0k";
+tmpl.legacyStylesheetToken = "x-non-optimized_non-optimized";
+if (_implicitStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+}
+if (_implicitScopedStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+}
+freezeTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/metadata.json
@@ -1,0 +1,26 @@
+{
+    "warnings": [
+        {
+            "code": 1057,
+            "message": "LWC1057: a`b`c is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 10,
+                "start": 20,
+                "length": 5
+            }
+        },
+        {
+            "code": 1057,
+            "message": "LWC1057: a`b`c is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 10,
+                "start": 42,
+                "length": 12
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/actual.html
@@ -1,0 +1,4 @@
+<template>
+    <div a`b`c></div>
+    <div a`b`c="yolo"></div>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/ast.json
@@ -1,0 +1,134 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 12,
+            "start": 0,
+            "end": 73,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 4,
+                "startColumn": 1,
+                "endLine": 4,
+                "endColumn": 12,
+                "start": 62,
+                "end": 73
+            }
+        },
+        "directives": [],
+        "children": [
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 2,
+                    "startColumn": 5,
+                    "endLine": 2,
+                    "endColumn": 22,
+                    "start": 15,
+                    "end": 32,
+                    "startTag": {
+                        "startLine": 2,
+                        "startColumn": 5,
+                        "endLine": 2,
+                        "endColumn": 16,
+                        "start": 15,
+                        "end": 26
+                    },
+                    "endTag": {
+                        "startLine": 2,
+                        "startColumn": 16,
+                        "endLine": 2,
+                        "endColumn": 22,
+                        "start": 26,
+                        "end": 32
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "a`b`c",
+                        "value": {
+                            "type": "Literal",
+                            "value": true
+                        },
+                        "location": {
+                            "startLine": 2,
+                            "startColumn": 10,
+                            "endLine": 2,
+                            "endColumn": 15,
+                            "start": 20,
+                            "end": 25
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            },
+            {
+                "type": "Element",
+                "name": "div",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "location": {
+                    "startLine": 3,
+                    "startColumn": 5,
+                    "endLine": 3,
+                    "endColumn": 29,
+                    "start": 37,
+                    "end": 61,
+                    "startTag": {
+                        "startLine": 3,
+                        "startColumn": 5,
+                        "endLine": 3,
+                        "endColumn": 23,
+                        "start": 37,
+                        "end": 55
+                    },
+                    "endTag": {
+                        "startLine": 3,
+                        "startColumn": 23,
+                        "endLine": 3,
+                        "endColumn": 29,
+                        "start": 55,
+                        "end": 61
+                    }
+                },
+                "attributes": [
+                    {
+                        "type": "Attribute",
+                        "name": "a`b`c",
+                        "value": {
+                            "type": "Literal",
+                            "value": "yolo"
+                        },
+                        "location": {
+                            "startLine": 3,
+                            "startColumn": 10,
+                            "endLine": 3,
+                            "endColumn": 22,
+                            "start": 42,
+                            "end": 54
+                        }
+                    }
+                ],
+                "properties": [],
+                "directives": [],
+                "listeners": [],
+                "children": []
+            }
+        ]
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/config.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/config.json
@@ -1,0 +1,3 @@
+{
+  "enableStaticContentOptimization": true
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/expected.js
@@ -1,0 +1,24 @@
+import _implicitStylesheets from "./optimized.css";
+import _implicitScopedStylesheets from "./optimized.scoped.css?scoped=true";
+import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
+const $fragment1 = parseFragment`<div a\`b\`c${3}></div>`;
+const $fragment2 = parseFragment`<div a\`b\`c="yolo"${3}></div>`;
+function tmpl($api, $cmp, $slotset, $ctx) {
+  const { st: api_static_fragment } = $api;
+  return [
+    api_static_fragment($fragment1, 1),
+    api_static_fragment($fragment2, 3),
+  ];
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];
+tmpl.stylesheetToken = "lwc-6dfvqpqt2d0";
+tmpl.legacyStylesheetToken = "x-optimized_optimized";
+if (_implicitStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+}
+if (_implicitScopedStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+}
+freezeTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/metadata.json
@@ -1,0 +1,26 @@
+{
+    "warnings": [
+        {
+            "code": 1057,
+            "message": "LWC1057: a`b`c is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 2,
+                "column": 10,
+                "start": 20,
+                "length": 5
+            }
+        },
+        {
+            "code": 1057,
+            "message": "LWC1057: a`b`c is not valid attribute for div. For more information refer to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+            "level": 2,
+            "location": {
+                "line": 3,
+                "column": 10,
+                "start": 42,
+                "length": 12
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -89,6 +89,9 @@ function serializeAttrs(element: Element, codeGen: CodeGen): string {
             v = String(v.toLowerCase() !== 'false');
         }
 
+        // See W-16614169
+        const escapedAttributeName = templateStringEscape(name);
+
         if (typeof v === 'string') {
             // IDs/IDRefs must be handled dynamically at runtime due to synthetic shadow scoping.
             // Skip serializing here and handle it as if it were a dynamic attribute instead.
@@ -98,9 +101,13 @@ function serializeAttrs(element: Element, codeGen: CodeGen): string {
 
             // Inject a placeholder where the staticPartId will go when an expression occurs.
             // This is only needed for SSR to inject the expression value during serialization.
-            attrs.push(needsPlaceholder ? `\${"${v}"}` : ` ${name}="${htmlEscape(v, true)}"`);
+            attrs.push(
+                needsPlaceholder
+                    ? `\${"${v}"}`
+                    : ` ${escapedAttributeName}="${htmlEscape(v, true)}"`
+            );
         } else {
-            attrs.push(` ${name}`);
+            attrs.push(` ${escapedAttributeName}`);
         }
     };
 


### PR DESCRIPTION
## Details

Similar to #4498, but for attribute names. We were not properly escaping these, so some invalid characters may be rendered.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Like the other PR, this only applies to extremely odd characters that are rarely if ever used in attribute names.

<!-- If yes, please describe the anticipated observable changes. -->
