### PR TITLE
fix: bump parse5, remove `<noframes>` special case

### DIFF
--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -46,6 +46,6 @@
         "@lwc/rollup-plugin": "8.1.3",
         "@lwc/shared": "8.1.3",
         "@rollup/plugin-virtual": "^3.0.2",
-        "parse5": "^7.1.2"
+        "parse5": "^7.2.0"
     }
 }

--- a/packages/@lwc/integration-karma/test/rendering/noframes/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/noframes/index.spec.js
@@ -12,13 +12,19 @@ it('renders noframes correctly - W-16784305', async () => {
     } = elm;
 
     expect(childNodes.length).toBe(1);
-    expect(childNodes[0].tagName).toBe('SECTION');
-    expect(childNodes[0].childNodes.length).toBe(1);
-    expect(childNodes[0].childNodes[0].tagName).toBe('NOFRAMES');
-    expect(childNodes[0].childNodes[0].childNodes.length).toBe(1);
-    expect(childNodes[0].childNodes[0].childNodes[0].tagName).toBe('DIV');
-    expect(childNodes[0].childNodes[0].childNodes[0].childNodes.length).toBe(0);
-    expect(childNodes[0].childNodes[0].childNodes[0].getAttribute('class')).toBe(
-        '</noframes><span>whee</span>'
-    );
+
+    const section = childNodes[0];
+    expect(section.tagName).toBe('SECTION');
+    expect(section.childNodes.length).toBe(3);
+
+    const [first, second, third] = section.childNodes;
+
+    expect(first.tagName).toBe('NOFRAMES');
+    expect(first.textContent).toBe('<div class="');
+
+    expect(second.tagName).toBe('SPAN');
+    expect(second.textContent).toBe('whee');
+
+    expect(third.nodeType).toBe(Node.TEXT_NODE);
+    expect(third.nodeValue).toBe('"></div> </noframes>');
 });

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -53,6 +53,6 @@
         "@types/estree": "1.0.6",
         "@types/he": "^1.2.3",
         "estree-walker": "~3.0.3",
-        "parse5": "~7.1.2"
+        "parse5": "^7.2.0"
     }
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/ast.json
@@ -214,55 +214,20 @@
                 "listeners": [],
                 "children": [
                     {
-                        "type": "Element",
-                        "name": "p",
-                        "namespace": "http://www.w3.org/1999/xhtml",
-                        "location": {
-                            "startLine": 14,
-                            "startColumn": 9,
-                            "endLine": 14,
-                            "endColumn": 97,
-                            "start": 313,
-                            "end": 401,
-                            "startTag": {
-                                "startLine": 14,
-                                "startColumn": 9,
-                                "endLine": 14,
-                                "endColumn": 12,
-                                "start": 313,
-                                "end": 316
-                            },
-                            "endTag": {
-                                "startLine": 14,
-                                "startColumn": 93,
-                                "endLine": 14,
-                                "endColumn": 97,
-                                "start": 397,
-                                "end": 401
-                            }
+                        "type": "Text",
+                        "raw": "<p>It seems your browser does not support frames or is configured to not allow them.</p>",
+                        "value": {
+                            "type": "Literal",
+                            "value": "<p>It seems your browser does not support frames or is configured to not allow them.</p>"
                         },
-                        "attributes": [],
-                        "properties": [],
-                        "directives": [],
-                        "listeners": [],
-                        "children": [
-                            {
-                                "type": "Text",
-                                "raw": "It seems your browser does not support frames or is configured to not allow them.",
-                                "value": {
-                                    "type": "Literal",
-                                    "value": "It seems your browser does not support frames or is configured to not allow them."
-                                },
-                                "location": {
-                                    "startLine": 14,
-                                    "startColumn": 12,
-                                    "endLine": 14,
-                                    "endColumn": 93,
-                                    "start": 316,
-                                    "end": 397
-                                }
-                            }
-                        ]
+                        "location": {
+                            "startLine": 13,
+                            "startColumn": 15,
+                            "endLine": 15,
+                            "endColumn": 5,
+                            "start": 304,
+                            "end": 406
+                        }
                     }
                 ]
             }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/expected.js
@@ -4,17 +4,14 @@ import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<xmp${3}>&lt;/xmp&gt;Hello &lt;div&gt;world&lt;/div&gt; <div>foo</div></xmp>`;
 const $fragment2 = parseFragment`<iframe${3}>Hello &lt;div&gt;world&lt;/div&gt; <div>foo</div></iframe>`;
 const $fragment3 = parseFragment`<noembed${3}>Hello &lt;div&gt;world&lt;/div&gt; <div>foo</div></noembed>`;
-const $fragment4 = parseFragment`<p${3}>It seems your browser does not support frames or is configured to not allow them.</p>`;
-const stc0 = {
-  key: 6,
-};
+const $fragment4 = parseFragment`<noframes${3}><p>It seems your browser does not support frames or is configured to not allow them.</p></noframes>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const { st: api_static_fragment, h: api_element } = $api;
+  const { st: api_static_fragment } = $api;
   return [
     api_static_fragment($fragment1, 1),
     api_static_fragment($fragment2, 3),
     api_static_fragment($fragment3, 5),
-    api_element("noframes", stc0, [api_static_fragment($fragment4, 8)]),
+    api_static_fragment($fragment4, 7),
   ];
   /*LWC compiler vX.X.X*/
 }

--- a/packages/@lwc/template-compiler/src/codegen/static-element.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element.ts
@@ -61,9 +61,6 @@ function isStaticNode(node: BaseElement, apiVersion: APIVersion): boolean {
     // it is an element
     result &&= isElement(node);
 
-    // See W-16784305
-    result &&= node.name !== 'noframes';
-
     // all attrs are static-safe
     // the criteria to determine safety can be found in computeAttrValue
     result &&= attributes.every(({ name }) => {

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -183,7 +183,6 @@ class TemplateHtmlTokenizer extends Tokenizer {
             // coming later in an unquoted attr value should not be considered
             // the beginning of a template expression.
             this.checkedAttrs.add(this.currentAttr);
-            // @ts-expect-error private method
             super._stateAttributeValueUnquoted(codePoint);
         }
     }
@@ -222,7 +221,6 @@ class TemplateHtmlTokenizer extends Tokenizer {
             this.currentToken = null;
             this.currentCharacterToken = null;
         } else {
-            // @ts-expect-error private method
             super._stateData(codePoint);
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10328,12 +10328,19 @@ parse5@^5.1.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
-parse5@^7.0.0, parse5@^7.1.2, parse5@~7.1.2:
+parse5@^7.0.0, parse5@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
   integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
   dependencies:
     entities "^4.4.0"
+
+parse5@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.0.tgz#8a0591ce9b7c5e2027173ab737d4d3fc3d826fab"
+  integrity sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==
+  dependencies:
+    entities "^4.5.0"
 
 parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
## Details

The `<noframes>` parsing issue was fixed in https://github.com/inikulin/parse5/pull/1277 so we can remove the special-casing now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
