### PR TITLE
feat: add mutation logging to DevTools profiler

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, toString } from '@lwc/shared';
+import { associateTargetWithPropertyKey } from '../mutation-logger';
 import { componentValueObserved } from '../mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
@@ -65,6 +66,9 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
                 }
             }
             const reactiveOrAnyValue = getReactiveProxy(newValue);
+            if (process.env.NODE_ENV !== 'production') {
+                associateTargetWithPropertyKey(key, newValue);
+            }
             updateComponentValue(vm, key, reactiveOrAnyValue);
         },
         enumerable: true,

--- a/packages/@lwc/engine-core/src/framework/decorators/track.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/track.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { assert, toString } from '@lwc/shared';
-import { associateTargetWithPropertyKey } from '../mutation-logger';
+import { trackTargetForMutationLogging } from '../mutation-logger';
 import { componentValueObserved } from '../mutation-tracker';
 import { isInvokingRender } from '../invoker';
 import { getAssociatedVM } from '../vm';
@@ -67,7 +67,7 @@ export function internalTrackDecorator(key: string): PropertyDescriptor {
             }
             const reactiveOrAnyValue = getReactiveProxy(newValue);
             if (process.env.NODE_ENV !== 'production') {
-                associateTargetWithPropertyKey(key, newValue);
+                trackTargetForMutationLogging(key, newValue);
             }
             updateComponentValue(vm, key, reactiveOrAnyValue);
         },

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -17,6 +17,7 @@ import {
     ArrayFilter,
     getOwnPropertyNames,
     getOwnPropertySymbols,
+    isString,
 } from '@lwc/shared';
 import { ReactiveObserver } from '../libs/mutation-tracker';
 import { VM } from './vm';
@@ -66,6 +67,9 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
         let prop;
         if (isUndefined(parentKey)) {
             prop = stringKey;
+        } else if (!isString(key)) {
+            // symbol/number, e.g. `obj[Symbol("foo")]` or `obj[1234]`
+            prop = `${toString(parentKey)}[${stringKey}]`;
         } else if (/^\w+$/.test(stringKey)) {
             // Human-readable prop like `items[0].name` on a deep object/array
             prop = `${toString(parentKey)}.${stringKey}`;

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -124,7 +124,7 @@ export function trackTargetForMutationLogging(key: PropertyKey, target: any) {
             // Track only own property names and symbols (including non-enumerated)
             // This is consistent with what observable-membrane does:
             // https://github.com/salesforce/observable-membrane/blob/b85417f/src/base-handler.ts#L142-L143
-            // Note this code path is very hot, hence doing two separate for-loops rather than creatinng a new array.
+            // Note this code path is very hot, hence doing two separate for-loops rather than creating a new array.
             for (const prop of getOwnPropertyNames(target)) {
                 trackTargetForMutationLogging(
                     `${toString(key)}.${toString(prop)}`,

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -27,7 +27,7 @@ export interface MutationLog {
 }
 
 const reactiveObserversToVMs = new WeakMap<ReactiveObserver, VM>();
-const trackedTargetsToPropertyKeys = new WeakMap<object, PropertyKey>();
+const targetsToPropertyKeys = new WeakMap<object, PropertyKey>();
 let mutationLogs: MutationLog[] = [];
 
 /**
@@ -48,7 +48,7 @@ export function getAndFlushMutationLogs() {
  */
 export function logMutation(reactiveObserver: ReactiveObserver, target: object, key: PropertyKey) {
     assertNotProd();
-    const parentKey = trackedTargetsToPropertyKeys.get(target);
+    const parentKey = targetsToPropertyKeys.get(target);
     const vm = reactiveObserversToVMs.get(reactiveObserver);
 
     /* istanbul ignore if */
@@ -99,7 +99,7 @@ export function trackTargetForMutationLogging(key: PropertyKey, target: object) 
     assertNotProd();
     if (isObject(target) && !isNull(target)) {
         // only track non-primitives; others are invalid as WeakMap keys
-        trackedTargetsToPropertyKeys.set(target, key);
+        targetsToPropertyKeys.set(target, key);
 
         // Deeply traverse arrays and objects to track every object within
         if (isArray(target)) {

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -63,7 +63,7 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
         const prop = isUndefined(parentKey)
             ? toString(key)
             : `${toString(parentKey)}.${toString(key)}`;
-        ArrayPush.call(mutationLogs, { vm, prop: prop });
+        ArrayPush.call(mutationLogs, { vm, prop });
     }
 }
 

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -35,12 +35,16 @@ export function getAndFlushMutationLogs() {
 /**
  * Log a new mutation
  * @param reactiveObserver - relevant ReactiveObserver
+ * @param target - target object that is being observed
  * @param key - key (property) that was mutated
  */
 export function logMutation(reactiveObserver: ReactiveObserver, target: object, key: PropertyKey) {
     assertNotProd();
     const parentKey = trackedTargetsToPropertyKeys.get(target);
-    const vm = reactiveObserversToVMs.get(reactiveObserver)!;
+    const vm = reactiveObserversToVMs.get(reactiveObserver);
+    if (isUndefined(vm)) {
+        throw new Error('vm must be defined');
+    }
     const displayKey = isUndefined(parentKey)
         ? toString(key)
         : `${toString(parentKey)}.${toString(key)}`;

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -28,7 +28,6 @@ export interface MutationLog {
 
 const reactiveObserversToVMs = new WeakMap<ReactiveObserver, VM>();
 const trackedTargetsToPropertyKeys = new WeakMap<object, PropertyKey>();
-
 let mutationLogs: MutationLog[] = [];
 
 /**
@@ -42,7 +41,7 @@ export function getAndFlushMutationLogs() {
 }
 
 /**
- * Log a new mutation
+ * Log a new mutation for this reactive observer.
  * @param reactiveObserver - relevant ReactiveObserver
  * @param target - target object that is being observed
  * @param key - key (property) that was mutated
@@ -61,7 +60,7 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
 }
 
 /**
- * Flush logs associated with a given VM
+ * Flush logs associated with a given VM.
  * @param vm - given VM
  */
 export function flushMutationLogsForVM(vm: VM) {
@@ -73,14 +72,18 @@ export function flushMutationLogsForVM(vm: VM) {
     }
 }
 
-// Keep a mapping of reactive observers to VMs which makes it simpler to track mutations
+/**
+ * Mark this ReactiveObserver as related to this VM. This is only needed for mutation tracking in dev mode.
+ * @param reactiveObserver
+ * @param vm
+ */
 export function associateReactiveObserverWithVM(reactiveObserver: ReactiveObserver, vm: VM) {
     assertNotProd();
     reactiveObserversToVMs.set(reactiveObserver, vm);
 }
 
 /**
- * Deeply track all objects in a target and associate with a given key
+ * Deeply track all objects in a target and associate with a given key.
  * @param key - key associated with the object in the component
  * @param target - tracked target object
  */

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
+//
 // Do additional mutation tracking for DevTools performance profiling, in dev mode only.
-
+//
+import { ArrayPush, ArraySplice } from '@lwc/shared';
+import { ReactiveObserver } from '../libs/mutation-tracker';
 import { VM } from './vm';
 import { assertNotProd } from './utils';
 
@@ -15,24 +17,45 @@ export interface MutationLog {
     key: PropertyKey;
 }
 
-const mutationLogs: MutationLog[] = [];
+const reactiveObserversToVMs = new WeakMap();
+
+let mutationLogs: MutationLog[] = [];
 
 /**
  * Flush all the logs we've written so far and return the current logs.
  */
 export function getAndFlushMutationLogs() {
     assertNotProd();
-    const result = [...mutationLogs];
-    mutationLogs.length = 0; // clear
+    const result = mutationLogs;
+    mutationLogs = [];
     return result;
 }
 
 /**
  * Log a new mutation
- * @param vm - relevant VM whose property was mutated
+ * @param reactiveObserver - relevant ReactiveObserver
  * @param key - key (property) that was mutated
  */
-export function logMutation(vm: VM, key: PropertyKey) {
+export function logMutation(reactiveObserver: ReactiveObserver, key: PropertyKey) {
     assertNotProd();
-    mutationLogs.push({ vm, key });
+    const vm = reactiveObserversToVMs.get(reactiveObserver);
+    ArrayPush.call(mutationLogs, { vm, key });
+}
+
+/**
+ * Flush logs associated with a given VM
+ * @param vm - given VM
+ */
+export function flushMutationLogsForVM(vm: VM) {
+    assertNotProd();
+    for (let i = mutationLogs.length - 1; i >= 0; i--) {
+        if (mutationLogs[i].vm === vm) {
+            ArraySplice.call(mutationLogs, i, 1);
+        }
+    }
+}
+
+// Keep a mapping of reactive observers to VMs which makes it simpler to track mutations
+export function associateReactiveObserverWithVM(reactiveObserver: ReactiveObserver, vm: VM) {
+    reactiveObserversToVMs.set(reactiveObserver, vm);
 }

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// Do additional mutation tracking for DevTools performance profiling, in dev mode only.
+
+import { VM } from './vm';
+import { assertNotProd } from './utils';
+
+export interface MutationLog {
+    vm: VM;
+    key: PropertyKey;
+}
+
+const mutationLogs: MutationLog[] = [];
+
+/**
+ * Flush all the logs we've written so far and return the current logs.
+ */
+export function getAndFlushMutationLogs() {
+    assertNotProd();
+    const result = [...mutationLogs];
+    mutationLogs.length = 0; // clear
+    return result;
+}
+
+/**
+ * Log a new mutation
+ * @param vm - relevant VM whose property was mutated
+ * @param key - key (property) that was mutated
+ */
+export function logMutation(vm: VM, key: PropertyKey) {
+    assertNotProd();
+    mutationLogs.push({ vm, key });
+}

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -73,11 +73,7 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
  */
 export function flushMutationLogsForVM(vm: VM) {
     assertNotProd();
-    for (let i = mutationLogs.length - 1; i >= 0; i--) {
-        if (mutationLogs[i].vm === vm) {
-            ArraySplice.call(mutationLogs, i, 1);
-        }
-    }
+    mutationLogs = ArrayFilter.call(mutationLogs, (log) => log.vm !== vm)
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -9,13 +9,13 @@
 //
 import {
     ArrayPush,
-    ArraySplice,
     isUndefined,
     toString,
     isObject,
     isNull,
     isArray,
     keys,
+    ArrayFilter,
 } from '@lwc/shared';
 import { ReactiveObserver } from '../libs/mutation-tracker';
 import { VM } from './vm';
@@ -73,7 +73,7 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
  */
 export function flushMutationLogsForVM(vm: VM) {
     assertNotProd();
-    mutationLogs = ArrayFilter.call(mutationLogs, (log) => log.vm !== vm)
+    mutationLogs = ArrayFilter.call(mutationLogs, (log) => log.vm !== vm);
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -124,10 +124,16 @@ export function trackTargetForMutationLogging(key: PropertyKey, target: any) {
             // Track only own property names and symbols (including non-enumerated)
             // This is consistent with what observable-membrane does:
             // https://github.com/salesforce/observable-membrane/blob/b85417f/src/base-handler.ts#L142-L143
-            const props = [...getOwnPropertyNames(target), ...getOwnPropertySymbols(target)];
-            for (const prop of props) {
+            // Note this code path is very hot, hence doing two separate for-loops rather than creatinng a new array.
+            for (const prop of getOwnPropertyNames(target)) {
                 trackTargetForMutationLogging(
                     `${toString(key)}.${toString(prop)}`,
+                    (target as any)[prop]
+                );
+            }
+            for (const prop of getOwnPropertySymbols(target)) {
+                trackTargetForMutationLogging(
+                    `${toString(key)}[${toString(prop)}]`,
                     (target as any)[prop]
                 );
             }

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -95,7 +95,7 @@ export function associateReactiveObserverWithVM(reactiveObserver: ReactiveObserv
  * @param key - key associated with the object in the component
  * @param target - tracked target object
  */
-export function trackTargetForMutationLogging(key: PropertyKey, target: object) {
+export function trackTargetForMutationLogging(key: PropertyKey, target: any) {
     assertNotProd();
     if (isObject(target) && !isNull(target)) {
         // only track non-primitives; others are invalid as WeakMap keys

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -107,6 +107,10 @@ export function associateReactiveObserverWithVM(reactiveObserver: ReactiveObserv
  */
 export function trackTargetForMutationLogging(key: PropertyKey, target: any) {
     assertNotProd();
+    if (targetsToPropertyKeys.has(target)) {
+        // Guard against recursive objects - don't traverse forever
+        return;
+    }
     if (isObject(target) && !isNull(target)) {
         // only track non-primitives; others are invalid as WeakMap keys
         targetsToPropertyKeys.set(target, key);

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -10,6 +10,7 @@
 import {
     ArrayPush,
     ArraySplice,
+    assert,
     isUndefined,
     toString,
     isObject,
@@ -50,13 +51,14 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
     assertNotProd();
     const parentKey = trackedTargetsToPropertyKeys.get(target);
     const vm = reactiveObserversToVMs.get(reactiveObserver);
-    if (isUndefined(vm)) {
-        throw new Error('vm must be defined');
+    if (process.env.NODE_ENV !== 'test' && isUndefined(vm)) {
+        // vitest tests do not always associate a reactive observer with a VM, but elsewhere it should
+        assert.fail('vm must be defined');
     }
     const displayKey = isUndefined(parentKey)
         ? toString(key)
         : `${toString(parentKey)}.${toString(key)}`;
-    ArrayPush.call(mutationLogs, { vm, prop: displayKey });
+    ArrayPush.call(mutationLogs, { vm: vm!, prop: displayKey });
 }
 
 /**

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -61,10 +61,17 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
             throw new Error('The VM should always be defined except possibly in unit tests');
         }
     } else {
-        // Human-readable prop like `items[0].name` on a deep object/array
-        const prop = isUndefined(parentKey)
-            ? toString(key)
-            : `${toString(parentKey)}.${toString(key)}`;
+        const stringKey = toString(key);
+        let prop;
+        if (isUndefined(parentKey)) {
+            prop = stringKey;
+        } else if (/^\w+$/.test(stringKey)) {
+            // Human-readable prop like `items[0].name` on a deep object/array
+            prop = `${toString(parentKey)}.${stringKey}`;
+        } else {
+            // e.g. `obj["prop with spaces"]`
+            prop = `${toString(parentKey)}[${JSON.stringify(stringKey)}]`;
+        }
         ArrayPush.call(mutationLogs, { vm, prop });
     }
 }

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -53,8 +53,10 @@ export function logMutation(reactiveObserver: ReactiveObserver, target: object, 
 
     /* istanbul ignore if */
     if (isUndefined(vm)) {
-        // VM should only be undefined in vitest tests, where a reactive observer is not always associated with a VM
+        // VM should only be undefined in Vitest tests, where a reactive observer is not always associated with a VM
         // because the unit tests just create Reactive Observers on-the-fly.
+        // Note we could explicitly target Vitest with `process.env.NODE_ENV === 'test'`, but then that would also
+        // affect our downstream consumers' Jest/Vitest tests, and we don't want to throw an error just for a logger.
         if (process.env.NODE_ENV === 'test-karma-lwc') {
             throw new Error('The VM should always be defined except possibly in unit tests');
         }

--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -15,6 +15,7 @@ import {
 } from '../libs/mutation-tracker';
 import { subscribeToSignal } from '../libs/signal-tracker';
 import { VM } from './vm';
+import { logMutation } from './mutation-logger';
 
 const DUMMY_REACTIVE_OBSERVER = {
     observe(job: JobFunction) {
@@ -27,6 +28,10 @@ const DUMMY_REACTIVE_OBSERVER = {
 export function componentValueMutated(vm: VM, key: PropertyKey) {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.
     if (process.env.IS_BROWSER) {
+        if (process.env.NODE_ENV !== 'production') {
+            // Track mutations in dev mode for the perf profiler
+            logMutation(vm, key);
+        }
         valueMutated(vm.component, key);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -15,7 +15,6 @@ import {
 } from '../libs/mutation-tracker';
 import { subscribeToSignal } from '../libs/signal-tracker';
 import { VM } from './vm';
-import { logMutation } from './mutation-logger';
 
 const DUMMY_REACTIVE_OBSERVER = {
     observe(job: JobFunction) {
@@ -28,10 +27,6 @@ const DUMMY_REACTIVE_OBSERVER = {
 export function componentValueMutated(vm: VM, key: PropertyKey) {
     // On the server side, we don't need mutation tracking. Skipping it improves performance.
     if (process.env.IS_BROWSER) {
-        if (process.env.NODE_ENV !== 'production') {
-            // Track mutations in dev mode for the perf profiler
-            logMutation(vm, key);
-        }
         valueMutated(vm.component, key);
     }
 }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -162,7 +162,8 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
         const tagNameAndId = `<${tagName}> (id: ${idx})`;
         let keys = tagNamesAndIdsToKeys.get(tagNameAndId);
         if (isUndefined(keys)) {
-            tagNamesAndIdsToKeys.set(tagNameAndId, (keys = new Set()));
+            keys = new Set();
+            tagNamesAndIdsToKeys.set(tagNameAndId, keys);
         }
         keys.add(prop);
     }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -154,7 +154,7 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
     if (isUndefined(mutationLogs)) {
         return EmptyArray;
     }
-    const tagNamesAndIdsToKeys = new Map();
+    const tagNamesAndIdsToKeys = new Map<string, Set<string>>();
     for (const {
         vm: { tagName, idx },
         prop,

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -49,6 +49,27 @@ const operationIdNameMapping = [
     'lwc-rehydrate',
 ] as const;
 
+const operationTooltipMapping = [
+    // constructor
+    'component constructor()',
+    // render
+    'component render() and virtual DOM rendered',
+    // patch
+    'component DOM rendered',
+    // connectedCallback
+    'component connectedCallback()',
+    // renderedCallback
+    'component renderedCallback()',
+    // disconnectedCallback
+    'component disconnectedCallback()',
+    // errorCallback
+    'component errorCallback()',
+    // lwc-hydrate
+    'component first rendered',
+    // lwc-rehydrate
+    'component re-rendered',
+] as const;
+
 // Even if all the browser the engine supports implements the UserTiming API, we need to guard the measure APIs.
 // JSDom (used in Jest) for example doesn't implement the UserTiming APIs.
 const isUserTimingSupported: boolean =
@@ -82,6 +103,7 @@ const end = !isUserTimingSupported
                   | 'tertiary-dark'
                   | 'error';
               properties?: [string, string][];
+              tooltipText?: string;
           }
       ) => {
           performance.measure(measureName, {
@@ -122,6 +144,10 @@ function getProperties(vm: VM<any, any>): [string, string][] {
         ['Render Mode', vm.renderMode === RenderMode.Light ? 'light DOM' : 'shadow DOM'],
         ['Shadow Mode', vm.shadowMode === ShadowMode.Native ? 'native' : 'synthetic'],
     ];
+}
+
+function getTooltipText(measureName: string, opId: OperationId) {
+    return `${measureName} - ${operationTooltipMapping[opId]}`;
 }
 
 /** Indicates if operations should be logged via the User Timing API. */
@@ -172,6 +198,7 @@ export function logOperationEnd(opId: OperationId, vm: VM) {
         const measureName = getMeasureName(opId, vm);
         end(measureName, markName, {
             properties: getProperties(vm),
+            tooltipText: getTooltipText(measureName, opId),
             color: opId === OperationId.Render ? 'primary' : 'secondary',
         });
     }
@@ -223,6 +250,7 @@ export function logGlobalOperationEndWithVM(opId: GlobalOperationId, vm: VM) {
         const markName = getMarkName(opId, vm);
         end(opName, markName, {
             properties: getProperties(vm),
+            tooltipText: getTooltipText(opName, opId),
             color: 'tertiary',
         });
     }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -166,7 +166,10 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
         }
         keys.add(prop);
     }
-    const components = ArraySort.call([...tagNamesAndIdsToKeys.keys()]);
+    const entries = ArraySort.call([...tagNamesAndIdsToKeys], (a, b) =>
+        a[0].localeCompare(b[0])
+    );
+    const components = ArrayMap.call(entries, (item) => item[0]);
     const result: [string, string][] = [
         [
             `Re-rendered Component${components.length !== 1 ? 's' : ''}`,

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -152,7 +152,7 @@ function getProperties(vm: VM<any, any>): [string, string][] {
 // "why did this component re-render?"
 function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string, string][] {
     // `mutationLogs` should never have length 0, but bail out if it does for whatever reason
-    if (isUndefined(mutationLogs) || mutationLogs.length === 0) {
+    if (isUndefined(mutationLogs)) {
         return EmptyArray;
     }
 

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -178,7 +178,7 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
         a[0].localeCompare(b[0])
     );
     for (const [tagNameAndId, keys] of entries) {
-        result.push([tagNameAndId, ArrayJoin.call(ArraySort.call([...keys]), ', ')]);
+        ArrayPush.call(result, [tagNameAndId, ArrayJoin.call(ArraySort.call([...keys]), ', ')]);
     }
     return result;
 }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -303,8 +303,7 @@ export function logGlobalOperationEnd(
         const opName = getOperationName(opId);
         const markName = opName;
         end(opName, markName, {
-            // not really an error, but we want to draw attention to re-renders since folks may want to debug it
-            color: 'error',
+            color: 'tertiary',
             tooltipText: getTooltipText(opName, opId),
             properties: getMutationProperties(mutationLogs),
         });

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -194,7 +194,7 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
     const usePlural = tagNames.length > 1 || tagNamesToIdsAndProps.get(tagNames[0])!.ids.size > 1;
     const result: [string, string][] = [
         [
-            `Re-rendered Component${usePlural ? 's' : ''}`,
+            `Component${usePlural ? 's' : ''}`,
             ArrayJoin.call(
                 ArrayMap.call(tagNames, (_) => tagNamesToDisplayTagNames.get(_)),
                 ', '

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -157,13 +157,13 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
     const tagNamesToKeys = new Map();
     for (const {
         vm: { tagName },
-        key,
+        prop,
     } of mutationLogs) {
         let keys = tagNamesToKeys.get(tagName);
         if (isUndefined(keys)) {
             tagNamesToKeys.set(tagName, (keys = new Set()));
         }
-        keys.add(key);
+        keys.add(prop);
     }
     const result: [string, string][] = [];
     for (const [tagName, keys] of tagNamesToKeys.entries()) {

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -167,10 +167,7 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
     }
     const result: [string, string][] = [];
     for (const [tagName, keys] of tagNamesToKeys.entries()) {
-        result.push([
-            `<${tagName}>`,
-            `Mutated properties: ${ArrayJoin.call(ArraySort.call([...keys]), ', ')}`,
-        ]);
+        result.push([`<${tagName}>`, ArrayJoin.call(ArraySort.call([...keys]), ', ')]);
     }
     return result;
 }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayJoin, ArraySort, isUndefined, noop } from '@lwc/shared';
+import { ArrayJoin, ArrayMap, ArrayPush, ArraySort, isUndefined, noop } from '@lwc/shared';
 
 import { getComponentTag } from '../shared/format';
 import { RenderMode, ShadowMode, VM } from './vm';
@@ -167,9 +167,7 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
         }
         keys.add(prop);
     }
-    const entries = ArraySort.call([...tagNamesAndIdsToKeys], (a, b) =>
-        a[0].localeCompare(b[0])
-    );
+    const entries = ArraySort.call([...tagNamesAndIdsToKeys], (a, b) => a[0].localeCompare(b[0]));
     const components = ArrayMap.call(entries, (item) => item[0]);
     const result: [string, string][] = [
         [
@@ -177,10 +175,6 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
             ArrayJoin.call(components, ', '),
         ],
     ];
-    // Sort tag names
-    const entries = ArraySort.call([...tagNamesAndIdsToKeys.entries()], (a, b) =>
-        a[0].localeCompare(b[0])
-    );
     for (const [tagNameAndId, keys] of entries) {
         ArrayPush.call(result, [tagNameAndId, ArrayJoin.call(ArraySort.call([...keys]), ', ')]);
     }

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -156,6 +156,12 @@ function getMutationProperties(mutationLogs: MutationLog[] | undefined): [string
         return EmptyArray;
     }
 
+    if (!mutationLogs.length) {
+        // Currently this only occurs for experimental signals, because those mutations are not triggered by accessors
+        // TODO [#4546]: support signals in mutation logging
+        return EmptyArray;
+    }
+
     // Keep track of unique IDs per tag name so we can just report a raw count at the end, e.g.
     // `<x-foo> (x2)` to indicate that two instances of `<x-foo>` were rendered.
     const tagNamesToIdsAndProps = new Map<string, { ids: Set<number>; keys: Set<string> }>();

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -255,6 +255,8 @@ export function connectRootElement(elm: any) {
     const vm = getAssociatedVM(elm);
 
     if (process.env.NODE_ENV !== 'production') {
+        // Flush any logs for this VM so that the initial properties from the constructor don't "count"
+        // in subsequent re-renders (lwc-rehydrate). Right now we're at the first render (lwc-hydrate).
         flushMutationLogsForVM(vm);
     }
 
@@ -655,7 +657,8 @@ export function runRenderedCallback(vm: VM) {
 let rehydrateQueue: VM[] = [];
 
 function flushRehydrationQueue() {
-    // gather the logs before rehydration starts so that the logs can be reported at the end
+    // Gather the logs before rehydration starts so they can be reported at the end of rehydration.
+    // Note that we also clear all existing logs at this point so that subsequent re-renders start from a clean slate.
     const mutationLogs =
         process.env.NODE_ENV !== 'production' ? getAndFlushMutationLogs() : undefined;
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -660,7 +660,7 @@ function flushRehydrationQueue() {
     // Gather the logs before rehydration starts so they can be reported at the end of rehydration.
     // Note that we also clear all existing logs at this point so that subsequent re-renders start from a clean slate.
     const mutationLogs =
-        process.env.NODE_ENV !== 'production' ? getAndFlushMutationLogs() : undefined;
+        process.env.NODE_ENV === 'production' ? undefined : getAndFlushMutationLogs();
 
     logGlobalOperationStart(OperationId.GlobalRehydrate);
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -53,7 +53,7 @@ import {
 } from './profiler';
 import { patchChildren } from './rendering';
 import { ReactiveObserver } from './mutation-tracker';
-import { getAndFlushMutationLogs } from './mutation-logger';
+import { flushMutationLogsForVM, getAndFlushMutationLogs } from './mutation-logger';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
 import {
     VNodes,
@@ -253,6 +253,10 @@ export function rerenderVM(vm: VM) {
 
 export function connectRootElement(elm: any) {
     const vm = getAssociatedVM(elm);
+
+    if (process.env.NODE_ENV !== 'production') {
+        flushMutationLogsForVM(vm);
+    }
 
     logGlobalOperationStartWithVM(OperationId.GlobalHydrate, vm);
 

--- a/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
@@ -6,9 +6,10 @@
  */
 
 import { assert, create, isUndefined, ArrayPush, defineProperty, noop } from '@lwc/shared';
+import { associateReactiveObserverWithVM } from '../mutation-logger';
 import { LightningElement } from '../base-lightning-element';
 import { createReactiveObserver, ReactiveObserver } from '../mutation-tracker';
-import { runWithBoundaryProtection, VMState, VM } from '../vm';
+import { runWithBoundaryProtection, VMState, VM, getAssociatedVM } from '../vm';
 import { updateComponentValue } from '../update-component-value';
 import { createContextWatcher } from './context';
 import type {
@@ -72,6 +73,9 @@ function createConfigWatcher(
             });
         }
     });
+    if (process.env.NODE_ENV !== 'production') {
+        associateReactiveObserverWithVM(ro, getAssociatedVM(component));
+    }
     const computeConfigAndUpdate = () => {
         let config: ConfigValue;
         ro.observe(() => (config = configCallback(component)));

--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
@@ -41,7 +41,7 @@ export function valueMutated(target: object, key: PropertyKey) {
             for (let i = 0, len = reactiveObservers.length; i < len; i += 1) {
                 const ro = reactiveObservers[i];
                 if (process.env.NODE_ENV !== 'production') {
-                    logMutation(ro, key);
+                    logMutation(ro, target, key);
                 }
                 ro.notify();
             }

--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/index.ts
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { create, isUndefined, ArrayIndexOf, ArrayPush, ArrayPop } from '@lwc/shared';
+import { logMutation } from '../../framework/mutation-logger';
 
 const TargetToReactiveRecordMap: WeakMap<object, ReactiveRecord> = new WeakMap();
 
@@ -39,6 +40,9 @@ export function valueMutated(target: object, key: PropertyKey) {
         if (!isUndefined(reactiveObservers)) {
             for (let i = 0, len = reactiveObservers.length; i < len; i += 1) {
                 const ro = reactiveObservers[i];
+                if (process.env.NODE_ENV !== 'production') {
+                    logMutation(ro, key);
+                }
                 ro.notify();
             }
         }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -68,7 +68,7 @@ it('Does deep mutation logging on an object', async () => {
 
     expect(entries.length).toBe(1);
     expect(entries[0].name).toBe('lwc-rehydrate');
-    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'first']]);
+    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'previousName.first']]);
 });
 
 it('Does deep mutation logging on an array', async () => {
@@ -86,5 +86,5 @@ it('Does deep mutation logging on an array', async () => {
 
     expect(entries.length).toBe(1);
     expect(entries[0].name).toBe('lwc-rehydrate');
-    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'length']]);
+    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'aliases.length']]);
 });

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -226,6 +226,13 @@ if (process.env.NODE_ENV === 'production') {
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(yolo)]');
         });
+
+        it('Logs for mutation on deeply-recursive object', async () => {
+            elm.setOnRecursiveObject('woohoo');
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'recursiveObject.foo');
+        });
     });
 
     describe('parent-child', () => {

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -117,6 +117,13 @@ if (process.env.NODE_ENV === 'production') {
             expectRehydrationEntry('x-child', 'previousName.first');
         });
 
+        it('Logs deep mutation on an object - characters requiring bracket member notation', async () => {
+            elm.setPreviousNameFullName('George Vancouver');
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'previousName["full name"]');
+        });
+
         it('Logs doubly-deep mutation on an object', async () => {
             elm.setPreviousNameSuffix('short', 'Jr.');
 

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -227,6 +227,13 @@ if (process.env.NODE_ENV === 'production') {
             expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(yolo)]');
         });
 
+        it('Logs for doubly deep symbol prop mutation', async () => {
+            elm.setWackyAccessorDoublyDeepSymbol('wahoo');
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(whoa)].baz');
+        });
+
         it('Logs for mutation on deeply-recursive object', async () => {
             elm.setOnRecursiveObject('woohoo');
 

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -212,6 +212,20 @@ if (process.env.NODE_ENV === 'production') {
                 ])
             );
         });
+
+        it('Logs for non-enumerable props', async () => {
+            elm.setWackyAccessorDeepValue('yolo');
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'wackyAccessors.foo.bar');
+        });
+
+        it('Logs for symbol props', async () => {
+            elm.setWackyAccessorSymbol('haha');
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'wackyAccessors["Symbol(yolo)"]');
+        });
     });
 
     describe('parent-child', () => {

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -44,7 +44,7 @@ function rehydrationEntry(tagName, propString) {
         detail: obj({
             devtools: obj({
                 properties: arr([
-                    arr(['Re-rendered Component', `<${tagName}>`]),
+                    arr(['Component', `<${tagName}>`]),
                     arr([`<${tagName}>`, propString]),
                 ]),
             }),
@@ -198,7 +198,7 @@ if (process.env.NODE_ENV === 'production') {
                             devtools: obj({
                                 properties: arr([
                                     arr([
-                                        'Re-rendered Components',
+                                        'Components',
                                         `<x-child> (\u00D72)`, // x2 with multiplication symbol
                                     ]),
                                     arr([
@@ -290,7 +290,7 @@ if (process.env.NODE_ENV === 'production') {
                         detail: obj({
                             devtools: obj({
                                 properties: arr([
-                                    arr(['Re-rendered Components', '<x-child>, <x-parent>']),
+                                    arr(['Components', '<x-child>, <x-parent>']),
                                     arr(['<x-child>', 'lastName']),
                                     arr(['<x-parent>', 'firstName']),
                                 ]),

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -159,7 +159,12 @@ if (process.env.NODE_ENV === 'production') {
 
             await waitForSentinelMeasure();
             expect(entries).toEqual(
-                arr([obj({ name: 'lwc-hydrate' }), obj({ name: 'lwc-hydrate' })])
+                arr(
+                    // synthetic lifecycle considers this one hydration event rather than two
+                    lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                        ? [obj({ name: 'lwc-hydrate' })]
+                        : [obj({ name: 'lwc-hydrate' }), obj({ name: 'lwc-hydrate' })]
+                )
             );
             entries = []; // reset
         });
@@ -171,7 +176,7 @@ if (process.env.NODE_ENV === 'production') {
             expectRehydrationEntry('x-parent', 'firstName');
         });
 
-        it('logs a mutation on the parent only', async () => {
+        it('logs a mutation on the child only', async () => {
             child.lastName = 'Magellan';
 
             await waitForSentinelMeasure();

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -90,35 +90,55 @@ if (process.env.NODE_ENV === 'production') {
             expectRehydrationEntry('x-child', 'firstName');
         });
 
-        it('Does deep mutation logging on an object', async () => {
+        it('Logs subsequent mutations on the same component', async () => {
+            elm.firstName = 'Ferdinand';
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'firstName');
+            entries = []; // reset
+
+            elm.lastName = 'Magellan';
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'lastName');
+            entries = []; // reset
+
+            elm.firstName = 'Vasco';
+            elm.lastName = 'da Gama';
+
+            await waitForSentinelMeasure();
+            expectRehydrationEntry('x-child', 'firstName, lastName');
+        });
+
+        it('Logs deep mutation on an object', async () => {
             elm.setPreviousName('first', 'Vancouver');
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'previousName.first');
         });
 
-        it('Does doubly-deep mutation logging on an object', async () => {
+        it('Logs doubly-deep mutation on an object', async () => {
             elm.setPreviousNameSuffix('short', 'Jr.');
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'previousName.suffix.short');
         });
 
-        it('Does deep mutation logging on an array', async () => {
+        it('Logs deep mutation on an array', async () => {
             elm.addAlias('Magellan');
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'aliases.length');
         });
 
-        it('Does deep mutation logging on an object within an array', async () => {
+        it('Logs deep mutation on an object within an array', async () => {
             elm.setFavoriteIceCreamFlavor('vanilla');
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'favoriteFlavors[0].flavor');
         });
 
-        it('Tracks multiple mutations on the same component', async () => {
+        it('Logs multiple mutations on the same component', async () => {
             elm.firstName = 'Ferdinand';
             elm.setPreviousNameSuffix('short', 'Jr.');
             elm.setFavoriteIceCreamFlavor('vanilla');
@@ -130,7 +150,7 @@ if (process.env.NODE_ENV === 'production') {
             );
         });
 
-        it('tracks a component mutation while another component is rendered for the first time', async () => {
+        it('Logs a component mutation while another component is rendered for the first time', async () => {
             const elm2 = createElement('x-child', { is: Child });
             document.body.appendChild(elm2);
             elm.firstName = 'Ferdinand';
@@ -169,21 +189,21 @@ if (process.env.NODE_ENV === 'production') {
             entries = []; // reset
         });
 
-        it('logs a mutation on the parent only', async () => {
+        it('Logs a mutation on the parent only', async () => {
             elm.firstName = 'Ferdinand';
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-parent', 'firstName');
         });
 
-        it('logs a mutation on the child only', async () => {
+        it('Logs a mutation on the child only', async () => {
             child.lastName = 'Magellan';
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'lastName');
         });
 
-        it('logs a mutation on both parent and child', async () => {
+        it('Logs a mutation on both parent and child', async () => {
             elm.firstName = 'Ferdinand';
             child.lastName = 'Magellan';
 

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -1,0 +1,90 @@
+import { createElement } from 'lwc';
+// import Parent from 'x/parent'
+import Child from 'x/child';
+
+const sentinelObserver = new EventTarget();
+
+let entries = [];
+let observer;
+
+beforeEach(() => {
+    observer = new PerformanceObserver((list) => {
+        const newEntries = list.getEntries();
+        entries.push(
+            ...newEntries.filter((_) => ['lwc-hydrate', 'lwc-rehydrate'].includes(_.name))
+        );
+        if (newEntries.some((_) => _.name === 'sentinel')) {
+            sentinelObserver.dispatchEvent(new CustomEvent('sentinel'));
+        }
+    });
+    observer.observe({ entryTypes: ['measure'] });
+});
+
+afterEach(() => {
+    entries = [];
+    observer.disconnect();
+});
+
+// We have to wait for a "sentinel" measure because the PerformanceObserver doesn't guarantee when it's
+// going to be called.
+async function waitForSentinelMeasure() {
+    await Promise.resolve(); // wait a tick for the component itself to render
+    await new Promise((resolve) => {
+        sentinelObserver.addEventListener('sentinel', resolve, { once: true });
+        performance.measure('sentinel');
+    });
+}
+
+it('Does basic mutation logging', async () => {
+    const elm = createElement('x-child', { is: Child });
+    document.body.appendChild(elm);
+
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-hydrate');
+    entries = [];
+
+    elm.firstName = 'Ferdinand';
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-rehydrate');
+    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'firstName']]);
+});
+
+it('Does deep mutation logging on an object', async () => {
+    const elm = createElement('x-child', { is: Child });
+    document.body.appendChild(elm);
+
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-hydrate');
+    entries = [];
+
+    elm.setPreviousName('first', 'Vancouver');
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-rehydrate');
+    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'first']]);
+});
+
+it('Does deep mutation logging on an array', async () => {
+    const elm = createElement('x-child', { is: Child });
+    document.body.appendChild(elm);
+
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-hydrate');
+    entries = [];
+
+    elm.addAlias('Magellan');
+    await waitForSentinelMeasure();
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].name).toBe('lwc-rehydrate');
+    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'length']]);
+});

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -35,56 +35,117 @@ async function waitForSentinelMeasure() {
     });
 }
 
-it('Does basic mutation logging', async () => {
-    const elm = createElement('x-child', { is: Child });
-    document.body.appendChild(elm);
+describe('basic', () => {
+    let elm;
 
-    await waitForSentinelMeasure();
+    beforeEach(async () => {
+        elm = createElement('x-child', { is: Child });
+        document.body.appendChild(elm);
 
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-hydrate');
-    entries = [];
+        await waitForSentinelMeasure();
 
-    elm.firstName = 'Ferdinand';
-    await waitForSentinelMeasure();
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-hydrate');
+        entries = [];
+    });
 
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-rehydrate');
-    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'firstName']]);
+    it('Does basic mutation logging', async () => {
+        elm.firstName = 'Ferdinand';
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'firstName'],
+        ]);
+    });
+
+    it('Does deep mutation logging on an object', async () => {
+        elm.setPreviousName('first', 'Vancouver');
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'previousName.first'],
+        ]);
+    });
+
+    it('Does doubly-deep mutation logging on an object', async () => {
+        elm.setPreviousNameSuffix('short', 'Jr.');
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'previousName.suffix.short'],
+        ]);
+    });
+
+    it('Does deep mutation logging on an array', async () => {
+        elm.addAlias('Magellan');
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'aliases.length'],
+        ]);
+    });
+
+    it('Does deep mutation logging on an object within an array', async () => {
+        elm.setFavoriteIceCreamFlavor('vanilla');
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'favoriteFlavors[0].flavor'],
+        ]);
+    });
+
+    it('Tracks multiple mutations on the same component', async () => {
+        elm.firstName = 'Ferdinand';
+        elm.setPreviousNameSuffix('short', 'Jr.');
+        elm.setFavoriteIceCreamFlavor('vanilla');
+        await waitForSentinelMeasure();
+
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-rehydrate');
+        expect(entries[0].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'favoriteFlavors[0].flavor, firstName, previousName.suffix.short'],
+        ]);
+    });
 });
 
-it('Does deep mutation logging on an object', async () => {
-    const elm = createElement('x-child', { is: Child });
-    document.body.appendChild(elm);
+describe('advanced', () => {
+    it('tracks a component mutation while another component is rendered for the first time', async () => {
+        const elm = createElement('x-child', { is: Child });
+        document.body.appendChild(elm);
 
-    await waitForSentinelMeasure();
+        await waitForSentinelMeasure();
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('lwc-hydrate');
+        entries = [];
 
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-hydrate');
-    entries = [];
+        const elm2 = createElement('x-child', { is: Child });
+        document.body.appendChild(elm2);
+        elm.firstName = 'Ferdinand';
 
-    elm.setPreviousName('first', 'Vancouver');
-    await waitForSentinelMeasure();
+        await waitForSentinelMeasure();
+        expect(entries.length).toBe(2);
+        expect(entries[0].name).toBe('lwc-hydrate');
 
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-rehydrate');
-    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'previousName.first']]);
-});
-
-it('Does deep mutation logging on an array', async () => {
-    const elm = createElement('x-child', { is: Child });
-    document.body.appendChild(elm);
-
-    await waitForSentinelMeasure();
-
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-hydrate');
-    entries = [];
-
-    elm.addAlias('Magellan');
-    await waitForSentinelMeasure();
-
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('lwc-rehydrate');
-    expect(entries[0].detail.devtools.properties).toEqual([['<x-child>', 'aliases.length']]);
+        expect(entries[1].name).toBe('lwc-rehydrate');
+        expect(entries[1].detail.devtools.properties).toEqual([
+            ['Re-rendered Components', '<x-child>'],
+            ['<x-child>', 'firstName'],
+        ]);
+    });
 });

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -213,18 +213,18 @@ if (process.env.NODE_ENV === 'production') {
             );
         });
 
-        it('Logs for non-enumerable props', async () => {
+        it('Logs for deep non-enumerable prop mutation', async () => {
             elm.setWackyAccessorDeepValue('yolo');
 
             await waitForSentinelMeasure();
             expectRehydrationEntry('x-child', 'wackyAccessors.foo.bar');
         });
 
-        it('Logs for symbol props', async () => {
+        it('Logs for deep symbol prop mutation', async () => {
             elm.setWackyAccessorSymbol('haha');
 
             await waitForSentinelMeasure();
-            expectRehydrationEntry('x-child', 'wackyAccessors["Symbol(yolo)"]');
+            expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(yolo)]');
         });
     });
 

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
@@ -14,4 +14,6 @@
         </template>
     </ul>
     <div><strong>Wacky accessors:</strong>{formattedWackyAccessors}</div>
+    <div><strong>Recursion:</strong>{recursiveObject.deep.deep.foo}</div>
 </template>
+

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
@@ -13,4 +13,5 @@
             <li key={fav.food}>{fav.food}: {fav.flavor}</li>
         </template>
     </ul>
+    <div><strong>Wacky accessors:</strong>{formattedWackyAccessors}</div>
 </template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
@@ -1,0 +1,12 @@
+<template>
+    <div><strong>First name:</strong> {firstName}</div>
+    <div><strong>Last name:</strong> {lastName}</div>
+    <div><strong>Previous first name:</strong> {previousName.first}</div>
+    <div><strong>Previous last name:</strong> {previousName.last}</div>
+    <div><strong>Aliases:</strong></div>
+    <ul>
+        <template for:each={aliases} for:item="alias">
+            <li key={alias}>{alias}</li>
+        </template>
+    </ul>
+</template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
@@ -1,9 +1,7 @@
 <template>
     <div><strong>First name:</strong> {firstName}</div>
     <div><strong>Last name:</strong> {lastName}</div>
-    <div><strong>Previous first name:</strong>{previousName.first}</div>
-    <div><strong>Previous last name:</strong>{previousName.last}</div>
-    <div><strong>Previous name suffix:</strong>{previousName.suffix.short} ({previousName.suffix.long})</div>
+    <div><strong>Previous name:</strong>{prettyPreviousName}</div>
     <div><strong>Aliases:</strong></div>
     <ul>
         <template for:each={aliases} for:item="alias">

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.html
@@ -1,12 +1,18 @@
 <template>
     <div><strong>First name:</strong> {firstName}</div>
     <div><strong>Last name:</strong> {lastName}</div>
-    <div><strong>Previous first name:</strong> {previousName.first}</div>
-    <div><strong>Previous last name:</strong> {previousName.last}</div>
+    <div><strong>Previous first name:</strong>{previousName.first}</div>
+    <div><strong>Previous last name:</strong>{previousName.last}</div>
+    <div><strong>Previous name suffix:</strong>{previousName.suffix.short} ({previousName.suffix.long})</div>
     <div><strong>Aliases:</strong></div>
     <ul>
         <template for:each={aliases} for:item="alias">
             <li key={alias}>{alias}</li>
+        </template>
+    </ul>
+    <ul>
+        <template for:each={favoriteFlavors} for:item="fav">
+            <li key={fav.food}>{fav.food}: {fav.flavor}</li>
         </template>
     </ul>
 </template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -3,8 +3,9 @@ import { LightningElement, api, track } from 'lwc';
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
-    @track previousName = { first: '', last: '' };
+    @track previousName = { first: '', last: '', suffix: { short: '', long: '' } };
     @track aliases = [];
+    @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
 
     @api setPreviousName(prop, value) {
         this.previousName[prop] = value;
@@ -12,5 +13,13 @@ export default class extends LightningElement {
 
     @api addAlias(alias) {
         this.aliases.push(alias);
+    }
+
+    @api setPreviousNameSuffix(prop, value) {
+        this.previousName.suffix[prop] = value;
+    }
+
+    @api setFavoriteIceCreamFlavor(value) {
+        this.favoriteFlavors[0].flavor = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -1,5 +1,24 @@
 import { LightningElement, api, track } from 'lwc';
 
+const symbol = Symbol('yolo');
+const createWackyAccessors = () => {
+    const res = {};
+    const deep = {};
+    // non-enumerable deep props
+    Object.defineProperty(res, 'foo', {
+        enumerable: false,
+        writable: true,
+        value: deep,
+    });
+    Object.defineProperty(deep, 'bar', {
+        enumerable: false,
+        writable: true,
+        value: '',
+    });
+    res[symbol] = '';
+    return res;
+};
+
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
@@ -9,11 +28,16 @@ export default class extends LightningElement {
         suffix: { short: '', long: '' },
         'full name': '',
     };
+    @track wackyAccessors = createWackyAccessors();
     @track aliases = [];
     @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
 
     get prettyPreviousName() {
         return `${this.previousName.first} ${this.previousName.last} (${this.previousName['full name']}) ${this.previousName.suffix.short} (${this.previousName.suffix.long})`;
+    }
+
+    get formattedWackyAccessors() {
+        return `${this.wackyAccessors.foo.bar} - ${this.wackyAccessors[symbol]}`;
     }
 
     @api setPreviousName(prop, value) {
@@ -34,5 +58,13 @@ export default class extends LightningElement {
 
     @api setPreviousNameFullName(value) {
         this.previousName['full name'] = value;
+    }
+
+    @api setWackyAccessorDeepValue(value) {
+        this.wackyAccessors.foo.bar = value;
+    }
+
+    @api setWackyAccessorSymbol(value) {
+        this.wackyAccessors[symbol] = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -19,6 +19,17 @@ const createWackyAccessors = () => {
     return res;
 };
 
+const createRecursiveObject = () => {
+    const deep = {
+        foo: '',
+    };
+    const res = {
+        deep,
+    };
+    deep.deep = res;
+    return res;
+};
+
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
@@ -31,6 +42,7 @@ export default class extends LightningElement {
     @track wackyAccessors = createWackyAccessors();
     @track aliases = [];
     @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
+    @track recursiveObject = createRecursiveObject();
 
     get prettyPreviousName() {
         return `${this.previousName.first} ${this.previousName.last} (${this.previousName['full name']}) ${this.previousName.suffix.short} (${this.previousName.suffix.long})`;
@@ -66,5 +78,9 @@ export default class extends LightningElement {
 
     @api setWackyAccessorSymbol(value) {
         this.wackyAccessors[symbol] = value;
+    }
+
+    @api setOnRecursiveObject(value) {
+        this.recursiveObject.deep.deep.foo = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -1,6 +1,8 @@
 import { LightningElement, api, track } from 'lwc';
 
 const symbol = Symbol('yolo');
+const anotherSymbol = Symbol('whoa');
+
 const createWackyAccessors = () => {
     const res = {};
     const deep = {};
@@ -16,6 +18,7 @@ const createWackyAccessors = () => {
         value: '',
     });
     res[symbol] = '';
+    res[anotherSymbol] = { baz: '' };
     return res;
 };
 
@@ -49,7 +52,7 @@ export default class extends LightningElement {
     }
 
     get formattedWackyAccessors() {
-        return `${this.wackyAccessors.foo.bar} - ${this.wackyAccessors[symbol]}`;
+        return `${this.wackyAccessors.foo.bar} - ${this.wackyAccessors[symbol]} - ${this.wackyAccessors[anotherSymbol].baz}`;
     }
 
     @api setPreviousName(prop, value) {
@@ -78,6 +81,10 @@ export default class extends LightningElement {
 
     @api setWackyAccessorSymbol(value) {
         this.wackyAccessors[symbol] = value;
+    }
+
+    @api setWackyAccessorDoublyDeepSymbol(value) {
+        this.wackyAccessors[anotherSymbol].baz = value;
     }
 
     @api setOnRecursiveObject(value) {

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -3,9 +3,18 @@ import { LightningElement, api, track } from 'lwc';
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
-    @track previousName = { first: '', last: '', suffix: { short: '', long: '' } };
+    @track previousName = {
+        first: '',
+        last: '',
+        suffix: { short: '', long: '' },
+        'full name': '',
+    };
     @track aliases = [];
     @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
+
+    get prettyPreviousName() {
+        return `${this.previousName.first} ${this.previousName.last} (${this.previousName['full name']}) ${this.previousName.suffix.short} (${this.previousName.suffix.long})`;
+    }
 
     @api setPreviousName(prop, value) {
         this.previousName[prop] = value;
@@ -21,5 +30,9 @@ export default class extends LightningElement {
 
     @api setFavoriteIceCreamFlavor(value) {
         this.favoriteFlavors[0].flavor = value;
+    }
+
+    @api setPreviousNameFullName(value) {
+        this.previousName['full name'] = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/child/child.js
@@ -1,0 +1,16 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class extends LightningElement {
+    @api firstName;
+    @api lastName;
+    @track previousName = { first: '', last: '' };
+    @track aliases = [];
+
+    @api setPreviousName(prop, value) {
+        this.previousName[prop] = value;
+    }
+
+    @api addAlias(alias) {
+        this.aliases.push(alias);
+    }
+}

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
@@ -1,12 +1,19 @@
 <template>
     <div><strong>First name:</strong> {firstName}</div>
     <div><strong>Last name:</strong> {lastName}</div>
-    <div><strong>Previous first name:</strong> {previousName.first}</div>
-    <div><strong>Previous last name:</strong> {previousName.last}</div>
-    <div><strong>Child:</strong></div>
+    <div><strong>Previous first name:</strong>{previousName.first}</div>
+    <div><strong>Previous last name:</strong>{previousName.last}</div>
+    <div><strong>Previous name suffix:</strong>{previousName.suffix.short} ({previousName.suffix.long})</div>
+    <div><strong>Aliases:</strong></div>
     <ul>
         <template for:each={aliases} for:item="alias">
             <li key={alias}>{alias}</li>
+        </template>
+    </ul>
+    <div><strong>Favorite flavors:</strong></div>
+    <ul>
+        <template for:each={favoriteFlavors} for:item="fav">
+            <li key={fav.food}>{fav.food}: {fav.flavor}</li>
         </template>
     </ul>
     <x-child></x-child>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
@@ -1,16 +1,13 @@
 <template>
     <div><strong>First name:</strong> {firstName}</div>
     <div><strong>Last name:</strong> {lastName}</div>
-    <div><strong>Previous first name:</strong>{previousName.first}</div>
-    <div><strong>Previous last name:</strong>{previousName.last}</div>
-    <div><strong>Previous name suffix:</strong>{previousName.suffix.short} ({previousName.suffix.long})</div>
+    <div><strong>Previous name:</strong>{prettyPreviousName}</div>
     <div><strong>Aliases:</strong></div>
     <ul>
         <template for:each={aliases} for:item="alias">
             <li key={alias}>{alias}</li>
         </template>
     </ul>
-    <div><strong>Favorite flavors:</strong></div>
     <ul>
         <template for:each={favoriteFlavors} for:item="fav">
             <li key={fav.food}>{fav.food}: {fav.flavor}</li>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
@@ -1,17 +1,5 @@
 <template>
     <div><strong>First name:</strong> {firstName}</div>
     <div><strong>Last name:</strong> {lastName}</div>
-    <div><strong>Previous name:</strong>{prettyPreviousName}</div>
-    <div><strong>Aliases:</strong></div>
-    <ul>
-        <template for:each={aliases} for:item="alias">
-            <li key={alias}>{alias}</li>
-        </template>
-    </ul>
-    <ul>
-        <template for:each={favoriteFlavors} for:item="fav">
-            <li key={fav.food}>{fav.food}: {fav.flavor}</li>
-        </template>
-    </ul>
     <x-child></x-child>
 </template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.html
@@ -1,0 +1,13 @@
+<template>
+    <div><strong>First name:</strong> {firstName}</div>
+    <div><strong>Last name:</strong> {lastName}</div>
+    <div><strong>Previous first name:</strong> {previousName.first}</div>
+    <div><strong>Previous last name:</strong> {previousName.last}</div>
+    <div><strong>Child:</strong></div>
+    <ul>
+        <template for:each={aliases} for:item="alias">
+            <li key={alias}>{alias}</li>
+        </template>
+    </ul>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
@@ -3,8 +3,9 @@ import { LightningElement, api, track } from 'lwc';
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
-    @track previousName = { first: '', last: '' };
+    @track previousName = { first: '', last: '', suffix: { short: '', long: '' } };
     @track aliases = [];
+    @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
 
     @api setPreviousName(prop, value) {
         this.previousName[prop] = value;
@@ -12,5 +13,13 @@ export default class extends LightningElement {
 
     @api addAlias(alias) {
         this.aliases.push(alias);
+    }
+
+    @api setPreviousNameSuffix(prop, value) {
+        this.previousName.suffix[prop] = value;
+    }
+
+    @api setFavoriteIceCreamFlavor(value) {
+        this.favoriteFlavors[0].flavor = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
@@ -1,38 +1,6 @@
-import { LightningElement, api, track } from 'lwc';
+import { LightningElement, api } from 'lwc';
 
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
-    @track previousName = {
-        first: '',
-        last: '',
-        suffix: { short: '', long: '' },
-        'full name': '',
-    };
-    @track aliases = [];
-    @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
-
-    get prettyPreviousName() {
-        return `${this.previousName.first} ${this.previousName.last} (${this.previousName['full name']}) ${this.previousName.suffix.short} (${this.previousName.suffix.long})`;
-    }
-
-    @api setPreviousName(prop, value) {
-        this.previousName[prop] = value;
-    }
-
-    @api addAlias(alias) {
-        this.aliases.push(alias);
-    }
-
-    @api setPreviousNameSuffix(prop, value) {
-        this.previousName.suffix[prop] = value;
-    }
-
-    @api setFavoriteIceCreamFlavor(value) {
-        this.favoriteFlavors[0].flavor = value;
-    }
-
-    @api setPreviousNameFullName(value) {
-        this.previousName['full name'] = value;
-    }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
@@ -3,9 +3,18 @@ import { LightningElement, api, track } from 'lwc';
 export default class extends LightningElement {
     @api firstName;
     @api lastName;
-    @track previousName = { first: '', last: '', suffix: { short: '', long: '' } };
+    @track previousName = {
+        first: '',
+        last: '',
+        suffix: { short: '', long: '' },
+        'full name': '',
+    };
     @track aliases = [];
     @track favoriteFlavors = [{ food: 'ice cream', flavor: '' }];
+
+    get prettyPreviousName() {
+        return `${this.previousName.first} ${this.previousName.last} (${this.previousName['full name']}) ${this.previousName.suffix.short} (${this.previousName.suffix.long})`;
+    }
 
     @api setPreviousName(prop, value) {
         this.previousName[prop] = value;
@@ -21,5 +30,9 @@ export default class extends LightningElement {
 
     @api setFavoriteIceCreamFlavor(value) {
         this.favoriteFlavors[0].flavor = value;
+    }
+
+    @api setPreviousNameFullName(value) {
+        this.previousName['full name'] = value;
     }
 }

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/parent/parent.js
@@ -1,0 +1,16 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class extends LightningElement {
+    @api firstName;
+    @api lastName;
+    @track previousName = { first: '', last: '' };
+    @track aliases = [];
+
+    @api setPreviousName(prop, value) {
+        this.previousName[prop] = value;
+    }
+
+    @api addAlias(alias) {
+        this.aliases.push(alias);
+    }
+}

--- a/packages/@lwc/shared/src/language.ts
+++ b/packages/@lwc/shared/src/language.ts
@@ -24,6 +24,8 @@ const {
     getOwnPropertyDescriptors,
     /** Detached {@linkcode Object.getOwnPropertyNames}; see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames MDN Reference}. */
     getOwnPropertyNames,
+    /** Detached {@linkcode Object.getOwnPropertySymbols}; see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols MDN Reference}. */
+    getOwnPropertySymbols,
     /** Detached {@linkcode Object.getPrototypeOf}; see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf MDN Reference}. */
     getPrototypeOf,
     /** Detached {@linkcode Object.hasOwnProperty}; see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty MDN Reference}. */
@@ -218,6 +220,7 @@ export {
     getOwnPropertyDescriptor,
     getOwnPropertyDescriptors,
     getOwnPropertyNames,
+    getOwnPropertySymbols,
     getPrototypeOf,
     hasOwnProperty,
     isFrozen,


### PR DESCRIPTION
## Details

Fixes #4542 

Adds mutation tracking to the existing DevTools extensions (https://github.com/salesforce/lwc/pull/4535, #4541), so component authors can figure out why a component was re-rendered.

![Screenshot 2024-09-10 at 4 15 50 PM](https://github.com/user-attachments/assets/2377c9d4-11ff-415b-95f9-8bc4252b5854)

For all `lwc-rehydrate` events, there is a list of which components were mutated, and which properties on those components were mutated.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Only in dev mode, and only if you're looking at perf timings.

The overhead of these new APIs should also be minimal – I counted the following times when running our full Karma test suite:

- `getMutationProperties` - 12.5ms
- `trackTargetForMutationLogging` – 0.3ms
- `flushMutationLogsForVM` – 0.9ms

<!-- If yes, please describe the anticipated observable changes. -->
