### PR TITLE
chore(dependabot): only use groups for major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,22 +11,32 @@ updates:
           babel:
               patterns:
                   - '@babel/*'
+              update-types:
+                  - 'major'
           best:
               patterns:
                   - 'best'
                   - '@best/*'
+              update-types:
+                  - 'major'
           nx:
               patterns:
                   - 'nx'
                   - '@nx/*'
+              update-types:
+                  - 'major'
           rollup:
               patterns:
                   - 'rollup'
                   - '@rollup/*'
+              update-types:
+                  - 'major'
           webdriverio:
               patterns:
                   - 'webdriverio'
                   - '@wdio/*'
+              update-types:
+                  - 'major'
           # Non-major version bumps hopefully shouldn't break anything,
           # so let's group them together into a single PR!
           theoretically-non-breaking:


### PR DESCRIPTION
## Details

In #4466 / #4473, we added dedicated groups for packages that should be kept in sync, like babel, because they break if you update just one at a time. We already have a `theoretically-non-breaking` group that bundles all patch/minor version bumps into one PR, but it turns out that the new groups we created take precedence, so we end up with multiple PRs for non-breaking changes. This PR updated our config so that our groups only apply to major versions, meaning we get the needed groups for breaking changes, but all non-breaking changes remain bundled in the single PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
