### PR TITLE
test(ssr): add ability to diverge from engine-server

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
 
+import path from 'node:path';
 import { vi } from 'vitest';
 import { rollup, RollupLog } from 'rollup';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
@@ -69,6 +69,9 @@ function testFixtures() {
                 dirname,
             });
 
+            const errorFile = config?.ssrFiles?.error ?? 'error.txt';
+            const expectedFile = config?.ssrFiles?.expected ?? 'expected.html';
+
             const module = (await import(compiledFixturePath)) as FixtureModule;
 
             let result;
@@ -80,20 +83,20 @@ function testFixtures() {
                 );
             } catch (err: any) {
                 return {
-                    'error.txt': err.message,
-                    'expected.html': '',
+                    [errorFile]: err.message,
+                    [expectedFile]: '',
                 };
             }
 
             try {
                 return {
-                    'expected.html': formatHTML(result),
-                    'error.txt': '',
+                    [errorFile]: '',
+                    [expectedFile]: formatHTML(result),
                 };
             } catch (_err: any) {
                 return {
-                    'error.txt': `Test helper could not format HTML:\n\n${result}`,
-                    'expected.html': '',
+                    [errorFile]: `Test helper could not format HTML:\n\n${result}`,
+                    [expectedFile]: '',
                 };
             }
         }

--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -31,10 +31,15 @@ function getTestFunc(dirname: string) {
 }
 
 export interface TestFixtureConfig extends StyleCompilerConfig {
+    /** Human-readable test description. A proxy for `test(description, ...)`. */
     description?: string;
+    /** Component name. */
     name?: string;
+    /** Component namespace. */
     namespace?: string;
+    /** Props to provide to the top-level component. */
     props?: Record<string, string | string[]>;
+    /** Output files used by ssr-compiler, when the output needs to differ fron engine-server */
     ssrFiles?: {
         error?: string;
         expected?: string;

--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -35,6 +35,10 @@ export interface TestFixtureConfig extends StyleCompilerConfig {
     name?: string;
     namespace?: string;
     props?: Record<string, string | string[]>;
+    ssrFiles?: {
+        error?: string;
+        expected?: string;
+    };
 }
 
 /** Loads the the contents of the `config.json` in the provided directory, if present. */


### PR DESCRIPTION
## Details

There are cases where `engine-server` and SSR necessarily must have divergent output (e.g. an error message containing a reference to an `engine-server` VM cannot be reproduced by SSR). This PR adds the ability to configure separate output files for use by SSR. It adds a new field, `ssrFiles` to the existing `config.json` pattern. If the `error.txt` or `expected.html` generated by `engine-server` is not the expected SSR output, an `error` or `expected` key can be used to provide an alternative file.

```jsonc
// config.json
{
  "ssrFiles": {
    "error": "error-ssr.txt",
    "expected": "expected-ssr.html"
  }
}
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
