### PR TITLE
chore(release): allow providing release version directly

### DIFF
--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -10,7 +10,7 @@ const readline = require('node:readline');
 const { globSync } = require('glob');
 
 (async () => {
-    const newVersion = await promptVersion();
+    const newVersion = process.argv[2] || (await promptVersion());
     updatePackages(newVersion);
 })().catch(console.error);
 


### PR DESCRIPTION
## Details

I don't like this:

```sh
$ yarn release:version                                                                   
yarn run v1.22.22
$ node ./scripts/release/version.js
Enter a new LWC version: x.y.z
```

I do like this:

```
$ yarn release:version x.y.z
```

This PR makes both possible.

(Hopefully this will be obsolete soon, anyway.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
