### PR TITLE
chore(tachometer): fix remote branches

### DIFF
--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -108,14 +108,14 @@ function createTachometerJson(htmlFilename, benchmarkName, directoryHash, cpuThr
                                         ref: BENCHMARK_REF,
                                         subdir: `packages/${pkg}`,
                                         setupCommands: [
-                                            'yarn --immutable',
                                             // Replace the `@lwc/perf-benchmarks-components` from the tip-of-tree
                                             // with ours, just in case we've modified them locally.
                                             // We want to recompile whatever benchmarks we've added with the
                                             // compiler code from tip-of-tree, but we also want Tachometer to serve
                                             // `@lwc/perf-benchmarks-components` itself.
-                                            'rm -fr ./packages/@lwc/perf-benchmarks-components',
-                                            `cp -R ${benchmarkComponentsDir} ./packages/@lwc/perf-benchmarks-components`,
+                                            'rm -fr ./packages/@lwc/perf-benchmarks-components/{src,scripts}',
+                                            `cp -R ${benchmarkComponentsDir}/{src,scripts} ./packages/@lwc/perf-benchmarks-components`,
+                                            'yarn --immutable',
                                             // bust the Tachometer cache in case these files change locally
                                             `echo '${directoryHash}'`,
                                             'yarn build:performance:components',


### PR DESCRIPTION
## Details

At some point our Tachometer scripts got messed up, and when it tries to compare against a remote branch (e.g. `master`) it fails because NX thinks that the `@lwc/perf-benchmarks-components` project doesn't exist.

    $ yarn build:performance:components
    NX   Cannot find project '@lwc/perf-benchmarks-components'

This seems to be something subtle with how we were copying directory around (maybe NX is using symlinks under the hood or something)? Doing `yarn install` after copying these files, and copying only the necessary source files, seems to fix the issue.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
