### PR TITLE
fix(engine): avoid non-string scope tokens

### DIFF
--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -26,7 +26,13 @@ import { Stylesheet, Stylesheets } from './stylesheet';
 import { onReportingEnabled, report, ReportingEventId } from './reporting';
 
 // See @lwc/engine-core/src/framework/template.ts
-const TEMPLATE_PROPS = ['slots', 'stylesheetToken', 'stylesheets', 'renderMode'] as const;
+const TEMPLATE_PROPS = [
+    'slots',
+    'stylesheetToken',
+    'stylesheets',
+    'renderMode',
+    'legacyStylesheetToken',
+] as const;
 
 // Expandos that may be placed on a stylesheet factory function, and which are meaningful to LWC at runtime
 const STYLESHEET_PROPS = [

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -270,6 +270,14 @@ function buildParseFragmentFn(
                 }
             }
 
+            // See W-16614556
+            if (
+                (hasStyleToken && !isString(stylesheetToken)) ||
+                (hasLegacyToken && !isString(legacyStylesheetToken))
+            ) {
+                throw new Error('stylesheet token must be a string');
+            }
+
             // If legacy stylesheet tokens are required, then add them to the rendered string
             const stylesheetTokenToRender =
                 stylesheetToken + (hasLegacyToken ? ` ${legacyStylesheetToken}` : '');

--- a/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/index.spec.js
@@ -51,7 +51,7 @@ props.forEach((prop) => {
 
                 expect(caughtError).not.toBeUndefined();
                 expect(caughtError.message).toMatch(
-                    /stylesheet token must be a string|Failed to execute 'setAttribute'|Invalid qualified name|String contains an invalid character/
+                    /stylesheet token must be a string|Failed to execute 'setAttribute'|Invalid qualified name|String contains an invalid character|The string contains invalid characters/
                 );
 
                 if (process.env.NODE_ENV === 'production') {

--- a/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/index.spec.js
@@ -1,0 +1,70 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import { catchUnhandledRejectionsAndErrors } from 'test-utils';
+import Component from 'x/component';
+
+let caughtError;
+let logger;
+
+catchUnhandledRejectionsAndErrors((error) => {
+    caughtError = error;
+});
+
+beforeEach(() => {
+    logger = spyOn(console, 'warn');
+});
+
+afterEach(() => {
+    caughtError = undefined;
+});
+
+const props = ['stylesheetToken', 'stylesheetTokens', 'legacyStylesheetToken'];
+
+props.forEach((prop) => {
+    describe(prop, () => {
+        beforeEach(() => {
+            setFeatureFlagForTest('ENABLE_LEGACY_SCOPE_TOKENS', prop === 'legacyStylesheetToken');
+        });
+
+        afterEach(() => {
+            setFeatureFlagForTest('ENABLE_LEGACY_SCOPE_TOKENS', false);
+            // We keep a cache of parsed static fragments; these need to be reset
+            // since they can vary based on whether we use the legacy scope token or not.
+            window.__lwcResetFragmentCache();
+            // Reset template object for clean state between tests
+            Component.resetTemplate();
+        });
+
+        it('W-16614556 should not render arbitrary content via stylesheet token', async () => {
+            const elm = createElement('x-component', { is: Component });
+            elm.propToUse = prop;
+            document.body.appendChild(elm);
+
+            await Promise.resolve();
+
+            if (process.env.NATIVE_SHADOW && process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION) {
+                // If we're rendering in native shadow and the static content optimization is disabled,
+                // then there's no problem with non-string stylesheet tokens because they are only rendered
+                // as class attribute values using either `classList` or `setAttribute`.
+                expect(elm.shadowRoot.children.length).toBe(1);
+            } else {
+                expect(elm.shadowRoot.children.length).toBe(0); // does not render
+
+                expect(caughtError).not.toBeUndefined();
+                expect(caughtError.message).toMatch(
+                    /stylesheet token must be a string|Failed to execute 'setAttribute'|Invalid qualified name|String contains an invalid character/
+                );
+
+                if (process.env.NODE_ENV === 'production') {
+                    // no warnings in prod mode
+                    expect(logger).not.toHaveBeenCalled();
+                } else {
+                    // dev mode
+                    expect(logger).toHaveBeenCalledTimes(1);
+                    expect(logger.calls.allArgs()[0]).toMatch(
+                        new RegExp(`Mutating the "${prop}" property on a template is deprecated`)
+                    );
+                }
+            }
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.css
+++ b/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.css
@@ -1,0 +1,3 @@
+div {
+    color: red;
+}

--- a/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/rendering/sanitize-stylesheet-token/x/component/component.js
@@ -1,0 +1,46 @@
+import { LightningElement, api } from 'lwc';
+import template from './component.html';
+
+export default class Component extends LightningElement {
+    @api propToUse;
+
+    count = 0;
+
+    render() {
+        const token = {
+            [Symbol.toPrimitive]: () => {
+                if (this.count === 0) {
+                    return `yolo-${++this.count}`;
+                } else {
+                    return `yolo=yolo-${++this.count}`;
+                }
+            },
+        };
+
+        const { propToUse } = this;
+        if (propToUse === 'stylesheetTokens') {
+            // this legacy format uses an object
+            template[propToUse] = {
+                hostAttribute: token,
+                shadowAttribute: token,
+            };
+        } else {
+            // stylesheetToken or legacyStylesheetToken
+            // this format uses a string
+            template[propToUse] = token;
+        }
+
+        return template;
+    }
+}
+
+// Reset template object for clean state between tests
+const { stylesheetToken, stylesheetTokens, legacyStylesheetToken } = template;
+
+Component.resetTemplate = () => {
+    Object.assign(template, {
+        stylesheetToken,
+        stylesheetTokens,
+        legacyStylesheetToken,
+    });
+};


### PR DESCRIPTION
## Details

Fixes validation of attribute names / static content HTML for dynamically-set stylesheet tokens.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Setting `template.stylesheetToken` now requires a string value.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-16614556