### PR TITLE
fix(ssr): use style normalizer from template compiler

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -719,7 +719,7 @@ function validateStyleAttr(
         // styleMap is used when style is set to static value.
         for (let i = 0, n = styleDecls.length; i < n; i++) {
             const [prop, value, important] = styleDecls[i];
-            expectedStyle.push(`${prop}: ${value + (important ? ' important!' : '')}`);
+            expectedStyle.push(`${prop}: ${value + (important ? ' !important' : '')}`);
 
             const parsedPropValue = parsedVnodeStyle[prop];
 

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -21,12 +21,13 @@ import {
     isAPIFeatureEnabled,
     isFalse,
     StringSplit,
+    parseStyleText,
 } from '@lwc/shared';
 
 import { logError, logWarn } from '../shared/logger';
 
 import { RendererAPI } from './renderer';
-import { cloneAndOmitKey, parseStyleText, shouldBeFormAssociated } from './utils';
+import { cloneAndOmitKey, shouldBeFormAssociated } from './utils';
 import { allocateChildren, mount, removeNode } from './rendering';
 import {
     createVM,

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -719,7 +719,7 @@ function validateStyleAttr(
         // styleMap is used when style is set to static value.
         for (let i = 0, n = styleDecls.length; i < n; i++) {
             const [prop, value, important] = styleDecls[i];
-            expectedStyle.push(`${prop}: ${value + (important ? ' !important' : '')}`);
+            expectedStyle.push(`${prop}: ${value + (important ? ' !important' : '')};`);
 
             const parsedPropValue = parsedVnodeStyle[prop];
 
@@ -736,7 +736,7 @@ function validateStyleAttr(
             nodesAreCompatible = false;
         }
 
-        vnodeStyle = ArrayJoin.call(expectedStyle, ';');
+        vnodeStyle = ArrayJoin.call(expectedStyle, ' ');
     }
 
     if (!nodesAreCompatible) {

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -67,28 +67,6 @@ export function guid(): string {
     return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
 }
 
-// Borrowed from Vue template compiler.
-// https://github.com/vuejs/vue/blob/531371b818b0e31a989a06df43789728f23dc4e8/src/platforms/web/util/style.js#L5-L16
-const DECLARATION_DELIMITER = /;(?![^(]*\))/g;
-const PROPERTY_DELIMITER = /:(.+)/;
-
-export function parseStyleText(cssText: string): { [name: string]: string } {
-    const styleMap: { [name: string]: string } = {};
-
-    const declarations = cssText.split(DECLARATION_DELIMITER);
-    for (const declaration of declarations) {
-        if (declaration) {
-            const [prop, value] = declaration.split(PROPERTY_DELIMITER);
-
-            if (prop !== undefined && value !== undefined) {
-                styleMap[prop.trim()] = value.trim();
-            }
-        }
-    }
-
-    return styleMap;
-}
-
 // Make a shallow copy of an object but omit the given key
 export function cloneAndOmitKey(object: { [key: string]: any }, keyToOmit: string) {
     const result: { [key: string]: any } = {};

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-component-global-html/expected.html
@@ -1,6 +1,6 @@
 <x-attribute-component-global-html>
   <template shadowrootmode="open">
-    <x-child accesskey="A" class="foo bar" contenteditable="true" data-test="test" draggable="true" hidden id="foo" itemprop="foo" spellcheck="true" style="color: red; background: blue" tabindex="-1">
+    <x-child accesskey="A" class="foo bar" contenteditable="true" data-test="test" draggable="true" hidden id="foo" itemprop="foo" spellcheck="true" style="color: red; background: blue;" tabindex="-1">
       <template shadowrootmode="open">
         Passthrough properties:
         <ul>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-style/expected.html
@@ -16,15 +16,15 @@
     </div>
     <div>
     </div>
-    <x-child style="color: red">
+    <x-child style="color: red;">
       <template shadowrootmode="open">
       </template>
     </x-child>
-    <x-child style="color: blue; background: black; border: 1px solid red">
+    <x-child style="color: blue; background: black; border: 1px solid red;">
       <template shadowrootmode="open">
       </template>
     </x-child>
-    <x-child style="border-width: 1px; border-style: solid; border-color: red">
+    <x-child style="border-width: 1px; border-style: solid; border-color: red;">
       <template shadowrootmode="open">
       </template>
     </x-child>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/expected.html
@@ -1,0 +1,8 @@
+<x-component>
+  <template shadowrootmode="open">
+    <div style="color: yellow;">
+    </div>
+    <span style="color: purple; background-color: orange;">
+    </span>
+  </template>
+</x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-component';
+export { default } from 'x/component';
+export * from 'x/component';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/modules/x/component/component.html
@@ -1,0 +1,9 @@
+<template>
+    <div style="color:
+    yellow"></div>
+
+    <span style="color:
+    purple;
+    background-color:
+    orange;"></span>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/modules/x/component/component.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/style-newline/modules/x/component/component.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -328,7 +328,7 @@ function setCSSStyleProperty(element: E, name: string, value: string, important:
         (attr) => attr.name === 'style' && isNull(attr[HostNamespaceKey])
     );
 
-    const serializedProperty = `${name}: ${value}${important ? ' !important' : ''}`;
+    const serializedProperty = `${name}: ${value}${important ? ' !important' : ''};`;
 
     if (isUndefined(styleAttribute)) {
         element[HostAttributesKey].push({
@@ -337,7 +337,7 @@ function setCSSStyleProperty(element: E, name: string, value: string, important:
             value: serializedProperty,
         });
     } else {
-        styleAttribute.value += `; ${serializedProperty}`;
+        styleAttribute.value += ` ${serializedProperty}`;
     }
 }
 

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
@@ -23,7 +23,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red important!" but found "background-color: red; border-color: red"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red !important" but found "background-color: red; border-color: red"',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
@@ -23,7 +23,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red !important" but found "background-color: red; border-color: red;".',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red !important;" but found "background-color: red; border-color: red;".',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-different-priority/index.spec.js
@@ -23,7 +23,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red !important" but found "background-color: red; border-color: red"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red !important" but found "background-color: red; border-color: red;".',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
@@ -23,7 +23,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red;"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red; margin: 1px;" but found "background-color: red; border-color: red;".',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-client/index.spec.js
@@ -23,7 +23,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red;margin: 1px" but found "background-color: red; border-color: red;"',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
@@ -21,7 +21,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px;"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red; border-color: red;" but found "background-color: red; border-color: red; margin: 1px;".',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/static/unoptimized-extra-from-server/index.spec.js
@@ -21,7 +21,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             error: [
-                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px"',
+                '[LWC error]: Mismatch hydrating element <p>: attribute "style" has different values, expected "background-color: red;border-color: red" but found "background-color: red; border-color: red; margin: 1px;"',
                 'Hydration completed with errors.',
             ],
         });

--- a/packages/@lwc/shared/src/index.ts
+++ b/packages/@lwc/shared/src/index.ts
@@ -17,5 +17,6 @@ export * from './html-escape';
 export * from './namespaces';
 export * from './meta';
 export * from './static-part-tokens';
+export * from './style';
 
 export { assert };

--- a/packages/@lwc/shared/src/style.ts
+++ b/packages/@lwc/shared/src/style.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export const IMPORTANT_FLAG = /\s*!\s*important\s*$/i;
+const DECLARATION_DELIMITER = /;(?![^(]*\))/g;
+const PROPERTY_DELIMITER = /:(.+)/s; // `/s` (dotAll) required to match styles across newlines, e.g. `color: \n red;`
+
+// Borrowed from Vue template compiler.
+// https://github.com/vuejs/vue/blob/531371b818b0e31a989a06df43789728f23dc4e8/src/platforms/web/util/style.js#L5-L16
+export function parseStyleText(cssText: string): { [name: string]: string } {
+    const styleMap: { [name: string]: string } = {};
+
+    const declarations = cssText.split(DECLARATION_DELIMITER);
+    for (const declaration of declarations) {
+        if (declaration) {
+            const [prop, value] = declaration.split(PROPERTY_DELIMITER);
+
+            if (prop !== undefined && value !== undefined) {
+                styleMap[prop.trim()] = value.trim();
+            }
+        }
+    }
+
+    return styleMap;
+}
+
+export function normalizeStyleAttribute(style: string): string {
+    const styleMap = parseStyleText(style);
+
+    const styles = Object.entries(styleMap).map(([key, value]) => {
+        value = value.replace(IMPORTANT_FLAG, ' !important').trim();
+        return `${key}: ${value};`;
+    });
+
+    return styles.join(' ');
+}

--- a/packages/@lwc/ssr-compiler/src/compile-template/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/component.ts
@@ -6,11 +6,8 @@
  */
 
 import { builders as b, is } from 'estree-toolkit';
-import {
-    kebabcaseToCamelcase,
-    normalizeStyleAttribute,
-    toPropertyName,
-} from '@lwc/template-compiler';
+import { kebabcaseToCamelcase, toPropertyName } from '@lwc/template-compiler';
+import { normalizeStyleAttribute } from '@lwc/shared';
 import { esTemplateWithYield } from '../estemplate';
 import { isValidIdentifier } from './shared';
 import { TransformerContext } from './types';

--- a/packages/@lwc/ssr-compiler/src/compile-template/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/component.ts
@@ -6,9 +6,13 @@
  */
 
 import { builders as b, is } from 'estree-toolkit';
-import { kebabcaseToCamelcase, toPropertyName } from '@lwc/template-compiler';
+import {
+    kebabcaseToCamelcase,
+    normalizeStyleAttribute,
+    toPropertyName,
+} from '@lwc/template-compiler';
 import { esTemplateWithYield } from '../estemplate';
-import { cleanStyleAttrVal, isValidIdentifier } from './shared';
+import { isValidIdentifier } from './shared';
 import { TransformerContext } from './types';
 import { expressionIrToEs } from './expression';
 
@@ -46,7 +50,9 @@ function getChildAttrsOrProps(
         const key = isValidIdentifier(attr.name) ? b.identifier(attr.name) : b.literal(attr.name);
         if (attr.value.type === 'Literal' && typeof attr.value.value === 'string') {
             const value =
-                attr.name === 'style' ? cleanStyleAttrVal(attr.value.value) : attr.value.value;
+                attr.name === 'style'
+                    ? normalizeStyleAttribute(attr.value.value)
+                    : attr.value.value;
             return b.property('init', key, b.literal(value));
         } else if (attr.value.type === 'Literal' && typeof attr.value.value === 'boolean') {
             return b.property('init', key, b.literal(attr.value.value));

--- a/packages/@lwc/ssr-compiler/src/compile-template/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/element.ts
@@ -6,14 +6,13 @@
  */
 
 import { builders as b, is } from 'estree-toolkit';
-import { HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
+import { HTML_NAMESPACE, isVoidElement, normalizeStyleAttribute } from '@lwc/shared';
 import {
     type Attribute as IrAttribute,
     type Expression as IrExpression,
     type Element as IrElement,
     type Literal as IrLiteral,
     type Property as IrProperty,
-    normalizeStyleAttribute,
 } from '@lwc/template-compiler';
 import { esTemplateWithYield } from '../estemplate';
 import { irChildrenToEs } from './ir-to-es';

--- a/packages/@lwc/ssr-compiler/src/compile-template/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/element.ts
@@ -7,17 +7,18 @@
 
 import { builders as b, is } from 'estree-toolkit';
 import { HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
+import {
+    type Attribute as IrAttribute,
+    type Expression as IrExpression,
+    type Element as IrElement,
+    type Literal as IrLiteral,
+    type Property as IrProperty,
+    normalizeStyleAttribute,
+} from '@lwc/template-compiler';
 import { esTemplateWithYield } from '../estemplate';
 import { irChildrenToEs } from './ir-to-es';
-import { bImportHtmlEscape, importHtmlEscapeKey, cleanStyleAttrVal } from './shared';
+import { bImportHtmlEscape, importHtmlEscapeKey } from './shared';
 
-import type {
-    Attribute as IrAttribute,
-    Expression as IrExpression,
-    Element as IrElement,
-    Literal as IrLiteral,
-    Property as IrProperty,
-} from '@lwc/template-compiler';
 import type {
     BinaryExpression,
     BlockStatement as EsBlockStatement,
@@ -55,7 +56,7 @@ function yieldAttrOrPropLiteralValue(
 ): EsStatement[] {
     const { value, type } = valueNode;
     if (typeof value === 'string') {
-        const yieldedValue = name === 'style' ? cleanStyleAttrVal(value) : value;
+        const yieldedValue = name === 'style' ? normalizeStyleAttribute(value) : value;
         return [bStringLiteralYield(b.literal(isClass), b.literal(name), b.literal(yieldedValue))];
     } else if (typeof value === 'boolean') {
         return [bYield(b.literal(` ${name}`))];

--- a/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
@@ -16,13 +16,6 @@ export const bImportHtmlEscape = esTemplate<EsImportDeclaration>`
 `;
 export const importHtmlEscapeKey = 'import:htmlEscape';
 
-export function cleanStyleAttrVal(styleAttrVal: string): string {
-    if (styleAttrVal.endsWith(';')) {
-        styleAttrVal = styleAttrVal.slice(0, -1);
-    }
-    return styleAttrVal.trim();
-}
-
 // This is a mostly-correct regular expression will only match if the entire string
 // provided is a valid ECMAScript identifier. Its imperfections lie in the fact that
 // it will match strings like "export" when "export" is actually a reserved keyword

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -238,6 +238,10 @@ export function parseStyleText(cssText: string): { [name: string]: string } {
     return styleMap;
 }
 
+/**
+ * Internal use only.
+ * @private
+ */
 export function normalizeStyleAttribute(style: string): string {
     const styleMap = parseStyleText(style);
 

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { APIFeature, isAPIFeatureEnabled } from '@lwc/shared';
+import { APIFeature, IMPORTANT_FLAG, isAPIFeatureEnabled } from '@lwc/shared';
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
 import { ChildNode, LWCDirectiveRenderMode, Node } from '../shared/types';
@@ -215,45 +215,6 @@ function generateStylesheetTokens(codeGen: CodeGen): t.ExpressionStatement[] {
 
     return styleTokens;
 }
-
-const DECLARATION_DELIMITER = /;(?![^(]*\))/g;
-const PROPERTY_DELIMITER = /:(.+)/s; // `/s` (dotAll) required to match styles across newlines, e.g. `color: \n red;`
-
-// Borrowed from Vue template compiler.
-// https://github.com/vuejs/vue/blob/531371b818b0e31a989a06df43789728f23dc4e8/src/platforms/web/util/style.js#L5-L16
-export function parseStyleText(cssText: string): { [name: string]: string } {
-    const styleMap: { [name: string]: string } = {};
-
-    const declarations = cssText.split(DECLARATION_DELIMITER);
-    for (const declaration of declarations) {
-        if (declaration) {
-            const [prop, value] = declaration.split(PROPERTY_DELIMITER);
-
-            if (prop !== undefined && value !== undefined) {
-                styleMap[prop.trim()] = value.trim();
-            }
-        }
-    }
-
-    return styleMap;
-}
-
-/**
- * Internal use only.
- * @private
- */
-export function normalizeStyleAttribute(style: string): string {
-    const styleMap = parseStyleText(style);
-
-    const styles = Object.entries(styleMap).map(([key, value]) => {
-        value = value.replace(IMPORTANT_FLAG, ' !important').trim();
-        return `${key}: ${value};`;
-    });
-
-    return styles.join(' ');
-}
-
-const IMPORTANT_FLAG = /\s*!\s*important\s*$/i;
 
 // Given a map of CSS property keys to values, return an array AST like:
 // ['color', 'blue', false]    // { color: 'blue' }

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -6,7 +6,13 @@
  */
 import * as astring from 'astring';
 
-import { isBooleanAttribute, SVG_NAMESPACE, LWC_VERSION_COMMENT, isUndefined } from '@lwc/shared';
+import {
+    isBooleanAttribute,
+    SVG_NAMESPACE,
+    LWC_VERSION_COMMENT,
+    isUndefined,
+    parseStyleText,
+} from '@lwc/shared';
 import { CompilerMetrics, generateCompilerError, TemplateErrors } from '@lwc/errors';
 
 import {
@@ -70,7 +76,6 @@ import {
     objectToAST,
     shouldFlatten,
     parseClassNames,
-    parseStyleText,
     hasIdAttribute,
     styleMapToStyleDeclsAST,
 } from './helpers';

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { HTML_NAMESPACE, htmlEscape, isVoidElement } from '@lwc/shared';
+import { HTML_NAMESPACE, htmlEscape, isVoidElement, normalizeStyleAttribute } from '@lwc/shared';
 import {
     isAllowedFragOnlyUrlsXHTML,
     isFragmentOnlyUrl,
@@ -21,7 +21,6 @@ import {
     isText,
 } from '../shared/ast';
 import { hasDynamicText, isContiguousText, transformStaticChildren } from './static-element';
-import { normalizeStyleAttribute } from './helpers';
 import type CodeGen from './codegen';
 
 // Implementation based on the parse5 serializer: https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/serializer/index.ts

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -25,6 +25,7 @@ export { Config } from './config';
 export { toPropertyName } from './shared/utils';
 export { kebabcaseToCamelcase } from './shared/naming';
 export { generateScopeTokens } from './scopeTokens';
+export { normalizeStyleAttribute } from './codegen/helpers';
 
 /**
  * Parses HTML markup into an AST

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -25,7 +25,6 @@ export { Config } from './config';
 export { toPropertyName } from './shared/utils';
 export { kebabcaseToCamelcase } from './shared/naming';
 export { generateScopeTokens } from './scopeTokens';
-export { normalizeStyleAttribute } from './codegen/helpers';
 
 /**
  * Parses HTML markup into an AST


### PR DESCRIPTION
## Details

Fixes normalization of `style` attributes in the `@lwc/ssr-compiler`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

