### PR TITLE
fix(ssr): disallow imports from `lwc` in SSR context

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -141,7 +141,7 @@ export default function compileJS(src: string, filename: string) {
         // file in question is likely not an LWC. With this v1 implementation,
         // we'll just return the original source.
         return {
-            code: src,
+            code: generate(ast, {}),
         };
     }
 

--- a/packages/@lwc/ssr-compiler/src/compile-js/lwc-import.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/lwc-import.ts
@@ -7,6 +7,7 @@
 
 import { builders as b } from 'estree-toolkit';
 
+import { allowedLwcImports } from '../runtime';
 import type { ImportDeclaration } from 'estree';
 import type { NodePath } from 'estree-toolkit';
 import type { ComponentMetaState } from './types';
@@ -30,6 +31,14 @@ export function replaceLwcImport(path: NodePath<ImportDeclaration>, state: Compo
         ) {
             state.lightningElementIdentifier = specifier.local.name;
             break;
+        }
+        if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+            if (!allowedLwcImports.has(specifier.imported.name)) {
+                throw new Error(`Cannot import "${specifier.imported.name}" in SSR context.`);
+            }
+            if (specifier.imported.name === 'LightningElement') {
+                state.lightningElementIdentifier = specifier.local.name;
+            }
         }
     }
 

--- a/packages/@lwc/ssr-compiler/src/runtime.ts
+++ b/packages/@lwc/ssr-compiler/src/runtime.ts
@@ -1,0 +1,5 @@
+/**
+ * Imports from `lwc` that are allowed in the SSR runtime context.
+ * Every listed item should be a top-level export from `@lwc/ssr-runtime`.
+ */
+export const allowedLwcImports = new Set(['LightningElement']);


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
