### PR TITLE
fix: revert "build(deps): bump meriyah from 5.0.0 to 6.0.0 (#4550)"

### DIFF
--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -50,7 +50,7 @@
         "astring": "^1.9.0",
         "estree-toolkit": "^1.7.8",
         "immer": "^10.1.1",
-        "meriyah": "^6.0.0"
+        "meriyah": "^5.0.0"
     },
     "devDependencies": {
         "@types/estree": "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8985,10 +8985,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meriyah@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-6.0.0.tgz#c35b6bde1e99c201ec1ae4edf5b0f673a809d868"
-  integrity sha512-hUU2w43bFaeEfNPWv8C0/OtxzLO2czNrwgCRsWtPGWmLmgTc1cDcvXlOeKro6/1ll7m8Th8wVM764FsVXJ07ig==
+meriyah@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-5.0.0.tgz#9f5fd811ee6e7952dcb48cf6962f27a885f108b8"
+  integrity sha512-tNlPDP4AzkH/7cROw7PKJ7mCLe/ZLpa2ja23uqB35vt63+8dgZi2NKLJMrkjxLcxArnLJVvd3Y/7pRl3OLR7yg==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Details

This reverts commit 485b715ba3d765d550319493adea057ac1983749.

We need Node v16 support for just a tad longer.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
