### PR TITLE
feat(ssr-runtime): export `renderComponent` alias

### DIFF
--- a/packages/@lwc/ssr-runtime/src/__tests__/server-side-render-component-alias.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/server-side-render-component-alias.spec.ts
@@ -1,0 +1,7 @@
+import { renderComponent, serverSideRenderComponent } from '../index';
+
+describe('renderComponent as alias of serverSideRenderComponent ', () => {
+    it('is an alias', () => {
+        expect(renderComponent).toBe(serverSideRenderComponent);
+    });
+});

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -8,6 +8,13 @@
 export { ClassList } from './class-list';
 export { LightningElement, LightningElementConstructor } from './lightning-element';
 export { MutationTracker } from './mutation-tracker';
-export { fallbackTmpl, GenerateMarkupFn, renderAttrs, serverSideRenderComponent } from './render';
+// renderComponent is an alias for serverSideRenderComponent
+export {
+    fallbackTmpl,
+    GenerateMarkupFn,
+    renderAttrs,
+    serverSideRenderComponent,
+    serverSideRenderComponent as renderComponent,
+} from './render';
 export { toIteratorDirective } from './to-iterator-directive';
 export { validateStyleTextContents } from './validate-style-text-contents';


### PR DESCRIPTION
## Details

This aligns with the naming convention in `@lwc/engine-server` without breaking backwards compat, by making `renderComponent` an alias of `serverSideRenderComponent`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
