### PR TITLE
chore(test): avoid timeout when debugging

### DIFF
--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -1,8 +1,11 @@
+import inspector from 'node:inspector';
 import { defineConfig } from 'vitest/config';
 import pkg from './package.json';
 
 export default defineConfig({
     test: {
+        // Don't time out if we detect a debugger attached
+        testTimeout: inspector.url() ? Number.MAX_SAFE_INTEGER : undefined,
         globals: true,
         include: ['**/*.{test,spec}.{mjs,js,ts}'],
         snapshotFormat: {


### PR DESCRIPTION
## Details

This just detects if a debugger is attached by checking `inspector.url()`. If we're debugging, then avoid timing out!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
