### PR TITLE
test(imports): add fixture for LWC imports from helper file @W-16872166

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/expected.html
@@ -1,0 +1,4 @@
+<x-cmp>
+  <template shadowrootmode="open">
+  </template>
+</x-cmp>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/imports.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/imports.js
@@ -1,0 +1,34 @@
+// Importing from 'lwc' from a non-component file should work
+// These imports are the ones that are allowed by the no-disallowed-lwc-imports eslint rule
+// Ref: https://github.com/salesforce/eslint-plugin-lwc/blob/34911de749e20cabbf48f5585c92a4b62d082a41/lib/rules/no-disallowed-lwc-imports.js#L11
+import {
+  LightningElement,
+  getComponentDef,
+  isComponentConstructor,
+  createContextProvider,
+  readonly,
+  setFeatureFlagForTest,
+  unwrap,
+  createElement,
+  renderComponent
+} from 'lwc';
+
+
+// "Using" the imports so they don't get removed by the compiler
+if (globalThis.propThatDoesntExistButWontGetCompiledAway) {
+  console.log(
+    LightningElement,
+    // The LWC compiler doesn't let us use decorators like this, so we don't need to check them here
+    // api,
+    // track,
+    // wire,
+    getComponentDef,
+    isComponentConstructor,
+    createContextProvider,
+    readonly,
+    setFeatureFlagForTest,
+    unwrap,
+    createElement,
+    renderComponent
+  )
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-cmp';
+export { default } from 'x/cmp';
+export * from 'x/cmp';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.js
@@ -1,0 +1,13 @@
+// Decorators can only be used on a component, so we check they work here
+import { LightningElement, api, wire, track } from 'lwc';
+import WireAdapter from '../../../wire-adapter';
+
+// Everything else can be imported in a helper, so we mush check in the helper
+import '../../../imports';
+
+export default class extends LightningElement {
+  // LWC compiler doesn't let us console.log decorators
+  @api api;
+  @track track = [];
+  @wire(WireAdapter) wire;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/modules/x/cmp/cmp.js
@@ -2,7 +2,7 @@
 import { LightningElement, api, wire, track } from 'lwc';
 import WireAdapter from '../../../wire-adapter';
 
-// Everything else can be imported in a helper, so we mush check in the helper
+// Everything else can be imported in a helper, so we must check in the helper
 import '../../../imports';
 
 export default class extends LightningElement {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/wire-adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/import-lwc-from-helper/wire-adapter.js
@@ -1,0 +1,5 @@
+export default class {
+    connect() {}
+    disconnect() {}
+    update() {}
+}


### PR DESCRIPTION
## Details

The SSR compiler transforms imports from `lwc` into imports from `@lwc/ssr-runtime`, but it only does so in component files, not helper files. This PR adds a test for imports from helper files that works for `@lwc/engine-server`, but not `@lwc/ssr-compiler`.

The test fails for `@lwc/ssr-compiler` because it allows imports from `lwc`, which in turn imports from `@lwc/engine-dom`, which gets compiled with `process.env.IS_BROWSER` set to `true`, leading to unguarded use of `Element`, which is not defined.

https://github.com/salesforce/lwc/blob/643a65ca8b94b19584db4c2b326e870b3f728764/packages/%40lwc/engine-core/src/patches/detect-non-standard-aria.ts#L123-L124

https://github.com/salesforce/lwc/blob/643a65ca8b94b19584db4c2b326e870b3f728764/packages/%40lwc/engine-core/src/patches/detect-non-standard-aria.ts#L35

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
