### PR TITLE
chore: add `DataCallback` as type export in `lwc`

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -54,7 +54,7 @@ export type {
     ContextConsumer as WireContextConsumer,
     ContextProvider as WireContextProvider,
     ContextValue as WireContextValue,
-    DataCallback,
+    DataCallback as WireDataCallback,
     WireAdapter,
     WireAdapterConstructor,
     WireAdapterSchemaValue,

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -40,13 +40,13 @@ export {
 
 // Engine-core public types ------------------------------------------------------------------------
 export type {
-    DataCallback,
     WireAdapter,
     WireAdapterConstructor,
     WireConfigValue,
     WireContextValue,
     WireContextConsumer,
     WireContextProvider,
+    WireDataCallback,
     Template,
 } from '@lwc/engine-core';
 

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -40,6 +40,7 @@ export {
 
 // Engine-core public types ------------------------------------------------------------------------
 export type {
+    DataCallback,
     WireAdapter,
     WireAdapterConstructor,
     WireConfigValue,

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { WireConfigValue, WireAdapter, DataCallback } from '@lwc/engine-core';
+import { WireConfigValue, WireAdapter, WireDataCallback } from '@lwc/engine-core';
 import { ValueChangedEvent } from './value-changed-event';
 
 const { freeze, defineProperty, isExtensible } = Object;
@@ -14,7 +14,7 @@ const { freeze, defineProperty, isExtensible } = Object;
 const DeprecatedWiredElementHost = '$$DeprecatedWiredElementHostKey$$';
 const DeprecatedWiredParamsMeta = '$$DeprecatedWiredParamsMetaKey$$';
 
-interface LegacyAdapterDataCallback extends DataCallback {
+interface LegacyAdapterDataCallback extends WireDataCallback {
     [DeprecatedWiredElementHost]: any;
     [DeprecatedWiredParamsMeta]: string[];
 }


### PR DESCRIPTION
## Details

This PR adds the `DataCallback` as a type definition export in `lwc`.

This type is needed when authoring wire adapters and it would be nice to have as part of the `lwc` package since the other adapter types are in there too.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

