### PR TITLE
fix(template-compiler): styles containing newlines

### DIFF
--- a/packages/@lwc/integration-karma/test/regression/style-newline/index.spec.js
+++ b/packages/@lwc/integration-karma/test/regression/style-newline/index.spec.js
@@ -1,0 +1,12 @@
+import { createElement } from 'lwc';
+import Component from 'x/component';
+
+it('should render style containing newline - issue #4579', async () => {
+    const elm = createElement('x-component', { is: Component });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    const div = elm.shadowRoot.querySelector('div');
+    expect(div.style.color).toBe('yellow');
+});

--- a/packages/@lwc/integration-karma/test/regression/style-newline/index.spec.js
+++ b/packages/@lwc/integration-karma/test/regression/style-newline/index.spec.js
@@ -9,4 +9,8 @@ it('should render style containing newline - issue #4579', async () => {
 
     const div = elm.shadowRoot.querySelector('div');
     expect(div.style.color).toBe('yellow');
+
+    const span = elm.shadowRoot.querySelector('span');
+    expect(span.style.color).toBe('purple');
+    expect(span.style.backgroundColor).toBe('orange');
 });

--- a/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.html
@@ -1,4 +1,9 @@
 <template>
     <div style="color:
     yellow"></div>
+
+    <span style="color:
+    purple;
+    background-color:
+    orange;"></span>
 </template>

--- a/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.html
+++ b/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.html
@@ -1,0 +1,4 @@
+<template>
+    <div style="color:
+    yellow"></div>
+</template>

--- a/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.js
+++ b/packages/@lwc/integration-karma/test/regression/style-newline/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -217,7 +217,7 @@ function generateStylesheetTokens(codeGen: CodeGen): t.ExpressionStatement[] {
 }
 
 const DECLARATION_DELIMITER = /;(?![^(]*\))/g;
-const PROPERTY_DELIMITER = /:(.+)/;
+const PROPERTY_DELIMITER = /:(.+)/s; // `/s` (dotAll) required to match styles across newlines, e.g. `color: \n red;`
 
 // Borrowed from Vue template compiler.
 // https://github.com/vuejs/vue/blob/531371b818b0e31a989a06df43789728f23dc4e8/src/platforms/web/util/style.js#L5-L16


### PR DESCRIPTION
## Details

Fixes #4579

Pretty straightforward fix, just required using [Regex dotAll](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) (available in Node v8+).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Technically yes, but it also fixes a recent regression (#4579). Also I suspect this use case is extremely uncommon (newlines separating style declarations), and it probably didn't work in the past with non-static-optimized elements anyway due to the style normalization previously only being applied to non-static-optimized elements.