### PR TITLE
chore(eslint): restore header rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,9 @@
-// @ts-check
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import jest from 'eslint-plugin-jest';
 import lwcInternal from '@lwc/eslint-plugin-lwc-internal';
 // @ts-expect-error CJS module; TS can't detect that it has a default export
@@ -9,6 +14,14 @@ import globals from 'globals';
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import gitignore from 'eslint-config-flat-gitignore';
+import { PUBLIC_PACKAGES as publicPackageData } from './scripts/shared/packages.mjs';
+
+// convert filepath to eslint glob
+const PUBLIC_PACKAGES = publicPackageData.map(({ path }) => `${path}/**`);
+
+// Workaround for plugin schema validation failing in eslint v9
+// Ref: https://github.com/Stuk/eslint-plugin-header/issues/57#issuecomment-2378485611
+header.rules.header.meta.schema = false;
 
 export default tseslint.config(
     // ------------- //
@@ -66,6 +79,7 @@ export default tseslint.config(
             '@typescript-eslint/unbound-method': 'off',
             'block-scoped-var': 'error',
             'no-alert': 'error',
+            // Deprecated, replace with rule in eslint-plugin-n when removed
             'no-buffer-constructor': 'error',
             'no-console': 'error',
             'no-eval': 'error',
@@ -74,12 +88,12 @@ export default tseslint.config(
             'no-extra-label': 'error',
             'no-iterator': 'error',
             'no-lone-blocks': 'error',
-            'no-new-require': 'error',
             'no-proto': 'error',
             'no-self-compare': 'error',
             'no-undef-init': 'error',
             'no-useless-computed-key': 'error',
             'no-useless-return': 'error',
+            // Deprecated, replace with rule in @stylistic/eslint-plugin-js when removed
             'template-curly-spacing': 'error',
             yoda: 'error',
 
@@ -240,6 +254,30 @@ export default tseslint.config(
     // ---------------------- //
     // Package-specific rules //
     // ---------------------- //
+    {
+        files: PUBLIC_PACKAGES,
+        ignores: PUBLIC_PACKAGES.map((path) => `${path}/vitest.config.mjs`),
+        rules: {
+            'header/header': [
+                'error',
+                'block',
+                [
+                    '',
+                    {
+                        pattern:
+                            '^ \\* Copyright \\(c\\) \\d{4}, ([sS]alesforce.com, inc|Salesforce, Inc)\\.$',
+                        // This copyright text should match the text used in the rollup config
+                        template: ` * Copyright (c) ${new Date().getFullYear()}, Salesforce, Inc.`,
+                    },
+                    ' * All rights reserved.',
+                    ' * SPDX-License-Identifier: MIT',
+                    ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT',
+                    ' ',
+                ],
+                2 /* newlines after comment */,
+            ],
+        },
+    },
     {
         files: [
             'packages/@lwc/engine-core/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,15 +50,20 @@ export default tseslint.config(
         },
 
         rules: {
-            '@typescript-eslint/no-unused-vars': [
-                'error',
-                {
-                    argsIgnorePattern: '^_',
-                    caughtErrorsIgnorePattern: '^_',
-                    destructuredArrayIgnorePattern: '^_',
-                },
-            ],
-
+            // Rules without config, sorted alphabetically by namespace, then rule
+            '@lwc/lwc-internal/no-invalid-todo': 'error',
+            '@typescript-eslint/no-base-to-string': 'off',
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-redundant-type-constituents': 'off',
+            '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+            '@typescript-eslint/no-unsafe-argument': 'off',
+            '@typescript-eslint/no-unsafe-assignment': 'off',
+            '@typescript-eslint/no-unsafe-call': 'off',
+            '@typescript-eslint/no-unsafe-enum-comparison': 'off',
+            '@typescript-eslint/no-unsafe-member-access': 'off',
+            '@typescript-eslint/no-unsafe-return': 'off',
+            '@typescript-eslint/restrict-template-expressions': 'off',
+            '@typescript-eslint/unbound-method': 'off',
             'block-scoped-var': 'error',
             'no-alert': 'error',
             'no-buffer-constructor': 'error',
@@ -69,9 +74,48 @@ export default tseslint.config(
             'no-extra-label': 'error',
             'no-iterator': 'error',
             'no-lone-blocks': 'error',
-            'no-proto': 'error',
             'no-new-require': 'error',
+            'no-proto': 'error',
+            'no-self-compare': 'error',
+            'no-undef-init': 'error',
+            'no-useless-computed-key': 'error',
+            'no-useless-return': 'error',
+            'template-curly-spacing': 'error',
+            yoda: 'error',
 
+            // Rule with config, sorted alphabetically by namespace, then rule
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    argsIgnorePattern: '^_',
+                    caughtErrorsIgnorePattern: '^_',
+                    destructuredArrayIgnorePattern: '^_',
+                },
+            ],
+            'import/order': [
+                'error',
+                {
+                    groups: [
+                        'builtin',
+                        'external',
+                        'internal',
+                        'parent',
+                        'index',
+                        'sibling',
+                        'object',
+                        'type',
+                    ],
+                },
+            ],
+            'no-restricted-imports': [
+                'error',
+                {
+                    name: '@lwc/features',
+                    importNames: ['lwcRuntimeFlags', 'runtimeFlags', 'default'],
+                    message:
+                        'Do not directly import runtime flags from @lwc/features. Use the global lwcRuntimeFlags variable instead.',
+                },
+            ],
             'no-restricted-properties': [
                 'error',
                 {
@@ -128,12 +172,6 @@ export default tseslint.config(
                     message: 'Use the bare global lwcRuntimeFlags instead.',
                 },
             ],
-
-            'no-self-compare': 'error',
-            'no-undef-init': 'error',
-            'no-useless-computed-key': 'error',
-            'no-useless-return': 'error',
-
             'prefer-const': [
                 'error',
                 {
@@ -141,49 +179,6 @@ export default tseslint.config(
                     ignoreReadBeforeAssign: true,
                 },
             ],
-
-            'template-curly-spacing': 'error',
-            yoda: 'error',
-            '@lwc/lwc-internal/no-invalid-todo': 'error',
-
-            'import/order': [
-                'error',
-                {
-                    groups: [
-                        'builtin',
-                        'external',
-                        'internal',
-                        'parent',
-                        'index',
-                        'sibling',
-                        'object',
-                        'type',
-                    ],
-                },
-            ],
-
-            'no-restricted-imports': [
-                'error',
-                {
-                    name: '@lwc/features',
-                    importNames: ['lwcRuntimeFlags', 'runtimeFlags', 'default'],
-                    message:
-                        'Do not directly import runtime flags from @lwc/features. Use the global lwcRuntimeFlags variable instead.',
-                },
-            ],
-
-            '@typescript-eslint/no-unsafe-enum-comparison': 'off',
-            '@typescript-eslint/unbound-method': 'off',
-            '@typescript-eslint/no-base-to-string': 'off',
-            '@typescript-eslint/restrict-template-expressions': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/no-redundant-type-constituents': 'off',
-            '@typescript-eslint/no-unsafe-member-access': 'off',
-            '@typescript-eslint/no-unsafe-call': 'off',
-            '@typescript-eslint/no-unsafe-assignment': 'off',
-            '@typescript-eslint/no-unsafe-return': 'off',
-            '@typescript-eslint/no-unsafe-argument': 'off',
-            '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         },
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -274,7 +274,7 @@ export default tseslint.config(
                     ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT',
                     ' ',
                 ],
-                2 /* newlines after comment */,
+                1 /* newline after header */,
             ],
         },
     },

--- a/packages/@lwc/engine-core/src/framework/sanitized-html-content.ts
+++ b/packages/@lwc/engine-core/src/framework/sanitized-html-content.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
 import { create as ObjectCreate, isNull, isObject, isUndefined } from '@lwc/shared';
 import { logWarn } from '../shared/logger';
 import type { RendererAPI } from './renderer';

--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
 import { is } from 'estree-toolkit';
 import { generateScopeTokens } from '@lwc/template-compiler';
 import { builders as b } from 'estree-toolkit/dist/builders';

--- a/scripts/shared/packages.mjs
+++ b/scripts/shared/packages.mjs
@@ -1,0 +1,22 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const readJsonSync = (filepath) => JSON.parse(readFileSync(filepath, 'utf8'));
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const lwcPackageDir = 'packages/lwc';
+const relativeNamespaceDir = 'packages/@lwc';
+const namespacedPackageDirs = readdirSync(join(root, 'packages/@lwc'), {
+    withFileTypes: true,
+})
+    .filter((fd) => fd.isDirectory() && !fd.name.startsWith('.'))
+    .map((fd) => join(relativeNamespaceDir, fd.name));
+const allPackageDirs = [lwcPackageDir, ...namespacedPackageDirs];
+
+export const ALL_PACKAGES = allPackageDirs.map((path) => ({
+    path,
+    package: readJsonSync(join(path, 'package.json')),
+}));
+export const PRIVATE_PACKAGES = ALL_PACKAGES.filter((data) => data.package.private);
+export const PUBLIC_PACKAGES = ALL_PACKAGES.filter((data) => !data.package.private);


### PR DESCRIPTION
## Details

When doing the refactor in #4618, I noticed that the `header/header` rule was not being enforced. Turns out we removed it in #4378, because of https://github.com/Stuk/eslint-plugin-header/issues/57. However, there's a simple workaround, so this PR restores the rule.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
