### PR TITLE
feat(engine): add tooltips for performance timings

### DIFF
--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -49,6 +49,27 @@ const operationIdNameMapping = [
     'lwc-rehydrate',
 ] as const;
 
+const operationTooltipMapping = [
+    // constructor
+    'component constructor()',
+    // render
+    'component render() and virtual DOM rendered',
+    // patch
+    'component DOM rendered',
+    // connectedCallback
+    'component connectedCallback()',
+    // renderedCallback
+    'component renderedCallback()',
+    // disconnectedCallback
+    'component disconnectedCallback()',
+    // errorCallback
+    'component errorCallback()',
+    // lwc-hydrate
+    'component first rendered',
+    // lwc-rehydrate
+    'component re-rendered',
+] as const;
+
 // Even if all the browser the engine supports implements the UserTiming API, we need to guard the measure APIs.
 // JSDom (used in Jest) for example doesn't implement the UserTiming APIs.
 const isUserTimingSupported: boolean =
@@ -82,6 +103,7 @@ const end = !isUserTimingSupported
                   | 'tertiary-dark'
                   | 'error';
               properties?: [string, string][];
+              tooltipText?: string;
           }
       ) => {
           performance.measure(measureName, {
@@ -122,6 +144,10 @@ function getProperties(vm: VM<any, any>): [string, string][] {
         ['Render Mode', vm.renderMode === RenderMode.Light ? 'light DOM' : 'shadow DOM'],
         ['Shadow Mode', vm.shadowMode === ShadowMode.Native ? 'native' : 'synthetic'],
     ];
+}
+
+function getTooltipText(measureName: string, opId: OperationId) {
+    return `${measureName} - ${operationTooltipMapping[opId]}`;
 }
 
 /** Indicates if operations should be logged via the User Timing API. */
@@ -172,6 +198,7 @@ export function logOperationEnd(opId: OperationId, vm: VM) {
         const measureName = getMeasureName(opId, vm);
         end(measureName, markName, {
             properties: getProperties(vm),
+            tooltipText: getTooltipText(measureName, opId),
             color: opId === OperationId.Render ? 'primary' : 'secondary',
         });
     }
@@ -223,6 +250,7 @@ export function logGlobalOperationEndWithVM(opId: GlobalOperationId, vm: VM) {
         const markName = getMarkName(opId, vm);
         end(opName, markName, {
             properties: getProperties(vm),
+            tooltipText: getTooltipText(opName, opId),
             color: 'tertiary',
         });
     }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -235,6 +235,7 @@ export function logGlobalOperationEnd(opId: GlobalOperationId) {
         const opName = getOperationName(opId);
         const markName = opName;
         end(opName, markName, {
+            tooltipText: getTooltipText(opName, opId),
             color: 'tertiary',
         });
     }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -47,7 +47,7 @@ const operationIdNameMapping = [
     'errorCallback',
     'lwc-hydrate',
     'lwc-rehydrate',
-] as const;
+] as const satisfies Record<OperationId, string>;
 
 const operationTooltipMapping = [
     // constructor

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -68,7 +68,7 @@ const operationTooltipMapping = [
     'component first rendered',
     // lwc-rehydrate
     'component re-rendered',
-] as const;
+] as const satisfies Record<OperationId, string>;
 
 // Even if all the browser the engine supports implements the UserTiming API, we need to guard the measure APIs.
 // JSDom (used in Jest) for example doesn't implement the UserTiming APIs.


### PR DESCRIPTION
## Details

This is a small follow-up to #4511: it adds tooltips that are visible when hovering over the custom timings in DevTools.

![Screenshot 2024-09-09 at 2 05 13 PM](https://github.com/user-attachments/assets/691688a8-342e-4955-b9dc-c4d019795977)

It seems to me that the main benefit of these tooltips is to merely recapitulate the same name as the slice (this is what a lot of the other tooltips in the DevTools UI do). I personally find it annoying to have to zoom in to read the full text, so it's nice to be able to see it without zooming.

These tooltips are pretty minimal because I didn't want to clutter the UI – they mostly just repeat the slice names while adding a hint of context.

The next PR would be to add mutation tracking so that we can report _why_ a component re-rendered (#4542), but I think this may be a bit trickier so I am holding off for now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

New DevTools visualizations! In dev mode only.

<!-- If yes, please describe the anticipated observable changes. -->
