### PR TITLE
fix(ssr): allow capital letters in component names

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
@@ -32,7 +32,7 @@ export function catalogStyleImport(path: NodePath<ImportDeclaration>, state: Com
     state.cssExplicitImports.set(specifier.local.name, path.node!.source.value);
 }
 
-const componentNamePattern = /(?<componentName>[a-z_-]+)\.[tj]s$/i;
+const componentNamePattern = /(?<componentName>[^/]+)\.[tj]s$/;
 
 /**
  * This adds implicit style imports to the compiled component artifact.

--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
@@ -32,7 +32,7 @@ export function catalogStyleImport(path: NodePath<ImportDeclaration>, state: Com
     state.cssExplicitImports.set(specifier.local.name, path.node!.source.value);
 }
 
-const componentNamePattern = /[/\\](?<componentName>[a-z_-]+)[/\\]\k<componentName>\.[tj]s$/;
+const componentNamePattern = /[/\\](?<componentName>[a-z_-]+)[/\\]\k<componentName>\.[tj]s$/i;
 
 /**
  * This adds implicit style imports to the compiled component artifact.

--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
@@ -32,7 +32,7 @@ export function catalogStyleImport(path: NodePath<ImportDeclaration>, state: Com
     state.cssExplicitImports.set(specifier.local.name, path.node!.source.value);
 }
 
-const componentNamePattern = /[/\\](?<componentName>[a-z_-]+)[/\\]\k<componentName>\.[tj]s$/i;
+const componentNamePattern = /(?<componentName>[a-z_-]+)\.[tj]s$/i;
 
 /**
  * This adds implicit style imports to the compiled component artifact.


### PR DESCRIPTION
## Details

The experimental SSR compiler currently doesn't support capital letters in component names. This fixes that.

This gets the new SSR tests down from 59 failures to 56 failures.

Related: #4555 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
