### PR TITLE
fix(ssr-compiler): boolean attribute value as empty string

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/component.ts
@@ -52,11 +52,15 @@ function getChildAttrsOrProps(
                     : attr.value.value;
             return b.property('init', key, b.literal(value));
         } else if (attr.value.type === 'Literal' && typeof attr.value.value === 'boolean') {
-            return b.property(
-                'init',
-                key,
-                b.literal(attr.type === 'Attribute' ? '' : attr.value.value)
-            );
+            if (attr.type === 'Attribute') {
+                return b.property(
+                    'init',
+                    key,
+                    attr.value.value === true ? b.literal('') : b.literal('null')
+                );
+            } else {
+                return b.property('init', key, b.literal(attr.value.value));
+            }
         } else if (attr.value.type === 'Identifier' || attr.value.type === 'MemberExpression') {
             const propValue = expressionIrToEs(attr.value, cxt);
             return b.property('init', key, propValue);

--- a/packages/@lwc/ssr-compiler/src/compile-template/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/component.ts
@@ -52,7 +52,11 @@ function getChildAttrsOrProps(
                     : attr.value.value;
             return b.property('init', key, b.literal(value));
         } else if (attr.value.type === 'Literal' && typeof attr.value.value === 'boolean') {
-            return b.property('init', key, b.literal(attr.value.value));
+            return b.property(
+                'init',
+                key,
+                b.literal(attr.type === 'Attribute' ? '' : attr.value.value)
+            );
         } else if (attr.value.type === 'Identifier' || attr.value.type === 'MemberExpression') {
             const propValue = expressionIrToEs(attr.value, cxt);
             return b.property('init', key, propValue);

--- a/packages/@lwc/ssr-compiler/src/compile-template/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/component.ts
@@ -52,15 +52,11 @@ function getChildAttrsOrProps(
                     : attr.value.value;
             return b.property('init', key, b.literal(value));
         } else if (attr.value.type === 'Literal' && typeof attr.value.value === 'boolean') {
-            if (attr.type === 'Attribute') {
-                return b.property(
-                    'init',
-                    key,
-                    attr.value.value === true ? b.literal('') : b.literal('null')
-                );
-            } else {
-                return b.property('init', key, b.literal(attr.value.value));
-            }
+            return b.property(
+                'init',
+                key,
+                b.literal(attr.type === 'Attribute' ? '' : attr.value.value)
+            );
         } else if (attr.value.type === 'Identifier' || attr.value.type === 'MemberExpression') {
             const propValue = expressionIrToEs(attr.value, cxt);
             return b.property('init', key, propValue);

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -300,12 +300,10 @@ export function* renderAttrs(attrs: Attributes) {
         return;
     }
     for (const [key, val] of Object.entries(attrs)) {
-        if (val) {
-            if (typeof val === 'string') {
-                yield ` ${key}="${escapeAttrVal(val)}"`;
-            } else {
-                yield ` ${key}`;
-            }
+        if (typeof val === 'string') {
+            yield val === '' ? ` ${key}` : ` ${key}="${escapeAttrVal(val)}"`;
+        } else if (val === null) {
+            return '';
         }
     }
 }


### PR DESCRIPTION
Boolean attributes have a value of `true` in the AST but the attribute value should be an empty string during runtime.