### PR TITLE
fix(ssr-compiler): define setters for reflected attributes

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -58,21 +58,43 @@ function bReflectedAttrsObj(reflectedPropNames: (keyof typeof AriaPropNameToAttr
     //
     // The props object will be kept up-to-date with any new values set on the corresponding
     // property name in the component instance.
-    const reflectedAttrGetters: Property[] = reflectedPropNames.map((propName) =>
-        b.property(
-            'get',
-            b.literal(AriaPropNameToAttrNameMap[propName]),
-            b.functionExpression(
-                null,
-                [],
-                b.blockStatement([
-                    b.returnStatement(
-                        b.memberExpression(b.identifier('props'), b.identifier(propName))
-                    ),
-                ])
+    const reflectedAttrAccessors: Property[] = [];
+    for (const propName of reflectedPropNames) {
+        reflectedAttrAccessors.push(
+            b.property(
+                'get',
+                b.literal(AriaPropNameToAttrNameMap[propName]),
+                b.functionExpression(
+                    null,
+                    [],
+                    b.blockStatement([
+                        b.returnStatement(
+                            b.callExpression(b.identifier('String'), [
+                                b.memberExpression(b.identifier('props'), b.identifier(propName)),
+                            ])
+                        ),
+                    ])
+                )
+            ),
+            b.property(
+                'set',
+                b.literal(AriaPropNameToAttrNameMap[propName]),
+                b.functionExpression(
+                    null,
+                    [b.identifier('val')],
+                    b.blockStatement([
+                        b.expressionStatement(
+                            b.assignmentExpression(
+                                '=',
+                                b.memberExpression(b.identifier('props'), b.identifier(propName)),
+                                b.identifier('val')
+                            )
+                        ),
+                    ])
+                )
             )
-        )
-    );
+        );
+    }
 
     // This mutates the `attrs` object, adding the reflected aria attributes that have been
     // detected. Example:
@@ -87,7 +109,7 @@ function bReflectedAttrsObj(reflectedPropNames: (keyof typeof AriaPropNameToAttr
         b.assignmentExpression(
             '=',
             b.identifier('attrs'),
-            b.objectExpression([b.spreadElement(b.identifier('attrs')), ...reflectedAttrGetters])
+            b.objectExpression([b.spreadElement(b.identifier('attrs')), ...reflectedAttrAccessors])
         )
     );
 }

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -193,6 +193,9 @@ export class LightningElement implements PropsAvailableAtConstruction {
 
     removeAttribute(attrName: string): void {
         if (this.hasAttribute(attrName)) {
+            // Reflected attributes use accessor methods to update their
+            // corresponding properties so we can't simply `delete`. Instead,
+            // we use `null` when we want to remove.
             this.#setAttribute(attrName, null);
         }
     }
@@ -308,7 +311,7 @@ export function* renderAttrs(attrs: Attributes) {
     if (!attrs) {
         return;
     }
-    for (const attrName in attrs) {
+    for (const attrName of Object.getOwnPropertyNames(attrs)) {
         const attrVal = attrs[attrName];
         if (typeof attrVal === 'string') {
             yield attrVal === '' ? ` ${attrName}` : ` ${attrName}="${escapeAttrVal(attrVal)}"`;

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -172,20 +172,29 @@ export class LightningElement implements PropsAvailableAtConstruction {
         return (this.__classList = new ClassList(this));
     }
 
-    getAttribute(attrName: string): string | null {
-        return this.__attrs[attrName] ?? null;
+    #setAttribute(attrName: string, attrValue: string | null): void {
+        this.__attrs[attrName] = attrValue;
     }
 
-    setAttribute(attrName: string, value: string | null): void {
-        this.__attrs[attrName] = String(value);
+    setAttribute(attrName: string, attrValue: unknown): void {
+        this.#setAttribute(attrName, String(attrValue));
     }
 
-    hasAttribute(attrName: string): boolean {
-        return Boolean(this.__attrs && attrName in this.__attrs);
+    getAttribute(attrName: unknown): string | null {
+        if (this.hasAttribute(attrName)) {
+            return this.__attrs[attrName as string];
+        }
+        return null;
+    }
+
+    hasAttribute(attrName: unknown): boolean {
+        return typeof attrName === 'string' && typeof this.__attrs[attrName] === 'string';
     }
 
     removeAttribute(attrName: string): void {
-        this.__attrs[attrName] = null;
+        if (this.hasAttribute(attrName)) {
+            this.#setAttribute(attrName, null);
+        }
     }
 
     addEventListener(
@@ -299,11 +308,12 @@ export function* renderAttrs(attrs: Attributes) {
     if (!attrs) {
         return;
     }
-    for (const [key, val] of Object.entries(attrs)) {
-        if (typeof val === 'string') {
-            yield val === '' ? ` ${key}` : ` ${key}="${escapeAttrVal(val)}"`;
-        } else if (val === null) {
-            return '';
+    for (const attrName in attrs) {
+        const attrVal = attrs[attrName];
+        if (typeof attrVal === 'string') {
+            yield attrVal === '' ? ` ${attrName}` : ` ${attrName}="${escapeAttrVal(attrVal)}"`;
+        } else if (attrVal === null) {
+            yield '';
         }
     }
 }


### PR DESCRIPTION
Define setters for reflected attributes. Needed to add a private `#setAttribute()` method that can set `null` without turning it into a string so that `removeAttribute()` works as expected.

Also `for-of` was also changed to `for-in` in `renderAttrs` so that we can iterate over non-string (accessor) enumerable entries.

This implementation is now more correct than `engine-server` as it seems the latter may not be handing `setAttribute(null)` correctly for standard reflected attributes:

```
 FAIL  |lwc-ssr-compiler| src/__tests__/fixtures.spec.ts > fixtures > attribute-null/index.js
Error: Received content for "/Users/ekashida/Repos/lwc/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-null/expected.html" doesn't match expected content.

Difference:

- Expected
+ Received

- <x-test aria-description="undefined" data-bar="null" data-foo="null" data-lwc-host-mutated="aria-description aria-label data-bar data-foo">
+ <x-test aria-description="undefined" aria-label="null" data-bar="null" data-foo="null">
```