### PR TITLE
feat(babel-plugin-compiler): observe string, number, and identifier bracketed fields

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/actual.js
@@ -3,5 +3,6 @@ const PREFIX = "prefix";
 export default class Test extends LightningElement {
   interface;
   ["a"] = 0;
+  [1337] = 0;
   [`${PREFIX}Field`] = "prefixed field";
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/actual.js
@@ -1,8 +1,10 @@
 import { api, wire, track, createElement, LightningElement } from "lwc";
+const symbol = Symbol("haha");
 const PREFIX = "prefix";
 export default class Test extends LightningElement {
   interface;
   ["a"] = 0;
   [1337] = 0;
+  [symbol] = "symbol!";
   [`${PREFIX}Field`] = "prefixed field";
 }

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
@@ -11,7 +11,7 @@ class Test extends LightningElement {
   /*LWC compiler vX.X.X*/
 }
 _registerDecorators(Test, {
-  fields: ["interface", "a", 1337, symbol, `${PREFIX}Field`]
+  fields: ["interface", "a", 1337, symbol]
 });
 const __lwc_component_class_internal = _registerComponent(Test, {
   tmpl: _tmpl,

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
@@ -1,15 +1,17 @@
 import { registerDecorators as _registerDecorators, createElement, LightningElement, registerComponent as _registerComponent } from "lwc";
 import _tmpl from "./test.html";
+const symbol = Symbol("haha");
 const PREFIX = "prefix";
 class Test extends LightningElement {
   interface;
   ["a"] = 0;
   [1337] = 0;
+  [symbol] = "symbol!";
   [`${PREFIX}Field`] = "prefixed field";
   /*LWC compiler vX.X.X*/
 }
 _registerDecorators(Test, {
-  fields: ["interface", "a", 1337]
+  fields: ["interface", "a", 1337, symbol]
 });
 const __lwc_component_class_internal = _registerComponent(Test, {
   tmpl: _tmpl,

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
@@ -11,7 +11,7 @@ class Test extends LightningElement {
   /*LWC compiler vX.X.X*/
 }
 _registerDecorators(Test, {
-  fields: ["interface", "a", 1337, symbol]
+  fields: ["interface", "a", 1337, symbol, `${PREFIX}Field`]
 });
 const __lwc_component_class_internal = _registerComponent(Test, {
   tmpl: _tmpl,

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-not-observe-changes-in-computed-fields/expected.js
@@ -4,11 +4,12 @@ const PREFIX = "prefix";
 class Test extends LightningElement {
   interface;
   ["a"] = 0;
+  [1337] = 0;
   [`${PREFIX}Field`] = "prefixed field";
   /*LWC compiler vX.X.X*/
 }
 _registerDecorators(Test, {
-  fields: ["interface"]
+  fields: ["interface", "a", 1337]
 });
 const __lwc_component_class_internal = _registerComponent(Test, {
   tmpl: _tmpl,

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-observe-changes-in-literal-fields/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-observe-changes-in-literal-fields/actual.js
@@ -1,0 +1,6 @@
+import { api, wire, track, createElement, LightningElement } from "lwc";
+
+export default class Test extends LightningElement {
+  "a" = 0;
+  1337 = 0;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-observe-changes-in-literal-fields/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/observed-fields/should-observe-changes-in-literal-fields/expected.js
@@ -1,0 +1,16 @@
+import { registerDecorators as _registerDecorators, createElement, LightningElement, registerComponent as _registerComponent } from "lwc";
+import _tmpl from "./test.html";
+class Test extends LightningElement {
+  "a" = 0;
+  1337 = 0;
+  /*LWC compiler vX.X.X*/
+}
+_registerDecorators(Test, {
+  fields: ["a", 1337]
+});
+const __lwc_component_class_internal = _registerComponent(Test, {
+  tmpl: _tmpl,
+  sel: "lwc-test",
+  apiVersion: 9999999
+});
+export default __lwc_component_class_internal;

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -263,6 +263,8 @@ function getMetadataObjectPropertyList(
                     return field.node.key;
                 case 'NumericLiteral':
                     return field.node.key;
+                case 'TemplateLiteral':
+                    return field.node.key;
             }
         })
         .filter((fieldName) => fieldName !== undefined);

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -248,7 +248,7 @@ function getMetadataObjectPropertyList(
         ...wire.transform(t, decoratorMetas),
     ];
 
-    const fieldNames = classBodyItems
+    const fieldKeys = classBodyItems
         .filter((field) => field.isClassProperty({ static: false }))
         .filter((field) => !field.node.decorators)
         .map((field) => {
@@ -263,14 +263,12 @@ function getMetadataObjectPropertyList(
                     return field.node.key;
                 case 'NumericLiteral':
                     return field.node.key;
-                case 'TemplateLiteral':
-                    return field.node.key;
             }
         })
-        .filter((fieldName) => fieldName !== undefined);
+        .filter((fieldKey) => fieldKey !== undefined);
 
-    if (fieldNames.length) {
-        list.push(t.objectProperty(t.identifier('fields'), t.arrayExpression(fieldNames)));
+    if (fieldKeys.length) {
+        list.push(t.objectProperty(t.identifier('fields'), t.arrayExpression(fieldKeys)));
     }
 
     return list;

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -254,16 +254,21 @@ function getMetadataObjectPropertyList(
         .map((field) => {
             switch (field.node.key.type) {
                 case 'Identifier':
-                    return field.node.key.name;
+                    if (field.node.computed) {
+                        return field.node.key;
+                    } else {
+                        return t.stringLiteral(field.node.key.name);
+                    }
                 case 'StringLiteral':
-                    return field.node.key.value;
+                    return field.node.key;
                 case 'NumericLiteral':
-                    return field.node.key.value;
+                    return field.node.key;
             }
         })
         .filter((fieldName) => fieldName !== undefined);
+
     if (fieldNames.length) {
-        list.push(t.objectProperty(t.identifier('fields'), t.valueToNode(fieldNames)));
+        list.push(t.objectProperty(t.identifier('fields'), t.arrayExpression(fieldNames)));
     }
 
     return list;

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -249,9 +249,19 @@ function getMetadataObjectPropertyList(
     ];
 
     const fieldNames = classBodyItems
-        .filter((field) => field.isClassProperty({ computed: false, static: false }))
-        .filter((field) => !(field.node as types.ClassProperty).decorators)
-        .map((field) => ((field.node as types.ClassProperty).key as types.Identifier).name);
+        .filter((field) => field.isClassProperty({ static: false }))
+        .filter((field) => !field.node.decorators)
+        .map((field) => {
+            switch (field.node.key.type) {
+                case 'Identifier':
+                    return field.node.key.name;
+                case 'StringLiteral':
+                    return field.node.key.value;
+                case 'NumericLiteral':
+                    return field.node.key.value;
+            }
+        })
+        .filter((fieldName) => fieldName !== undefined);
     if (fieldNames.length) {
         list.push(t.objectProperty(t.identifier('fields'), t.valueToNode(fieldNames)));
     }

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -161,6 +161,19 @@ describe('observed-fields', () => {
         });
     });
 
+    it('should rerender component when computed field with symbol is mutated', () => {
+        const elm = createElement('x-computed', { is: Computed });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue(Computed.symbol)).toBe('symbol!');
+
+        elm.setValue(Computed.symbol, 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.symbol').textContent).toBe('mutated');
+        });
+    });
+
     describe('restrictions', () => {
         it('logs a property error when a reactive field conflicts with a method', () => {
             expect(() => {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -199,18 +199,6 @@ describe('observed-fields', () => {
         });
     });
 
-    it('should rerender component when computed field with prefixed field is mutated', () => {
-        const elm = createElement('x-computed', { is: Computed });
-        document.body.appendChild(elm);
-
-        expect(elm.getValue(`${Computed.prefix}Field`)).toBe('prefixed!');
-        elm.setValue(`${Computed.prefix}Field`, 'mutated');
-
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.prefixed').textContent).toBe('mutated');
-        });
-    });
-
     describe('restrictions', () => {
         it('logs a property error when a reactive field conflicts with a method', () => {
             expect(() => {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -174,6 +174,18 @@ describe('observed-fields', () => {
         });
     });
 
+    it('should rerender component when computed field with prefixed field is mutated', () => {
+        const elm = createElement('x-computed', { is: Computed });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue(`${Computed.prefix}Field`)).toBe('prefixed!');
+        elm.setValue(`${Computed.prefix}Field`, 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.prefixed').textContent).toBe('mutated');
+        });
+    });
+
     describe('restrictions', () => {
         it('logs a property error when a reactive field conflicts with a method', () => {
             expect(() => {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -7,6 +7,7 @@ import FieldForCache from 'x/fieldForCache';
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
 
 import Computed from 'x/computed';
+import Literal from 'x/literal';
 
 describe('observed-fields', () => {
     it('should rerender component when field is mutated', () => {
@@ -132,6 +133,30 @@ describe('observed-fields', () => {
             expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
                 'static value modified'
             );
+        });
+    });
+
+    it('should rerender component when literal string field is mutated', () => {
+        const elm = createElement('x-literal', { is: Literal });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue('reg')).toBe('string!');
+        elm.setValue('reg', 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.string').textContent).toBe('mutated');
+        });
+    });
+
+    it('should rerender component when literal number field is mutated', () => {
+        const elm = createElement('x-literal', { is: Literal });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue(1337)).toBe('number!');
+        elm.setValue(1337, 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.number').textContent).toBe('mutated');
         });
     });
 

--- a/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/index.spec.js
@@ -6,6 +6,8 @@ import FieldForCache from 'x/fieldForCache';
 
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
 
+import Computed from 'x/computed';
+
 describe('observed-fields', () => {
     it('should rerender component when field is mutated', () => {
         const elm = createElement('x-simple', { is: Simple });
@@ -130,6 +132,32 @@ describe('observed-fields', () => {
             expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
                 'static value modified'
             );
+        });
+    });
+
+    it('should rerender component when computed field with spaces is mutated', () => {
+        const elm = createElement('x-computed', { is: Computed });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue('with spaces')).toBe('spaces!');
+
+        elm.setValue('with spaces', 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.spaces').textContent).toBe('mutated');
+        });
+    });
+
+    it('should rerender component when computed field with number is mutated', () => {
+        const elm = createElement('x-computed', { is: Computed });
+        document.body.appendChild(elm);
+
+        expect(elm.getValue(1337)).toBe('number!');
+
+        elm.setValue(1337, 'mutated');
+
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.querySelector('.number').textContent).toBe('mutated');
         });
     });
 

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
@@ -2,5 +2,4 @@
     <p class="spaces">{spaces}</p>
     <p class="number">{number}</p>
     <p class="symbol">{symbol}</p>
-    <p class="prefixed">{prefixed}</p>
 </template>

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
@@ -1,0 +1,4 @@
+<template>
+    <p class="spaces">{spaces}</p>
+    <p class="number">{number}</p>
+</template>

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
@@ -1,4 +1,5 @@
 <template>
     <p class="spaces">{spaces}</p>
     <p class="number">{number}</p>
+    <p class="symbol">{symbol}</p>
 </template>

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.html
@@ -2,4 +2,5 @@
     <p class="spaces">{spaces}</p>
     <p class="number">{number}</p>
     <p class="symbol">{symbol}</p>
+    <p class="prefixed">{prefixed}</p>
 </template>

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
@@ -1,14 +1,17 @@
 import { api, LightningElement } from 'lwc';
 
-const symbol = Symbol('haha');
+const SYMBOL = Symbol('haha');
+const PREFIX = 'prefix';
 
 export default class App extends LightningElement {
-    static symbol = symbol;
+    static symbol = SYMBOL;
+    static prefix = PREFIX;
     // eslint-disable-next-line no-useless-computed-key
     ['with spaces'] = 'spaces!';
     // eslint-disable-next-line no-useless-computed-key
     [1337] = 'number!';
-    [symbol] = 'symbol!';
+    [SYMBOL] = 'symbol!';
+    [`${PREFIX}Field`] = 'prefixed!';
 
     get spaces() {
         return this['with spaces'];
@@ -19,7 +22,11 @@ export default class App extends LightningElement {
     }
 
     get symbol() {
-        return this[symbol];
+        return this[SYMBOL];
+    }
+
+    get prefixed() {
+        return this[`${PREFIX}Field`];
     }
 
     @api setValue(field, value) {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
@@ -1,17 +1,14 @@
 import { api, LightningElement } from 'lwc';
 
 const SYMBOL = Symbol('haha');
-const PREFIX = 'prefix';
 
 export default class App extends LightningElement {
     static symbol = SYMBOL;
-    static prefix = PREFIX;
     // eslint-disable-next-line no-useless-computed-key
     ['with spaces'] = 'spaces!';
     // eslint-disable-next-line no-useless-computed-key
     [1337] = 'number!';
     [SYMBOL] = 'symbol!';
-    [`${PREFIX}Field`] = 'prefixed!';
 
     get spaces() {
         return this['with spaces'];
@@ -23,10 +20,6 @@ export default class App extends LightningElement {
 
     get symbol() {
         return this[SYMBOL];
-    }
-
-    get prefixed() {
-        return this[`${PREFIX}Field`];
     }
 
     @api setValue(field, value) {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
@@ -1,0 +1,24 @@
+import { api, LightningElement } from 'lwc';
+
+export default class App extends LightningElement {
+    // eslint-disable-next-line no-useless-computed-key
+    ['with spaces'] = 'spaces!';
+    // eslint-disable-next-line no-useless-computed-key
+    [1337] = 'number!';
+
+    get spaces() {
+        return this['with spaces'];
+    }
+
+    get number() {
+        return this[1337];
+    }
+
+    @api setValue(field, value) {
+        this[field] = value;
+    }
+
+    @api getValue(field) {
+        return this[field];
+    }
+}

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/computed/computed.js
@@ -1,10 +1,14 @@
 import { api, LightningElement } from 'lwc';
 
+const symbol = Symbol('haha');
+
 export default class App extends LightningElement {
+    static symbol = symbol;
     // eslint-disable-next-line no-useless-computed-key
     ['with spaces'] = 'spaces!';
     // eslint-disable-next-line no-useless-computed-key
     [1337] = 'number!';
+    [symbol] = 'symbol!';
 
     get spaces() {
         return this['with spaces'];
@@ -12,6 +16,10 @@ export default class App extends LightningElement {
 
     get number() {
         return this[1337];
+    }
+
+    get symbol() {
+        return this[symbol];
     }
 
     @api setValue(field, value) {

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/literal/literal.html
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/literal/literal.html
@@ -1,0 +1,4 @@
+<template>
+    <p class="string">{string}</p>
+    <p class="number">{number}</p>
+</template>

--- a/packages/@lwc/integration-karma/test/component/observed-fields/x/literal/literal.js
+++ b/packages/@lwc/integration-karma/test/component/observed-fields/x/literal/literal.js
@@ -1,0 +1,22 @@
+import { api, LightningElement } from 'lwc';
+
+export default class App extends LightningElement {
+    reg = 'string!';
+    1337 = 'number!';
+
+    get string() {
+        return this['reg'];
+    }
+
+    get number() {
+        return this[1337];
+    }
+
+    @api setValue(field, value) {
+        this[field] = value;
+    }
+
+    @api getValue(field) {
+        return this[field];
+    }
+}


### PR DESCRIPTION
## Details

Adds support for observing simple string and number bracketed fields (eg: ['with spaces'] and [1337]), as well as identifiers (eg: [symbol]). Support for non-computed numbers and strings is also included eg 1337 and 'with spaces'

String and number literals are very straightforward. Bracketed identifiers (to support symbol) deserve a deeper look.

Support for booleans [true] [false] is not included since it wasn't in the original issue, but it could be desirable for completeness and consistency, although it's hard for me to see why one would do that.

Closes #4547

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

It can be a breaking change if a bracketed identifier, string or number property is expected to not be observable, but I doubt anyone would be relying on this behavior, especially since most linters will warn/error about it.

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Simple bracketed identifier, strings and number properties will now be observed.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
