### PR TITLE
chore(rollup-plugin): speed up and reduce memory usage in tests

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
@@ -19,6 +19,7 @@ describe('API versioning', () => {
         const bundle = await rollup({
             input: path.resolve(__dirname, pathname),
             plugins: [lwc(options)],
+            external: ['lwc'],
             onwarn(warning) {
                 warnings.push(warning);
             },

--- a/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
@@ -17,6 +17,7 @@ describe('enableStaticContentOptimization: ', () => {
         const bundle = await rollup({
             input: path.resolve(__dirname, pathname),
             plugins: [lwc(options)],
+            external: ['lwc'],
             onwarn(warning) {
                 warnings.push(warning);
             },

--- a/packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts
@@ -15,6 +15,7 @@ describe('integration', () => {
             const bundle = await rollup({
                 input: path.resolve(__dirname, 'fixtures/typescript/typescript.ts'),
                 plugins: [lwc()],
+                external: ['lwc'],
             });
 
             const result = await bundle.generate({

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
@@ -37,6 +37,7 @@ describe('warnings', () => {
                     apiVersion: APIVersion.V58_244_SUMMER_23,
                 }),
             ],
+            external: ['lwc'],
             onwarn(warning) {
                 warnings.push(warning);
             },


### PR DESCRIPTION
## Details

This PR makes a few tweaks to tests in `@lwc/rollup-plugin`.

It improve overall execution time from ~3.78s to ~1.44s (-62%) in my local environment.

It also reduces memory usage significantly in some tests.

This makes development while running tests in watch mode a bit more pleasant.

#### Before
```sh
 ✓ resolver  (13 tests) 2843ms 530 MB heap used
 ✓ compilerConfig  (6 tests) 1920ms 102 MB heap used
 ✓ apiVersion  (5 tests) 1669ms 261 MB heap used
 ✓ enableStaticContentOptimization  (4 tests) 1266ms 205 MB heap used
 ✓ warnings  (1 test) 497ms 97 MB heap used
 ✓ integrations  (1 test) 466ms 98 MB heap used
 ✓ rootDir  (2 tests) 19ms 34 MB heap used

 Test Files  7 passed (7)
      Tests  32 passed (32)
   Start at  05:29:27
   Duration  3.78s (transform 422ms, setup 0ms, collect 4.45s, tests 8.68s, environment 1ms, prepare 399ms)
```
#### After
```sh
 ✓ resolver  (13 tests) 190ms 50 MB heap used
 ✓ compilerConfig  (6 tests) 164ms 51 MB heap used
 ✓ apiVersion  (5 tests) 64ms 35 MB heap used
 ✓ enableStaticContentOptimization  (4 tests) 64ms 40 MB heap used
 ✓ warnings  (1 test) 49ms 36 MB heap used
 ✓ integrations  (1 test) 39ms 35 MB heap used
 ✓ rootDir  (2 tests) 20ms 37 MB heap used

 Test Files  7 passed (7)
      Tests  32 passed (32)
   Start at  05:26:25
   Duration  1.44s (transform 413ms, setup 0ms, collect 4.19s, tests 590ms, environment 1ms, prepare 362ms)
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
