### PR TITLE
test(fixtures): add option to have human-friendly description

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import fs from 'node:fs';
 import path from 'node:path';
 import { transformSync } from '@babel/core';
 import { LWC_VERSION, HIGHEST_API_VERSION } from '@lwc/shared';
@@ -67,16 +66,7 @@ describe('fixtures', () => {
             root: path.resolve(__dirname, 'fixtures'),
             pattern: '**/actual.js',
         },
-        ({ src, dirname }) => {
-            const configPath = path.resolve(dirname, 'config.json');
-
-            let config = {};
-            if (fs.existsSync(configPath)) {
-                // Using require() to read JSON, rather than load a module
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                config = require(configPath);
-            }
-
+        ({ src, config }) => {
             let result;
             let error;
 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import fs from 'fs';
 import path from 'path';
 
 import { rollup } from 'rollup';
@@ -77,16 +76,7 @@ function testFixtures() {
             root: path.resolve(__dirname, 'fixtures'),
             pattern: '**/index.js',
         },
-        async ({ filename, dirname }) => {
-            const configPath = path.resolve(dirname, 'config.json');
-
-            let config: any = {};
-            if (fs.existsSync(configPath)) {
-                // Using require() to read JSON, rather than load a module
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                config = require(configPath);
-            }
-
+        async ({ filename, dirname, config }) => {
             const compiledFixturePath = await compileFixture({
                 input: filename,
                 dirname,
@@ -111,7 +101,7 @@ function testFixtures() {
                 result = lwcEngineServer!.renderComponent(
                     module!.tagName,
                     module!.default,
-                    config.props || {}
+                    config?.props ?? {}
                 );
             } catch (_err: any) {
                 err = _err.message;

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -1,11 +1,9 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-import fs from 'fs';
 import path from 'path';
 
 import { vi } from 'vitest';
@@ -65,16 +63,7 @@ function testFixtures() {
             root: path.resolve(__dirname, '../../../engine-server/src/__tests__/fixtures'),
             pattern: '**/index.js',
         },
-        async ({ filename, dirname }) => {
-            const configPath = path.resolve(dirname, 'config.json');
-
-            let config: any = {};
-            if (fs.existsSync(configPath)) {
-                // Using require() to read JSON, rather than load a module
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                config = require(configPath);
-            }
-
+        async ({ filename, dirname, config }) => {
             const compiledFixturePath = await compileFixture({
                 input: filename,
                 dirname,
@@ -87,7 +76,7 @@ function testFixtures() {
                 result = await serverSideRenderComponent(
                     module!.tagName,
                     module!.generateMarkup,
-                    config.props || {}
+                    config?.props ?? {}
                 );
             } catch (err: any) {
                 return {

--- a/packages/@lwc/style-compiler/src/__tests__/index.spec.ts
+++ b/packages/@lwc/style-compiler/src/__tests__/index.spec.ts
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import fs from 'fs';
 import path from 'path';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';
 import { LWC_VERSION } from '@lwc/shared';
 
-import { transform, Config } from '../index';
+import { transform } from '../index';
 
 import type { CssSyntaxError } from 'postcss';
 
@@ -35,16 +34,7 @@ describe('fixtures', () => {
             root: path.resolve(__dirname, 'fixtures'),
             pattern: '**/actual.css',
         },
-        ({ src, filename, dirname }) => {
-            const configPath = path.resolve(dirname, 'config.json');
-
-            let config: Config = {};
-            if (fs.existsSync(configPath)) {
-                // Using require() to read JSON, rather than load a module
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                config = require(configPath);
-            }
-
+        ({ src, filename, config }) => {
             let result;
             let error;
 

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import fs from 'fs';
 import path from 'path';
 import { LWC_VERSION } from '@lwc/shared';
 import prettier from 'prettier';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';
 
-import compiler, { Config } from '../index';
+import compiler from '../index';
 
 describe('fixtures', () => {
     testFixtureDir(
@@ -18,16 +17,10 @@ describe('fixtures', () => {
             root: path.resolve(__dirname, 'fixtures'),
             pattern: '**/actual.html',
         },
-        async ({ src, dirname }) => {
-            const configPath = path.resolve(dirname, 'config.json');
+        async ({ src, dirname, config }) => {
             const filename = path.basename(dirname);
 
-            let config: Config = { namespace: 'x', name: filename };
-            if (fs.existsSync(configPath)) {
-                // Using require() to read JSON, rather than load a module
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                config = { ...config, ...require(configPath) };
-            }
+            config = { namespace: 'x', name: filename, ...config };
 
             const compiled = compiler(src, filename, config);
             const { warnings, root } = compiled;

--- a/scripts/test-utils/matchers.ts
+++ b/scripts/test-utils/matchers.ts
@@ -113,14 +113,17 @@ function toMatchFile(this: MatcherState, receivedContent: string, filename: stri
 
 import 'vitest';
 
-// interface CustomMatchers<R = unknown> {
-//     toMatchFile: (receivedContent: string, filename?: string) => R;
-// }
+interface CustomMatchers<R = unknown> {
+    toMatchFile: (receivedContent: string, filename?: string) => R;
+}
 
-// declare module 'vitest' {
-//     interface Assertion<T = any> extends CustomMatchers<T> {}
-//     interface AsymmetricMatchersContaining extends CustomMatchers {}
-// }
+declare module 'vitest' {
+    // False positives -- these add `CustomMatchers` to the interfaces used by vitest
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface Assertion<T = any> extends CustomMatchers<T> {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface AsymmetricMatchersContaining extends CustomMatchers {}
+}
 
 // Register vitest matcher.
 expect.extend({ toMatchFile });


### PR DESCRIPTION
## Details

Using the filename as the test description severely limits how useful the test descriptions are. This PR adds the ability to include a description in each fixture's `config.json`. It does not add any descriptions because there are 241 fixtures, and ain't nobody got time for that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
