### PR TITLE
fix(engine-server): setAttribute should gracefully handle non-string values

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/expected.html
@@ -1,0 +1,4 @@
+<x-test aria-description="undefined" data-bar="null" data-foo="null" data-lwc-host-mutated="aria-description aria-label data-bar data-foo">
+  <template shadowrootmode="open">
+  </template>
+</x-test>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-test';
+export { default } from 'x/test';
+export * from 'x/test';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/modules/x/test/test.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/modules/x/test/test.js
@@ -1,0 +1,14 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+  connectedCallback() {
+    this.setAttribute('data-foo', 'foo');
+    this.setAttribute('data-foo', null);
+    this.setAttribute('data-bar', null);
+
+    this.setAttribute('aria-label', 'awesome label');
+    this.ariaLabel = null;
+    this.setAttribute('aria-description', 'awesome description');
+    this.ariaDescription = undefined;
+  }
+}

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -257,7 +257,7 @@ function getAttribute(element: E, name: string, namespace: string | null = null)
     return attribute ? attribute.value : null;
 }
 
-function setAttribute(element: E, name: string, value: any, namespace: string | null = null) {
+function setAttribute(element: E, name: string, value: unknown, namespace: string | null = null) {
     reportMutation(element, name);
     const attribute = element[HostAttributesKey].find(
         (attr) => attr.name === name && attr[HostNamespaceKey] === namespace

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -257,7 +257,7 @@ function getAttribute(element: E, name: string, namespace: string | null = null)
     return attribute ? attribute.value : null;
 }
 
-function setAttribute(element: E, name: string, value: string, namespace: string | null = null) {
+function setAttribute(element: E, name: string, value: any, namespace: string | null = null) {
     reportMutation(element, name);
     const attribute = element[HostAttributesKey].find(
         (attr) => attr.name === name && attr[HostNamespaceKey] === namespace
@@ -274,7 +274,7 @@ function setAttribute(element: E, name: string, value: string, namespace: string
             value: String(value),
         });
     } else {
-        attribute.value = value;
+        attribute.value = String(value);
     }
 }
 


### PR DESCRIPTION
## Details

setAttribute should gracefully handle non-string values

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

[W-16871277](https://gus.lightning.force.com/a07EE000022ISyQYAW)