### PR TITLE
chore(deps): pin typescript version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       directory: '/' # Location of package manifests
       schedule:
           interval: 'weekly'
+      ignore:
+          # As a library, we want to avoid bumping TypeScript, so that we don't accidentally use
+          # language features from a version newer than our downstream users have installed
+          - dependency-name: typescript
       groups:
           babel:
               patterns:

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "rollup": "^4.24.0",
         "terser": "^5.34.1",
         "tslib": "^2.7.0",
-        "typescript": "5.6.2",
+        "typescript": "5.4.5",
         "typescript-eslint": "^8.8.0",
         "vitest": "^2.1.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,9 +2247,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4", "@napi-rs/wasm-runtime@^0.2.4":
   version "0.2.4"
@@ -12551,10 +12553,10 @@ typescript-eslint@^8.8.0:
     "@typescript-eslint/parser" "8.8.0"
     "@typescript-eslint/utils" "8.8.0"
 
-typescript@5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+typescript@5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Details

As a library, if we generate type definitions using a newer version of TypeScript than our downstream users have installed, then they will not be able to use those types. Therefore, to avoid inadvertently breaking users, we should pin our version of TypeScript. This PR prevents dependabot from upgrading our version of TypeScript, and it reverts the version we use to our [officially supported version](https://developer.salesforce.com/docs/platform/lwc/guide/ts.html#:~:text=type%20definitions%20with-,TypeScript%20v5.4.5,-to%20develop%20Lightning). There are only very minor differences in the type definitions between v5.4.5 and v5.6.2, so the downgrade should be safe to do.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
