### PR TITLE
fix(hydration): fix `validationOptOut` with auto-detection

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -189,7 +189,7 @@ function getValidationPredicate(
         !isValidArray
     ) {
         logWarn(
-            'Validation opt out must be `true` or an array of attributes that should not be validated.'
+            '`validationOptOut` must be `true` or an array of attributes that should not be validated.'
         );
     }
 

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -179,13 +179,14 @@ function getValidationPredicate(
 
     // If validationOptOut is an array of strings, attributes specified in the array will be "opted out". Attributes
     // not specified in the array will still be validated.
-    const conditionalOptOut = isArray(optOutStaticProp) ? new Set(optOutStaticProp) : undefined;
+    const isValidArray = isArray(optOutStaticProp) && arrayEvery(optOutStaticProp, isString);
+    const conditionalOptOut = isValidArray ? new Set(optOutStaticProp) : undefined;
 
     if (
         process.env.NODE_ENV !== 'production' &&
         !isUndefined(optOutStaticProp) &&
         !isTrue(optOutStaticProp) &&
-        !(isArray(optOutStaticProp) && arrayEvery(optOutStaticProp, isString))
+        !isValidArray
     ) {
         logWarn(
             'Validation opt out must be `true` or an array of attributes that should not be validated.'

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/index.spec.js
@@ -1,0 +1,19 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).not.toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [],
+            error: [
+                'Mismatch hydrating element <x-child>: attribute "data-mutate-during-render" has different values, expected "false" but found "true"',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/child/child.js
@@ -1,0 +1,13 @@
+import { LightningElement } from 'lwc';
+import template from './template.html';
+
+export default class extends LightningElement {
+    connectedCallback() {
+        this.setAttribute('data-mutate-during-connected-callback', 'true');
+    }
+
+    render() {
+        this.setAttribute('data-mutate-during-render', 'true');
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/child/template.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/child/template.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child data-mutate-during-render="false"></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/no-opt-out/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/index.spec.js
@@ -1,0 +1,13 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+        expect(consoleCalls.warn).toHaveSize(0);
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/child/child.js
@@ -1,0 +1,15 @@
+import { LightningElement } from 'lwc';
+import template from './template.html';
+
+export default class extends LightningElement {
+    static validationOptOut = ['data-mutate-during-render'];
+
+    connectedCallback() {
+        this.setAttribute('data-mutate-during-connected-callback', 'true');
+    }
+
+    render() {
+        this.setAttribute('data-mutate-during-render', 'true');
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/child/template.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/child/template.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child data-mutate-during-render="false"></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-array/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/index.spec.js
@@ -1,0 +1,13 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+        expect(consoleCalls.warn).toHaveSize(0);
+        expect(consoleCalls.error).toHaveSize(0);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/child/child.js
@@ -1,0 +1,15 @@
+import { LightningElement } from 'lwc';
+import template from './template.html';
+
+export default class extends LightningElement {
+    static validationOptOut = true;
+
+    connectedCallback() {
+        this.setAttribute('data-mutate-during-connected-callback', 'true');
+    }
+
+    render() {
+        this.setAttribute('data-mutate-during-render', 'true');
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/child/template.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/child/template.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child data-mutate-during-render="false"></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-true/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/index.spec.js
@@ -1,0 +1,19 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).not.toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [],
+            error: [
+                'Mismatch hydrating element <x-child>: attribute "data-mutate-during-render" has different values, expected "false" but found "true"',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/child/child.js
@@ -1,0 +1,15 @@
+import { LightningElement } from 'lwc';
+import template from './template.html';
+
+export default class extends LightningElement {
+    static validationOptOut = ['does-not-exist'];
+
+    connectedCallback() {
+        this.setAttribute('data-mutate-during-connected-callback', 'true');
+    }
+
+    render() {
+        this.setAttribute('data-mutate-during-render', 'true');
+        return template;
+    }
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/child/template.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/child/template.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child data-mutate-during-render="false"></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/mutate-in-connected-and-render/opt-out-wrong-array/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/index.spec.js
@@ -1,0 +1,18 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+            ],
+            error: [],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/index.spec.js
@@ -10,7 +10,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             warn: [
-                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+                '`validationOptOut` must be `true` or an array of attributes that should not be validated.',
             ],
             error: [],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/child/child.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static validationOptOut = [undefined];
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-array-of-non-strings/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/index.spec.js
@@ -1,0 +1,18 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+            ],
+            error: [],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/index.spec.js
@@ -10,7 +10,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             warn: [
-                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+                '`validationOptOut` must be `true` or an array of attributes that should not be validated.',
             ],
             error: [],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/child/child.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static validationOptOut = false;
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-false/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/index.spec.js
@@ -1,0 +1,18 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+            ],
+            error: [],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/index.spec.js
@@ -10,7 +10,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             warn: [
-                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+                '`validationOptOut` must be `true` or an array of attributes that should not be validated.',
             ],
             error: [],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/child/child.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static validationOptOut = {};
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-non-array/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/index.spec.js
@@ -1,0 +1,18 @@
+export default {
+    snapshot(target) {
+        return {
+            child: target.shadowRoot.querySelector('x-child'),
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const hydratedSnapshot = this.snapshot(target);
+        expect(hydratedSnapshot.child).toBe(snapshots.child);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            warn: [
+                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+            ],
+            error: [],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/index.spec.js
@@ -10,7 +10,7 @@ export default {
 
         TestUtils.expectConsoleCallsDev(consoleCalls, {
             warn: [
-                'Validation opt out must be `true` or an array of attributes that should not be validated.',
+                '`validationOptOut` must be `true` or an array of attributes that should not be validated.',
             ],
             error: [],
         });

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/child/child.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/child/child.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/child/child.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/child/child.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static validationOptOut = null;
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/with-validation-opt-out/warnings/opt-out-null/x/main/main.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}


### PR DESCRIPTION
## Details

Fixes #4500

We broke `validationOptOut` in #4358 because, if `data-host-mutated` is applied to the host, then `validationOptOut` is totally ignored. This breaks cases where one attribute (e.g. `data-foo`) is being mutated in `connectedCallback`, but another one (e.g. `data-bar`) is being mutated in `render`, and the component wants us to ignore it using `validationOptOut`:

```js
export default class extends LightningElement {
    static validationOptOut = ['data-mutate-during-render'];

    connectedCallback() {
        // This line breaks validationOptOut!
        this.setAttribute('data-mutate-during-connected-callback', 'true');
    }

    render() {
        this.setAttribute('data-mutate-during-render', 'true');
        return template;
    }
}
```

We should honor `validationOptOut` regardless of whether we automatically detected host mutations during `connectedCallback`. This fixes that, and adds a bunch of tests to confirm.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

[W-16627950](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020JyFrYAK/view)
