### PR TITLE
chore(integration-karma): avoid conditional tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -253,6 +253,12 @@ export default tseslint.config(
         },
     },
     {
+        files: ['packages/@lwc/integration-karma/**'],
+        rules: {
+            'vitest/no-conditional-tests': 'error',
+        },
+    },
+    {
         files: ['**/scripts/**'],
         rules: {
             'no-console': 'off',

--- a/packages/@lwc/integration-karma/helpers/test-setup.js
+++ b/packages/@lwc/integration-karma/helpers/test-setup.js
@@ -116,5 +116,21 @@ afterAll(function () {
     throwIfConsoleCalled();
 });
 
+describe.runIf = function (condition) {
+    return condition ? describe : xdescribe;
+};
+
+describe.skipIf = function (condition) {
+    return condition ? xdescribe : describe;
+};
+
+it.runIf = function (condition) {
+    return condition ? it : xit;
+};
+
+it.skipIf = function (condition) {
+    return condition ? xit : it;
+};
+
 // The default of 5000ms seems to get surpassed frequently in Safari 14 in SauceLabs
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;

--- a/packages/@lwc/integration-karma/helpers/test-setup.js
+++ b/packages/@lwc/integration-karma/helpers/test-setup.js
@@ -116,6 +116,9 @@ afterAll(function () {
     throwIfConsoleCalled();
 });
 
+// The following (`runIf`, `skipIf`, etc.) are based on Vite's APIs: https://vitest.dev/api/
+// This allows us to use the vitest/no-conditional-tests ESLint rule and get the same total # of tests for
+// every variant of a test run (e.g. `DISABLE_SYNTHETIC=1`, `NODE_ENV_FOR_TEST=production`, etc.)
 describe.runIf = function (condition) {
     return condition ? describe : xdescribe;
 };

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -111,6 +111,8 @@ function throwOnUnexpectedConsoleCalls(runnable) {
         console[method] = function (error) {
             if (
                 method === 'warn' &&
+                // This is a false positive due to RegExp.prototype.test
+                // eslint-disable-next-line vitest/no-conditional-tests
                 /Cannot set property "(inner|outer)HTML"/.test(error?.message)
             ) {
                 return;

--- a/packages/@lwc/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/LightningElement.focus/index.spec.js
@@ -105,20 +105,18 @@ describe('LightningElement.focus', () => {
             return isCEFocused;
         };
 
-        if (
+        it.runIf(
             !(process.env.NATIVE_SHADOW && delegatesFocus) &&
-            !customElementFocusableWhenFormAssociated()
-        ) {
-            it(`should not move focus if an internal element is already focused ${category}`, () => {
-                const elm = createElement('x-focus', { is: Ctor });
-                document.body.appendChild(elm);
+                !customElementFocusableWhenFormAssociated()
+        )(`should not move focus if an internal element is already focused ${category}`, () => {
+            const elm = createElement('x-focus', { is: Ctor });
+            document.body.appendChild(elm);
 
-                const input = elm.shadowRoot.querySelector('.second');
-                input.focus();
-                elm.focus();
-                expect(elm.shadowRoot.activeElement).toBe(input);
-            });
-        }
+            const input = elm.shadowRoot.querySelector('.second');
+            input.focus();
+            elm.focus();
+            expect(elm.shadowRoot.activeElement).toBe(input);
+        });
     }
 
     runFocusTests({ delegatesFocus: true });

--- a/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/non-standard-aria-props/index.spec.js
@@ -8,8 +8,9 @@ import Light from 'x/light';
 import Shadow from 'x/shadow';
 
 // This test only works if the ARIA reflection polyfill is loaded
-if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
-    describe('non-standard ARIA properties', () => {
+describe.runIf(process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL)(
+    'non-standard ARIA properties',
+    () => {
         let dispatcher;
 
         beforeEach(() => {
@@ -121,5 +122,5 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                 });
             });
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -14,169 +14,139 @@ const expectedMessageForNonStandardAria =
     'Error: [LWC warn]: Element <input> owned by <x-aria-source> uses non-standard property "ariaLabelledBy". This will be removed in a future version of LWC. See https://sfdc.co/deprecated-aria';
 
 // These tests are designed to detect non-standard cross-root ARIA usage in synthetic shadow DOM
-if (!process.env.NATIVE_SHADOW) {
-    describe('synthetic shadow cross-root ARIA', () => {
-        let dispatcher;
+describe.skipIf(process.env.NATIVE_SHADOW)('synthetic shadow cross-root ARIA', () => {
+    let dispatcher;
+
+    beforeEach(() => {
+        dispatcher = jasmine.createSpy();
+        attachReportingControlDispatcher(dispatcher, [
+            'CrossRootAriaInSyntheticShadow',
+            'NonStandardAriaReflection',
+        ]);
+    });
+
+    afterEach(() => {
+        detachReportingControlDispatcher();
+    });
+
+    describe('detection', () => {
+        let elm;
+        let sourceElm;
+        let targetElm;
 
         beforeEach(() => {
-            dispatcher = jasmine.createSpy();
-            attachReportingControlDispatcher(dispatcher, [
-                'CrossRootAriaInSyntheticShadow',
-                'NonStandardAriaReflection',
-            ]);
+            elm = createElement('x-aria-container', { is: AriaContainer });
+            document.body.appendChild(elm);
+            sourceElm = elm.shadowRoot.querySelector('x-aria-source');
+            targetElm = elm.shadowRoot.querySelector('x-aria-target');
         });
 
-        afterEach(() => {
-            detachReportingControlDispatcher();
-        });
+        const usePropertyAccessValues = [false];
 
-        describe('detection', () => {
-            let elm;
-            let sourceElm;
-            let targetElm;
+        // It doesn't make sense to test setting e.g. `elm.ariaLabelledBy` if the global
+        // polyfill is not applied
+        if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
+            usePropertyAccessValues.push(true);
+        }
 
-            beforeEach(() => {
-                elm = createElement('x-aria-container', { is: AriaContainer });
-                document.body.appendChild(elm);
-                sourceElm = elm.shadowRoot.querySelector('x-aria-source');
-                targetElm = elm.shadowRoot.querySelector('x-aria-target');
-            });
+        usePropertyAccessValues.forEach((usePropertyAccess) => {
+            const expectedMessages = [
+                ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
+                expectedMessageForCrossRoot,
+            ];
 
-            const usePropertyAccessValues = [false];
+            const getExpectedDispatcherCalls = (isSetter) => [
+                ...(usePropertyAccess
+                    ? [
+                          [
+                              'NonStandardAriaReflection',
+                              {
+                                  tagName: 'x-aria-source',
+                                  propertyName: 'ariaLabelledBy',
+                                  isSetter,
+                                  setValueType: isSetter ? 'string' : undefined,
+                              },
+                          ],
+                      ]
+                    : []),
+                [
+                    'CrossRootAriaInSyntheticShadow',
+                    {
+                        tagName: 'x-aria-source',
+                        attributeName: 'aria-labelledby',
+                    },
+                ],
+            ];
 
-            // It doesn't make sense to test setting e.g. `elm.ariaLabelledBy` if the global
-            // polyfill is not applied
-            if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
-                usePropertyAccessValues.push(true);
+            function expectWarningForNonStandardPropertyAccess(callback) {
+                // eslint-disable-next-line jest/valid-expect
+                let expected = expect(callback);
+                if (!usePropertyAccess) {
+                    expected = expected.not;
+                }
+                expected.toLogWarningDev(
+                    `Error: [LWC warn]: Element <input> owned by <x-aria-source> uses non-standard property "ariaLabelledBy". This will be removed in a future version of LWC. See https://sfdc.co/deprecated-aria`
+                );
             }
 
-            usePropertyAccessValues.forEach((usePropertyAccess) => {
-                const expectedMessages = [
-                    ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
-                    expectedMessageForCrossRoot,
-                ];
+            describe(usePropertyAccess ? 'property' : 'attribute', () => {
+                beforeEach(() => {
+                    elm.usePropertyAccess = usePropertyAccess;
+                    return Promise.resolve();
+                });
 
-                const getExpectedDispatcherCalls = (isSetter) => [
-                    ...(usePropertyAccess
-                        ? [
-                              [
-                                  'NonStandardAriaReflection',
-                                  {
-                                      tagName: 'x-aria-source',
-                                      propertyName: 'ariaLabelledBy',
-                                      isSetter,
-                                      setValueType: isSetter ? 'string' : undefined,
-                                  },
-                              ],
-                          ]
-                        : []),
-                    [
-                        'CrossRootAriaInSyntheticShadow',
-                        {
-                            tagName: 'x-aria-source',
-                            attributeName: 'aria-labelledby',
-                        },
-                    ],
-                ];
+                it('setting aria-labelledby', () => {
+                    expect(() => {
+                        elm.linkUsingAriaLabelledBy();
+                    }).toLogWarningDev(expectedMessages);
+                    expect(dispatcher.calls.allArgs()).toEqual(getExpectedDispatcherCalls(true));
+                });
 
-                function expectWarningForNonStandardPropertyAccess(callback) {
-                    // eslint-disable-next-line jest/valid-expect
-                    let expected = expect(callback);
-                    if (!usePropertyAccess) {
-                        expected = expected.not;
-                    }
-                    expected.toLogWarningDev(
-                        `Error: [LWC warn]: Element <input> owned by <x-aria-source> uses non-standard property "ariaLabelledBy". This will be removed in a future version of LWC. See https://sfdc.co/deprecated-aria`
-                    );
-                }
+                it('setting id', () => {
+                    expect(() => {
+                        elm.linkUsingId();
+                    }).toLogWarningDev(expectedMessages);
+                    expect(dispatcher.calls.allArgs()).toEqual(getExpectedDispatcherCalls(false));
+                });
 
-                describe(usePropertyAccess ? 'property' : 'attribute', () => {
-                    beforeEach(() => {
-                        elm.usePropertyAccess = usePropertyAccess;
-                        return Promise.resolve();
+                it('linking to an element in global light DOM', () => {
+                    const label = document.createElement('label');
+                    label.id = 'foo';
+                    document.body.appendChild(label);
+                    expect(() => {
+                        sourceElm.setAriaLabelledBy('foo');
+                    }).toLogWarningDev(expectedMessages);
+                    expect(dispatcher.calls.allArgs()).toEqual(getExpectedDispatcherCalls(true));
+                });
+
+                it('linking from an element in global light DOM', () => {
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.setAttribute('aria-labelledby', 'foo');
+                    document.body.appendChild(input);
+                    expect(() => {
+                        targetElm.setId('foo');
+                    }).toLogWarningDev(expectedMessageForCrossRootWithTargetAsVM);
+                    expect(dispatcher.calls.allArgs()).toEqual([
+                        [
+                            'CrossRootAriaInSyntheticShadow',
+                            {
+                                tagName: 'x-aria-target',
+                                attributeName: 'aria-labelledby',
+                            },
+                        ],
+                    ]);
+                });
+
+                [null, '', '  '].forEach((value) => {
+                    it(`ignores setting id to ${JSON.stringify(value)}`, () => {
+                        targetElm.setId(value);
+                        expect(dispatcher).not.toHaveBeenCalled();
                     });
 
-                    it('setting aria-labelledby', () => {
-                        expect(() => {
-                            elm.linkUsingAriaLabelledBy();
-                        }).toLogWarningDev(expectedMessages);
-                        expect(dispatcher.calls.allArgs()).toEqual(
-                            getExpectedDispatcherCalls(true)
-                        );
-                    });
-
-                    it('setting id', () => {
-                        expect(() => {
-                            elm.linkUsingId();
-                        }).toLogWarningDev(expectedMessages);
-                        expect(dispatcher.calls.allArgs()).toEqual(
-                            getExpectedDispatcherCalls(false)
-                        );
-                    });
-
-                    it('linking to an element in global light DOM', () => {
-                        const label = document.createElement('label');
-                        label.id = 'foo';
-                        document.body.appendChild(label);
-                        expect(() => {
-                            sourceElm.setAriaLabelledBy('foo');
-                        }).toLogWarningDev(expectedMessages);
-                        expect(dispatcher.calls.allArgs()).toEqual(
-                            getExpectedDispatcherCalls(true)
-                        );
-                    });
-
-                    it('linking from an element in global light DOM', () => {
-                        const input = document.createElement('input');
-                        input.type = 'text';
-                        input.setAttribute('aria-labelledby', 'foo');
-                        document.body.appendChild(input);
-                        expect(() => {
-                            targetElm.setId('foo');
-                        }).toLogWarningDev(expectedMessageForCrossRootWithTargetAsVM);
-                        expect(dispatcher.calls.allArgs()).toEqual([
-                            [
-                                'CrossRootAriaInSyntheticShadow',
-                                {
-                                    tagName: 'x-aria-target',
-                                    attributeName: 'aria-labelledby',
-                                },
-                            ],
-                        ]);
-                    });
-
-                    [null, '', '  '].forEach((value) => {
-                        it(`ignores setting id to ${JSON.stringify(value)}`, () => {
-                            targetElm.setId(value);
-                            expect(dispatcher).not.toHaveBeenCalled();
-                        });
-
-                        it(`ignores setting aria-labelledby to ${JSON.stringify(value)}`, () => {
-                            expectWarningForNonStandardPropertyAccess(() => {
-                                sourceElm.setAriaLabelledBy(value);
-                            });
-
-                            if (usePropertyAccess) {
-                                expect(dispatcher.calls.allArgs()).toEqual([
-                                    [
-                                        'NonStandardAriaReflection',
-                                        {
-                                            tagName: 'x-aria-source',
-                                            propertyName: 'ariaLabelledBy',
-                                            isSetter: true,
-                                            setValueType: value === null ? 'null' : typeof value,
-                                        },
-                                    ],
-                                ]);
-                            } else {
-                                expect(dispatcher).not.toHaveBeenCalled();
-                            }
-                        });
-                    });
-
-                    it('ignores id that references nonexistent element', () => {
+                    it(`ignores setting aria-labelledby to ${JSON.stringify(value)}`, () => {
                         expectWarningForNonStandardPropertyAccess(() => {
-                            sourceElm.setAriaLabelledBy('does-not-exist-at-all-lol');
+                            sourceElm.setAriaLabelledBy(value);
                         });
 
                         if (usePropertyAccess) {
@@ -187,7 +157,7 @@ if (!process.env.NATIVE_SHADOW) {
                                         tagName: 'x-aria-source',
                                         propertyName: 'ariaLabelledBy',
                                         isSetter: true,
-                                        setValueType: 'string',
+                                        setValueType: value === null ? 'null' : typeof value,
                                     },
                                 ],
                             ]);
@@ -195,91 +165,113 @@ if (!process.env.NATIVE_SHADOW) {
                             expect(dispatcher).not.toHaveBeenCalled();
                         }
                     });
+                });
 
-                    [
-                        {},
-                        { specialChars: true },
-                        { reverseOrder: true },
-                        { reverseOrder: true, specialChars: true },
-                        { addWhitespace: true },
-                        { addWhitespace: true, reverseOrder: true },
-                    ].forEach((options) => {
-                        describe(`${JSON.stringify(options)}`, () => {
-                            it('setting both id and aria-labelledby', () => {
-                                expect(() => {
-                                    elm.linkUsingBoth(options);
-                                }).toLogWarningDev(expectedMessages);
-                                expect(dispatcher.calls.allArgs()).toEqual(
-                                    getExpectedDispatcherCalls(true)
-                                );
-                            });
+                it('ignores id that references nonexistent element', () => {
+                    expectWarningForNonStandardPropertyAccess(() => {
+                        sourceElm.setAriaLabelledBy('does-not-exist-at-all-lol');
+                    });
 
-                            it('linking multiple targets', () => {
-                                expect(() => {
-                                    elm.linkUsingBoth({ ...options, multipleTargets: true });
-                                }).toLogWarningDev([
-                                    ...expectedMessages,
-                                    expectedMessageForCrossRootForSecondTarget,
-                                ]);
+                    if (usePropertyAccess) {
+                        expect(dispatcher.calls.allArgs()).toEqual([
+                            [
+                                'NonStandardAriaReflection',
+                                {
+                                    tagName: 'x-aria-source',
+                                    propertyName: 'ariaLabelledBy',
+                                    isSetter: true,
+                                    setValueType: 'string',
+                                },
+                            ],
+                        ]);
+                    } else {
+                        expect(dispatcher).not.toHaveBeenCalled();
+                    }
+                });
 
-                                expect(dispatcher.calls.allArgs()).toEqual([
-                                    ...getExpectedDispatcherCalls(true),
-                                    [
-                                        'CrossRootAriaInSyntheticShadow',
-                                        {
-                                            tagName: 'x-aria-source',
-                                            attributeName: 'aria-labelledby',
-                                        },
-                                    ],
-                                ]);
-                            });
+                [
+                    {},
+                    { specialChars: true },
+                    { reverseOrder: true },
+                    { reverseOrder: true, specialChars: true },
+                    { addWhitespace: true },
+                    { addWhitespace: true, reverseOrder: true },
+                ].forEach((options) => {
+                    describe(`${JSON.stringify(options)}`, () => {
+                        it('setting both id and aria-labelledby', () => {
+                            expect(() => {
+                                elm.linkUsingBoth(options);
+                            }).toLogWarningDev(expectedMessages);
+                            expect(dispatcher.calls.allArgs()).toEqual(
+                                getExpectedDispatcherCalls(true)
+                            );
+                        });
+
+                        it('linking multiple targets', () => {
+                            expect(() => {
+                                elm.linkUsingBoth({ ...options, multipleTargets: true });
+                            }).toLogWarningDev([
+                                ...expectedMessages,
+                                expectedMessageForCrossRootForSecondTarget,
+                            ]);
+
+                            expect(dispatcher.calls.allArgs()).toEqual([
+                                ...getExpectedDispatcherCalls(true),
+                                [
+                                    'CrossRootAriaInSyntheticShadow',
+                                    {
+                                        tagName: 'x-aria-source',
+                                        attributeName: 'aria-labelledby',
+                                    },
+                                ],
+                            ]);
                         });
                     });
                 });
             });
         });
+    });
 
-        it('does not log duplicates warnings', () => {
-            const elm1 = createElement('x-aria-container', { is: AriaContainer });
-            const elm2 = createElement('x-aria-container', { is: AriaContainer });
-            document.body.appendChild(elm1);
-            document.body.appendChild(elm2);
+    it('does not log duplicates warnings', () => {
+        const elm1 = createElement('x-aria-container', { is: AriaContainer });
+        const elm2 = createElement('x-aria-container', { is: AriaContainer });
+        document.body.appendChild(elm1);
+        document.body.appendChild(elm2);
 
-            // warning is logged only once
-            expect(() => {
-                elm1.linkUsingBoth({ idPrefix: 'prefix-1' });
-                elm2.linkUsingBoth({ idPrefix: 'prefix-2' }); // ids must be globally unique
-            }).toLogWarningDev(expectedMessageForCrossRoot);
+        // warning is logged only once
+        expect(() => {
+            elm1.linkUsingBoth({ idPrefix: 'prefix-1' });
+            elm2.linkUsingBoth({ idPrefix: 'prefix-2' }); // ids must be globally unique
+        }).toLogWarningDev(expectedMessageForCrossRoot);
 
-            // dispatcher is still called twice
-            expect(dispatcher.calls.allArgs()).toEqual([
-                [
-                    'CrossRootAriaInSyntheticShadow',
-                    {
-                        tagName: 'x-aria-source',
-                        attributeName: 'aria-labelledby',
-                    },
-                ],
-                [
-                    'CrossRootAriaInSyntheticShadow',
-                    {
-                        tagName: 'x-aria-source',
-                        attributeName: 'aria-labelledby',
-                    },
-                ],
-            ]);
-        });
+        // dispatcher is still called twice
+        expect(dispatcher.calls.allArgs()).toEqual([
+            [
+                'CrossRootAriaInSyntheticShadow',
+                {
+                    tagName: 'x-aria-source',
+                    attributeName: 'aria-labelledby',
+                },
+            ],
+            [
+                'CrossRootAriaInSyntheticShadow',
+                {
+                    tagName: 'x-aria-source',
+                    attributeName: 'aria-labelledby',
+                },
+            ],
+        ]);
+    });
 
-        [false, true].forEach((reverseOrder) => {
-            describe(`reverseOrder: ${reverseOrder}`, () => {
-                it('ignores valid usage', () => {
-                    const valid = createElement('x-valid', { is: Valid });
-                    document.body.appendChild(valid);
-                    valid.linkElements({ reverseOrder });
+    [false, true].forEach((reverseOrder) => {
+        describe(`reverseOrder: ${reverseOrder}`, () => {
+            it('ignores valid usage', () => {
+                const valid = createElement('x-valid', { is: Valid });
+                document.body.appendChild(valid);
+                valid.linkElements({ reverseOrder });
 
-                    expect(dispatcher).not.toHaveBeenCalled();
-                });
+                expect(dispatcher).not.toHaveBeenCalled();
             });
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/accessibility/synthetic-cross-root-aria/index.spec.js
@@ -41,15 +41,16 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic shadow cross-root ARIA', (
             targetElm = elm.shadowRoot.querySelector('x-aria-target');
         });
 
-        const usePropertyAccessValues = [false];
+        const usePropertyAccessValues = [false].map((value) => ({ value }));
 
         // It doesn't make sense to test setting e.g. `elm.ariaLabelledBy` if the global
         // polyfill is not applied
-        if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
-            usePropertyAccessValues.push(true);
-        }
+        usePropertyAccessValues.push({
+            value: true,
+            suite: describe.runIf(process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL),
+        });
 
-        usePropertyAccessValues.forEach((usePropertyAccess) => {
+        usePropertyAccessValues.forEach(({ value: usePropertyAccess, suite = describe }) => {
             const expectedMessages = [
                 ...(usePropertyAccess ? [expectedMessageForNonStandardAria] : []),
                 expectedMessageForCrossRoot,
@@ -89,7 +90,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic shadow cross-root ARIA', (
                 );
             }
 
-            describe(usePropertyAccess ? 'property' : 'attribute', () => {
+            suite(usePropertyAccess ? 'property' : 'attribute', () => {
                 beforeEach(() => {
                     elm.usePropertyAccess = usePropertyAccess;
                     return Promise.resolve();

--- a/packages/@lwc/integration-karma/test/api/createElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/createElement/index.spec.js
@@ -48,13 +48,14 @@ it('returns an HTMLElement', () => {
     expect(elm instanceof HTMLElement).toBe(true);
 });
 
-if (!process.env.NATIVE_SHADOW) {
-    it('should create an element with a synthetic shadow root by default', () => {
+it.skipIf(process.env.NATIVE_SHADOW)(
+    'should create an element with a synthetic shadow root by default',
+    () => {
         const elm = createElement('x-component', { is: Test });
         expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBeTrue();
         expect(elm.isSynthetic()).toBeTrue();
-    });
-}
+    }
+);
 
 it('supports component constructors in circular dependency', () => {
     function Circular() {
@@ -66,7 +67,7 @@ it('supports component constructors in circular dependency', () => {
     expect(elm instanceof HTMLElement).toBe(true);
 });
 
-if (process.env.NATIVE_SHADOW) {
+describe.runIf(process.env.NATIVE_SHADOW)('native shadow', () => {
     it('should create an element with a native shadow root if fallback is false', () => {
         const elm = createElement('x-component', { is: Test });
         expect(isNativeShadowRootInstance(elm.shadowRoot)).toBeTrue();
@@ -93,7 +94,7 @@ if (process.env.NATIVE_SHADOW) {
         expect(shadowRoot).toBeInstanceOf(ShadowRoot);
         expect(shadowRoot.mode).toBe('closed');
     });
-}
+});
 
 describe('locker integration', () => {
     it('should support component class that extend a mirror of the LightningElement', () => {

--- a/packages/@lwc/integration-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/@lwc/integration-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -60,8 +60,9 @@ it('should return true on elements manually inserted in the DOM inside an elemen
 
 // TODO [#1252]: old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
-if (!process.env.NATIVE_SHADOW) {
-    it('should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"', () => {
+it.skipIf(process.env.NATIVE_SHADOW)(
+    'should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"',
+    () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual"
@@ -74,5 +75,5 @@ if (!process.env.NATIVE_SHADOW) {
         }).then(() => {
             expect(isNodeFromTemplate(span)).toBe(false);
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/formAssociated/index.spec.js
@@ -8,12 +8,12 @@ import NotFormAssociatedNoAttachInternals from 'x/notFormAssociatedNoAttachInter
 import FormAssociatedNoAttachInternals from 'x/formAssociatedNoAttachInternals';
 import FormAssociatedFalseNoAttachInternals from 'x/formAssociatedFalseNoAttachInternals';
 
-if (
+describe.runIf(
     ENABLE_ELEMENT_INTERNALS_AND_FACE &&
-    typeof ElementInternals !== 'undefined' &&
-    !IS_SYNTHETIC_SHADOW_LOADED
-) {
-    it('should throw an error when duplicate tag name used with different formAssociated value', () => {
+        typeof ElementInternals !== 'undefined' &&
+        !IS_SYNTHETIC_SHADOW_LOADED
+)('should throw an error when duplicate tag name used', () => {
+    it('with different formAssociated value', () => {
         // Register tag with formAssociated = true
         createElement('x-form-associated', { is: FormAssociated });
         // Try to register again with formAssociated = false
@@ -37,19 +37,20 @@ if (
             createElement('x-not-form-associated', { is: NotFormAssociated })
         ).not.toThrow();
     });
-}
+});
 
-if (typeof ElementInternals !== 'undefined' && !IS_SYNTHETIC_SHADOW_LOADED) {
-    const isFormAssociated = (elm) => {
-        const form = document.createElement('form');
-        document.body.appendChild(form);
-        form.appendChild(elm);
-        const result = elm.formAssociatedCallbackCalled;
-        document.body.removeChild(form); // cleanup
-        return result;
-    };
+it.runIf(typeof ElementInternals !== 'undefined' && !IS_SYNTHETIC_SHADOW_LOADED)(
+    'disallows form association on older API versions',
+    () => {
+        const isFormAssociated = (elm) => {
+            const form = document.createElement('form');
+            document.body.appendChild(form);
+            form.appendChild(elm);
+            const result = elm.formAssociatedCallbackCalled;
+            document.body.removeChild(form); // cleanup
+            return result;
+        };
 
-    it('disallows form association on older API versions', () => {
         let elm;
 
         // formAssociated = true
@@ -79,11 +80,12 @@ if (typeof ElementInternals !== 'undefined' && !IS_SYNTHETIC_SHADOW_LOADED) {
             is: NotFormAssociatedNoAttachInternals,
         });
         expect(isFormAssociated(elm)).toBe(false);
-    });
-}
+    }
+);
 
-if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
-    it('warns for attachInternals on older API versions', () => {
+it.skipIf(ENABLE_ELEMENT_INTERNALS_AND_FACE)(
+    'warns for attachInternals on older API versions',
+    () => {
         // formAssociated = true
         expect(() => {
             expect(() => createElement('x-form-associated', { is: FormAssociated })).toThrowError(
@@ -102,5 +104,5 @@ if (!ENABLE_ELEMENT_INTERNALS_AND_FACE) {
         expect(() =>
             createElement('x-not-form-associated', { is: NotFormAssociated })
         ).toThrowError(/The attachInternals API is only supported in API version 61 and above/);
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -3,59 +3,57 @@ import { ariaProperties, ariaAttributes, ENABLE_ELEMENT_INTERNALS_AND_FACE } fro
 
 import ElementInternal from 'ei/component';
 
-if (
+let elm;
+beforeEach(() => {
+    elm = createElement('ei-component', { is: ElementInternal });
+    document.body.appendChild(elm);
+});
+
+afterEach(() => {
+    document.body.removeChild(elm);
+});
+
+describe.runIf(
     ENABLE_ELEMENT_INTERNALS_AND_FACE &&
-    process.env.NATIVE_SHADOW &&
-    typeof ElementInternals !== 'undefined'
-) {
-    let elm;
-    beforeEach(() => {
-        elm = createElement('ei-component', { is: ElementInternal });
-        document.body.appendChild(elm);
+        process.env.NATIVE_SHADOW &&
+        typeof ElementInternals !== 'undefined'
+)('ElementInternals', () => {
+    it('should be associated to the correct element', () => {
+        // Ensure external and internal views of shadowRoot are the same
+        expect(elm.internals.shadowRoot).toBe(elm.template);
+        expect(elm.internals.shadowRoot).toBe(elm.shadowRoot);
     });
 
-    afterEach(() => {
-        document.body.removeChild(elm);
-    });
-
-    describe('ElementInternals', () => {
-        it('should be associated to the correct element', () => {
-            // Ensure external and internal views of shadowRoot are the same
-            expect(elm.internals.shadowRoot).toBe(elm.template);
-            expect(elm.internals.shadowRoot).toBe(elm.shadowRoot);
+    // Firefox does not support ARIAMixin inside ElementInternals.
+    // Check to see if ARIAMixin value is defined on ElementInternals before
+    // testing accessibility.
+    // #TODO[3693]: Firefox is shipping ARIAMixin support in the nightly distribution, remove this check
+    // once support has officially been released.
+    describe.runIf(
+        Object.prototype.hasOwnProperty.call(window.ElementInternals.prototype, 'ariaAtomic')
+    )('accessibility', () => {
+        it('should be able to set ARIAMixin properties on ElementInternals', () => {
+            elm.setAllAriaProps('foo');
+            // Verify ElementInternals proxy setter and getter
+            for (const ariaProp of ariaProperties) {
+                expect(elm.internals[ariaProp]).toEqual('foo');
+            }
         });
 
-        // Firefox does not support ARIAMixin inside ElementInternals.
-        // Check to see if ARIAMixin value is defined on ElementInternals before
-        // testing accessibility.
-        // #TODO[3693]: Firefox is shipping ARIAMixin support in the nightly distribution, remove this check
-        // once support has officially been released.
-        if (Object.prototype.hasOwnProperty.call(window.ElementInternals.prototype, 'ariaAtomic')) {
-            describe('accessibility', () => {
-                it('should be able to set ARIAMixin properties on ElementInternals', () => {
-                    elm.setAllAriaProps('foo');
-                    // Verify ElementInternals proxy setter and getter
-                    for (const ariaProp of ariaProperties) {
-                        expect(elm.internals[ariaProp]).toEqual('foo');
-                    }
-                });
+        it('should not reflect to aria-* attributes', () => {
+            elm.setAllAriaProps('foo');
+            for (const attr of ariaAttributes) {
+                expect(elm.getAttribute(attr)).not.toEqual('foo');
+            }
+        });
 
-                it('should not reflect to aria-* attributes', () => {
-                    elm.setAllAriaProps('foo');
-                    for (const attr of ariaAttributes) {
-                        expect(elm.getAttribute(attr)).not.toEqual('foo');
-                    }
-                });
-
-                it('aria-* attributes do not reflect to internals', () => {
-                    for (const attr of ariaAttributes) {
-                        elm.setAttribute(attr, 'bar');
-                    }
-                    for (const prop of ariaProperties) {
-                        expect(elm.internals[prop]).toBeFalsy();
-                    }
-                });
-            });
-        }
+        it('aria-* attributes do not reflect to internals', () => {
+            for (const attr of ariaAttributes) {
+                elm.setAttribute(attr, 'bar');
+            }
+            for (const prop of ariaProperties) {
+                expect(elm.internals[prop]).toBeFalsy();
+            }
+        });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.attachInternals/elementInternals/sanity/index.spec.js
@@ -24,14 +24,7 @@ describe.runIf(
         expect(elm.internals.shadowRoot).toBe(elm.shadowRoot);
     });
 
-    // Firefox does not support ARIAMixin inside ElementInternals.
-    // Check to see if ARIAMixin value is defined on ElementInternals before
-    // testing accessibility.
-    // #TODO[3693]: Firefox is shipping ARIAMixin support in the nightly distribution, remove this check
-    // once support has officially been released.
-    describe.runIf(
-        Object.prototype.hasOwnProperty.call(window.ElementInternals.prototype, 'ariaAtomic')
-    )('accessibility', () => {
+    describe('accessibility', () => {
         it('should be able to set ARIAMixin properties on ElementInternals', () => {
             elm.setAllAriaProps('foo');
             // Verify ElementInternals proxy setter and getter

--- a/packages/@lwc/integration-karma/test/component/LightningElement.hostElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.hostElement/index.spec.js
@@ -9,8 +9,9 @@ function createWrapper() {
     return elm;
 }
 
-if (ENABLE_THIS_DOT_HOST_ELEMENT) {
-    it('should provide the root element for light rendering', () => {
+it.runIf(ENABLE_THIS_DOT_HOST_ELEMENT)(
+    'should provide the root element for light rendering',
+    () => {
         const elm = createWrapper();
 
         const divElement = elm.getDivElement();
@@ -23,9 +24,12 @@ if (ENABLE_THIS_DOT_HOST_ELEMENT) {
 
         expect(hostElement).toEqual(lightElement);
         expect(hostElement.parentElement).toEqual(divElement);
-    });
+    }
+);
 
-    it('should provide the root element for shadow rendering', () => {
+it.runIf(ENABLE_THIS_DOT_HOST_ELEMENT)(
+    'should provide the root element for shadow rendering',
+    () => {
         const elm = createWrapper();
 
         const divElement = elm.getDivElement();
@@ -38,10 +42,13 @@ if (ENABLE_THIS_DOT_HOST_ELEMENT) {
 
         expect(hostElement).toEqual(shadowElement);
         expect(hostElement.parentElement).toEqual(divElement);
-    });
-} else {
-    // this.hostElement unsupported
-    it('this.hostElement unsupported in older API versions', () => {
+    }
+);
+
+// this.hostElement unsupported
+it.skipIf(ENABLE_THIS_DOT_HOST_ELEMENT)(
+    'this.hostElement unsupported in older API versions',
+    () => {
         const elm = createWrapper();
 
         const shadowElement = elm.getShadowElement();
@@ -53,5 +60,5 @@ if (ENABLE_THIS_DOT_HOST_ELEMENT) {
         }).toLogWarningDev(/Increase the API version to use it/);
 
         expect(hostElement).toBeUndefined();
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/component/LightningElement.style/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.style/index.spec.js
@@ -2,8 +2,9 @@ import { createElement } from 'lwc';
 import { ENABLE_THIS_DOT_STYLE } from 'test-utils';
 import Test from 'x/test';
 
-if (ENABLE_THIS_DOT_STYLE) {
-    it('this.style should return the CSSStyleDeclaration of host element', async () => {
+it.runIf(ENABLE_THIS_DOT_STYLE)(
+    'this.style should return the CSSStyleDeclaration of host element',
+    async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
@@ -31,19 +32,19 @@ if (ENABLE_THIS_DOT_STYLE) {
 
         elm.style.setProperty('color', 'rgb(128, 0, 128)');
         await assertColor('rgb(128, 0, 128)');
-    });
-} else {
-    it('this.style should be undefined for older API versions', () => {
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
+    }
+);
 
-        expect(elm.style.color).toEqual('');
-        let thisDotStyle;
+it.skipIf(ENABLE_THIS_DOT_STYLE)('this.style should be undefined for older API versions', () => {
+    const elm = createElement('x-test', { is: Test });
+    document.body.appendChild(elm);
 
-        expect(() => {
-            thisDotStyle = elm.thisDotStyle;
-        }).toLogWarningDev(/only supported in API version 62 and above/);
+    expect(elm.style.color).toEqual('');
+    let thisDotStyle;
 
-        expect(thisDotStyle).toBeUndefined();
-    });
-}
+    expect(() => {
+        thisDotStyle = elm.thisDotStyle;
+    }).toLogWarningDev(/only supported in API version 62 and above/);
+
+    expect(thisDotStyle).toBeUndefined();
+});

--- a/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/face-callbacks/index.spec.js
@@ -145,75 +145,77 @@ const testFaceLifecycleMethodsNotCallable = (createFace) => {
     // Note there is no good way to test formStateRestoreCallback in karma tests
 };
 
-if (typeof ElementInternals !== 'undefined') {
-    if (ENABLE_ELEMENT_INTERNALS_AND_FACE) {
-        // native lifecycle enabled
-        describe('ElementInternals/FACE enabled', () => {
-            if (process.env.NATIVE_SHADOW) {
-                describe('native shadow', () => {
-                    faceSanityTest('native-shadow', FormAssociated);
-                    notFormAssociatedSanityTest('native-shadow', NotFormAssociated);
+describe.runIf(typeof ElementInternals !== 'undefined')('ElementInternals', () => {
+    // native lifecycle enabled
+    describe.runIf(ENABLE_ELEMENT_INTERNALS_AND_FACE)('ElementInternals/FACE enabled', () => {
+        describe.runIf(process.env.NATIVE_SHADOW)('native shadow', () => {
+            faceSanityTest('native-shadow', FormAssociated);
+            notFormAssociatedSanityTest('native-shadow', NotFormAssociated);
+        });
+        describe.skipIf(process.env.NATIVE_SHADOW)('synthetic shadow', () => {
+            createFaceTests('synthetic-shadow', FormAssociated, (createFace) => {
+                it('cannot be used and throws an error', () => {
+                    const face = createFace();
+                    const form = createFormElement();
+                    expect(() =>
+                        form.appendChild(face)
+                    ).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
+                        'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
+                    );
                 });
-            } else {
-                describe('synthetic shadow', () => {
-                    createFaceTests('synthetic-shadow', FormAssociated, (createFace) => {
-                        it('cannot be used and throws an error', () => {
+            });
+        });
+        describe('light DOM', () => {
+            faceSanityTest('light-dom', LightDomFormAssociated);
+            notFormAssociatedSanityTest('light-dom', LightDomNotFormAssociated);
+        });
+    });
+});
+
+describe.skipIf(ENABLE_ELEMENT_INTERNALS_AND_FACE)('ElementInternals/FACE disabled', () => {
+    [
+        { name: 'shadow DOM', tagName: 'synthetic-lifecycle-shadow', ctor: FormAssociated },
+        {
+            name: 'light DOM',
+            tagName: 'synthetic-lifecycle-light',
+            ctor: LightDomFormAssociated,
+        },
+    ].forEach(({ name, tagName, ctor }) => {
+        createFaceTests(tagName, ctor, (createFace, scenario) => {
+            it.runIf(scenario === 'lwc.createElement')(
+                `${name} does not call face lifecycle methods when upgraded by LWC`,
+                () => {
+                    testFaceLifecycleMethodsNotCallable(createFace);
+                }
+            );
+
+            describe.skipIf(scenario === 'lwc.createElement')(name, () => {
+                // Face throws error message when synthetic shadow is enabled
+                it.runIf(name === 'light DOM' || process.env.NATIVE_SHADOW)(
+                    `${name} calls face lifecycle methods when using CustomElementConstructor`,
+                    () => {
+                        // CustomElementConstructor is to be upgraded independently of LWC, it will always use native lifecycle
+                        testFaceLifecycleMethodsCallable(createFace);
+                    }
+                );
+
+                // synthetic shadow mode
+                it.skipIf(name === 'light DOM' || process.env.NATIVE_SHADOW)(
+                    `${name} cannot call face lifecycle methods when using CustomElementConstructor`,
+                    () => {
+                        // this is always a callback reaction error, even in "synthetic lifecycle" mode,
+                        // because synthetic lifecycle mode only includes connected/disconnected callbacks,
+                        // not the FACE callbacks
+                        expect(() => {
                             const face = createFace();
                             const form = createFormElement();
-                            expect(() =>
-                                form.appendChild(face)
-                            ).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
-                                'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
-                            );
-                        });
-                    });
-                });
-            }
-            describe('light DOM', () => {
-                faceSanityTest('light-dom', LightDomFormAssociated);
-                notFormAssociatedSanityTest('light-dom', LightDomNotFormAssociated);
-            });
-        });
-    } else {
-        describe('ElementInternals/FACE disabled', () => {
-            [
-                { name: 'shadow DOM', tagName: 'synthetic-lifecycle-shadow', ctor: FormAssociated },
-                {
-                    name: 'light DOM',
-                    tagName: 'synthetic-lifecycle-light',
-                    ctor: LightDomFormAssociated,
-                },
-            ].forEach(({ name, tagName, ctor }) => {
-                createFaceTests(tagName, ctor, (createFace, scenario) => {
-                    if (scenario === 'lwc.createElement') {
-                        it(`${name} does not call face lifecycle methods when upgraded by LWC`, () => {
-                            testFaceLifecycleMethodsNotCallable(createFace);
-                        });
-                    } else {
-                        // Face throws error message when synthetic shadow is enabled
-                        if (name === 'light DOM' || process.env.NATIVE_SHADOW) {
-                            it(`${name} calls face lifecycle methods when using CustomElementConstructor`, () => {
-                                // CustomElementConstructor is to be upgraded independently of LWC, it will always use native lifecycle
-                                testFaceLifecycleMethodsCallable(createFace);
-                            });
-                        } else {
-                            // synthetic shadow mode
-                            it(`${name} cannot call face lifecycle methods when using CustomElementConstructor`, () => {
-                                // this is always a callback reaction error, even in "synthetic lifecycle" mode,
-                                // because synthetic lifecycle mode only includes connected/disconnected callbacks,
-                                // not the FACE callbacks
-                                expect(() => {
-                                    const face = createFace();
-                                    const form = createFormElement();
-                                    form.appendChild(face);
-                                }).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
-                                    'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
-                                );
-                            });
-                        }
+                            form.appendChild(face);
+                        }).toThrowCallbackReactionErrorEvenInSyntheticLifecycleMode(
+                            'Form associated lifecycle methods are not available in synthetic shadow. Please use native shadow or light DOM.'
+                        );
                     }
-                });
+                );
             });
         });
-    }
-}
+    });
+});

--- a/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/html-properties/index.spec.js
@@ -170,37 +170,33 @@ describe('global html properties', () => {
                 expect(retrievedPropValue).toEqual(valueToSet);
             });
 
-            if (attribute) {
-                it('attribute reflection', () => {
-                    const initialNumAttributes = elm.attributes.length;
-                    expect(elm.getAttribute(attribute)).toBeNull(); // initial attribute value
+            it.runIf(attribute)('attribute reflection', () => {
+                const initialNumAttributes = elm.attributes.length;
+                expect(elm.getAttribute(attribute)).toBeNull(); // initial attribute value
 
-                    const valueToSet = getValueToSet();
-                    setPropertyValue(valueToSet);
+                const valueToSet = getValueToSet();
+                setPropertyValue(valueToSet);
 
-                    // In the case of non-original descriptors, the attribute is not set
-                    let expectedAttributeValue = isOriginalDescriptor
-                        ? valueToSet.toString()
-                        : null;
-                    if (propName === 'hidden') {
-                        // `hidden` is a special case; it's reflected to the empty string
-                        expectedAttributeValue = '';
-                    }
-                    expect(elm.getAttribute(attribute)).toEqual(expectedAttributeValue);
+                // In the case of non-original descriptors, the attribute is not set
+                let expectedAttributeValue = isOriginalDescriptor ? valueToSet.toString() : null;
+                if (propName === 'hidden') {
+                    // `hidden` is a special case; it's reflected to the empty string
+                    expectedAttributeValue = '';
+                }
+                expect(elm.getAttribute(attribute)).toEqual(expectedAttributeValue);
 
-                    // In the case of non-original descriptors, the attribute is not set
-                    const expectedNumAddedAttributes = isOriginalDescriptor ? 1 : 0;
-                    expect(elm.attributes.length).toEqual(
-                        initialNumAttributes + expectedNumAddedAttributes
-                    );
-                });
-            } else {
-                it('no attribute reflection', () => {
-                    const initialNumAttributes = elm.attributes.length;
-                    setPropertyValue(getValueToSet());
-                    expect(elm.attributes.length).toEqual(initialNumAttributes); // no attributes added
-                });
-            }
+                // In the case of non-original descriptors, the attribute is not set
+                const expectedNumAddedAttributes = isOriginalDescriptor ? 1 : 0;
+                expect(elm.attributes.length).toEqual(
+                    initialNumAttributes + expectedNumAddedAttributes
+                );
+            });
+
+            it.skipIf(attribute)('no attribute reflection', () => {
+                const initialNumAttributes = elm.attributes.length;
+                setPropertyValue(getValueToSet());
+                expect(elm.attributes.length).toEqual(initialNumAttributes); // no attributes added
+            });
         });
     }
 });

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -63,21 +63,21 @@ describe.runIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(
                 ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
             ]);
         });
+
+        // This only applies to synthetic custom element lifecycle, because that's the case
+        // where we monkey-patch the global `Element.prototype.insertBefore`.
+        it('should log a warning when insertBefore is called with fewer than 2 arguments', () => {
+            const div = document.createElement('div');
+            const span = document.createElement('span');
+
+            expect(() => {
+                div.insertBefore(span);
+            }).toLogWarningDev(
+                /insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported./
+            );
+        });
     }
 );
-
-// This only applies to synthetic custom element lifecycle, because that's the case
-// where we monkey-patch the global `Element.prototype.insertBefore`.
-it('should log a warning when insertBefore is called with fewer than 2 arguments', () => {
-    const div = document.createElement('div');
-    const span = document.createElement('span');
-
-    expect(() => {
-        div.insertBefore(span);
-    }).toLogWarningDev(
-        /insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported./
-    );
-});
 
 // native lifecycle mode
 describe.skipIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(

--- a/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/native-vs-synthetic-lifecycle/index.spec.js
@@ -30,9 +30,10 @@ const expectLogs = (regexes) => {
     }
 };
 
-if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-    // synthetic lifecycle mode
-    describe('ConnectedCallbackWhileDisconnected reporting', () => {
+// synthetic lifecycle mode
+describe.runIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(
+    'ConnectedCallbackWhileDisconnected reporting',
+    () => {
         it('disconnected DOM', () => {
             const div = document.createElement('div');
             const elm = createElement('x-component', { is: Component });
@@ -62,23 +63,26 @@ if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
                 ['ConnectedCallbackWhileDisconnected', { tagName: 'x-child' }],
             ]);
         });
-    });
+    }
+);
 
-    // This only applies to synthetic custom element lifecycle, because that's the case
-    // where we monkey-patch the global `Element.prototype.insertBefore`.
-    it('should log a warning when insertBefore is called with fewer than 2 arguments', () => {
-        const div = document.createElement('div');
-        const span = document.createElement('span');
+// This only applies to synthetic custom element lifecycle, because that's the case
+// where we monkey-patch the global `Element.prototype.insertBefore`.
+it('should log a warning when insertBefore is called with fewer than 2 arguments', () => {
+    const div = document.createElement('div');
+    const span = document.createElement('span');
 
-        expect(() => {
-            div.insertBefore(span);
-        }).toLogWarningDev(
-            /insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported./
-        );
-    });
-} else {
-    // native lifecycle mode
-    describe('Lazily setting lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE to true', () => {
+    expect(() => {
+        div.insertBefore(span);
+    }).toLogWarningDev(
+        /insertBefore should be called with 2 arguments. Calling with only 1 argument is not supported./
+    );
+});
+
+// native lifecycle mode
+describe.skipIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(
+    'Lazily setting lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE to true',
+    () => {
         beforeEach(() => {
             setFeatureFlagForTest('DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE', true);
             window.timingBuffer = [];
@@ -102,5 +106,5 @@ if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
                 ['ConnectedCallbackWhileDisconnected', { tagName: 'x-logs-when-connected' }],
             ]);
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-karma/test/custom-elements/index.spec.js
@@ -341,106 +341,104 @@ const supportsFACE =
     'ElementInternals' in window &&
     'setFormValue' in window.ElementInternals.prototype;
 
-if (supportsFACE) {
-    describe('form-associated custom element (FACE) lifecycle callbacks', () => {
-        function testFormAssociated(shouldBeFormAssociated, tagName, Ctor) {
-            const calls = [];
+describe.runIf(supportsFACE)('form-associated custom element (FACE) lifecycle callbacks', () => {
+    function testFormAssociated(shouldBeFormAssociated, tagName, Ctor) {
+        const calls = [];
 
-            Ctor.prototype.formAssociatedCallback = function (form) {
-                calls.push({
-                    name: 'formAssociatedCallback',
-                    elm: this,
-                    form: form,
-                });
-            };
-
-            Ctor.prototype.formDisabledCallback = function (disabled) {
-                calls.push({
-                    name: 'formDisabledCallback',
-                    elm: this,
-                    disabled,
-                });
-            };
-
-            Ctor.prototype.formResetCallback = function () {
-                calls.push({
-                    name: 'formResetCallback',
-                    elm: this,
-                });
-            };
-
-            Ctor.prototype.formStateRestoreCallback = function (state, mode) {
-                calls.push({
-                    name: 'formStateRestoreCallback',
-                    elm: this,
-                    state,
-                    mode,
-                });
-            };
-
-            customElements.define(tagName, Ctor);
-
-            const form = document.createElement('form');
-            const fieldset = document.createElement('fieldset');
-            const elm = document.createElement(tagName);
-            form.appendChild(fieldset);
-            fieldset.appendChild(elm);
-            document.body.appendChild(form);
-
-            // formAssociatedCallback should be called with the form
-            expect(calls.length).toEqual(shouldBeFormAssociated ? 1 : 0);
-            expect(calls[0]).toEqual(
-                shouldBeFormAssociated ? { name: 'formAssociatedCallback', elm, form } : undefined
-            );
-
-            // check formDisabledCallback
-            fieldset.disabled = true;
-            expect(calls.length).toEqual(shouldBeFormAssociated ? 2 : 0);
-            expect(calls[1]).toEqual(
-                shouldBeFormAssociated
-                    ? { name: 'formDisabledCallback', elm, disabled: true }
-                    : undefined
-            );
-
-            // check formResetCallback
-            form.reset();
-            expect(calls.length).toEqual(shouldBeFormAssociated ? 3 : 0);
-            expect(calls[2]).toEqual(
-                shouldBeFormAssociated ? { name: 'formResetCallback', elm } : undefined
-            );
-
-            // formStateRestoreCallback cannot be manually invoked, just call it ourselves
-            elm.formStateRestoreCallback('foo', 'bar');
-            expect(calls.length).toEqual(shouldBeFormAssociated ? 4 : 1);
-            expect(calls.at(-1)).toEqual({
-                name: 'formStateRestoreCallback',
-                elm,
-                state: 'foo',
-                mode: 'bar',
+        Ctor.prototype.formAssociatedCallback = function (form) {
+            calls.push({
+                name: 'formAssociatedCallback',
+                elm: this,
+                form: form,
             });
-        }
+        };
 
-        it('supports FACE callbacks', () => {
-            testFormAssociated(
-                true,
-                'x-face-callbacks',
-                class extends HTMLElement {
-                    static formAssociated = true;
-                }
-            );
-        });
+        Ctor.prototype.formDisabledCallback = function (disabled) {
+            calls.push({
+                name: 'formDisabledCallback',
+                elm: this,
+                disabled,
+            });
+        };
 
-        it('does not call FACE callbacks if not form-associated', () => {
-            testFormAssociated(
-                false,
-                'x-face-callbacks-not-form-associated',
-                class extends HTMLElement {
-                    static formAssociated = false;
-                }
-            );
+        Ctor.prototype.formResetCallback = function () {
+            calls.push({
+                name: 'formResetCallback',
+                elm: this,
+            });
+        };
+
+        Ctor.prototype.formStateRestoreCallback = function (state, mode) {
+            calls.push({
+                name: 'formStateRestoreCallback',
+                elm: this,
+                state,
+                mode,
+            });
+        };
+
+        customElements.define(tagName, Ctor);
+
+        const form = document.createElement('form');
+        const fieldset = document.createElement('fieldset');
+        const elm = document.createElement(tagName);
+        form.appendChild(fieldset);
+        fieldset.appendChild(elm);
+        document.body.appendChild(form);
+
+        // formAssociatedCallback should be called with the form
+        expect(calls.length).toEqual(shouldBeFormAssociated ? 1 : 0);
+        expect(calls[0]).toEqual(
+            shouldBeFormAssociated ? { name: 'formAssociatedCallback', elm, form } : undefined
+        );
+
+        // check formDisabledCallback
+        fieldset.disabled = true;
+        expect(calls.length).toEqual(shouldBeFormAssociated ? 2 : 0);
+        expect(calls[1]).toEqual(
+            shouldBeFormAssociated
+                ? { name: 'formDisabledCallback', elm, disabled: true }
+                : undefined
+        );
+
+        // check formResetCallback
+        form.reset();
+        expect(calls.length).toEqual(shouldBeFormAssociated ? 3 : 0);
+        expect(calls[2]).toEqual(
+            shouldBeFormAssociated ? { name: 'formResetCallback', elm } : undefined
+        );
+
+        // formStateRestoreCallback cannot be manually invoked, just call it ourselves
+        elm.formStateRestoreCallback('foo', 'bar');
+        expect(calls.length).toEqual(shouldBeFormAssociated ? 4 : 1);
+        expect(calls.at(-1)).toEqual({
+            name: 'formStateRestoreCallback',
+            elm,
+            state: 'foo',
+            mode: 'bar',
         });
+    }
+
+    it('supports FACE callbacks', () => {
+        testFormAssociated(
+            true,
+            'x-face-callbacks',
+            class extends HTMLElement {
+                static formAssociated = true;
+            }
+        );
     });
-}
+
+    it('does not call FACE callbacks if not form-associated', () => {
+        testFormAssociated(
+            false,
+            'x-face-callbacks-not-form-associated',
+            class extends HTMLElement {
+                static formAssociated = false;
+            }
+        );
+    });
+});
 
 describe('observedAttributes', () => {
     it('custom element with observedAttributes but no attributeChangedCallback', () => {

--- a/packages/@lwc/integration-karma/test/events/focus-event-composed/index.spec.js
+++ b/packages/@lwc/integration-karma/test/events/focus-event-composed/index.spec.js
@@ -9,7 +9,7 @@ function isFocusEventConstructorSupported() {
     }
 }
 
-if (isFocusEventConstructorSupported()) {
+describe.runIf(isFocusEventConstructorSupported())('FocusEvent constructor supported', () => {
     it('should set composed to false by default', () => {
         const focusEvent = new FocusEvent('focus');
         expect(focusEvent.composed).toBe(false);
@@ -22,4 +22,4 @@ if (isFocusEventConstructorSupported()) {
         const nonComposedEvt = new FocusEvent('focus', { composed: false });
         expect(nonComposedEvt.composed).toBe(false);
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/hydration/index.spec.js
+++ b/packages/@lwc/integration-karma/test/hydration/index.spec.js
@@ -8,8 +8,10 @@ it('throws error when hydrating non DOM element', () => {
         '"hydrateComponent" expects a valid DOM element as the first parameter but instead received [object Object].'
     );
 });
-if (process.env.NATIVE_SHADOW) {
-    it('should log an error when passing an invalid LightningElement constructor.', () => {
+
+it.runIf(process.env.NATIVE_SHADOW)(
+    'should log an error when passing an invalid LightningElement constructor.',
+    () => {
         const anElement = document.createElement('x-div');
 
         expect(() => {
@@ -21,5 +23,5 @@ if (process.env.NATIVE_SHADOW) {
         }).toLogError(
             /is not a valid component, or does not extends LightningElement from "lwc". You probably forgot to add the extend clause on the class declaration./
         );
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/light-dom/lifecycle/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/lifecycle/index.spec.js
@@ -97,160 +97,158 @@ describe('standard slotting', () => {
     });
 });
 
-if (USE_LIGHT_DOM_SLOT_FORWARDING) {
-    describe('slot forwarding', () => {
-        describe('static', () => {
-            let elm;
-            const setup = async () => {
-                elm = createElement('x-slot-forwarding', { is: SlotForwarding });
-                document.body.appendChild(elm);
-                await Promise.resolve();
+describe.runIf(USE_LIGHT_DOM_SLOT_FORWARDING)('slot forwarding', () => {
+    describe('static', () => {
+        let elm;
+        const setup = async () => {
+            elm = createElement('x-slot-forwarding', { is: SlotForwarding });
+            document.body.appendChild(elm);
+            await Promise.resolve();
 
-                expect(window.timingBuffer).toEqual([
-                    '0:connectedCallback',
-                    '1:connectedCallback',
-                    '2:connectedCallback',
-                ]);
+            expect(window.timingBuffer).toEqual([
+                '0:connectedCallback',
+                '1:connectedCallback',
+                '2:connectedCallback',
+            ]);
 
-                resetTimingBuffer();
+            resetTimingBuffer();
 
-                elm.showTop = true;
-                await Promise.resolve();
+            elm.showTop = true;
+            await Promise.resolve();
 
-                expect(window.timingBuffer).toEqual([
-                    '3:connectedCallback',
-                    '4:connectedCallback',
-                    '5:connectedCallback',
-                    '2:disconnectedCallback',
-                    '0:disconnectedCallback',
-                    '1:disconnectedCallback',
-                ]);
+            expect(window.timingBuffer).toEqual([
+                '3:connectedCallback',
+                '4:connectedCallback',
+                '5:connectedCallback',
+                '2:disconnectedCallback',
+                '0:disconnectedCallback',
+                '1:disconnectedCallback',
+            ]);
 
-                resetTimingBuffer();
-            };
+            resetTimingBuffer();
+        };
 
-            it('invokes lifecycle methods in correct order', async () => {
-                await setup();
+        it('invokes lifecycle methods in correct order', async () => {
+            await setup();
 
-                elm.showTop = false;
-                await Promise.resolve();
+            elm.showTop = false;
+            await Promise.resolve();
 
-                expect(window.timingBuffer).toEqual([
-                    '6:connectedCallback',
-                    '7:connectedCallback',
-                    '8:connectedCallback',
-                    '5:disconnectedCallback',
-                    '3:disconnectedCallback',
-                    '4:disconnectedCallback',
-                ]);
-            });
-
-            it('invokes disconnectedCallback after removing entire element', async () => {
-                await setup();
-
-                // remove entire element
-                document.body.removeChild(elm);
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '5:disconnectedCallback',
-                    '3:disconnectedCallback',
-                    '4:disconnectedCallback',
-                ]);
-            });
+            expect(window.timingBuffer).toEqual([
+                '6:connectedCallback',
+                '7:connectedCallback',
+                '8:connectedCallback',
+                '5:disconnectedCallback',
+                '3:disconnectedCallback',
+                '4:disconnectedCallback',
+            ]);
         });
 
-        describe('dynamic', () => {
-            let elm;
-            const setup = async () => {
-                elm = createElement('x-dynamic-slot-forwarding', { is: DynamicSlotForwarding });
-                document.body.appendChild(elm);
-                await Promise.resolve();
+        it('invokes disconnectedCallback after removing entire element', async () => {
+            await setup();
 
-                // Initial connection
-                expect(window.timingBuffer).toEqual([
-                    '0:connectedCallback',
-                    '1:connectedCallback',
-                    '2:connectedCallback',
-                ]);
+            // remove entire element
+            document.body.removeChild(elm);
+            await Promise.resolve();
 
-                resetTimingBuffer();
-
-                // Trigger vdom diffing
-                elm.showTop = true;
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '3:connectedCallback',
-                    '4:connectedCallback',
-                    '5:connectedCallback',
-                    '2:disconnectedCallback',
-                    '0:disconnectedCallback',
-                    '1:disconnectedCallback',
-                ]);
-
-                resetTimingBuffer();
-
-                // Trigger vdom diffing from top level
-                elm.topTop = 'bottom';
-                elm.topBottom = 'top';
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '6:connectedCallback',
-                    '5:disconnectedCallback',
-                    '7:connectedCallback',
-                    '3:disconnectedCallback',
-                ]);
-
-                resetTimingBuffer();
-
-                const { topSlot } = extractDataIds(elm);
-                // Trigger vdom diffing from forwarded slot level
-                topSlot.top = 'top';
-                topSlot.bottom = 'bottom';
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '8:connectedCallback',
-                    '6:disconnectedCallback',
-                    '9:connectedCallback',
-                    '7:disconnectedCallback',
-                ]);
-
-                resetTimingBuffer();
-            };
-
-            it('invokes lifecycle methods in correct order', async () => {
-                await setup();
-
-                // vdom diffing after changing vnodes
-                elm.showTop = false;
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '10:connectedCallback',
-                    '11:connectedCallback',
-                    '12:connectedCallback',
-                    '8:disconnectedCallback',
-                    '9:disconnectedCallback',
-                    '4:disconnectedCallback',
-                ]);
-            });
-
-            it('invokes disconnectedCallback after removing entire element', async () => {
-                await setup();
-
-                // remove entire element
-                document.body.removeChild(elm);
-                await Promise.resolve();
-
-                expect(window.timingBuffer).toEqual([
-                    '8:disconnectedCallback',
-                    '9:disconnectedCallback',
-                    '4:disconnectedCallback',
-                ]);
-            });
+            expect(window.timingBuffer).toEqual([
+                '5:disconnectedCallback',
+                '3:disconnectedCallback',
+                '4:disconnectedCallback',
+            ]);
         });
     });
-}
+
+    describe('dynamic', () => {
+        let elm;
+        const setup = async () => {
+            elm = createElement('x-dynamic-slot-forwarding', { is: DynamicSlotForwarding });
+            document.body.appendChild(elm);
+            await Promise.resolve();
+
+            // Initial connection
+            expect(window.timingBuffer).toEqual([
+                '0:connectedCallback',
+                '1:connectedCallback',
+                '2:connectedCallback',
+            ]);
+
+            resetTimingBuffer();
+
+            // Trigger vdom diffing
+            elm.showTop = true;
+            await Promise.resolve();
+
+            expect(window.timingBuffer).toEqual([
+                '3:connectedCallback',
+                '4:connectedCallback',
+                '5:connectedCallback',
+                '2:disconnectedCallback',
+                '0:disconnectedCallback',
+                '1:disconnectedCallback',
+            ]);
+
+            resetTimingBuffer();
+
+            // Trigger vdom diffing from top level
+            elm.topTop = 'bottom';
+            elm.topBottom = 'top';
+            await Promise.resolve();
+
+            expect(window.timingBuffer).toEqual([
+                '6:connectedCallback',
+                '5:disconnectedCallback',
+                '7:connectedCallback',
+                '3:disconnectedCallback',
+            ]);
+
+            resetTimingBuffer();
+
+            const { topSlot } = extractDataIds(elm);
+            // Trigger vdom diffing from forwarded slot level
+            topSlot.top = 'top';
+            topSlot.bottom = 'bottom';
+            await Promise.resolve();
+
+            expect(window.timingBuffer).toEqual([
+                '8:connectedCallback',
+                '6:disconnectedCallback',
+                '9:connectedCallback',
+                '7:disconnectedCallback',
+            ]);
+
+            resetTimingBuffer();
+        };
+
+        it('invokes lifecycle methods in correct order', async () => {
+            await setup();
+
+            // vdom diffing after changing vnodes
+            elm.showTop = false;
+            await Promise.resolve();
+
+            expect(window.timingBuffer).toEqual([
+                '10:connectedCallback',
+                '11:connectedCallback',
+                '12:connectedCallback',
+                '8:disconnectedCallback',
+                '9:disconnectedCallback',
+                '4:disconnectedCallback',
+            ]);
+        });
+
+        it('invokes disconnectedCallback after removing entire element', async () => {
+            await setup();
+
+            // remove entire element
+            document.body.removeChild(elm);
+            await Promise.resolve();
+
+            expect(window.timingBuffer).toEqual([
+                '8:disconnectedCallback',
+                '9:disconnectedCallback',
+                '4:disconnectedCallback',
+            ]);
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/reactivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/slot-fowarding/slots/reactivity/index.spec.js
@@ -183,11 +183,8 @@ describe('light DOM slot forwarding reactivity', () => {
                       },
                   ],
         },
-    ];
-
-    if (process.env.NATIVE_SHADOW) {
-        // TODO [#3885]: Using expressions on forwarded synthetic shadow DOM slots throws an error, only test in native for now
-        testCases.push({
+        {
+            test: it.runIf(process.env.NATIVE_SHADOW),
             testName: 'shadowLight',
             expectedDefaultSlotContent: expectedDefaultSlotContent('shadow'),
             expectedSlotContentAfterParentMutation:
@@ -216,8 +213,8 @@ describe('light DOM slot forwarding reactivity', () => {
                           slotContent: 'Conditional slot content',
                       },
                   ],
-        });
-    }
+        },
+    ];
 
     testCases.forEach(
         ({
@@ -227,8 +224,9 @@ describe('light DOM slot forwarding reactivity', () => {
             expectedSlotContentAfterForwardedSlotMutation,
             expectedSlotContentAfterLeafMutation,
             expectedSlotContentAfterConditionalMutation,
+            test = it,
         }) => {
-            it(`should update correctly for ${testName} slots`, async () => {
+            test(`should update correctly for ${testName} slots`, async () => {
                 const parent = nodes[testName];
                 const leaf = parent.leaf;
                 expect((leaf.shadowRoot?.children ?? leaf.children).length).toBe(3);

--- a/packages/@lwc/integration-karma/test/light-dom/style-with-host/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/style-with-host/index.spec.js
@@ -2,15 +2,13 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 // synthetic shadow can't do this kind of style encapsulation
-if (process.env.NATIVE_SHADOW) {
-    describe('Light DOM styling with :host', () => {
-        it(':host can style a containing shadow component', () => {
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
+describe.runIf(process.env.NATIVE_SHADOW)('Light DOM styling with :host', () => {
+    it(':host can style a containing shadow component', () => {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
 
-            expect(elm.shadowRoot).not.toBeNull();
+        expect(elm.shadowRoot).not.toBeNull();
 
-            expect(getComputedStyle(elm).backgroundColor).toEqual('rgb(139, 69, 19)');
-        });
+        expect(getComputedStyle(elm).backgroundColor).toEqual('rgb(139, 69, 19)');
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/light-dom/synthetic-shadow-styles/index.spec.js
@@ -3,36 +3,34 @@ import { LOWERCASE_SCOPE_TOKENS } from 'test-utils';
 import Container from 'x/container';
 
 // This test only matters for synthetic shadow
-if (!process.env.NATIVE_SHADOW) {
-    describe('Light DOM and synthetic shadow', () => {
-        it('shadow scoping tokens are not set for light DOM components', () => {
-            // shadow grandparent, light child, shadow grandchild
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
+describe.skipIf(process.env.NATIVE_SHADOW)('Light DOM and synthetic shadow', () => {
+    it('shadow scoping tokens are not set for light DOM components', () => {
+        // shadow grandparent, light child, shadow grandchild
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
 
-            // shadow grandparent
-            expect(elm.shadowRoot.querySelector('h1').outerHTML).toContain(
-                LOWERCASE_SCOPE_TOKENS ? 'lwc-7c9hba002d8' : 'x-container_container'
-            );
-            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                'rgb(0, 128, 0)'
-            );
+        // shadow grandparent
+        expect(elm.shadowRoot.querySelector('h1').outerHTML).toContain(
+            LOWERCASE_SCOPE_TOKENS ? 'lwc-7c9hba002d8' : 'x-container_container'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
+            'rgb(0, 128, 0)'
+        );
 
-            // light child
-            const child = elm.shadowRoot.querySelector('x-light');
-            expect(child.querySelector('h1').outerHTML).not.toContain('x-child_child');
-            expect(getComputedStyle(child.querySelector('h1')).backgroundColor).toEqual(
-                'rgb(255, 0, 0)'
-            );
+        // light child
+        const child = elm.shadowRoot.querySelector('x-light');
+        expect(child.querySelector('h1').outerHTML).not.toContain('x-child_child');
+        expect(getComputedStyle(child.querySelector('h1')).backgroundColor).toEqual(
+            'rgb(255, 0, 0)'
+        );
 
-            // shadow grandchild
-            const grandchild = child.querySelector('x-grandchild');
-            expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toContain(
-                LOWERCASE_SCOPE_TOKENS ? 'lwc-42b236sbaik' : 'x-grandchild_grandchild'
-            );
-            expect(
-                getComputedStyle(grandchild.shadowRoot.querySelector('h1')).outlineColor
-            ).toEqual('rgb(0, 255, 255)');
-        });
+        // shadow grandchild
+        const grandchild = child.querySelector('x-grandchild');
+        expect(grandchild.shadowRoot.querySelector('h1').outerHTML).toContain(
+            LOWERCASE_SCOPE_TOKENS ? 'lwc-42b236sbaik' : 'x-grandchild_grandchild'
+        );
+        expect(getComputedStyle(grandchild.shadowRoot.querySelector('h1')).outlineColor).toEqual(
+            'rgb(0, 255, 255)'
+        );
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/misc/performance-timing/index.spec.js
+++ b/packages/@lwc/integration-karma/test/misc/performance-timing/index.spec.js
@@ -77,245 +77,250 @@ function testNestedComponentCreation(expected) {
 }
 
 // Timings are not enabled in prod mode
-if (isUserTimingSupported && process.env.NODE_ENV !== 'production') {
-    beforeEach(() => {
-        patchUserTiming();
-        resetMeasures();
-    });
+describe.runIf(isUserTimingSupported && process.env.NODE_ENV !== 'production')(
+    'performance timing',
+    () => {
+        beforeEach(() => {
+            patchUserTiming();
+            resetMeasures();
+        });
 
-    afterEach(() => {
-        resetUserTiming();
-    });
+        afterEach(() => {
+            resetUserTiming();
+        });
 
-    if (process.env.NODE_ENV === 'production') {
-        testConstructor([
-            {
-                label: /lwc-hydrate/,
-            },
-        ]);
+        describe.runIf(process.env.NODE_ENV === 'production')('production mode', () => {
+            testConstructor([
+                {
+                    label: /lwc-hydrate/,
+                },
+            ]);
 
-        testRehydration([
-            {
-                label: /lwc-rehydrate/,
-            },
-        ]);
+            testRehydration([
+                {
+                    label: /lwc-rehydrate/,
+                },
+            ]);
 
-        testNestedTree([
-            {
-                label: /lwc-hydrate/,
-            },
-        ]);
+            testNestedTree([
+                {
+                    label: /lwc-hydrate/,
+                },
+            ]);
 
-        testNestedRehydration([
-            {
-                label: /lwc-rehydrate/,
-            },
-        ]);
+            testNestedRehydration([
+                {
+                    label: /lwc-rehydrate/,
+                },
+            ]);
 
-        testLifecycleHooks([
-            {
-                label: /lwc-hydrate/,
-            },
-        ]);
+            testLifecycleHooks([
+                {
+                    label: /lwc-hydrate/,
+                },
+            ]);
 
-        testNestedComponentCreation([
-            {
-                label: /lwc-hydrate/,
-                children: [
-                    {
-                        label: /lwc-hydrate/,
-                    },
-                ],
-            },
-        ]);
-    } else {
-        testConstructor([
-            {
-                label: /<x-child> - constructor/,
-            },
-            {
-                label: /lwc-hydrate/,
-                children: [
-                    {
-                        label: /<x-child> - render/,
-                    },
-                    {
-                        label: /<x-child> - patch/,
-                    },
-                ],
-            },
-        ]);
+            testNestedComponentCreation([
+                {
+                    label: /lwc-hydrate/,
+                    children: [
+                        {
+                            label: /lwc-hydrate/,
+                        },
+                    ],
+                },
+            ]);
+        });
 
-        testRehydration([
-            {
-                label: /lwc-rehydrate/,
-                children: [
-                    {
-                        label: /<x-child> - render/,
-                    },
-                    {
-                        label: /<x-child> - patch/,
-                    },
-                ],
-            },
-        ]);
+        describe.skipIf(process.env.NODE_ENV === 'production')('development mode', () => {
+            testConstructor([
+                {
+                    label: /<x-child> - constructor/,
+                },
+                {
+                    label: /lwc-hydrate/,
+                    children: [
+                        {
+                            label: /<x-child> - render/,
+                        },
+                        {
+                            label: /<x-child> - patch/,
+                        },
+                    ],
+                },
+            ]);
 
-        // Timing is slightly different with native custom element lifecycle callbacks
-        testNestedTree(
-            !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
-                ? [
-                      { label: '<x-parent> - constructor', children: [] },
-                      {
-                          label: 'lwc-hydrate',
-                          children: [
-                              { label: '<x-parent> - render', children: [] },
-                              {
-                                  label: '<x-parent> - patch',
-                                  children: [
-                                      { label: '<x-child> - constructor', children: [] },
-                                      {
-                                          label: 'lwc-hydrate',
-                                          children: [
-                                              { label: '<x-child> - render', children: [] },
-                                              { label: '<x-child> - patch', children: [] },
-                                          ],
-                                      },
-                                      { label: '<x-child> - constructor', children: [] },
-                                      {
-                                          label: 'lwc-hydrate',
-                                          children: [
-                                              { label: '<x-child> - render', children: [] },
-                                              { label: '<x-child> - patch', children: [] },
-                                          ],
-                                      },
-                                  ],
-                              },
-                          ],
-                      },
-                  ]
-                : [
-                      {
-                          label: /<x-parent> - constructor/,
-                      },
-                      {
-                          label: /lwc-hydrate/,
-                          children: [
-                              {
-                                  label: /<x-parent> - render/,
-                              },
-                              {
-                                  label: /<x-parent> - patch/,
-                                  children: [
-                                      {
-                                          label: /<x-child> - constructor/,
-                                      },
-                                      {
-                                          label: /<x-child> - render/,
-                                      },
-                                      {
-                                          label: /<x-child> - patch/,
-                                      },
-                                      {
-                                          label: /<x-child> - constructor/,
-                                      },
-                                      {
-                                          label: /<x-child> - render/,
-                                      },
-                                      {
-                                          label: /<x-child> - patch/,
-                                      },
-                                  ],
-                              },
-                          ],
-                      },
-                  ]
-        );
+            testRehydration([
+                {
+                    label: /lwc-rehydrate/,
+                    children: [
+                        {
+                            label: /<x-child> - render/,
+                        },
+                        {
+                            label: /<x-child> - patch/,
+                        },
+                    ],
+                },
+            ]);
 
-        testNestedRehydration([
-            {
-                label: /lwc-rehydrate/,
-                children: [
-                    {
-                        label: /<x-parent> - render/,
-                    },
-                    {
-                        label: /<x-parent> - patch/,
-                        children: [
-                            {
-                                label: /<x-child> - render/,
-                            },
-                            {
-                                label: /<x-child> - patch/,
-                            },
-                            {
-                                label: /<x-child> - render/,
-                            },
-                            {
-                                label: /<x-child> - patch/,
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]);
+            // Timing is slightly different with native custom element lifecycle callbacks
+            testNestedTree(
+                !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+                    ? [
+                          { label: '<x-parent> - constructor', children: [] },
+                          {
+                              label: 'lwc-hydrate',
+                              children: [
+                                  { label: '<x-parent> - render', children: [] },
+                                  {
+                                      label: '<x-parent> - patch',
+                                      children: [
+                                          { label: '<x-child> - constructor', children: [] },
+                                          {
+                                              label: 'lwc-hydrate',
+                                              children: [
+                                                  { label: '<x-child> - render', children: [] },
+                                                  { label: '<x-child> - patch', children: [] },
+                                              ],
+                                          },
+                                          { label: '<x-child> - constructor', children: [] },
+                                          {
+                                              label: 'lwc-hydrate',
+                                              children: [
+                                                  { label: '<x-child> - render', children: [] },
+                                                  { label: '<x-child> - patch', children: [] },
+                                              ],
+                                          },
+                                      ],
+                                  },
+                              ],
+                          },
+                      ]
+                    : [
+                          {
+                              label: /<x-parent> - constructor/,
+                          },
+                          {
+                              label: /lwc-hydrate/,
+                              children: [
+                                  {
+                                      label: /<x-parent> - render/,
+                                  },
+                                  {
+                                      label: /<x-parent> - patch/,
+                                      children: [
+                                          {
+                                              label: /<x-child> - constructor/,
+                                          },
+                                          {
+                                              label: /<x-child> - render/,
+                                          },
+                                          {
+                                              label: /<x-child> - patch/,
+                                          },
+                                          {
+                                              label: /<x-child> - constructor/,
+                                          },
+                                          {
+                                              label: /<x-child> - render/,
+                                          },
+                                          {
+                                              label: /<x-child> - patch/,
+                                          },
+                                      ],
+                                  },
+                              ],
+                          },
+                      ]
+            );
 
-        testLifecycleHooks([
-            {
-                label: /<x-lifecycle> - constructor/,
-            },
-            {
-                label: /lwc-hydrate/,
-                children: [
-                    {
-                        label: /<x-lifecycle> - connectedCallback/,
-                    },
-                    {
-                        label: /<x-lifecycle> - render/,
-                    },
-                    {
-                        label: /<x-lifecycle> - patch/,
-                    },
-                    {
-                        label: /<x-lifecycle> - renderedCallback/,
-                    },
-                ],
-            },
-            {
-                label: /<x-lifecycle> - disconnectedCallback/,
-            },
-        ]);
+            testNestedRehydration([
+                {
+                    label: /lwc-rehydrate/,
+                    children: [
+                        {
+                            label: /<x-parent> - render/,
+                        },
+                        {
+                            label: /<x-parent> - patch/,
+                            children: [
+                                {
+                                    label: /<x-child> - render/,
+                                },
+                                {
+                                    label: /<x-child> - patch/,
+                                },
+                                {
+                                    label: /<x-child> - render/,
+                                },
+                                {
+                                    label: /<x-child> - patch/,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
 
-        testNestedComponentCreation([
-            {
-                label: /<x-nested> - constructor/,
-            },
-            {
-                label: /lwc-hydrate/,
-                children: [
-                    {
-                        label: /<x-nested> - render/,
-                    },
-                    {
-                        label: /<x-nested> - renderedCallback/,
-                        children: [
-                            {
-                                label: /<x-child> - constructor/,
-                            },
-                            {
-                                label: /lwc-hydrate/,
-                                children: [
-                                    {
-                                        label: /<x-child> - render/,
-                                    },
-                                    {
-                                        label: /<x-child> - patch/,
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]);
+            testLifecycleHooks([
+                {
+                    label: /<x-lifecycle> - constructor/,
+                },
+                {
+                    label: /lwc-hydrate/,
+                    children: [
+                        {
+                            label: /<x-lifecycle> - connectedCallback/,
+                        },
+                        {
+                            label: /<x-lifecycle> - render/,
+                        },
+                        {
+                            label: /<x-lifecycle> - patch/,
+                        },
+                        {
+                            label: /<x-lifecycle> - renderedCallback/,
+                        },
+                    ],
+                },
+                {
+                    label: /<x-lifecycle> - disconnectedCallback/,
+                },
+            ]);
+
+            testNestedComponentCreation([
+                {
+                    label: /<x-nested> - constructor/,
+                },
+                {
+                    label: /lwc-hydrate/,
+                    children: [
+                        {
+                            label: /<x-nested> - render/,
+                        },
+                        {
+                            label: /<x-nested> - renderedCallback/,
+                            children: [
+                                {
+                                    label: /<x-child> - constructor/,
+                                },
+                                {
+                                    label: /lwc-hydrate/,
+                                    children: [
+                                        {
+                                            label: /<x-child> - render/,
+                                        },
+                                        {
+                                            label: /<x-child> - patch/,
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+        });
     }
-}
+);

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/slotting/index.spec.js
@@ -2,14 +2,12 @@ import { createElement } from 'lwc';
 
 import Parent from 'x/parent';
 
-if (process.env.NATIVE_SHADOW) {
-    describe('when slotting into a native mode component', () => {
-        it('should render default slot content to the dom', () => {
-            const parent = createElement('x-parent', { is: Parent });
-            document.body.appendChild(parent);
+describe.runIf(process.env.NATIVE_SHADOW)('when slotting into a native mode component', () => {
+    it('should render default slot content to the dom', () => {
+        const parent = createElement('x-parent', { is: Parent });
+        document.body.appendChild(parent);
 
-            const childElm = parent.shadowRoot.querySelector('x-child');
-            expect(childElm.shadowRoot.querySelector('.default-slot')).not.toBeNull();
-        });
+        const childElm = parent.shadowRoot.querySelector('x-child');
+        expect(childElm.shadowRoot.querySelector('.default-slot')).not.toBeNull();
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/synthetic-behavior/index.spec.js
@@ -15,115 +15,113 @@ import GrandparentResetParentAnyChildReset from 'x/grandparentResetParentAnyChil
 import GrandparentResetParentResetChildAny from 'x/grandparentResetParentResetChildAny';
 import GrandparentResetParentResetChildReset from 'x/grandparentResetParentResetChildReset';
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('synthetic behavior', () => {
-        const scenarios = [
-            {
-                Component: ParentAnyChildAny,
-                tagName: 'x-parent-any-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: ParentAnyChildReset,
-                tagName: 'x-parent-any-child-reset',
-                nativeLeaf: true,
-            },
-            {
-                Component: ParentResetChildAny,
-                tagName: 'x-parent-reset-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: ParentResetChildReset,
-                tagName: 'x-parent-reset-child-reset',
-                nativeLeaf: false,
-            },
-            {
-                Component: ParentLightChildAny,
-                tagName: 'x-parent-light-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: ParentLightChildReset,
-                tagName: 'x-parent-light-child-reset',
-                nativeLeaf: false,
-            },
-            {
-                Component: GrandparentAnyParentAnyChildAny,
-                tagName: 'x-grandparent-any-parent-any-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentAnyParentAnyChildReset,
-                tagName: 'x-grandparent-any-parent-any-child-reset',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentAnyParentResetChildAny,
-                tagName: 'x-grandparent-any-parent-reset-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentAnyParentResetChildReset,
-                tagName: 'x-grandparent-any-parent-reset-child-reset',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentResetParentAnyChildAny,
-                tagName: 'x-grandparent-reset-parent-any-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentResetParentAnyChildReset,
-                tagName: 'x-grandparent-reset-parent-any-child-reset',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentResetParentResetChildAny,
-                tagName: 'x-grandparent-reset-parent-reset-child-any',
-                nativeLeaf: true,
-            },
-            {
-                Component: GrandparentResetParentResetChildReset,
-                tagName: 'x-grandparent-reset-parent-reset-child-reset',
-                nativeLeaf: false,
-            },
-        ];
+describe.skipIf(process.env.NATIVE_SHADOW)('synthetic behavior', () => {
+    const scenarios = [
+        {
+            Component: ParentAnyChildAny,
+            tagName: 'x-parent-any-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: ParentAnyChildReset,
+            tagName: 'x-parent-any-child-reset',
+            nativeLeaf: true,
+        },
+        {
+            Component: ParentResetChildAny,
+            tagName: 'x-parent-reset-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: ParentResetChildReset,
+            tagName: 'x-parent-reset-child-reset',
+            nativeLeaf: false,
+        },
+        {
+            Component: ParentLightChildAny,
+            tagName: 'x-parent-light-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: ParentLightChildReset,
+            tagName: 'x-parent-light-child-reset',
+            nativeLeaf: false,
+        },
+        {
+            Component: GrandparentAnyParentAnyChildAny,
+            tagName: 'x-grandparent-any-parent-any-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentAnyParentAnyChildReset,
+            tagName: 'x-grandparent-any-parent-any-child-reset',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentAnyParentResetChildAny,
+            tagName: 'x-grandparent-any-parent-reset-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentAnyParentResetChildReset,
+            tagName: 'x-grandparent-any-parent-reset-child-reset',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentResetParentAnyChildAny,
+            tagName: 'x-grandparent-reset-parent-any-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentResetParentAnyChildReset,
+            tagName: 'x-grandparent-reset-parent-any-child-reset',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentResetParentResetChildAny,
+            tagName: 'x-grandparent-reset-parent-reset-child-any',
+            nativeLeaf: true,
+        },
+        {
+            Component: GrandparentResetParentResetChildReset,
+            tagName: 'x-grandparent-reset-parent-reset-child-reset',
+            nativeLeaf: false,
+        },
+    ];
 
-        scenarios.forEach(({ Component, nativeLeaf, tagName }) => {
-            describe(tagName, () => {
-                let elm;
-                let ids;
+    scenarios.forEach(({ Component, nativeLeaf, tagName }) => {
+        describe(tagName, () => {
+            let elm;
+            let ids;
 
-                beforeEach(() => {
-                    elm = createElement(tagName, { is: Component });
-                    document.body.appendChild(elm);
-                    ids = extractDataIds(elm);
-                });
+            beforeEach(() => {
+                elm = createElement(tagName, { is: Component });
+                document.body.appendChild(elm);
+                ids = extractDataIds(elm);
+            });
 
-                it('should render the shadow root in the correct shadow mode', () => {
-                    expect(isNativeShadowRootInstance(ids.leaf.shadowRoot)).toEqual(nativeLeaf);
-                });
+            it('should render the shadow root in the correct shadow mode', () => {
+                expect(isNativeShadowRootInstance(ids.leaf.shadowRoot)).toEqual(nativeLeaf);
+            });
 
-                it(`should set the scope attributes only in synthetic shadow`, () => {
-                    const attributes = Array.from(ids.div.attributes)
-                        .map((_) => _.name)
-                        .filter((_) => _ !== 'data-id');
-                    expect(attributes.length).toEqual(nativeLeaf ? 0 : 1);
-                    expect(getComputedStyle(ids.div).color).toEqual('rgb(0, 0, 255)');
-                });
+            it(`should set the scope attributes only in synthetic shadow`, () => {
+                const attributes = Array.from(ids.div.attributes)
+                    .map((_) => _.name)
+                    .filter((_) => _ !== 'data-id');
+                expect(attributes.length).toEqual(nativeLeaf ? 0 : 1);
+                expect(getComputedStyle(ids.div).color).toEqual('rgb(0, 0, 255)');
+            });
 
-                it(`should mangle the IDs only in synthetic shadow`, () => {
-                    if (nativeLeaf) {
-                        expect(ids.label.id).toEqual('foo');
-                        expect(ids.input.getAttribute('aria-labelledby')).toEqual('foo');
-                    } else {
-                        expect(ids.label.id).not.toEqual('foo');
-                        expect(ids.input.getAttribute('aria-labelledby')).not.toEqual('foo');
-                        expect(ids.label.id).toEqual(ids.input.getAttribute('aria-labelledby'));
-                    }
-                });
+            it(`should mangle the IDs only in synthetic shadow`, () => {
+                if (nativeLeaf) {
+                    expect(ids.label.id).toEqual('foo');
+                    expect(ids.input.getAttribute('aria-labelledby')).toEqual('foo');
+                } else {
+                    expect(ids.label.id).not.toEqual('foo');
+                    expect(ids.input.getAttribute('aria-labelledby')).not.toEqual('foo');
+                    expect(ids.label.id).toEqual(ids.input.getAttribute('aria-labelledby'));
+                }
             });
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
+++ b/packages/@lwc/integration-karma/test/mixed-shadow-mode/transitivity/index.spec.js
@@ -5,7 +5,7 @@ import ResetExtendsAny from 'x/resetExtendsAny';
 import LightContainer from 'x/lightContainer';
 import NativeContainer from 'x/nativeContainer';
 
-if (!process.env.NATIVE_SHADOW) {
+describe.skipIf(process.env.NATIVE_SHADOW)('transitivity', () => {
     describe('when root component shadowSupportMode="native"', () => {
         let elm;
 
@@ -90,4 +90,4 @@ if (!process.env.NATIVE_SHADOW) {
             expect(isSyntheticShadowRootInstance(synthetic.shadowRoot)).toBeTrue();
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/native-shadow/force-shadow-migrate-mode/index.spec.js
+++ b/packages/@lwc/integration-karma/test/native-shadow/force-shadow-migrate-mode/index.spec.js
@@ -19,8 +19,9 @@ function isClaimingToBeSyntheticShadow(shadowRoot) {
 // This test only makes sense for true native shadow mode, because if ENABLE_FORCE_SHADOW_MIGRATE_MODE is true,
 // then the polyfill should not be loaded at all.
 
-if (process.env.NATIVE_SHADOW && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST) {
-    describe('shadow migrate mode', () => {
+describe.runIf(process.env.NATIVE_SHADOW && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST)(
+    'shadow migrate mode',
+    () => {
         beforeEach(() => {
             const style = document.createElement('style');
             style.textContent = 'h1 { color: blue }';
@@ -143,5 +144,5 @@ if (process.env.NATIVE_SHADOW && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST)
                 );
             });
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/aria-properties/index.spec.js
@@ -207,8 +207,11 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
             testAriaProperty(ariaProperty, ariaAttribute);
         }
     }
+}
 
-    describe('non-standard properties do not log/report for LightningElement/BaseBridgeElement', () => {
+describe.runIf(process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL)(
+    'non-standard properties do not log/report for LightningElement/BaseBridgeElement',
+    () => {
         let dispatcher;
 
         beforeEach(() => {
@@ -243,5 +246,5 @@ if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
                 });
             });
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/document-properties/index.spec.js
@@ -51,11 +51,12 @@ describe('dynamic nodes', () => {
             expect(document.querySelector('span.manual-span')).toBe(null);
         });
     });
-    if (!process.env.NATIVE_SHADOW) {
-        // TODO [#1252]: old behavior that is still used by some pieces of the platform
-        // that is only useful in synthetic mode where elements inserted manually without lwc:dom="manual"
-        // are still considered global elements
-        it('if parent node does not have lwc:dom="manual", child node is accessible', () => {
+    // TODO [#1252]: old behavior that is still used by some pieces of the platform
+    // that is only useful in synthetic mode where elements inserted manually without lwc:dom="manual"
+    // are still considered global elements
+    it.skipIf(process.env.NATIVE_SHADOW)(
+        'if parent node does not have lwc:dom="manual", child node is accessible',
+        () => {
             const elm = createElement('x-test', { is: XTest });
             document.body.appendChild(elm);
             spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual
@@ -69,8 +70,8 @@ describe('dynamic nodes', () => {
             }).then(() => {
                 expect(document.querySelector('h2.manual-h2')).toBe(h2);
             });
-        });
-    }
+        }
+    );
 });
 
 describe('should provide access to elements outside shadow tree', () => {

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -56,18 +56,20 @@ function expectRehydrationEntry(tagName, propString) {
     expect(entries).toEqual(arr([rehydrationEntry(tagName, propString)]));
 }
 
-if (process.env.NODE_ENV === 'production') {
-    it('No perf measures in prod mode', async () => {
-        const elm = createElement('x-child', { is: Child });
-        document.body.appendChild(elm);
+const isProd = process.env.NODE_ENV === 'production';
 
-        await waitForSentinelMeasure();
-        elm.firstName = 'Ferdinand';
+it.runIf(isProd)('No perf measures in prod mode', async () => {
+    const elm = createElement('x-child', { is: Child });
+    document.body.appendChild(elm);
 
-        await waitForSentinelMeasure();
-        expect(entries).toEqual([]);
-    });
-} else {
+    await waitForSentinelMeasure();
+    elm.firstName = 'Ferdinand';
+
+    await waitForSentinelMeasure();
+    expect(entries).toEqual([]);
+});
+
+describe.skipIf(isProd)('Perf measures in dev mode', () => {
     // dev mode
     describe('basic', () => {
         let elm;
@@ -301,4 +303,4 @@ if (process.env.NODE_ENV === 'production') {
             );
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -56,9 +56,7 @@ function expectRehydrationEntry(tagName, propString) {
     expect(entries).toEqual(arr([rehydrationEntry(tagName, propString)]));
 }
 
-const isProd = process.env.NODE_ENV === 'production';
-
-it.runIf(isProd)('No perf measures in prod mode', async () => {
+it.runIf(process.env.NODE_ENV === 'production')('No perf measures in prod mode', async () => {
     const elm = createElement('x-child', { is: Child });
     document.body.appendChild(elm);
 
@@ -69,7 +67,7 @@ it.runIf(isProd)('No perf measures in prod mode', async () => {
     expect(entries).toEqual([]);
 });
 
-describe.skipIf(isProd)('Perf measures in dev mode', () => {
+describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mode', () => {
     // dev mode
     describe('basic', () => {
         let elm;

--- a/packages/@lwc/integration-karma/test/rendering/dynamic-slots/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/dynamic-slots/index.spec.js
@@ -72,21 +72,24 @@ describe('dynamic slotting', () => {
         document.body.appendChild(elm);
         expect(elm.shadowRoot.textContent).toEqual('BigInt');
     });
-    if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-        // it actually throws in this scenario as well, but in a different callstack, so we can't assert
-        it('should throw on symbol', () => {
-            expect(() => {
-                const elm = createElement('x-symbol', { is: Symbol });
-                document.body.appendChild(elm);
-            }).toThrowError(/convert.*symbol.*string.*/i); // cannot convert symbol to string (and variations of this message across browsers)
-        });
-    }
-    if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-        it('should throw on empty object', () => {
-            expect(() => {
-                const elm = createElement('x-emptyobject', { is: EmptyObject });
-                document.body.appendChild(elm);
-            }).toThrowError(TypeError);
-        });
-    }
+
+    describe.runIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(
+        'disabled native custom element lifecycle',
+        () => {
+            // it actually throws in this scenario as well, but in a different callstack, so we can't assert
+            it('should throw on symbol', () => {
+                expect(() => {
+                    const elm = createElement('x-symbol', { is: Symbol });
+                    document.body.appendChild(elm);
+                }).toThrowError(/convert.*symbol.*string.*/i); // cannot convert symbol to string (and variations of this message across browsers)
+            });
+
+            it('should throw on empty object', () => {
+                expect(() => {
+                    const elm = createElement('x-emptyobject', { is: EmptyObject });
+                    document.body.appendChild(elm);
+                }).toThrowError(TypeError);
+            });
+        }
+    );
 });

--- a/packages/@lwc/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -37,31 +37,29 @@ describe('custom elements', () => {
 });
 
 describe('elements', () => {
-    if (!process.env.NATIVE_SHADOW) {
-        it('should not be reused when slotted', function () {
-            const elm = createElement('x-container', { is: Container });
-            elm.isElement = true;
-            document.body.appendChild(elm);
+    it.skipIf(process.env.NATIVE_SHADOW)('should not be reused when slotted', function () {
+        const elm = createElement('x-container', { is: Container });
+        elm.isElement = true;
+        document.body.appendChild(elm);
 
-            const child = elm.shadowRoot.querySelector('x-child');
-            let firstRenderElement;
+        const child = elm.shadowRoot.querySelector('x-child');
+        let firstRenderElement;
 
-            return Promise.resolve()
-                .then(() => (child.open = true))
-                .then(() => {
-                    firstRenderElement = elm.shadowRoot.querySelector('button');
-                    child.open = false;
-                })
-                .then(() => (child.open = true))
-                .then(() => {
-                    const btnElement = elm.shadowRoot.querySelector('button');
+        return Promise.resolve()
+            .then(() => (child.open = true))
+            .then(() => {
+                firstRenderElement = elm.shadowRoot.querySelector('button');
+                child.open = false;
+            })
+            .then(() => (child.open = true))
+            .then(() => {
+                const btnElement = elm.shadowRoot.querySelector('button');
 
-                    expect(btnElement).not.toBeNull();
-                    expect(btnElement.assignedSlot).not.toBeNull();
-                    expect(btnElement).not.toBe(firstRenderElement);
-                });
-        });
-    }
+                expect(btnElement).not.toBeNull();
+                expect(btnElement.assignedSlot).not.toBeNull();
+                expect(btnElement).not.toBe(firstRenderElement);
+            });
+    });
 
     it('should not add listener multiple times', function () {
         const elm = createElement('x-container', { is: Container });
@@ -94,8 +92,9 @@ describe('elements', () => {
     });
 });
 
-if (process.env.NATIVE_SHADOW) {
-    it('should render same styles for custom element instances', function () {
+it.runIf(process.env.NATIVE_SHADOW)(
+    'should render same styles for custom element instances',
+    function () {
         const elm = createElement('x-container', { is: Container });
         elm.isStyleCheck = true;
         document.body.appendChild(elm);
@@ -115,5 +114,5 @@ if (process.env.NATIVE_SHADOW) {
             expect(styles[0]).toEqual(styles[1]);
             expect(styles[1]).toEqual(styles[2]);
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/legacy-scope-tokens/index.spec.js
@@ -91,67 +91,65 @@ describe('legacy scope tokens', () => {
                 verify();
             });
 
-            if (!process.env.NATIVE_SHADOW) {
-                it('shadow dom', async () => {
-                    const elm = createElement('x-shadow', { is: Shadow });
-                    document.body.appendChild(elm);
+            it.skipIf(process.env.NATIVE_SHADOW)('shadow dom', async () => {
+                const elm = createElement('x-shadow', { is: Shadow });
+                document.body.appendChild(elm);
 
-                    const verify = () => {
-                        const staticDiv = elm.shadowRoot.querySelector('.static');
-                        const dynamicDiv = elm.shadowRoot.querySelector('.dynamic');
-                        const manualDiv = elm.shadowRoot.querySelector('.manual');
-                        const span = elm.shadowRoot.querySelector('span'); // inserted inside dom:manual
-                        const expressionDiv = elm.shadowRoot.querySelector('.expression');
+                const verify = () => {
+                    const staticDiv = elm.shadowRoot.querySelector('.static');
+                    const dynamicDiv = elm.shadowRoot.querySelector('.dynamic');
+                    const manualDiv = elm.shadowRoot.querySelector('.manual');
+                    const span = elm.shadowRoot.querySelector('span'); // inserted inside dom:manual
+                    const expressionDiv = elm.shadowRoot.querySelector('.expression');
 
-                        expect(getClasses(elm)).toEqual(
-                            expectTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
-                        );
-                        expect(getClasses(staticDiv)).toEqual(
-                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getClasses(dynamicDiv)).toEqual(
-                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getClasses(manualDiv)).toEqual(
-                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getClasses(span)).toEqual([]);
-                        expect(getClasses(expressionDiv)).toEqual(
-                            expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
+                    expect(getClasses(elm)).toEqual(
+                        expectTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
+                    );
+                    expect(getClasses(staticDiv)).toEqual(
+                        expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getClasses(dynamicDiv)).toEqual(
+                        expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getClasses(manualDiv)).toEqual(
+                        expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getClasses(span)).toEqual([]);
+                    expect(getClasses(expressionDiv)).toEqual(
+                        expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
 
-                        expect(getAttributes(elm)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
-                        );
-                        expect(getAttributes(staticDiv)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getAttributes(dynamicDiv)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getClasses(manualDiv)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getAttributes(span)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                        expect(getAttributes(expressionDiv)).toEqual(
-                            expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-                        );
-                    };
+                    expect(getAttributes(elm)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
+                    );
+                    expect(getAttributes(staticDiv)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getAttributes(dynamicDiv)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getClasses(manualDiv)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getAttributes(span)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                    expect(getAttributes(expressionDiv)).toEqual(
+                        expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                    );
+                };
 
-                    await Promise.resolve();
+                await Promise.resolve();
 
-                    verify();
+                verify();
 
-                    // force re-render
-                    elm.rerender = 1;
-                    await Promise.resolve();
-                    await Promise.resolve(); // second microtask is for MutationObserver callbacks (portal)
+                // force re-render
+                elm.rerender = 1;
+                await Promise.resolve();
+                await Promise.resolve(); // second microtask is for MutationObserver callbacks (portal)
 
-                    verify();
-                });
-            }
+                verify();
+            });
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/rendering/stylesheets/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/stylesheets/index.spec.js
@@ -7,52 +7,44 @@ import Sharing2 from 'x/sharing2';
 
 // This test makes no sense for browsers that don't support constructable stylesheets
 // or for synthetic shadow
-if (process.env.NATIVE_SHADOW && document.adoptedStyleSheets) {
-    describe('stylesheets', () => {
-        it('re-uses constructable stylesheets for instances of the same component', () => {
-            const elm1 = createElement('x-component', { is: Component });
-            const elm2 = createElement('x-component', { is: Component });
+describe.runIf(process.env.NATIVE_SHADOW && document.adoptedStyleSheets)('stylesheets', () => {
+    it('re-uses constructable stylesheets for instances of the same component', () => {
+        const elm1 = createElement('x-component', { is: Component });
+        const elm2 = createElement('x-component', { is: Component });
 
-            document.body.appendChild(elm1);
-            document.body.appendChild(elm2);
+        document.body.appendChild(elm1);
+        document.body.appendChild(elm2);
 
-            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
-            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
-            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
-                elm2.shadowRoot.adoptedStyleSheets[0]
-            );
-        });
-
-        it('re-uses constructable stylesheets for components with identical styles', () => {
-            const elm1 = createElement('x-component', { is: Component });
-            const elm2 = createElement('x-identical-component', { is: IdenticalComponent });
-
-            document.body.appendChild(elm1);
-            document.body.appendChild(elm2);
-
-            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
-            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
-            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
-                elm2.shadowRoot.adoptedStyleSheets[0]
-            );
-        });
-
-        it('re-uses constructable stylesheets for components with shared style', () => {
-            const elm1 = createElement('x-sharing1', { is: Sharing1 });
-            const elm2 = createElement('x-sharing2', { is: Sharing2 });
-
-            document.body.appendChild(elm1);
-            document.body.appendChild(elm2);
-
-            // imported style is the same, but after the import they're different
-            expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(2);
-            expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(2);
-            expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(
-                elm2.shadowRoot.adoptedStyleSheets[0]
-            );
-            expect(elm1.shadowRoot.adoptedStyleSheets[1]).not.toBe(
-                elm2.shadowRoot.adoptedStyleSheets[1]
-            );
-        });
+        expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+        expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+        expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(elm2.shadowRoot.adoptedStyleSheets[0]);
     });
-}
+
+    it('re-uses constructable stylesheets for components with identical styles', () => {
+        const elm1 = createElement('x-component', { is: Component });
+        const elm2 = createElement('x-identical-component', { is: IdenticalComponent });
+
+        document.body.appendChild(elm1);
+        document.body.appendChild(elm2);
+
+        expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+        expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(1);
+        expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(elm2.shadowRoot.adoptedStyleSheets[0]);
+    });
+
+    it('re-uses constructable stylesheets for components with shared style', () => {
+        const elm1 = createElement('x-sharing1', { is: Sharing1 });
+        const elm2 = createElement('x-sharing2', { is: Sharing2 });
+
+        document.body.appendChild(elm1);
+        document.body.appendChild(elm2);
+
+        // imported style is the same, but after the import they're different
+        expect(elm1.shadowRoot.adoptedStyleSheets.length).toEqual(2);
+        expect(elm2.shadowRoot.adoptedStyleSheets.length).toEqual(2);
+        expect(elm1.shadowRoot.adoptedStyleSheets[0]).toBe(elm2.shadowRoot.adoptedStyleSheets[0]);
+        expect(elm1.shadowRoot.adoptedStyleSheets[1]).not.toBe(
+            elm2.shadowRoot.adoptedStyleSheets[1]
+        );
+    });
+});

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -74,46 +74,44 @@ describe('Event.target', () => {
         div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
     });
 
-    if (!process.env.NATIVE_SHADOW) {
-        describe('legacy behavior', () => {
-            beforeAll(() => {
-                // Suppress error logging
-                spyOn(console, 'warn');
-            });
+    describe.skipIf(process.env.NATIVE_SHADOW)('legacy behavior', () => {
+        beforeAll(() => {
+            // Suppress error logging
+            spyOn(console, 'warn');
+        });
 
-            it('should not retarget when the target was manually added without lwc:dom="manual" and accessed asynchronously [W-6626752]', (done) => {
-                const container = createElement('x-container', { is: Container });
-                document.body.appendChild(container);
+        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed asynchronously [W-6626752]', (done) => {
+            const container = createElement('x-container', { is: Container });
+            document.body.appendChild(container);
 
-                const child = container.shadowRoot.querySelector('x-child');
-                const span = child.appendSpanAndReturn();
+            const child = container.shadowRoot.querySelector('x-child');
+            const span = child.appendSpanAndReturn();
 
-                container.addEventListener('test', (event) => {
-                    expect(event.target).toEqual(container);
-                    setTimeout(() => {
-                        expect(event.target).toEqual(span);
-                        done();
-                    });
-                });
-
-                span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
-            });
-
-            it('should not retarget when the target was manually added without lwc:dom="manual" and accessed in a document event listener [W-6626752]', (done) => {
-                const container = createElement('x-container', { is: Container });
-                document.body.appendChild(container);
-
-                const child = container.shadowRoot.querySelector('x-child');
-                const span = child.appendSpanAndReturn();
-
-                globalListener = (event) => {
+            container.addEventListener('test', (event) => {
+                expect(event.target).toEqual(container);
+                setTimeout(() => {
                     expect(event.target).toEqual(span);
                     done();
-                };
-                document.addEventListener('test', globalListener);
-
-                span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+                });
             });
+
+            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
-    }
+
+        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed in a document event listener [W-6626752]', (done) => {
+            const container = createElement('x-container', { is: Container });
+            document.body.appendChild(container);
+
+            const child = container.shadowRoot.querySelector('x-child');
+            const span = child.appendSpanAndReturn();
+
+            globalListener = (event) => {
+                expect(event.target).toEqual(span);
+                done();
+            };
+            document.addEventListener('test', globalListener);
+
+            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        });
+    });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
@@ -67,13 +67,11 @@ describe('global HTML Properties', () => {
     cases.forEach((testCase) => {
         const { prop, value } = testCase;
         describe(`#${prop}`, () => {
-            if (prop !== 'hidden') {
-                it(`should reflect ${prop} attribute by default`, () => {
-                    const element = createElement(`prop-reflect-${prop}`, { is: Test });
-                    element[prop] = value;
-                    expect(HTMLEmbedElement.prototype.getAttribute.call(element, prop)).toBe(value);
-                });
-            }
+            it.skipIf(prop === 'hidden')(`should reflect ${prop} attribute by default`, () => {
+                const element = createElement(`prop-reflect-${prop}`, { is: Test });
+                element[prop] = value;
+                expect(HTMLEmbedElement.prototype.getAttribute.call(element, prop)).toBe(value);
+            });
 
             it(`should return correct value from native ${prop} getter`, () => {
                 const element = createElement(`prop-getter-${prop}`, { is: Test });

--- a/packages/@lwc/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -182,7 +182,7 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             document.body.appendChild(container);
         });
 
-        if (!process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST) {
+        describe.skipIf(process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST)('MutationObserver', () => {
             it('should invoke observer with correct MutationRecords when adding child nodes using innerHTML', (done) => {
                 const parent = createElement('x-parent', { is: XParent });
                 container.appendChild(parent);
@@ -358,7 +358,7 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 expect(actualMutationRecords[1].addedNodes.length).toBe(1);
                 expect(actualMutationRecords[1].addedNodes[0].tagName).toBe('OL');
             });
-        }
+        });
 
         it('should retarget MutationRecord for mutations directly under shadowRoot - added nodes', () => {
             const host = createElement('x-template-mutations', { is: XTemplateMutations });
@@ -419,8 +419,10 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
     });
-    if (!process.env.NATIVE_SHADOW) {
-        describe('References to mutation observers are not leaked', () => {
+
+    describe.skipIf(process.env.NATIVE_SHADOW)(
+        'References to mutation observers are not leaked',
+        () => {
             let container;
             beforeEach(() => {
                 container = document.createElement('div');
@@ -475,6 +477,6 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 observer.disconnect();
                 expect(node.$$lwcNodeObservers$$.length).toBe(0);
             });
-        });
-    }
+        }
+    );
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.childNodes.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.childNodes.spec.js
@@ -54,8 +54,9 @@ describe('Node.childNodes', () => {
 
     // TODO [#1761]: Difference in behavior of slot.childNodes in native and synthetic-shadow
     // enable this test in synthetic-shadow mode once the bug is fixed
-    if (process.env.NATIVE_SHADOW) {
-        it('should always return an default content for slots not rendering default content', () => {
+    it.runIf(process.env.NATIVE_SHADOW)(
+        'should always return an default content for slots not rendering default content',
+        () => {
             const elm = createElement('x-slotted-parent', { is: SlottedParent });
             document.body.appendChild(elm);
             const slot = elm.shadowRoot
@@ -64,8 +65,8 @@ describe('Node.childNodes', () => {
             // Per spec, slot elements will retain default content
             expect(slot.childNodes.length).toBe(1);
             expect(slot.assignedNodes().length).toBe(2);
-        });
-    }
+        }
+    );
 
     it('should return correct elements for slots rendering default content', () => {
         const elm = createElement('x-unslotted-parent', { is: UnslottedParent });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
@@ -324,7 +324,7 @@ describe('Node.getRootNode', () => {
             expect(processingInstruction.getRootNode(composedTrueConfig)).toBe(fragment);
         });
 
-        if (process.env.NATIVE_SHADOW) {
+        describe.runIf(process.env.NATIVE_SHADOW)('native shadow', () => {
             it('native shadow dom', () => {
                 const shadowHost = document.createElement('div');
                 document.body.appendChild(shadowHost);
@@ -355,6 +355,6 @@ describe('Node.getRootNode', () => {
                 expect(lwcTemplateNode.getRootNode(composedTrueConfig)).toBe(document);
                 expect(lwcTemplateNode.getRootNode()).toBe(syntheticShadowRoot);
             });
-        }
+        });
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.delegatesFocus.spec.js
@@ -1,26 +1,24 @@
 import { LightningElement } from 'lwc';
 import { createElement } from 'lwc';
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('ShadowRoot.delegatesFocus', () => {
-        // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
-        it('ShadowRoot.delegatesFocus should be false by default', () => {
-            class NoDelegatesFocus extends LightningElement {}
+describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.delegatesFocus', () => {
+    // TODO [#985]: delegatedFocus is only implemented the native ShadowRoot by Blink
+    it('ShadowRoot.delegatesFocus should be false by default', () => {
+        class NoDelegatesFocus extends LightningElement {}
 
-            const elm = createElement('x-test', { is: NoDelegatesFocus });
-            document.body.appendChild(elm);
+        const elm = createElement('x-test', { is: NoDelegatesFocus });
+        document.body.appendChild(elm);
 
-            expect(elm.shadowRoot.delegatesFocus).toBe(false);
-        });
-        it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
-            class DelegatesFocus extends LightningElement {
-                static delegatesFocus = true;
-            }
-
-            const elm = createElement('x-test', { is: DelegatesFocus });
-            document.body.appendChild(elm);
-
-            expect(elm.shadowRoot.delegatesFocus).toBe(true);
-        });
+        expect(elm.shadowRoot.delegatesFocus).toBe(false);
     });
-}
+    it('ShadowRoot.delegatesFocus should be true if class has delegatesFocus static property set to true', () => {
+        class DelegatesFocus extends LightningElement {
+            static delegatesFocus = true;
+        }
+
+        const elm = createElement('x-test', { is: DelegatesFocus });
+        document.body.appendChild(elm);
+
+        expect(elm.shadowRoot.delegatesFocus).toBe(true);
+    });
+});

--- a/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -66,30 +66,28 @@ describe('Properties overrides', () => {
     });
 });
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('synthetic-shadow restrictions', () => {
-        let elm;
+describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () => {
+    let elm;
 
-        beforeAll(() => {
-            elm = createElement('x-test', { is: Test });
-        });
-
-        it(`should throw when invoking ShadowRoot.getSelection`, () => {
-            expect(() => elm.shadowRoot.getSelection()).toThrowError(
-                `Disallowed method "getSelection" on ShadowRoot.`
-            );
-        });
-
-        it(`should throw when invoking ShadowRoot.cloneNode`, () => {
-            expect(() => elm.shadowRoot.cloneNode()).toThrowError(
-                `Disallowed method "cloneNode" on ShadowRoot.`
-            );
-        });
-
-        it(`should throw when invoking ShadowRoot.getElementById`, () => {
-            expect(() => elm.shadowRoot.getElementById()).toThrowError(
-                `Disallowed method "getElementById" on ShadowRoot.`
-            );
-        });
+    beforeAll(() => {
+        elm = createElement('x-test', { is: Test });
     });
-}
+
+    it(`should throw when invoking ShadowRoot.getSelection`, () => {
+        expect(() => elm.shadowRoot.getSelection()).toThrowError(
+            `Disallowed method "getSelection" on ShadowRoot.`
+        );
+    });
+
+    it(`should throw when invoking ShadowRoot.cloneNode`, () => {
+        expect(() => elm.shadowRoot.cloneNode()).toThrowError(
+            `Disallowed method "cloneNode" on ShadowRoot.`
+        );
+    });
+
+    it(`should throw when invoking ShadowRoot.getElementById`, () => {
+        expect(() => elm.shadowRoot.getElementById()).toThrowError(
+            `Disallowed method "getElementById" on ShadowRoot.`
+        );
+    });
+});

--- a/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -3,190 +3,177 @@ import Container from 'x/container';
 import Grandparent from 'x/grandparent';
 import { extractShadowDataIds } from 'test-utils';
 
-// Safari <v11 does not support this API
-function supportsElementsFromPoint() {
-    try {
-        document.elementsFromPoint(0, 0);
-        return true;
-    } catch (_err) {
-        /* ignore */
+// The browsers disagree on whether elements _above_ the shadow root should also be included
+// when calling shadowRoot.elementsFromPoint(). Firefox only returns elements inside of the
+// immediate shadow root, whereas Chrome and Safari return elements above (outside) of that root.
+// https://crbug.com/1207863#c4
+const onlyIncludesElementsInImmediateShadowRoot = (() => {
+    function detect() {
+        if (!process.env.NATIVE_SHADOW) {
+            return false; // in synthetic shadow we control the behavior, so we match Chrome/Safari
+        }
+        // detect the Firefox behavior
+        const div = document.createElement('div');
+        div.attachShadow({ mode: 'open' }).innerHTML = '<div>foo</div>';
+        document.body.appendChild(div);
+        const { left, top, width, height } = div.shadowRoot
+            .querySelector('div')
+            .getBoundingClientRect();
+        const elements = div.shadowRoot.elementsFromPoint(left + width / 2, top + height / 2);
+        document.body.removeChild(div);
+        return elements.length === 1;
     }
-    return false;
+
+    let cachedResult;
+    return () => {
+        if (typeof cachedResult === 'undefined') {
+            cachedResult = detect();
+        }
+        return cachedResult;
+    };
+})();
+
+function testElementsFromPoint(rootNode, x, y, expectedElements) {
+    const elementsFromPoint = rootNode.elementsFromPoint(x, y);
+
+    if (onlyIncludesElementsInImmediateShadowRoot()) {
+        expectedElements = expectedElements.filter((el) => el.getRootNode() === rootNode);
+    }
+
+    expect(elementsFromPoint).toEqual(expectedElements);
 }
 
-describe.runIf(supportsElementsFromPoint())('elementsFromPoint', () => {
-    // The browsers disagree on whether elements _above_ the shadow root should also be included
-    // when calling shadowRoot.elementsFromPoint(). Firefox only returns elements inside of the
-    // immediate shadow root, whereas Chrome and Safari return elements above (outside) of that root.
-    // https://crbug.com/1207863#c4
-    const onlyIncludesElementsInImmediateShadowRoot = (() => {
-        function detect() {
-            if (!process.env.NATIVE_SHADOW) {
-                return false; // in synthetic shadow we control the behavior, so we match Chrome/Safari
-            }
-            // detect the Firefox behavior
-            const div = document.createElement('div');
-            div.attachShadow({ mode: 'open' }).innerHTML = '<div>foo</div>';
-            document.body.appendChild(div);
-            const { left, top, width, height } = div.shadowRoot
-                .querySelector('div')
-                .getBoundingClientRect();
-            const elements = div.shadowRoot.elementsFromPoint(left + width / 2, top + height / 2);
-            document.body.removeChild(div);
-            return elements.length === 1;
-        }
+// Safari <v11 doesn't support elementsFromPoint
+it('non-shadow example', () => {
+    const div = document.createElement('div');
+    div.textContent = 'foo';
+    document.body.appendChild(div);
 
-        let cachedResult;
-        return () => {
-            if (typeof cachedResult === 'undefined') {
-                cachedResult = detect();
-            }
-            return cachedResult;
-        };
-    })();
+    const { left, top, width, height } = div.getBoundingClientRect();
+    const elementsFromPoint = document.elementsFromPoint(left + width / 2, top + height / 2);
 
-    function testElementsFromPoint(rootNode, x, y, expectedElements) {
-        const elementsFromPoint = rootNode.elementsFromPoint(x, y);
+    expect(elementsFromPoint).toEqual([div, document.body, document.documentElement]);
+});
 
-        if (onlyIncludesElementsInImmediateShadowRoot()) {
-            expectedElements = expectedElements.filter((el) => el.getRootNode() === rootNode);
-        }
+it('shadow example', () => {
+    const elm = createElement('x-container', { is: Container });
+    document.body.appendChild(elm);
+    const nodes = extractShadowDataIds(elm.shadowRoot);
 
-        expect(elementsFromPoint).toEqual(expectedElements);
+    const { body } = document;
+    const html = document.documentElement;
+    const {
+        aboveContainer,
+        inContainer,
+        slottable,
+        aroundSlotted,
+        slotted,
+        inSlotted,
+        slotWrapper,
+        inSlottable,
+        inSlottableInner,
+    } = nodes;
+
+    function test(element, expectedElements) {
+        const { left, top, width, height } = element.getBoundingClientRect();
+        const rootNode = element.getRootNode();
+        const x = left + width / 2;
+        const y = top + height / 2;
+        testElementsFromPoint(rootNode, x, y, [...expectedElements, elm, body, html]);
     }
 
-    // Safari <v11 doesn't support elementsFromPoint
-    it('non-shadow example', () => {
-        const div = document.createElement('div');
-        div.textContent = 'foo';
-        document.body.appendChild(div);
+    test(elm, []);
+    test(aboveContainer, [aboveContainer]);
+    test(inContainer, [slottable, inContainer]);
+    test(slottable, [slottable, inContainer]);
+    test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer]);
+    test(slotted, [slotted, aroundSlotted, slottable, inContainer]);
+    test(inSlotted, [inSlotted, slotted, aroundSlotted, slottable, inContainer]);
+    test(slotWrapper, [slotted, aroundSlotted, slotWrapper, slottable, inContainer]);
+    test(inSlottable, [inSlottableInner, inSlottable, slottable, inContainer]);
+    test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
+});
 
-        const { left, top, width, height } = div.getBoundingClientRect();
-        const elementsFromPoint = document.elementsFromPoint(left + width / 2, top + height / 2);
+it('host elements are not all visible', () => {
+    const grandparent = createElement('x-grandparent', { is: Grandparent });
+    document.body.appendChild(grandparent);
+    const nodes = extractShadowDataIds(grandparent.shadowRoot);
+    const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
+    const html = document.documentElement;
 
-        expect(elementsFromPoint).toEqual([div, document.body, document.documentElement]);
-    });
+    const resetStyles = () => {
+        [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
+            el.style = '';
+        });
+    };
 
-    it('shadow example', () => {
-        const elm = createElement('x-container', { is: Container });
-        document.body.appendChild(elm);
-        const nodes = extractShadowDataIds(elm.shadowRoot);
+    function test(element, expectedElements) {
+        testElementsFromPoint(element.getRootNode(), 50, 50, [...expectedElements, html]);
+    }
 
-        const { body } = document;
-        const html = document.documentElement;
-        const {
-            aboveContainer,
-            inContainer,
-            slottable,
-            aroundSlotted,
-            slotted,
-            inSlotted,
-            slotWrapper,
-            inSlottable,
-            inSlottableInner,
-        } = nodes;
+    test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
+    test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        function test(element, expectedElements) {
-            const { left, top, width, height } = element.getBoundingClientRect();
-            const rootNode = element.getRootNode();
-            const x = left + width / 2;
-            const y = top + height / 2;
-            testElementsFromPoint(rootNode, x, y, [...expectedElements, elm, body, html]);
-        }
+    grandparent.style = 'width: 0px; height: 0px;';
 
-        test(elm, []);
-        test(aboveContainer, [aboveContainer]);
-        test(inContainer, [slottable, inContainer]);
-        test(slottable, [slottable, inContainer]);
-        test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer]);
-        test(slotted, [slotted, aroundSlotted, slottable, inContainer]);
-        test(inSlotted, [inSlotted, slotted, aroundSlotted, slottable, inContainer]);
-        test(slotWrapper, [slotted, aroundSlotted, slotWrapper, slottable, inContainer]);
-        test(inSlottable, [inSlottableInner, inSlottable, slottable, inContainer]);
-        test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
-    });
+    test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
+    test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
+    test(grandparentDiv, [parent, grandparentDiv]);
 
-    it('host elements are not all visible', () => {
-        const grandparent = createElement('x-grandparent', { is: Grandparent });
-        document.body.appendChild(grandparent);
-        const nodes = extractShadowDataIds(grandparent.shadowRoot);
-        const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
-        const html = document.documentElement;
+    resetStyles();
+    parent.style = 'width: 0px; height: 0px;';
 
-        const resetStyles = () => {
-            [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
-                el.style = '';
-            });
-        };
+    test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
+    test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        function test(element, expectedElements) {
-            testElementsFromPoint(element.getRootNode(), 50, 50, [...expectedElements, html]);
-        }
+    resetStyles();
+    child.style = 'width: 0px; height: 0px;';
 
-        test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
-        test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+    test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
+    test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        grandparent.style = 'width: 0px; height: 0px;';
+    resetStyles();
+    parent.style = 'width: 0px; height: 0px;';
+    parentDiv.style = 'width: 0px; height: 0px;';
 
-        test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
-        test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
-        test(grandparentDiv, [parent, grandparentDiv]);
+    test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
+    test(parentDiv, [child, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        resetStyles();
-        parent.style = 'width: 0px; height: 0px;';
+    resetStyles();
+    parent.style = 'width: 0px; height: 0px;';
+    parentDiv.style = 'width: 0px; height: 0px;';
+    child.style = 'width: 0px; height: 0px;';
 
-        test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
-        test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+    test(childDiv, [childDiv, grandparentDiv, grandparent]);
+    test(parentDiv, [child, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        resetStyles();
-        child.style = 'width: 0px; height: 0px;';
+    resetStyles();
+    parent.style = 'width: 0px; height: 0px;';
+    child.style = 'width: 0px; height: 0px;';
+    test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
+    test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-        test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
-        test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+    resetStyles();
+    parent.style = 'width: 0px; height: 0px;';
+    parentDiv.style = 'width: 0px; height: 0px;';
+    child.style = 'width: 0px; height: 0px;';
+    childDiv.style = 'width: 0px; height: 0px;';
 
-        resetStyles();
-        parent.style = 'width: 0px; height: 0px;';
-        parentDiv.style = 'width: 0px; height: 0px;';
+    test(childDiv, [grandparentDiv, grandparent]);
+    test(parentDiv, [grandparentDiv, grandparent]);
+    test(grandparentDiv, [grandparentDiv, grandparent]);
 
-        test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
-        test(parentDiv, [child, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+    resetStyles();
+    parentDiv.style = 'width: 0px; height: 0px;';
+    child.style = 'width: 0px; height: 0px;';
 
-        resetStyles();
-        parent.style = 'width: 0px; height: 0px;';
-        parentDiv.style = 'width: 0px; height: 0px;';
-        child.style = 'width: 0px; height: 0px;';
-
-        test(childDiv, [childDiv, grandparentDiv, grandparent]);
-        test(parentDiv, [child, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
-
-        resetStyles();
-        parent.style = 'width: 0px; height: 0px;';
-        child.style = 'width: 0px; height: 0px;';
-        test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
-        test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
-
-        resetStyles();
-        parent.style = 'width: 0px; height: 0px;';
-        parentDiv.style = 'width: 0px; height: 0px;';
-        child.style = 'width: 0px; height: 0px;';
-        childDiv.style = 'width: 0px; height: 0px;';
-
-        test(childDiv, [grandparentDiv, grandparent]);
-        test(parentDiv, [grandparentDiv, grandparent]);
-        test(grandparentDiv, [grandparentDiv, grandparent]);
-
-        resetStyles();
-        parentDiv.style = 'width: 0px; height: 0px;';
-        child.style = 'width: 0px; height: 0px;';
-
-        test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
-        test(parentDiv, [child, parent, grandparentDiv, grandparent]);
-        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
-    });
+    test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
+    test(parentDiv, [child, parent, grandparentDiv, grandparent]);
+    test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/ShadowRoot.elementsFromPoint/index.spec.js
@@ -3,18 +3,18 @@ import Container from 'x/container';
 import Grandparent from 'x/grandparent';
 import { extractShadowDataIds } from 'test-utils';
 
-describe('elementsFromPoint', () => {
-    // Safari <v11 does not support this API
-    function supportsElementsFromPoint() {
-        try {
-            document.elementsFromPoint(0, 0);
-            return true;
-        } catch (_err) {
-            /* ignore */
-        }
-        return false;
+// Safari <v11 does not support this API
+function supportsElementsFromPoint() {
+    try {
+        document.elementsFromPoint(0, 0);
+        return true;
+    } catch (_err) {
+        /* ignore */
     }
+    return false;
+}
 
+describe.runIf(supportsElementsFromPoint())('elementsFromPoint', () => {
     // The browsers disagree on whether elements _above_ the shadow root should also be included
     // when calling shadowRoot.elementsFromPoint(). Firefox only returns elements inside of the
     // immediate shadow root, whereas Chrome and Safari return elements above (outside) of that root.
@@ -55,143 +55,138 @@ describe('elementsFromPoint', () => {
         expect(elementsFromPoint).toEqual(expectedElements);
     }
 
-    if (supportsElementsFromPoint()) {
-        // Safari <v11 doesn't support elementsFromPoint
-        it('non-shadow example', () => {
-            const div = document.createElement('div');
-            div.textContent = 'foo';
-            document.body.appendChild(div);
+    // Safari <v11 doesn't support elementsFromPoint
+    it('non-shadow example', () => {
+        const div = document.createElement('div');
+        div.textContent = 'foo';
+        document.body.appendChild(div);
 
-            const { left, top, width, height } = div.getBoundingClientRect();
-            const elementsFromPoint = document.elementsFromPoint(
-                left + width / 2,
-                top + height / 2
-            );
+        const { left, top, width, height } = div.getBoundingClientRect();
+        const elementsFromPoint = document.elementsFromPoint(left + width / 2, top + height / 2);
 
-            expect(elementsFromPoint).toEqual([div, document.body, document.documentElement]);
-        });
+        expect(elementsFromPoint).toEqual([div, document.body, document.documentElement]);
+    });
 
-        it('shadow example', () => {
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
-            const nodes = extractShadowDataIds(elm.shadowRoot);
+    it('shadow example', () => {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+        const nodes = extractShadowDataIds(elm.shadowRoot);
 
-            const { body } = document;
-            const html = document.documentElement;
-            const {
-                aboveContainer,
-                inContainer,
-                slottable,
-                aroundSlotted,
-                slotted,
-                inSlotted,
-                slotWrapper,
-                inSlottable,
-                inSlottableInner,
-            } = nodes;
+        const { body } = document;
+        const html = document.documentElement;
+        const {
+            aboveContainer,
+            inContainer,
+            slottable,
+            aroundSlotted,
+            slotted,
+            inSlotted,
+            slotWrapper,
+            inSlottable,
+            inSlottableInner,
+        } = nodes;
 
-            function test(element, expectedElements) {
-                const { left, top, width, height } = element.getBoundingClientRect();
-                const rootNode = element.getRootNode();
-                const x = left + width / 2;
-                const y = top + height / 2;
-                testElementsFromPoint(rootNode, x, y, [...expectedElements, elm, body, html]);
-            }
+        function test(element, expectedElements) {
+            const { left, top, width, height } = element.getBoundingClientRect();
+            const rootNode = element.getRootNode();
+            const x = left + width / 2;
+            const y = top + height / 2;
+            testElementsFromPoint(rootNode, x, y, [...expectedElements, elm, body, html]);
+        }
 
-            test(elm, []);
-            test(aboveContainer, [aboveContainer]);
-            test(inContainer, [slottable, inContainer]);
-            test(slottable, [slottable, inContainer]);
-            test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer]);
-            test(slotted, [slotted, aroundSlotted, slottable, inContainer]);
-            test(inSlotted, [inSlotted, slotted, aroundSlotted, slottable, inContainer]);
-            test(slotWrapper, [slotted, aroundSlotted, slotWrapper, slottable, inContainer]);
-            test(inSlottable, [inSlottableInner, inSlottable, slottable, inContainer]);
-            test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
-        });
+        test(elm, []);
+        test(aboveContainer, [aboveContainer]);
+        test(inContainer, [slottable, inContainer]);
+        test(slottable, [slottable, inContainer]);
+        test(aroundSlotted, [slotted, aroundSlotted, slottable, inContainer]);
+        test(slotted, [slotted, aroundSlotted, slottable, inContainer]);
+        test(inSlotted, [inSlotted, slotted, aroundSlotted, slottable, inContainer]);
+        test(slotWrapper, [slotted, aroundSlotted, slotWrapper, slottable, inContainer]);
+        test(inSlottable, [inSlottableInner, inSlottable, slottable, inContainer]);
+        test(inSlottableInner, [inSlottableInner, inSlottable, slottable, inContainer]);
+    });
 
-        it('host elements are not all visible', () => {
-            const grandparent = createElement('x-grandparent', { is: Grandparent });
-            document.body.appendChild(grandparent);
-            const nodes = extractShadowDataIds(grandparent.shadowRoot);
-            const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
-            const html = document.documentElement;
+    it('host elements are not all visible', () => {
+        const grandparent = createElement('x-grandparent', { is: Grandparent });
+        document.body.appendChild(grandparent);
+        const nodes = extractShadowDataIds(grandparent.shadowRoot);
+        const { child, childDiv, parent, parentDiv, grandparentDiv } = nodes;
+        const html = document.documentElement;
 
-            const resetStyles = () => {
-                [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
-                    el.style = '';
-                });
-            };
+        const resetStyles = () => {
+            [child, childDiv, parent, parentDiv, grandparent, grandparentDiv].forEach((el) => {
+                el.style = '';
+            });
+        };
 
-            function test(element, expectedElements) {
-                testElementsFromPoint(element.getRootNode(), 50, 50, [...expectedElements, html]);
-            }
+        function test(element, expectedElements) {
+            testElementsFromPoint(element.getRootNode(), 50, 50, [...expectedElements, html]);
+        }
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv, grandparent]);
+        test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            grandparent.style = 'width: 0px; height: 0px;';
+        grandparent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
-            test(grandparentDiv, [parent, grandparentDiv]);
+        test(childDiv, [childDiv, child, parentDiv, parent, grandparentDiv]);
+        test(parentDiv, [child, parentDiv, parent, grandparentDiv]);
+        test(grandparentDiv, [parent, grandparentDiv]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        parent.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        test(childDiv, [childDiv, child, parentDiv, grandparentDiv, grandparent]);
+        test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            child.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        test(childDiv, [childDiv, parentDiv, parent, grandparentDiv, grandparent]);
+        test(parentDiv, [child, parentDiv, parent, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        parent.style = 'width: 0px; height: 0px;';
+        parentDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
-            test(parentDiv, [child, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        test(childDiv, [childDiv, child, grandparentDiv, grandparent]);
+        test(parentDiv, [child, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        parent.style = 'width: 0px; height: 0px;';
+        parentDiv.style = 'width: 0px; height: 0px;';
+        child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        test(childDiv, [childDiv, grandparentDiv, grandparent]);
+        test(parentDiv, [child, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
-            test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+        resetStyles();
+        parent.style = 'width: 0px; height: 0px;';
+        child.style = 'width: 0px; height: 0px;';
+        test(childDiv, [childDiv, parentDiv, grandparentDiv, grandparent]);
+        test(parentDiv, [child, parentDiv, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
 
-            resetStyles();
-            parent.style = 'width: 0px; height: 0px;';
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
-            childDiv.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        parent.style = 'width: 0px; height: 0px;';
+        parentDiv.style = 'width: 0px; height: 0px;';
+        child.style = 'width: 0px; height: 0px;';
+        childDiv.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [grandparentDiv, grandparent]);
-            test(parentDiv, [grandparentDiv, grandparent]);
-            test(grandparentDiv, [grandparentDiv, grandparent]);
+        test(childDiv, [grandparentDiv, grandparent]);
+        test(parentDiv, [grandparentDiv, grandparent]);
+        test(grandparentDiv, [grandparentDiv, grandparent]);
 
-            resetStyles();
-            parentDiv.style = 'width: 0px; height: 0px;';
-            child.style = 'width: 0px; height: 0px;';
+        resetStyles();
+        parentDiv.style = 'width: 0px; height: 0px;';
+        child.style = 'width: 0px; height: 0px;';
 
-            test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
-            test(parentDiv, [child, parent, grandparentDiv, grandparent]);
-            test(grandparentDiv, [parent, grandparentDiv, grandparent]);
-        });
-    }
+        test(childDiv, [childDiv, parent, grandparentDiv, grandparent]);
+        test(parentDiv, [child, parent, grandparentDiv, grandparent]);
+        test(grandparentDiv, [parent, grandparentDiv, grandparent]);
+    });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/dir-pseudoclass/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/dir-pseudoclass/index.spec.js
@@ -20,76 +20,75 @@ function supportsDirPseudoclass() {
 }
 
 // In native shadow we delegate to the browser, so it has to support :dir()
-if (!process.env.NATIVE_SHADOW || supportsDirPseudoclass()) {
-    describe(':dir() pseudoclass', () => {
-        it('can apply styles based on :dir()', () => {
-            const elm = createElement('x-parent', { is: Component });
-            document.body.appendChild(elm);
+describe.runIf(!process.env.NATIVE_SHADOW || supportsDirPseudoclass())(':dir() pseudoclass', () => {
+    it('can apply styles based on :dir()', () => {
+        const elm = createElement('x-parent', { is: Component });
+        document.body.appendChild(elm);
 
-            elm.setAttribute('dir', 'ltr');
+        elm.setAttribute('dir', 'ltr');
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 1)'
-                    );
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
-                        'rgb(0, 0, 3)'
-                    );
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color
-                    ).toEqual('rgb(0, 0, 5)');
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color
-                    ).toEqual('rgb(0, 0, 7)');
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color
-                    ).toEqual('rgb(0, 0, 9)');
-                    elm.setAttribute('dir', 'rtl');
-                })
-                .then(() => {
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 2)'
-                    );
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
-                        'rgb(0, 0, 4)'
-                    );
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color
-                    ).toEqual('rgb(0, 0, 6)');
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color
-                    ).toEqual('rgb(0, 0, 8)');
-                    expect(
-                        getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color
-                    ).toEqual('rgb(0, 0, 10)');
-                });
-        });
-
-        it('can apply styles based on :dir() for light-within-shadow', () => {
-            const elm = createElement('x-shadow-container', { is: ShadowContainer });
-            document.body.appendChild(elm);
-
-            elm.setAttribute('dir', 'ltr');
-
-            return Promise.resolve()
-                .then(() => {
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 1)'
-                    );
-                    elm.setAttribute('dir', 'rtl');
-                })
-                .then(() => {
-                    expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 2)'
-                    );
-                });
-        });
+        return Promise.resolve()
+            .then(() => {
+                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
+                    'rgb(0, 0, 1)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
+                    'rgb(0, 0, 3)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
+                    'rgb(0, 0, 5)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
+                    'rgb(0, 0, 7)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
+                    'rgb(0, 0, 9)'
+                );
+                elm.setAttribute('dir', 'rtl');
+            })
+            .then(() => {
+                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
+                    'rgb(0, 0, 2)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
+                    'rgb(0, 0, 4)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
+                    'rgb(0, 0, 6)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
+                    'rgb(0, 0, 8)'
+                );
+                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
+                    'rgb(0, 0, 10)'
+                );
+            });
     });
-}
 
-if (process.env.NATIVE_SHADOW && supportsDirPseudoclass()) {
-    it('can apply styles based on :dir() for light-at-root', () => {
+    it('can apply styles based on :dir() for light-within-shadow', () => {
+        const elm = createElement('x-shadow-container', { is: ShadowContainer });
+        document.body.appendChild(elm);
+
+        elm.setAttribute('dir', 'ltr');
+
+        return Promise.resolve()
+            .then(() => {
+                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
+                    'rgb(0, 0, 1)'
+                );
+                elm.setAttribute('dir', 'rtl');
+            })
+            .then(() => {
+                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
+                    'rgb(0, 0, 2)'
+                );
+            });
+    });
+});
+
+it.runIf(process.env.NATIVE_SHADOW && supportsDirPseudoclass())(
+    'can apply styles based on :dir() for light-at-root',
+    () => {
         const elm = createElement('x-light', { is: Light });
         document.body.appendChild(elm);
 
@@ -106,5 +105,5 @@ if (process.env.NATIVE_SHADOW && supportsDirPseudoclass()) {
             .then(() => {
                 expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
             });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -534,8 +534,9 @@ describe('event propagation', () => {
 
     // This test does not work with native custom element lifecycle because disconnected
     // fragments cannot fire connectedCallback/disconnectedCallback events
-    if (lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE) {
-        describe('dispatched within a disconnected tree', () => {
+    describe.runIf(lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE)(
+        'dispatched within a disconnected tree',
+        () => {
             it('{bubbles: true, composed: true}', () => {
                 const nodes = createDisconnectedTestElement();
                 const event = new CustomEvent('test', { bubbles: true, composed: true });
@@ -606,8 +607,8 @@ describe('event propagation', () => {
                 const actualLogs = dispatchEventWithLog(nodes.container_div, nodes, event);
                 expect(actualLogs).toEqual(expectedLogs);
             });
-        });
-    }
+        }
+    );
 });
 
 describe('declarative event listener', () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/multiple-templates/index.spec.js
@@ -2,8 +2,9 @@ import { createElement } from 'lwc';
 import Multi from 'x/multi';
 import MultiNoStyleInFirst from 'x/multiNoStyleInFirst';
 
-if (process.env.NATIVE_SHADOW) {
-    describe('Shadow DOM styling - multiple shadow DOM components', () => {
+describe.runIf(process.env.NATIVE_SHADOW)(
+    'Shadow DOM styling - multiple shadow DOM components',
+    () => {
         it('Does not duplicate styles if template is re-rendered', () => {
             const element = createElement('x-multi', { is: Multi });
 
@@ -39,8 +40,8 @@ if (process.env.NATIVE_SHADOW) {
                     expect(getNumStyleSheets()).toEqual(2);
                 });
         });
-    });
-}
+    }
+);
 
 describe('multiple stylesheets rendered in same component', () => {
     it('works when first template has no style but second template does', () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/part-and-exportparts/index.spec.js
@@ -2,19 +2,17 @@ import { createElement } from 'lwc';
 import { extractDataIds } from 'test-utils';
 import Grandparent from 'x/grandparent';
 
-if (process.env.NATIVE_SHADOW) {
-    describe('part and exportparts', () => {
-        it('supports part and exportparts', () => {
-            const elm = createElement('x-grandparent', { is: Grandparent });
-            document.body.appendChild(elm);
+describe.runIf(process.env.NATIVE_SHADOW)('part and exportparts', () => {
+    it('supports part and exportparts', () => {
+        const elm = createElement('x-grandparent', { is: Grandparent });
+        document.body.appendChild(elm);
 
-            const ids = extractDataIds(elm);
+        const ids = extractDataIds(elm);
 
-            return Promise.resolve().then(() => {
-                expect(getComputedStyle(ids.overlay).color).toEqual('rgb(255, 0, 0)');
-                expect(getComputedStyle(ids.text).color).toEqual('rgb(0, 0, 255)');
-                expect(getComputedStyle(ids.badge).color).toEqual('rgb(0, 128, 0)');
-            });
+        return Promise.resolve().then(() => {
+            expect(getComputedStyle(ids.overlay).color).toEqual('rgb(255, 0, 0)');
+            expect(getComputedStyle(ids.text).color).toEqual('rgb(0, 0, 255)');
+            expect(getComputedStyle(ids.badge).color).toEqual('rgb(0, 128, 0)');
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-karma/test/static-content/index.spec.js
@@ -25,29 +25,27 @@ import TableWithExpression from 'x/tableWithExpressions';
 import TextWithoutPreserveComments from 'x/textWithoutPreserveComments';
 import TextWithPreserveComments from 'x/textWithPreserveComments';
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('Mixed mode for static content', () => {
-        ['native', 'synthetic'].forEach((firstRenderMode) => {
-            it(`should set the tokens for synthetic shadow when it renders first in ${firstRenderMode}`, () => {
-                const elm = createElement('x-container', { is: Container });
-                elm.syntheticFirst = firstRenderMode === 'synthetic';
-                document.body.appendChild(elm);
+describe.skipIf(process.env.NATIVE_SHADOW)('Mixed mode for static content', () => {
+    ['native', 'synthetic'].forEach((firstRenderMode) => {
+        it(`should set the tokens for synthetic shadow when it renders first in ${firstRenderMode}`, () => {
+            const elm = createElement('x-container', { is: Container });
+            elm.syntheticFirst = firstRenderMode === 'synthetic';
+            document.body.appendChild(elm);
 
-                const syntheticMode = elm.shadowRoot
-                    .querySelector('x-component')
-                    .shadowRoot.querySelector('div');
-                const nativeMode = elm.shadowRoot
-                    .querySelector('x-native')
-                    .shadowRoot.querySelector('x-component')
-                    .shadowRoot.querySelector('div');
+            const syntheticMode = elm.shadowRoot
+                .querySelector('x-component')
+                .shadowRoot.querySelector('div');
+            const nativeMode = elm.shadowRoot
+                .querySelector('x-native')
+                .shadowRoot.querySelector('x-component')
+                .shadowRoot.querySelector('div');
 
-                const token = LOWERCASE_SCOPE_TOKENS ? 'lwc-6a8uqob2ku4' : 'x-component_component';
-                expect(syntheticMode.hasAttribute(token)).toBe(true);
-                expect(nativeMode.hasAttribute(token)).toBe(false);
-            });
+            const token = LOWERCASE_SCOPE_TOKENS ? 'lwc-6a8uqob2ku4' : 'x-component_component';
+            expect(syntheticMode.hasAttribute(token)).toBe(true);
+            expect(nativeMode.hasAttribute(token)).toBe(false);
         });
     });
-}
+});
 
 describe('static content when stylesheets change', () => {
     it('should reflect correct token for scoped styles', () => {

--- a/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
@@ -10,55 +10,53 @@ import X from 'base/libraryx';
 import Z from 'base/libraryz';
 
 // Swapping is only enabled in dev mode
-if (process.env.NODE_ENV !== 'production') {
-    describe('component swapping', () => {
-        it('should work before and after instantiation', () => {
-            expect(swapComponent(A, B)).toBe(true);
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
+describe.runIf(process.env.NODE_ENV !== 'production')('component swapping', () => {
+    it('should work before and after instantiation', () => {
+        expect(swapComponent(A, B)).toBe(true);
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+        expect(elm.shadowRoot.firstChild.shadowRoot.firstChild.outerHTML).toBe(
+            '<p class="b">b</p>'
+        );
+        expect(swapComponent(B, C)).toBe(true);
+        return Promise.resolve().then(() => {
             expect(elm.shadowRoot.firstChild.shadowRoot.firstChild.outerHTML).toBe(
-                '<p class="b">b</p>'
+                '<p class="c">c</p>'
             );
-            expect(swapComponent(B, C)).toBe(true);
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.firstChild.shadowRoot.firstChild.outerHTML).toBe(
-                    '<p class="c">c</p>'
-                );
-            });
-        });
-
-        it('should return false for root elements', () => {
-            const elm = createElement('x-d', { is: D });
-            document.body.appendChild(elm);
-            expect(swapComponent(D, E)).toBe(false); // meaning you can reload the page
-        });
-
-        it('should throw for invalid old component', () => {
-            expect(() => {
-                swapComponent(function () {}, D);
-            }).toThrowError(
-                TypeError,
-                /Invalid Component: Attempting to swap a non-component with a component/
-            );
-        });
-
-        it('should throw for invalid new componeont', () => {
-            expect(() => {
-                swapComponent(D, function () {});
-            }).toThrowError(
-                TypeError,
-                /Invalid Component: Attempting to swap a component with a non-component/
-            );
-        });
-
-        it('should be a no-op for non components', () => {
-            const elm = createElement('x-container', { is: Container });
-            document.body.appendChild(elm);
-            expect(elm.testValue).toBe('I may look like a component');
-            expect(swapComponent(Z, X)).toBe(false);
-            return Promise.resolve().then(() => {
-                expect(elm.testValue).toBe('I may look like a component');
-            });
         });
     });
-}
+
+    it('should return false for root elements', () => {
+        const elm = createElement('x-d', { is: D });
+        document.body.appendChild(elm);
+        expect(swapComponent(D, E)).toBe(false); // meaning you can reload the page
+    });
+
+    it('should throw for invalid old component', () => {
+        expect(() => {
+            swapComponent(function () {}, D);
+        }).toThrowError(
+            TypeError,
+            /Invalid Component: Attempting to swap a non-component with a component/
+        );
+    });
+
+    it('should throw for invalid new componeont', () => {
+        expect(() => {
+            swapComponent(D, function () {});
+        }).toThrowError(
+            TypeError,
+            /Invalid Component: Attempting to swap a component with a non-component/
+        );
+    });
+
+    it('should be a no-op for non components', () => {
+        const elm = createElement('x-container', { is: Container });
+        document.body.appendChild(elm);
+        expect(elm.testValue).toBe('I may look like a component');
+        expect(swapComponent(Z, X)).toBe(false);
+        return Promise.resolve().then(() => {
+            expect(elm.testValue).toBe('I may look like a component');
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/components/index.spec.js
@@ -10,7 +10,7 @@ import X from 'base/libraryx';
 import Z from 'base/libraryz';
 
 // Swapping is only enabled in dev mode
-describe.runIf(process.env.NODE_ENV !== 'production')('component swapping', () => {
+describe.skipIf(process.env.NODE_ENV === 'production')('component swapping', () => {
     it('should work before and after instantiation', () => {
         expect(swapComponent(A, B)).toBe(true);
         const elm = createElement('x-container', { is: Container });

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -24,300 +24,298 @@ function expectStyles(elm, styles) {
 }
 
 // Swapping is only enabled in dev mode
-if (process.env.NODE_ENV !== 'production') {
-    describe('style swapping', () => {
-        afterEach(() => {
-            window.__lwcResetHotSwaps();
-            window.__lwcResetStylesheetCache();
-            window.__lwcResetGlobalStylesheets();
-        });
+describe.runIf(process.env.NODE_ENV !== 'production')('style swapping', () => {
+    afterEach(() => {
+        window.__lwcResetHotSwaps();
+        window.__lwcResetStylesheetCache();
+        window.__lwcResetGlobalStylesheets();
+    });
 
-        const scenarios = [
-            {
-                testName: 'shadow',
-                components: {
-                    Simple: ShadowSimple,
-                    StaleProp: ShadowStaleProp,
-                    UsesStaticStylesheets: ShadowUsesStaticStylesheets,
-                },
+    const scenarios = [
+        {
+            testName: 'shadow',
+            components: {
+                Simple: ShadowSimple,
+                StaleProp: ShadowStaleProp,
+                UsesStaticStylesheets: ShadowUsesStaticStylesheets,
             },
-            {
-                testName: 'light',
-                components: {
-                    Simple: LightSimple,
-                    StaleProp: LightStaleProp,
-                    UsesStaticStylesheets: LightUsesStaticStylesheets,
-                },
+        },
+        {
+            testName: 'light',
+            components: {
+                Simple: LightSimple,
+                StaleProp: LightStaleProp,
+                UsesStaticStylesheets: LightUsesStaticStylesheets,
             },
-            {
-                testName: 'light-global',
-                components: {
-                    Simple: LightGlobalSimple,
-                    StaleProp: LightGlobalStaleProp,
-                    UsesStaticStylesheets: LightGlobalUsesStaticStylesheets,
-                },
+        },
+        {
+            testName: 'light-global',
+            components: {
+                Simple: LightGlobalSimple,
+                StaleProp: LightGlobalStaleProp,
+                UsesStaticStylesheets: LightGlobalUsesStaticStylesheets,
             },
-        ];
-        scenarios.forEach(({ testName, components }) => {
-            describe(testName, () => {
-                const { Simple, StaleProp, UsesStaticStylesheets } = components;
-                it('should work with components with implicit style definition', async () => {
-                    const { blockStyle, inlineStyle, noneStyle } = Simple;
-                    const elm = createElement(`${testName}-simple`, { is: Simple });
-                    document.body.appendChild(elm);
+        },
+    ];
+    scenarios.forEach(({ testName, components }) => {
+        describe(testName, () => {
+            const { Simple, StaleProp, UsesStaticStylesheets } = components;
+            it('should work with components with implicit style definition', async () => {
+                const { blockStyle, inlineStyle, noneStyle } = Simple;
+                const elm = createElement(`${testName}-simple`, { is: Simple });
+                document.body.appendChild(elm);
 
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'block',
-                    });
-                    swapStyle(blockStyle[0], inlineStyle[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'inline',
-                    });
-                    swapStyle(inlineStyle[0], noneStyle[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'none',
-                    });
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
                 });
+                swapStyle(blockStyle[0], inlineStyle[0]);
 
-                it('should remove stale prop', async () => {
-                    const { stylesV1, stylesV2, stylesV3 } = StaleProp;
-                    const elm = createElement(`${testName}-stale-prop`, { is: StaleProp });
-                    document.body.appendChild(elm);
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'inline',
+                });
+                swapStyle(inlineStyle[0], noneStyle[0]);
 
-                    await Promise.resolve();
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'none',
+                });
+            });
+
+            it('should remove stale prop', async () => {
+                const { stylesV1, stylesV2, stylesV3 } = StaleProp;
+                const elm = createElement(`${testName}-stale-prop`, { is: StaleProp });
+                document.body.appendChild(elm);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'flex',
+                    opacity: '1',
+                    borderRadius: '0px',
+                });
+                swapStyle(stylesV1[0], stylesV2[0]);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
+                    opacity: '0.5',
+                    borderRadius: '0px',
+                });
+                swapStyle(stylesV2[0], stylesV3[0]);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
+                    opacity: '1',
+                    borderRadius: '5px',
+                });
+            });
+
+            it('should remove stale prop while swapping back and forth', async () => {
+                const { stylesV1, stylesV2 } = StaleProp;
+                const elm = createElement(`${testName}-stale-prop`, { is: StaleProp });
+                document.body.appendChild(elm);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'flex',
+                    opacity: '1',
+                });
+                swapStyle(stylesV1[0], stylesV2[0]);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
+                    opacity: '0.5',
+                });
+                swapStyle(stylesV2[0], stylesV1[0]);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'flex',
+                    opacity: '1',
+                });
+            });
+
+            it('should replace the same stylesheet in multiple components', async () => {
+                const { stylesV1, stylesV2 } = StaleProp;
+                const elm1 = createElement(`${testName}-stale-prop`, { is: StaleProp });
+                const elm2 = createElement(`${testName}-stale-prop`, { is: StaleProp });
+                document.body.appendChild(elm1);
+                document.body.appendChild(elm2);
+
+                await Promise.resolve();
+                for (const elm of [elm1, elm2]) {
                     expectStyles(extractDataIds(elm).paragraph, {
                         display: 'flex',
                         opacity: '1',
-                        borderRadius: '0px',
                     });
-                    swapStyle(stylesV1[0], stylesV2[0]);
+                }
+                swapStyle(stylesV1[0], stylesV2[0]);
 
-                    await Promise.resolve();
+                await Promise.resolve();
+                for (const elm of [elm1, elm2]) {
                     expectStyles(extractDataIds(elm).paragraph, {
                         display: 'block',
                         opacity: '0.5',
-                        borderRadius: '0px',
                     });
-                    swapStyle(stylesV2[0], stylesV3[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'block',
-                        opacity: '1',
-                        borderRadius: '5px',
-                    });
-                });
-
-                it('should remove stale prop while swapping back and forth', async () => {
-                    const { stylesV1, stylesV2 } = StaleProp;
-                    const elm = createElement(`${testName}-stale-prop`, { is: StaleProp });
-                    document.body.appendChild(elm);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'flex',
-                        opacity: '1',
-                    });
-                    swapStyle(stylesV1[0], stylesV2[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'block',
-                        opacity: '0.5',
-                    });
-                    swapStyle(stylesV2[0], stylesV1[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'flex',
-                        opacity: '1',
-                    });
-                });
-
-                it('should replace the same stylesheet in multiple components', async () => {
-                    const { stylesV1, stylesV2 } = StaleProp;
-                    const elm1 = createElement(`${testName}-stale-prop`, { is: StaleProp });
-                    const elm2 = createElement(`${testName}-stale-prop`, { is: StaleProp });
-                    document.body.appendChild(elm1);
-                    document.body.appendChild(elm2);
-
-                    await Promise.resolve();
-                    for (const elm of [elm1, elm2]) {
-                        expectStyles(extractDataIds(elm).paragraph, {
-                            display: 'flex',
-                            opacity: '1',
-                        });
-                    }
-                    swapStyle(stylesV1[0], stylesV2[0]);
-
-                    await Promise.resolve();
-                    for (const elm of [elm1, elm2]) {
-                        expectStyles(extractDataIds(elm).paragraph, {
-                            display: 'block',
-                            opacity: '0.5',
-                        });
-                    }
-                });
-
-                it('should replace static stylesheets', async () => {
-                    const { asStatic, asStaticV2 } = UsesStaticStylesheets;
-                    const elm = createElement(`${testName}-uses-static-stylesheets`, {
-                        is: UsesStaticStylesheets,
-                    });
-                    document.body.appendChild(elm);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        color: 'rgba(255, 0, 0, 0)',
-                        fontStyle: 'italic',
-                    });
-
-                    swapStyle(asStatic[0], asStaticV2[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        color: 'rgba(0, 0, 255, 0)',
-                        fontStyle: 'italic',
-                    });
-                });
-
-                it('should be able to swap a style that will be used in future', async () => {
-                    const { blockStyle, inlineStyle, noneStyle } = Simple;
-                    const elm = createElement(`${testName}-simple`, { is: Simple });
-                    document.body.appendChild(elm);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'block',
-                    });
-                    // Swap inlineStyle that hasn't been rendered yet
-                    swapStyle(inlineStyle[0], noneStyle[0]);
-
-                    await Promise.resolve();
-                    // Verify that rendered content did not change
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'block',
-                    });
-                    // Swap blockStyle to inlineStyle, which will transitively be swapped to noneStyle
-                    swapStyle(blockStyle[0], inlineStyle[0]);
-
-                    await Promise.resolve();
-                    expectStyles(extractDataIds(elm).paragraph, {
-                        display: 'none',
-                    });
-                });
-            });
-        });
-
-        it('should be able to swap stylesheets that produce identical content', async () => {
-            const { style, identicalStyle, newStyle, implicitTemplate, newTemplate } =
-                IdenticalStylesheets;
-            const elm = createElement(`identical-stylesheets`, {
-                is: IdenticalStylesheetsContainer,
-            });
-            document.body.appendChild(elm);
-
-            // Step 1: wait for first render
-            // implicitTemplate is associated with identicalStyle
-            await Promise.resolve();
-            expectStyles(extractDataIds(elm).paragraph, {
-                display: 'inline',
+                }
             });
 
-            // Step 2: swap template with a new template to trigger rehydration
-            swapTemplate(implicitTemplate, newTemplate);
-            await Promise.resolve();
-
-            // Step 3: Associate an identical stylesheet with the same template(or a template with the same shadow token)
-            // associate identical stylesheet with the original template
-            expect(() => {
-                implicitTemplate.stylesheets = style;
-            }).toLogWarningDev(/Mutating the "stylesheets" property on a template/);
-            // reswap the template to implicit template
-            swapTemplate(newTemplate, implicitTemplate);
-            await Promise.resolve();
-
-            // Act to trigger the unrender of the identical stylesheets
-            swapStyle(style[0], newStyle[0]);
-            swapStyle(identicalStyle[0], newStyle[0]);
-            await Promise.resolve();
-
-            // Assert that the swap is successful
-            expectStyles(extractDataIds(elm).paragraph, {
-                display: 'none',
-            });
-        });
-
-        describe('CSS library', () => {
-            const { style: styleA, styleV2: styleAV2 } = LibraryUserA;
-            const { style: styleB, styleV2: styleBV2 } = LibraryUserB;
-
-            let elmA;
-            let elmB;
-
-            beforeEach(async () => {
-                elmA = createElement('x-library-user-a', { is: LibraryUserA });
-                elmB = createElement(`x-library-user-b`, { is: LibraryUserB });
-                document.body.appendChild(elmA);
-                document.body.appendChild(elmB);
+            it('should replace static stylesheets', async () => {
+                const { asStatic, asStaticV2 } = UsesStaticStylesheets;
+                const elm = createElement(`${testName}-uses-static-stylesheets`, {
+                    is: UsesStaticStylesheets,
+                });
+                document.body.appendChild(elm);
 
                 await Promise.resolve();
-                expectStyles(extractDataIds(elmA).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '100',
+                expectStyles(extractDataIds(elm).paragraph, {
+                    color: 'rgba(255, 0, 0, 0)',
+                    fontStyle: 'italic',
                 });
-                expectStyles(extractDataIds(elmB).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '800',
+
+                swapStyle(asStatic[0], asStaticV2[0]);
+
+                await Promise.resolve();
+                expectStyles(extractDataIds(elm).paragraph, {
+                    color: 'rgba(0, 0, 255, 0)',
+                    fontStyle: 'italic',
                 });
             });
 
-            it('swaps a library CSS file', async () => {
-                swapStyle(libraryStyle[0], libraryStyleV2[0]);
+            it('should be able to swap a style that will be used in future', async () => {
+                const { blockStyle, inlineStyle, noneStyle } = Simple;
+                const elm = createElement(`${testName}-simple`, { is: Simple });
+                document.body.appendChild(elm);
 
                 await Promise.resolve();
-                expectStyles(extractDataIds(elmA).paragraph, {
-                    fontSize: '20px',
-                    fontWeight: '100',
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
                 });
-                expectStyles(extractDataIds(elmB).paragraph, {
-                    fontSize: '20px',
-                    fontWeight: '800',
-                });
-            });
-
-            it('swaps a non-library CSS file while keeping library styles', async () => {
-                // The library (`@import`) is the first stylesheet, so grab the second instead
-                swapStyle(styleA[1], styleAV2[1]);
+                // Swap inlineStyle that hasn't been rendered yet
+                swapStyle(inlineStyle[0], noneStyle[0]);
 
                 await Promise.resolve();
-                expectStyles(extractDataIds(elmA).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '200',
+                // Verify that rendered content did not change
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'block',
                 });
-                expectStyles(extractDataIds(elmB).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '800',
-                });
-
-                // The library (`@import`) is the first stylesheet, so grab the second instead
-                swapStyle(styleB[1], styleBV2[1]);
+                // Swap blockStyle to inlineStyle, which will transitively be swapped to noneStyle
+                swapStyle(blockStyle[0], inlineStyle[0]);
 
                 await Promise.resolve();
-                expectStyles(extractDataIds(elmA).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '200',
-                });
-                expectStyles(extractDataIds(elmB).paragraph, {
-                    fontSize: '10px',
-                    fontWeight: '900',
+                expectStyles(extractDataIds(elm).paragraph, {
+                    display: 'none',
                 });
             });
         });
     });
-}
+
+    it('should be able to swap stylesheets that produce identical content', async () => {
+        const { style, identicalStyle, newStyle, implicitTemplate, newTemplate } =
+            IdenticalStylesheets;
+        const elm = createElement(`identical-stylesheets`, {
+            is: IdenticalStylesheetsContainer,
+        });
+        document.body.appendChild(elm);
+
+        // Step 1: wait for first render
+        // implicitTemplate is associated with identicalStyle
+        await Promise.resolve();
+        expectStyles(extractDataIds(elm).paragraph, {
+            display: 'inline',
+        });
+
+        // Step 2: swap template with a new template to trigger rehydration
+        swapTemplate(implicitTemplate, newTemplate);
+        await Promise.resolve();
+
+        // Step 3: Associate an identical stylesheet with the same template(or a template with the same shadow token)
+        // associate identical stylesheet with the original template
+        expect(() => {
+            implicitTemplate.stylesheets = style;
+        }).toLogWarningDev(/Mutating the "stylesheets" property on a template/);
+        // reswap the template to implicit template
+        swapTemplate(newTemplate, implicitTemplate);
+        await Promise.resolve();
+
+        // Act to trigger the unrender of the identical stylesheets
+        swapStyle(style[0], newStyle[0]);
+        swapStyle(identicalStyle[0], newStyle[0]);
+        await Promise.resolve();
+
+        // Assert that the swap is successful
+        expectStyles(extractDataIds(elm).paragraph, {
+            display: 'none',
+        });
+    });
+
+    describe('CSS library', () => {
+        const { style: styleA, styleV2: styleAV2 } = LibraryUserA;
+        const { style: styleB, styleV2: styleBV2 } = LibraryUserB;
+
+        let elmA;
+        let elmB;
+
+        beforeEach(async () => {
+            elmA = createElement('x-library-user-a', { is: LibraryUserA });
+            elmB = createElement(`x-library-user-b`, { is: LibraryUserB });
+            document.body.appendChild(elmA);
+            document.body.appendChild(elmB);
+
+            await Promise.resolve();
+            expectStyles(extractDataIds(elmA).paragraph, {
+                fontSize: '10px',
+                fontWeight: '100',
+            });
+            expectStyles(extractDataIds(elmB).paragraph, {
+                fontSize: '10px',
+                fontWeight: '800',
+            });
+        });
+
+        it('swaps a library CSS file', async () => {
+            swapStyle(libraryStyle[0], libraryStyleV2[0]);
+
+            await Promise.resolve();
+            expectStyles(extractDataIds(elmA).paragraph, {
+                fontSize: '20px',
+                fontWeight: '100',
+            });
+            expectStyles(extractDataIds(elmB).paragraph, {
+                fontSize: '20px',
+                fontWeight: '800',
+            });
+        });
+
+        it('swaps a non-library CSS file while keeping library styles', async () => {
+            // The library (`@import`) is the first stylesheet, so grab the second instead
+            swapStyle(styleA[1], styleAV2[1]);
+
+            await Promise.resolve();
+            expectStyles(extractDataIds(elmA).paragraph, {
+                fontSize: '10px',
+                fontWeight: '200',
+            });
+            expectStyles(extractDataIds(elmB).paragraph, {
+                fontSize: '10px',
+                fontWeight: '800',
+            });
+
+            // The library (`@import`) is the first stylesheet, so grab the second instead
+            swapStyle(styleB[1], styleBV2[1]);
+
+            await Promise.resolve();
+            expectStyles(extractDataIds(elmA).paragraph, {
+                fontSize: '10px',
+                fontWeight: '200',
+            });
+            expectStyles(extractDataIds(elmB).paragraph, {
+                fontSize: '10px',
+                fontWeight: '900',
+            });
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/styles/index.spec.js
@@ -24,7 +24,7 @@ function expectStyles(elm, styles) {
 }
 
 // Swapping is only enabled in dev mode
-describe.runIf(process.env.NODE_ENV !== 'production')('style swapping', () => {
+describe.skipIf(process.env.NODE_ENV === 'production')('style swapping', () => {
     afterEach(() => {
         window.__lwcResetHotSwaps();
         window.__lwcResetStylesheetCache();

--- a/packages/@lwc/integration-karma/test/swapping/templates/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/templates/index.spec.js
@@ -8,45 +8,41 @@ const simpleBaseTemplate = Simple.baseTemplate;
 const advancedBaseTemplate = Advanced.baseTemplate;
 
 // Swapping is only enabled in dev mode
-if (process.env.NODE_ENV !== 'production') {
-    describe('template swapping', () => {
-        it('should work with components with implicit template definition', () => {
-            const elm = createElement('x-simple', { is: Simple });
-            document.body.appendChild(elm);
-            expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="simple">simple</p>');
-            swapTemplate(simpleBaseTemplate, first);
-            return Promise.resolve()
-                .then(() => {
-                    expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="first">first</p>');
-                    swapTemplate(first, second);
-                })
-                .then(() => {
-                    expect(elm.shadowRoot.firstChild.outerHTML).toBe(
-                        '<p class="second">second</p>'
-                    );
-                });
-        });
-
-        it('should work with components with explict template definition', () => {
-            const elm = createElement('x-advanced', { is: Advanced });
-            document.body.appendChild(elm);
-            expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="advanced">advanced</p>');
-            swapTemplate(advancedBaseTemplate, second);
-            return Promise.resolve().then(() => {
+describe.runIf(process.env.NODE_ENV !== 'production')('template swapping', () => {
+    it('should work with components with implicit template definition', () => {
+        const elm = createElement('x-simple', { is: Simple });
+        document.body.appendChild(elm);
+        expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="simple">simple</p>');
+        swapTemplate(simpleBaseTemplate, first);
+        return Promise.resolve()
+            .then(() => {
+                expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="first">first</p>');
+                swapTemplate(first, second);
+            })
+            .then(() => {
                 expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
             });
-        });
+    });
 
-        it('should throw for invalid old template', () => {
-            expect(() => {
-                swapTemplate(function () {}, second);
-            }).toThrow();
-        });
-
-        it('should throw for invalid new template', () => {
-            expect(() => {
-                swapTemplate(second, function () {});
-            }).toThrow();
+    it('should work with components with explict template definition', () => {
+        const elm = createElement('x-advanced', { is: Advanced });
+        document.body.appendChild(elm);
+        expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="advanced">advanced</p>');
+        swapTemplate(advancedBaseTemplate, second);
+        return Promise.resolve().then(() => {
+            expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
         });
     });
-}
+
+    it('should throw for invalid old template', () => {
+        expect(() => {
+            swapTemplate(function () {}, second);
+        }).toThrow();
+    });
+
+    it('should throw for invalid new template', () => {
+        expect(() => {
+            swapTemplate(second, function () {});
+        }).toThrow();
+    });
+});

--- a/packages/@lwc/integration-karma/test/swapping/templates/index.spec.js
+++ b/packages/@lwc/integration-karma/test/swapping/templates/index.spec.js
@@ -8,7 +8,7 @@ const simpleBaseTemplate = Simple.baseTemplate;
 const advancedBaseTemplate = Advanced.baseTemplate;
 
 // Swapping is only enabled in dev mode
-describe.runIf(process.env.NODE_ENV !== 'production')('template swapping', () => {
+describe.skipIf(process.env.NODE_ENV === 'production')('template swapping', () => {
     it('should work with components with implicit template definition', () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/active-element/index.spec.js
@@ -2,33 +2,31 @@ import { createElement } from 'lwc';
 import Source from 'x/source';
 import Target from 'x/target';
 
-if (!process.env.NATIVE_SHADOW) {
-    describe('activeElement', () => {
-        it('can call shadowRoot.activeElement on transported node with no lwc:dom=manual', async () => {
-            const source = createElement('x-source', { is: Source });
-            const target = createElement('x-target', { is: Target });
-            document.body.appendChild(source);
-            document.body.appendChild(target);
-            await Promise.resolve();
+describe.skipIf(process.env.NATIVE_SHADOW)('activeElement', () => {
+    it('can call shadowRoot.activeElement on transported node with no lwc:dom=manual', async () => {
+        const source = createElement('x-source', { is: Source });
+        const target = createElement('x-target', { is: Target });
+        document.body.appendChild(source);
+        document.body.appendChild(target);
+        await Promise.resolve();
 
-            const button = source.shadowRoot.querySelector('button');
+        const button = source.shadowRoot.querySelector('button');
 
-            // append directly to the element, not to some <div lwc:dom=manual> inside of it as recommended
-            target.appendChild(button);
+        // append directly to the element, not to some <div lwc:dom=manual> inside of it as recommended
+        target.appendChild(button);
 
-            // make active
-            button.focus();
+        // make active
+        button.focus();
 
-            let activeElement;
+        let activeElement;
 
-            expect(() => {
-                activeElement = target.shadowRoot.activeElement;
-            }).toLogErrorDev(
-                /NodeOwnedBy\(\) should never be called with a node that is not a child node of/
-            );
+        expect(() => {
+            activeElement = target.shadowRoot.activeElement;
+        }).toLogErrorDev(
+            /NodeOwnedBy\(\) should never be called with a node that is not a child node of/
+        );
 
-            // synthetic shadow gets this wrong when lwc:dom=manual is not used, so just assert that it exists
-            expect(activeElement).not.toBeNull();
-        });
+        // synthetic shadow gets this wrong when lwc:dom=manual is not used, so just assert that it exists
+        expect(activeElement).not.toBeNull();
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/disable-synthetic-shadow/index.spec.js
@@ -2,8 +2,9 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 import { IS_SYNTHETIC_SHADOW_LOADED, isSyntheticShadowRootInstance } from 'test-utils';
 import Component from 'x/component';
 
-if (IS_SYNTHETIC_SHADOW_LOADED && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST) {
-    describe('DISABLE_SYNTHETIC_SHADOW', () => {
+describe.runIf(IS_SYNTHETIC_SHADOW_LOADED && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST)(
+    'DISABLE_SYNTHETIC_SHADOW',
+    () => {
         describe('flag disabled', () => {
             it('renders synthetic shadow', () => {
                 const elm = createElement('x-component', { is: Component });
@@ -27,5 +28,5 @@ if (IS_SYNTHETIC_SHADOW_LOADED && !process.env.FORCE_NATIVE_SHADOW_MODE_FOR_TEST
                 expect(isSyntheticShadowRootInstance(elm.shadowRoot)).toBe(false);
             });
         });
-    });
-}
+    }
+);

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/element-api/element-api.spec.js
@@ -37,368 +37,363 @@ import ParentSpecialized from 'x/parentSpecialized';
      </x-container>
  </div>
  */
-if (!process.env.NATIVE_SHADOW) {
-    describe('synthetic shadow with patch flags OFF', () => {
-        let lwcElementInsideShadow,
-            divManuallyApendedToShadow,
-            elementInShadow,
-            slottedComponent,
-            slottedNode,
-            elementOutsideLWC,
-            rootLwcElement,
-            cmpShadow;
-        beforeEach(() => {
-            spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual"
-            const elm = createElement('x-container', { is: Container });
+describe.skipIf(process.env.NATIVE_SHADOW)('synthetic shadow with patch flags OFF', () => {
+    let lwcElementInsideShadow,
+        divManuallyApendedToShadow,
+        elementInShadow,
+        slottedComponent,
+        slottedNode,
+        elementOutsideLWC,
+        rootLwcElement,
+        cmpShadow;
+    beforeEach(() => {
+        spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual"
+        const elm = createElement('x-container', { is: Container });
 
-            elementOutsideLWC = document.createElement('div');
-            elementOutsideLWC.appendChild(elm);
+        elementOutsideLWC = document.createElement('div');
+        elementOutsideLWC.appendChild(elm);
 
-            document.body.appendChild(elementOutsideLWC);
+        document.body.appendChild(elementOutsideLWC);
 
-            rootLwcElement = elm;
-            lwcElementInsideShadow = elm;
-            divManuallyApendedToShadow = elm.shadowRoot.querySelector('div.manual-ctx');
-            cmpShadow = elm.shadowRoot.querySelector('x-slot-container').shadowRoot;
-            elementInShadow = rootLwcElement.shadowRoot.querySelector('div');
-            slottedComponent = cmpShadow.querySelector('x-with-slot');
-            slottedNode = cmpShadow.querySelector('.slotted');
+        rootLwcElement = elm;
+        lwcElementInsideShadow = elm;
+        divManuallyApendedToShadow = elm.shadowRoot.querySelector('div.manual-ctx');
+        cmpShadow = elm.shadowRoot.querySelector('x-slot-container').shadowRoot;
+        elementInShadow = rootLwcElement.shadowRoot.querySelector('div');
+        slottedComponent = cmpShadow.querySelector('x-with-slot');
+        slottedNode = cmpShadow.querySelector('.slotted');
+    });
+
+    describe('Element.prototype API', () => {
+        it('should keep behavior for innerHTML', () => {
+            expect(elementOutsideLWC.innerHTML.length).toBe(455);
+            expect(rootLwcElement.innerHTML.length).toBe(0);
+            expect(lwcElementInsideShadow.innerHTML.length).toBe(0);
+
+            expect(divManuallyApendedToShadow.innerHTML.length).toBe(176); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
+
+            expect(cmpShadow.innerHTML.length).toBe(99);
+
+            expect(slottedComponent.innerHTML.length).toBe(46);
+            expect(slottedNode.innerHTML.length).toBe(19);
         });
 
-        describe('Element.prototype API', () => {
-            it('should keep behavior for innerHTML', () => {
-                expect(elementOutsideLWC.innerHTML.length).toBe(455);
-                expect(rootLwcElement.innerHTML.length).toBe(0);
-                expect(lwcElementInsideShadow.innerHTML.length).toBe(0);
+        it('should keep behavior for outerHTML', () => {
+            expect(elementOutsideLWC.outerHTML.length).toBe(466);
+            expect(rootLwcElement.outerHTML.length).toBe(27);
+            expect(lwcElementInsideShadow.outerHTML.length).toBe(27);
 
-                expect(divManuallyApendedToShadow.innerHTML.length).toBe(176); // <x-manually-inserted><p>slot-container text</p><x-with-slot><p>with
+            expect(divManuallyApendedToShadow.outerHTML.length).toBe(206); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
 
-                expect(cmpShadow.innerHTML.length).toBe(99);
+            expect(cmpShadow.outerHTML).toBe(undefined);
 
-                expect(slottedComponent.innerHTML.length).toBe(46);
-                expect(slottedNode.innerHTML.length).toBe(19);
-            });
+            expect(slottedComponent.outerHTML.length).toBe(73);
+            expect(slottedNode.outerHTML.length).toBe(46);
+        });
 
-            it('should keep behavior for outerHTML', () => {
-                expect(elementOutsideLWC.outerHTML.length).toBe(466);
-                expect(rootLwcElement.outerHTML.length).toBe(27);
-                expect(lwcElementInsideShadow.outerHTML.length).toBe(27);
+        it('should keep behavior for children', () => {
+            expect(elementOutsideLWC.children.length).toBe(1);
+            expect(rootLwcElement.children.length).toBe(0);
+            expect(lwcElementInsideShadow.children.length).toBe(0);
 
-                expect(divManuallyApendedToShadow.outerHTML.length).toBe(206); // <div class="manual-ctx"><x-manually-inserted><p>slot-container text</p><x-with-slot><p>wi ....
+            expect(divManuallyApendedToShadow.children.length).toBe(1);
 
-                expect(cmpShadow.outerHTML).toBe(undefined);
+            expect(cmpShadow.children.length).toBe(2);
 
-                expect(slottedComponent.outerHTML.length).toBe(73);
-                expect(slottedNode.outerHTML.length).toBe(46);
-            });
+            expect(slottedComponent.children.length).toBe(1);
+            expect(slottedNode.children.length).toBe(1);
+        });
 
-            it('should keep behavior for children', () => {
-                expect(elementOutsideLWC.children.length).toBe(1);
-                expect(rootLwcElement.children.length).toBe(0);
-                expect(lwcElementInsideShadow.children.length).toBe(0);
+        it('should keep behavior for firstElementChild', () => {
+            expect(elementOutsideLWC.firstElementChild.tagName).toBe('X-CONTAINER');
+            expect(rootLwcElement.firstElementChild).toBe(null);
+            expect(lwcElementInsideShadow.firstElementChild).toBe(null);
 
-                expect(divManuallyApendedToShadow.children.length).toBe(1);
+            expect(divManuallyApendedToShadow.firstElementChild.tagName).toBe(
+                'X-MANUALLY-INSERTED'
+            );
 
-                expect(cmpShadow.children.length).toBe(2);
+            expect(cmpShadow.firstElementChild.tagName).toBe('P');
 
-                expect(slottedComponent.children.length).toBe(1);
-                expect(slottedNode.children.length).toBe(1);
-            });
+            expect(slottedComponent.firstElementChild.tagName).toBe('DIV');
+            expect(slottedNode.firstElementChild.tagName).toBe('P');
+        });
 
-            it('should keep behavior for firstElementChild', () => {
-                expect(elementOutsideLWC.firstElementChild.tagName).toBe('X-CONTAINER');
-                expect(rootLwcElement.firstElementChild).toBe(null);
-                expect(lwcElementInsideShadow.firstElementChild).toBe(null);
+        it('should keep behavior for lastElementChild', () => {
+            expect(elementOutsideLWC.lastElementChild.tagName).toBe('X-CONTAINER');
+            expect(rootLwcElement.lastElementChild).toBe(null);
+            expect(lwcElementInsideShadow.lastElementChild).toBe(null);
 
-                expect(divManuallyApendedToShadow.firstElementChild.tagName).toBe(
-                    'X-MANUALLY-INSERTED'
+            expect(divManuallyApendedToShadow.lastElementChild.tagName).toBe('X-MANUALLY-INSERTED');
+
+            expect(cmpShadow.lastElementChild.tagName).toBe('X-WITH-SLOT');
+
+            expect(slottedComponent.lastElementChild.tagName).toBe('DIV');
+            expect(slottedNode.lastElementChild.tagName).toBe('P');
+        });
+
+        describe('querySelector', () => {
+            it('should preserve element outside lwc boundary behavior', () => {
+                expect(elementOutsideLWC.querySelector('p').innerText).toBe('ctx first text');
+                expect(elementOutsideLWC.querySelector('x-with-slot p').innerText).toBe(
+                    'with-slot text'
                 );
-
-                expect(cmpShadow.firstElementChild.tagName).toBe('P');
-
-                expect(slottedComponent.firstElementChild.tagName).toBe('DIV');
-                expect(slottedNode.firstElementChild.tagName).toBe('P');
-            });
-
-            it('should keep behavior for lastElementChild', () => {
-                expect(elementOutsideLWC.lastElementChild.tagName).toBe('X-CONTAINER');
-                expect(rootLwcElement.lastElementChild).toBe(null);
-                expect(lwcElementInsideShadow.lastElementChild).toBe(null);
-
-                expect(divManuallyApendedToShadow.lastElementChild.tagName).toBe(
-                    'X-MANUALLY-INSERTED'
+                expect(elementOutsideLWC.querySelector('.manual-ctx x-with-slot p').innerText).toBe(
+                    'with-slot text'
                 );
-
-                expect(cmpShadow.lastElementChild.tagName).toBe('X-WITH-SLOT');
-
-                expect(slottedComponent.lastElementChild.tagName).toBe('DIV');
-                expect(slottedNode.lastElementChild.tagName).toBe('P');
+                expect(elementOutsideLWC.querySelector('div.slotted')).not.toBe(null);
             });
 
-            describe('querySelector', () => {
-                it('should preserve element outside lwc boundary behavior', () => {
-                    expect(elementOutsideLWC.querySelector('p').innerText).toBe('ctx first text');
-                    expect(elementOutsideLWC.querySelector('x-with-slot p').innerText).toBe(
-                        'with-slot text'
-                    );
-                    expect(
-                        elementOutsideLWC.querySelector('.manual-ctx x-with-slot p').innerText
-                    ).toBe('with-slot text');
-                    expect(elementOutsideLWC.querySelector('div.slotted')).not.toBe(null);
-                });
-
-                it('should preserve root custom element behavior', () => {
-                    expect(rootLwcElement.querySelector('p')).toBe(null);
-                    expect(rootLwcElement.querySelector('x-with-slot p')).toBe(null);
-                    expect(rootLwcElement.querySelector('.manual-ctx x-with-slot p')).toBe(null);
-                });
-
-                it('should preserve behavior for element inside shadow', () => {
-                    const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
-
-                    expect(elemInShadow.querySelector('x-slot-container')).not.toBe(null);
-                    expect(elemInShadow.querySelector('x-with-slot p')).toBe(null);
-                });
-
-                it('should preserve behavior for shadowRoot', () => {
-                    expect(cmpShadow.querySelector('p').innerText).toBe('slot-container text');
-                    expect(cmpShadow.querySelector('x-with-slot p').innerText).toBe('slotted text'); // skipped the one in the shadow of x-with-slot.
-                });
-
-                it('should preserve behavior for manually inserted element in shadow and with lwc components', () => {
-                    expect(divManuallyApendedToShadow.querySelector('p').innerText).toBe(
-                        'slot-container text'
-                    );
-                    expect(
-                        divManuallyApendedToShadow.querySelector('x-with-slot p').innerText
-                    ).toBe('with-slot text');
-                    expect(divManuallyApendedToShadow.querySelector('div.slotted')).not.toBe(null);
-                });
+            it('should preserve root custom element behavior', () => {
+                expect(rootLwcElement.querySelector('p')).toBe(null);
+                expect(rootLwcElement.querySelector('x-with-slot p')).toBe(null);
+                expect(rootLwcElement.querySelector('.manual-ctx x-with-slot p')).toBe(null);
             });
 
-            it('should preserve behavior for querySelectorAll', () => {
-                expect(elementOutsideLWC.querySelectorAll('p').length).toBe(8);
-                expect(rootLwcElement.querySelectorAll('p').length).toBe(0);
-
+            it('should preserve behavior for element inside shadow', () => {
                 const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
 
-                // everything is inside a shadow, :+1:
-                expect(elemInShadow.querySelectorAll('p').length).toBe(0);
-
-                expect(cmpShadow.querySelectorAll('p').length).toBe(2); // slotted elements
-                expect(slottedComponent.querySelectorAll('p').length).toBe(1);
-                expect(divManuallyApendedToShadow.querySelectorAll('p').length).toBe(3);
+                expect(elemInShadow.querySelector('x-slot-container')).not.toBe(null);
+                expect(elemInShadow.querySelector('x-with-slot p')).toBe(null);
             });
 
-            it('should preserve behavior for getElementsByTagName', () => {
-                expect(elementOutsideLWC.getElementsByTagName('p').length).toBe(8);
-                // This is an exception: not patching root lwc elements
-                expect(rootLwcElement.getElementsByTagName('p').length).toBe(8);
-
-                // f, same, restricting this.
-                // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
-                // expect(elemInShadow.getElementsByTagName('p').length).toBe(6);
-
-                // getElementsByTagName is not supported in the shadowRoot
-                // expect(cmpShadow.getElementsByTagName('p').length).toBe(2);
-
-                // f: restricting, you should only get 1, that is inside the slot
-                // expect(slottedComponent.getElementsByTagName('p').length).toBe(2);
-                expect(slottedComponent.getElementsByTagName('p').length).toBe(1);
-
-                expect(divManuallyApendedToShadow.getElementsByTagName('p').length).toBe(3);
+            it('should preserve behavior for shadowRoot', () => {
+                expect(cmpShadow.querySelector('p').innerText).toBe('slot-container text');
+                expect(cmpShadow.querySelector('x-with-slot p').innerText).toBe('slotted text'); // skipped the one in the shadow of x-with-slot.
             });
 
-            it('should preserve behavior for getElementsByClassName', () => {
-                expect(elementOutsideLWC.getElementsByClassName('slotted').length).toBe(2);
-                // This is an exception: not patching root lwc elements
-                expect(rootLwcElement.getElementsByClassName('slotted').length).toBe(2);
-
-                // f: inside shadow
-                // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
-                // expect(elemInShadow.getElementsByClassName('slotted').length).toBe(2);
-
-                // getElementsByTagName is not supported in the shadowRoot
-                // expect(cmpShadow.getElementsByTagName('p').length).toBe(2);
-
-                expect(slottedComponent.getElementsByClassName('slotted').length).toBe(1);
-
-                expect(divManuallyApendedToShadow.getElementsByClassName('slotted').length).toBe(1);
+            it('should preserve behavior for manually inserted element in shadow and with lwc components', () => {
+                expect(divManuallyApendedToShadow.querySelector('p').innerText).toBe(
+                    'slot-container text'
+                );
+                expect(divManuallyApendedToShadow.querySelector('x-with-slot p').innerText).toBe(
+                    'with-slot text'
+                );
+                expect(divManuallyApendedToShadow.querySelector('div.slotted')).not.toBe(null);
             });
         });
 
-        describe('Node.prototype API', () => {
-            it('should preserve behaviour for firstChild', () => {
-                expect(elementOutsideLWC.firstChild.tagName).toBe('X-CONTAINER');
-                expect(rootLwcElement.firstChild).toBe(null);
-                expect(lwcElementInsideShadow.firstChild).toBe(null);
+        it('should preserve behavior for querySelectorAll', () => {
+            expect(elementOutsideLWC.querySelectorAll('p').length).toBe(8);
+            expect(rootLwcElement.querySelectorAll('p').length).toBe(0);
 
-                expect(elementInShadow.firstChild.tagName).toBe('X-SLOT-CONTAINER');
-                expect(divManuallyApendedToShadow.firstChild.tagName).toBe('X-MANUALLY-INSERTED');
+            const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
 
-                expect(cmpShadow.firstChild.tagName).toBe('P');
+            // everything is inside a shadow, :+1:
+            expect(elemInShadow.querySelectorAll('p').length).toBe(0);
 
-                expect(slottedComponent.firstChild.tagName).toBe('DIV');
-                expect(slottedNode.firstChild.tagName).toBe('P');
-            });
+            expect(cmpShadow.querySelectorAll('p').length).toBe(2); // slotted elements
+            expect(slottedComponent.querySelectorAll('p').length).toBe(1);
+            expect(divManuallyApendedToShadow.querySelectorAll('p').length).toBe(3);
+        });
 
-            it('should preserve behaviour for lastChild', () => {
-                expect(elementOutsideLWC.lastChild.tagName).toBe('X-CONTAINER');
-                expect(rootLwcElement.lastChild).toBe(null);
-                expect(lwcElementInsideShadow.lastChild).toBe(null);
+        it('should preserve behavior for getElementsByTagName', () => {
+            expect(elementOutsideLWC.getElementsByTagName('p').length).toBe(8);
+            // This is an exception: not patching root lwc elements
+            expect(rootLwcElement.getElementsByTagName('p').length).toBe(8);
 
-                expect(elementInShadow.lastChild.tagName).toBe('DIV');
-                expect(divManuallyApendedToShadow.lastChild.tagName).toBe('X-MANUALLY-INSERTED');
+            // f, same, restricting this.
+            // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
+            // expect(elemInShadow.getElementsByTagName('p').length).toBe(6);
 
-                expect(cmpShadow.lastChild.tagName).toBe('X-WITH-SLOT');
+            // getElementsByTagName is not supported in the shadowRoot
+            // expect(cmpShadow.getElementsByTagName('p').length).toBe(2);
 
-                expect(slottedComponent.lastChild.tagName).toBe('DIV');
-                expect(slottedNode.lastChild.tagName).toBe('P');
-            });
+            // f: restricting, you should only get 1, that is inside the slot
+            // expect(slottedComponent.getElementsByTagName('p').length).toBe(2);
+            expect(slottedComponent.getElementsByTagName('p').length).toBe(1);
 
-            it('should preserve behaviour for textContent', () => {
-                expect(elementOutsideLWC.textContent.length).toBe(117);
-                expect(rootLwcElement.textContent.length).toBe(0);
-                expect(lwcElementInsideShadow.textContent.length).toBe(0);
+            expect(divManuallyApendedToShadow.getElementsByTagName('p').length).toBe(3);
+        });
 
-                expect(elementInShadow.textContent.length).toBe(0);
-                expect(divManuallyApendedToShadow.textContent.length).toBe(45);
+        it('should preserve behavior for getElementsByClassName', () => {
+            expect(elementOutsideLWC.getElementsByClassName('slotted').length).toBe(2);
+            // This is an exception: not patching root lwc elements
+            expect(rootLwcElement.getElementsByClassName('slotted').length).toBe(2);
 
-                expect(cmpShadow.textContent.length).toBe(31);
+            // f: inside shadow
+            // const elemInShadow = rootLwcElement.shadowRoot.querySelector('div');
+            // expect(elemInShadow.getElementsByClassName('slotted').length).toBe(2);
 
-                expect(slottedComponent.textContent.length).toBe(12);
-                expect(slottedNode.textContent.length).toBe(12);
-            });
+            // getElementsByTagName is not supported in the shadowRoot
+            // expect(cmpShadow.getElementsByTagName('p').length).toBe(2);
 
-            it('should preserve behaviour for parentNode', () => {
-                expect(elementOutsideLWC.parentNode.tagName).toBe('BODY');
-                expect(rootLwcElement.parentNode.tagName).toBe('DIV');
-                expect(lwcElementInsideShadow.parentNode.tagName).toBe('DIV');
+            expect(slottedComponent.getElementsByClassName('slotted').length).toBe(1);
 
-                expect(elementInShadow.parentNode).toBe(rootLwcElement.shadowRoot);
-                expect(divManuallyApendedToShadow.parentNode.tagName).toBe('DIV');
-
-                expect(cmpShadow.parentNode).toBe(null);
-
-                const slotContainer = rootLwcElement.shadowRoot.querySelector('x-slot-container');
-                expect(slottedComponent.parentNode).toBe(slotContainer.shadowRoot);
-
-                // Note: check, but this is may be difference with the native shadow
-                expect(slottedNode.parentNode.tagName).toBe('X-WITH-SLOT');
-            });
-
-            it('should preserve parentNode behavior when node was manually inserted', () => {
-                // this is a specialized test only for parentNode and parentElement
-                const lwcElem = createElement('x-parent-specialized', { is: ParentSpecialized });
-                const containingElement = document.createElement('div');
-                containingElement.appendChild(lwcElem);
-                document.body.appendChild(containingElement);
-
-                const lwcRenderedNode = lwcElem.shadowRoot.querySelector('.lwc-rendered');
-                const manualRenderedNode = lwcElem.shadowRoot.querySelector('.manual-rendered');
-
-                expect(lwcRenderedNode.parentNode).toBe(lwcElem.shadowRoot);
-                // is returning the custom element instead of the shadow root
-                expect(manualRenderedNode.parentNode).toBe(lwcElem);
-            });
-
-            it('should preserve behaviour for parentElement', () => {
-                expect(elementOutsideLWC.parentElement.tagName).toBe('BODY');
-                expect(rootLwcElement.parentElement.tagName).toBe('DIV');
-                expect(lwcElementInsideShadow.parentElement.tagName).toBe('DIV');
-
-                expect(elementInShadow.parentElement).toBe(null);
-                expect(divManuallyApendedToShadow.parentElement.tagName).toBe('DIV');
-
-                expect(cmpShadow.parentElement).toBe(null);
-
-                expect(slottedComponent.parentElement).toBe(null);
-
-                // Note: check, but this is may be difference with the native shadow
-                expect(slottedNode.parentElement.tagName).toBe('X-WITH-SLOT');
-            });
-
-            it('should preserve parentElement behavior when node was manually inserted', () => {
-                // this is a specialized test only for parentNode and parentElement
-                const lwcElem = createElement('x-parent-specialized', { is: ParentSpecialized });
-                const containingElement = document.createElement('div');
-                containingElement.appendChild(lwcElem);
-                document.body.appendChild(containingElement);
-
-                const lwcRenderedNode = lwcElem.shadowRoot.querySelector('.lwc-rendered');
-                const manualRenderedNode = lwcElem.shadowRoot.querySelector('.manual-rendered');
-
-                expect(lwcRenderedNode.parentElement).toBe(null);
-                // is returning the custom element instead of the shadow root
-                expect(manualRenderedNode.parentElement).toBe(lwcElem);
-            });
-
-            it('should preserve childNodes behavior', () => {
-                expect(elementOutsideLWC.childNodes.length).toBe(1);
-
-                expect(rootLwcElement.childNodes.length).toBe(0);
-                expect(lwcElementInsideShadow.childNodes.length).toBe(0);
-                expect(slottedComponent.childNodes.length).toBe(1);
-
-                expect(divManuallyApendedToShadow.childNodes.length).toBe(1);
-
-                expect(cmpShadow.childNodes.length).toBe(2);
-
-                expect(slottedNode.childNodes.length).toBe(1);
-            });
-
-            it('should preserve hasChildNodes behavior', () => {
-                expect(elementOutsideLWC.hasChildNodes()).toBe(true);
-                expect(rootLwcElement.hasChildNodes()).toBe(false);
-                expect(lwcElementInsideShadow.hasChildNodes()).toBe(false);
-
-                expect(divManuallyApendedToShadow.hasChildNodes()).toBe(true);
-
-                expect(cmpShadow.hasChildNodes()).toBe(true);
-
-                expect(slottedComponent.hasChildNodes()).toBe(true);
-                expect(slottedNode.hasChildNodes()).toBe(true);
-            });
-
-            it('should preserve compareDocumentPosition behavior', () => {
-                expect(
-                    elementOutsideLWC.compareDocumentPosition(lwcElementInsideShadow) &
-                        Node.DOCUMENT_POSITION_CONTAINED_BY
-                ).toBeGreaterThan(0);
-
-                expect(
-                    rootLwcElement.compareDocumentPosition(elementOutsideLWC) &
-                        Node.DOCUMENT_POSITION_CONTAINS
-                ).toBeGreaterThan(0);
-                expect(
-                    lwcElementInsideShadow.compareDocumentPosition(divManuallyApendedToShadow) &
-                        Node.DOCUMENT_POSITION_FOLLOWING
-                ).toBeGreaterThan(0);
-
-                expect(
-                    divManuallyApendedToShadow.compareDocumentPosition(elementOutsideLWC) &
-                        Node.DOCUMENT_POSITION_CONTAINS
-                ).toBeGreaterThan(0);
-
-                expect(
-                    cmpShadow.compareDocumentPosition(slottedNode) &
-                        Node.DOCUMENT_POSITION_CONTAINED_BY
-                ).toBeGreaterThan(0);
-            });
-
-            it('should preserve contains behavior', () => {
-                expect(elementOutsideLWC.contains(lwcElementInsideShadow)).toBe(true);
-
-                expect(rootLwcElement.contains(elementOutsideLWC)).toBe(false);
-                expect(lwcElementInsideShadow.contains(divManuallyApendedToShadow)).toBe(true);
-
-                expect(divManuallyApendedToShadow.contains(elementOutsideLWC)).toBe(false);
-
-                expect(cmpShadow.contains(slottedNode)).toBe(true);
-            });
+            expect(divManuallyApendedToShadow.getElementsByClassName('slotted').length).toBe(1);
         });
     });
-}
+
+    describe('Node.prototype API', () => {
+        it('should preserve behaviour for firstChild', () => {
+            expect(elementOutsideLWC.firstChild.tagName).toBe('X-CONTAINER');
+            expect(rootLwcElement.firstChild).toBe(null);
+            expect(lwcElementInsideShadow.firstChild).toBe(null);
+
+            expect(elementInShadow.firstChild.tagName).toBe('X-SLOT-CONTAINER');
+            expect(divManuallyApendedToShadow.firstChild.tagName).toBe('X-MANUALLY-INSERTED');
+
+            expect(cmpShadow.firstChild.tagName).toBe('P');
+
+            expect(slottedComponent.firstChild.tagName).toBe('DIV');
+            expect(slottedNode.firstChild.tagName).toBe('P');
+        });
+
+        it('should preserve behaviour for lastChild', () => {
+            expect(elementOutsideLWC.lastChild.tagName).toBe('X-CONTAINER');
+            expect(rootLwcElement.lastChild).toBe(null);
+            expect(lwcElementInsideShadow.lastChild).toBe(null);
+
+            expect(elementInShadow.lastChild.tagName).toBe('DIV');
+            expect(divManuallyApendedToShadow.lastChild.tagName).toBe('X-MANUALLY-INSERTED');
+
+            expect(cmpShadow.lastChild.tagName).toBe('X-WITH-SLOT');
+
+            expect(slottedComponent.lastChild.tagName).toBe('DIV');
+            expect(slottedNode.lastChild.tagName).toBe('P');
+        });
+
+        it('should preserve behaviour for textContent', () => {
+            expect(elementOutsideLWC.textContent.length).toBe(117);
+            expect(rootLwcElement.textContent.length).toBe(0);
+            expect(lwcElementInsideShadow.textContent.length).toBe(0);
+
+            expect(elementInShadow.textContent.length).toBe(0);
+            expect(divManuallyApendedToShadow.textContent.length).toBe(45);
+
+            expect(cmpShadow.textContent.length).toBe(31);
+
+            expect(slottedComponent.textContent.length).toBe(12);
+            expect(slottedNode.textContent.length).toBe(12);
+        });
+
+        it('should preserve behaviour for parentNode', () => {
+            expect(elementOutsideLWC.parentNode.tagName).toBe('BODY');
+            expect(rootLwcElement.parentNode.tagName).toBe('DIV');
+            expect(lwcElementInsideShadow.parentNode.tagName).toBe('DIV');
+
+            expect(elementInShadow.parentNode).toBe(rootLwcElement.shadowRoot);
+            expect(divManuallyApendedToShadow.parentNode.tagName).toBe('DIV');
+
+            expect(cmpShadow.parentNode).toBe(null);
+
+            const slotContainer = rootLwcElement.shadowRoot.querySelector('x-slot-container');
+            expect(slottedComponent.parentNode).toBe(slotContainer.shadowRoot);
+
+            // Note: check, but this is may be difference with the native shadow
+            expect(slottedNode.parentNode.tagName).toBe('X-WITH-SLOT');
+        });
+
+        it('should preserve parentNode behavior when node was manually inserted', () => {
+            // this is a specialized test only for parentNode and parentElement
+            const lwcElem = createElement('x-parent-specialized', { is: ParentSpecialized });
+            const containingElement = document.createElement('div');
+            containingElement.appendChild(lwcElem);
+            document.body.appendChild(containingElement);
+
+            const lwcRenderedNode = lwcElem.shadowRoot.querySelector('.lwc-rendered');
+            const manualRenderedNode = lwcElem.shadowRoot.querySelector('.manual-rendered');
+
+            expect(lwcRenderedNode.parentNode).toBe(lwcElem.shadowRoot);
+            // is returning the custom element instead of the shadow root
+            expect(manualRenderedNode.parentNode).toBe(lwcElem);
+        });
+
+        it('should preserve behaviour for parentElement', () => {
+            expect(elementOutsideLWC.parentElement.tagName).toBe('BODY');
+            expect(rootLwcElement.parentElement.tagName).toBe('DIV');
+            expect(lwcElementInsideShadow.parentElement.tagName).toBe('DIV');
+
+            expect(elementInShadow.parentElement).toBe(null);
+            expect(divManuallyApendedToShadow.parentElement.tagName).toBe('DIV');
+
+            expect(cmpShadow.parentElement).toBe(null);
+
+            expect(slottedComponent.parentElement).toBe(null);
+
+            // Note: check, but this is may be difference with the native shadow
+            expect(slottedNode.parentElement.tagName).toBe('X-WITH-SLOT');
+        });
+
+        it('should preserve parentElement behavior when node was manually inserted', () => {
+            // this is a specialized test only for parentNode and parentElement
+            const lwcElem = createElement('x-parent-specialized', { is: ParentSpecialized });
+            const containingElement = document.createElement('div');
+            containingElement.appendChild(lwcElem);
+            document.body.appendChild(containingElement);
+
+            const lwcRenderedNode = lwcElem.shadowRoot.querySelector('.lwc-rendered');
+            const manualRenderedNode = lwcElem.shadowRoot.querySelector('.manual-rendered');
+
+            expect(lwcRenderedNode.parentElement).toBe(null);
+            // is returning the custom element instead of the shadow root
+            expect(manualRenderedNode.parentElement).toBe(lwcElem);
+        });
+
+        it('should preserve childNodes behavior', () => {
+            expect(elementOutsideLWC.childNodes.length).toBe(1);
+
+            expect(rootLwcElement.childNodes.length).toBe(0);
+            expect(lwcElementInsideShadow.childNodes.length).toBe(0);
+            expect(slottedComponent.childNodes.length).toBe(1);
+
+            expect(divManuallyApendedToShadow.childNodes.length).toBe(1);
+
+            expect(cmpShadow.childNodes.length).toBe(2);
+
+            expect(slottedNode.childNodes.length).toBe(1);
+        });
+
+        it('should preserve hasChildNodes behavior', () => {
+            expect(elementOutsideLWC.hasChildNodes()).toBe(true);
+            expect(rootLwcElement.hasChildNodes()).toBe(false);
+            expect(lwcElementInsideShadow.hasChildNodes()).toBe(false);
+
+            expect(divManuallyApendedToShadow.hasChildNodes()).toBe(true);
+
+            expect(cmpShadow.hasChildNodes()).toBe(true);
+
+            expect(slottedComponent.hasChildNodes()).toBe(true);
+            expect(slottedNode.hasChildNodes()).toBe(true);
+        });
+
+        it('should preserve compareDocumentPosition behavior', () => {
+            expect(
+                elementOutsideLWC.compareDocumentPosition(lwcElementInsideShadow) &
+                    Node.DOCUMENT_POSITION_CONTAINED_BY
+            ).toBeGreaterThan(0);
+
+            expect(
+                rootLwcElement.compareDocumentPosition(elementOutsideLWC) &
+                    Node.DOCUMENT_POSITION_CONTAINS
+            ).toBeGreaterThan(0);
+            expect(
+                lwcElementInsideShadow.compareDocumentPosition(divManuallyApendedToShadow) &
+                    Node.DOCUMENT_POSITION_FOLLOWING
+            ).toBeGreaterThan(0);
+
+            expect(
+                divManuallyApendedToShadow.compareDocumentPosition(elementOutsideLWC) &
+                    Node.DOCUMENT_POSITION_CONTAINS
+            ).toBeGreaterThan(0);
+
+            expect(
+                cmpShadow.compareDocumentPosition(slottedNode) & Node.DOCUMENT_POSITION_CONTAINED_BY
+            ).toBeGreaterThan(0);
+        });
+
+        it('should preserve contains behavior', () => {
+            expect(elementOutsideLWC.contains(lwcElementInsideShadow)).toBe(true);
+
+            expect(rootLwcElement.contains(elementOutsideLWC)).toBe(false);
+            expect(lwcElementInsideShadow.contains(divManuallyApendedToShadow)).toBe(true);
+
+            expect(divManuallyApendedToShadow.contains(elementOutsideLWC)).toBe(false);
+
+            expect(cmpShadow.contains(slottedNode)).toBe(true);
+        });
+    });
+});
 
 describe('synthetic shadow for mixed mode', () => {
     describe('Element.prototype API', () => {

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/global-styles/index.spec.js
@@ -3,16 +3,15 @@ import Component from 'x/component';
 
 // TODO [#2922]: remove this test when we can support document.adoptedStyleSheets.
 // Currently we can't, due to backwards compat.
-if (!process.env.NATIVE_SHADOW) {
-    describe('global styles', () => {
-        it('injects global styles in document.head in synthetic shadow', () => {
-            const numStyleSheetsBefore = document.styleSheets.length;
-            const elm = createElement('x-component', { is: Component });
-            document.body.appendChild(elm);
-            return Promise.resolve().then(() => {
-                const numStyleSheetsAfter = document.styleSheets.length;
-                expect(numStyleSheetsBefore + 1).toEqual(numStyleSheetsAfter);
-            });
+
+describe.skipIf(process.env.NATIVE_SHADOW)('global styles', () => {
+    it('injects global styles in document.head in synthetic shadow', () => {
+        const numStyleSheetsBefore = document.styleSheets.length;
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+        return Promise.resolve().then(() => {
+            const numStyleSheetsAfter = document.styleSheets.length;
+            expect(numStyleSheetsBefore + 1).toEqual(numStyleSheetsAfter);
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/host-pseudo/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/host-pseudo/index.spec.js
@@ -3,8 +3,8 @@ import Valid from 'x/valid';
 import Invalid from 'x/invalid';
 
 describe('host pseudo', () => {
-    function testComponent(Component, name) {
-        it(`supports :host() pseudo class - ${name}`, async () => {
+    function testComponent(Component, name, test = it) {
+        test(`supports :host() pseudo class - ${name}`, async () => {
             const elm = createElement('x-component', { is: Component });
             document.body.appendChild(elm);
             const div = elm.shadowRoot.querySelector('.quux');
@@ -29,9 +29,7 @@ describe('host pseudo', () => {
     }
 
     // TODO [#3225]: we should  not support selector lists in :host()
-    if (!process.env.NATIVE_SHADOW) {
-        testComponent(Invalid, 'invalid syntax');
-    }
+    testComponent(Invalid, 'invalid syntax', it.skipIf(process.env.NATIVE_SHADOW));
 
     // Here we are using the correct syntax here for :host(), so it should work in both native and synthetic shadow
     // See: https://github.com/salesforce/lwc/issues/3225

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/inner-outer-text/inner-outer-text.spec.js
@@ -6,7 +6,7 @@ import Container from 'x/container';
 // synthetic shadow behavior, which is not necessarily consistent with native shadow behavior.
 // If you're wondering why so many of the tests are doing toMatch() on a regex, it's because of
 // differences in how browsers serialize text using innerText/outerText.
-if (!process.env.NATIVE_SHADOW) {
+describe.skipIf(process.env.NATIVE_SHADOW)('innerText and outerText', () => {
     describe('innerText', () => {
         let elm;
         beforeEach(() => {
@@ -140,37 +140,35 @@ if (!process.env.NATIVE_SHADOW) {
     const outerTextDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'outerText');
 
     // Firefox does not have outerText.
-    if (outerTextDescriptor) {
-        describe('outerText', () => {
-            let elm;
-            beforeEach(() => {
-                elm = createElement('x-container', { is: Container });
-                document.body.appendChild(elm);
-            });
-
-            it('should go inside custom element shadow', () => {
-                const testElement = elm.shadowRoot.querySelector('.without-slotted-content');
-
-                expect(testElement.outerText).toMatch(
-                    /first text\n+shadow start text\n+default slot content\n+shadow end text\n+second text/
-                );
-            });
-
-            it('should process custom elements light dom', () => {
-                const testElement = elm.shadowRoot.querySelector('.with-slotted-content');
-
-                expect(testElement.outerText).toMatch(
-                    /first text\n+shadow start text\n+slotted element\n+shadow end text\n+second text/
-                );
-            });
-
-            it('should process custom elements light dom across multiple shadows', () => {
-                const testElement = elm.shadowRoot.querySelector('.with-slotted-content-2-levels');
-
-                expect(testElement.outerText).toMatch(
-                    /first text\n+shadow start text\n+slotted element\n+shadow end text\n+second text/
-                );
-            });
+    describe.runIf(outerTextDescriptor)('outerText', () => {
+        let elm;
+        beforeEach(() => {
+            elm = createElement('x-container', { is: Container });
+            document.body.appendChild(elm);
         });
-    }
-}
+
+        it('should go inside custom element shadow', () => {
+            const testElement = elm.shadowRoot.querySelector('.without-slotted-content');
+
+            expect(testElement.outerText).toMatch(
+                /first text\n+shadow start text\n+default slot content\n+shadow end text\n+second text/
+            );
+        });
+
+        it('should process custom elements light dom', () => {
+            const testElement = elm.shadowRoot.querySelector('.with-slotted-content');
+
+            expect(testElement.outerText).toMatch(
+                /first text\n+shadow start text\n+slotted element\n+shadow end text\n+second text/
+            );
+        });
+
+        it('should process custom elements light dom across multiple shadows', () => {
+            const testElement = elm.shadowRoot.querySelector('.with-slotted-content-2-levels');
+
+            expect(testElement.outerText).toMatch(
+                /first text\n+shadow start text\n+slotted element\n+shadow end text\n+second text/
+            );
+        });
+    });
+});

--- a/packages/@lwc/integration-karma/test/synthetic-shadow/shadow-token/index.spec.js
+++ b/packages/@lwc/integration-karma/test/synthetic-shadow/shadow-token/index.spec.js
@@ -4,84 +4,82 @@ import { IS_SYNTHETIC_SHADOW_LOADED } from 'test-utils';
 const KEY__SHADOW_RESOLVER = '$shadowResolver$';
 const KEY__SHADOW_STATIC = '$shadowStaticNode$';
 
-if (IS_SYNTHETIC_SHADOW_LOADED) {
-    describe('sets shadow resolver correctly on static trees', () => {
-        const fragments = [
-            '<div></div>',
-            '<div>hello</div>',
-            '<div><!-- foo --></div>',
-            '<section><div></div><div></div></section>',
-            '<section><div>hello</div><div></div></section>',
-            '<section><div></div><div>hello</div></section>',
-            '<section><div>hello</div><div>hello</div></section>',
-            '<section><div><!-- foo --></div><div></div></section>',
-            '<section><div></div><div><!-- foo --></div></section>',
-            '<section><div><!-- foo --></div><div><!-- foo --></div></section>',
-            '<section><div>hello</div><div><!-- foo --></div></section>',
-        ];
+describe.runIf(IS_SYNTHETIC_SHADOW_LOADED)('sets shadow resolver correctly on static trees', () => {
+    const fragments = [
+        '<div></div>',
+        '<div>hello</div>',
+        '<div><!-- foo --></div>',
+        '<section><div></div><div></div></section>',
+        '<section><div>hello</div><div></div></section>',
+        '<section><div></div><div>hello</div></section>',
+        '<section><div>hello</div><div>hello</div></section>',
+        '<section><div><!-- foo --></div><div></div></section>',
+        '<section><div></div><div><!-- foo --></div></section>',
+        '<section><div><!-- foo --></div><div><!-- foo --></div></section>',
+        '<section><div>hello</div><div><!-- foo --></div></section>',
+    ];
 
-        const scenarios = [
-            {},
-            {
-                withParent: true,
-            },
-            {
-                withParent: true,
-                withRightSibling: true,
-            },
-            {
-                withParent: true,
-                withLeftSibling: true,
-            },
-            {
-                withParent: true,
-                withLeftSibling: true,
-                withRightSibling: true,
-            },
-        ];
+    const scenarios = [
+        {},
+        {
+            withParent: true,
+        },
+        {
+            withParent: true,
+            withRightSibling: true,
+        },
+        {
+            withParent: true,
+            withLeftSibling: true,
+        },
+        {
+            withParent: true,
+            withLeftSibling: true,
+            withRightSibling: true,
+        },
+    ];
 
-        fragments.forEach((fragment) => {
-            scenarios.forEach(({ withParent, withRightSibling, withLeftSibling }) => {
-                describe(`${withParent ? 'with parent' : 'without parent'}${
-                    withLeftSibling ? ' and left sibling' : ''
-                }${withRightSibling ? ' and right sibling' : ''}`, () => {
-                    it(fragment, () => {
-                        const parent = document.createElement('div');
-                        parent.innerHTML = fragment;
-                        const root = parent.firstChild;
+    fragments.forEach((fragment) => {
+        scenarios.forEach(({ withParent, withRightSibling, withLeftSibling }) => {
+            describe(`${withParent ? 'with parent' : 'without parent'}${
+                withLeftSibling ? ' and left sibling' : ''
+            }${withRightSibling ? ' and right sibling' : ''}`, () => {
+                it(fragment, () => {
+                    const parent = document.createElement('div');
+                    parent.innerHTML = fragment;
+                    const root = parent.firstChild;
 
-                        if (!withParent) {
-                            parent.removeChild(root);
+                    if (!withParent) {
+                        parent.removeChild(root);
+                    }
+                    const leftSibling = document.createElement('div');
+                    if (withLeftSibling) {
+                        parent.insertBefore(leftSibling, root);
+                    }
+                    const rightSibling = document.createElement('div');
+                    if (withRightSibling) {
+                        parent.appendChild(rightSibling);
+                    }
+
+                    const resolver = () => {};
+                    root[KEY__SHADOW_RESOLVER] = resolver;
+                    root[KEY__SHADOW_STATIC] = true;
+
+                    // ensure the shadow resolver is set on all nodes in the tree
+                    const expectShadowResolver = (node) => {
+                        expect(node[KEY__SHADOW_RESOLVER]).toBe(resolver);
+                        for (const childNode of Array.from(node.childNodes)) {
+                            expectShadowResolver(childNode);
                         }
-                        const leftSibling = document.createElement('div');
-                        if (withLeftSibling) {
-                            parent.insertBefore(leftSibling, root);
-                        }
-                        const rightSibling = document.createElement('div');
-                        if (withRightSibling) {
-                            parent.appendChild(rightSibling);
-                        }
+                    };
+                    expectShadowResolver(root);
 
-                        const resolver = () => {};
-                        root[KEY__SHADOW_RESOLVER] = resolver;
-                        root[KEY__SHADOW_STATIC] = true;
-
-                        // ensure the shadow resolver is set on all nodes in the tree
-                        const expectShadowResolver = (node) => {
-                            expect(node[KEY__SHADOW_RESOLVER]).toBe(resolver);
-                            for (const childNode of Array.from(node.childNodes)) {
-                                expectShadowResolver(childNode);
-                            }
-                        };
-                        expectShadowResolver(root);
-
-                        // ensure we don't traverse up past the root
-                        for (const node of [parent, leftSibling, rightSibling]) {
-                            expect(node[KEY__SHADOW_RESOLVER]).toBeUndefined();
-                        }
-                    });
+                    // ensure we don't traverse up past the root
+                    for (const node of [parent, leftSibling, rightSibling]) {
+                        expect(node[KEY__SHADOW_RESOLVER]).toBeUndefined();
+                    }
                 });
             });
         });
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/template/attribute-aria/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-aria/index.spec.js
@@ -74,12 +74,10 @@ describe('setting aria attributes', () => {
 
         // If the polyfill is not enabled, then we can't expect the div to have all the ARIA properties,
         // because some are non-standard or not supported in all browsers
-        if (process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL) {
-            it('aria prop is set', () => {
-                for (const prop of ariaProperties) {
-                    expect(childComponent[prop]).toMatch(/^foo/);
-                }
-            });
-        }
+        it.runIf(process.env.ENABLE_ARIA_REFLECTION_GLOBAL_POLYFILL)('aria prop is set', () => {
+            for (const prop of ariaProperties) {
+                expect(childComponent[prop]).toMatch(/^foo/);
+            }
+        });
     });
 });

--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -73,7 +73,7 @@ describe('type coercion', () => {
     }
 });
 
-if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
+describe.runIf(TEMPLATE_CLASS_NAME_OBJECT_BINDING)('class value', () => {
     describe('plain object class value', () => {
         testClassNameValue('empty', {}, '');
         testClassNameValue('single class', { foo: true }, 'foo');
@@ -156,4 +156,4 @@ if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
             'bar'
         );
     });
-}
+});

--- a/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-karma/test/template/attribute-class/object-values.spec.js
@@ -15,8 +15,8 @@ function createDynamicClass(value) {
     };
 }
 
-function testClassNameValue(name, value, expected) {
-    it(name, () => {
+function testClassNameValue(name, value, expected, test = it) {
+    test(name, () => {
         const { target } = createDynamicClass(value);
         expect(target.className).toBe(expected);
     });
@@ -68,9 +68,7 @@ describe('type coercion', () => {
     testClassNameValue('object with enumerable prototype props', classSet({ foo: true }), 'foo');
 
     // Passing a symbol as a class name prior to API v61 would throw an error.
-    if (TEMPLATE_CLASS_NAME_OBJECT_BINDING) {
-        testClassNameValue('symbol', Symbol(), '');
-    }
+    testClassNameValue('symbol', Symbol(), '', it.runIf(TEMPLATE_CLASS_NAME_OBJECT_BINDING));
 });
 
 describe.runIf(TEMPLATE_CLASS_NAME_OBJECT_BINDING)('class value', () => {

--- a/packages/@lwc/integration-karma/test/template/directive-if/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-if/index.spec.js
@@ -69,10 +69,11 @@ describe('if:true directive', () => {
                 expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
             });
     });
-    if (process.env.NATIVE_SHADOW) {
-        // In native shadow, the slotted content from parent is always queriable, its only the
-        // child's <slot> that is rendered/unrendered based on the directive
-        it('should update child with slot content if value changes', () => {
+    // In native shadow, the slotted content from parent is always queriable, its only the
+    // child's <slot> that is rendered/unrendered based on the directive
+    it.runIf(process.env.NATIVE_SHADOW)(
+        'should update child with slot content if value changes',
+        () => {
             const elm = createElement('x-test', { is: XSlotted });
             document.body.appendChild(elm);
             const assignedSlotContent = elm.shadowRoot.querySelector('div.content');
@@ -102,9 +103,11 @@ describe('if:true directive', () => {
                     expect(assignedNodes.length).toBe(1);
                     expect(assignedNodes[0]).toBe(assignedSlotContent);
                 });
-        });
-    } else {
-        it('should update child with slot content if value changes', () => {
+        }
+    );
+    it.skipIf(process.env.NATIVE_SHADOW)(
+        'should update child with slot content if value changes',
+        () => {
             const elm = createElement('x-test', { is: XSlotted });
             document.body.appendChild(elm);
             const child = elm.shadowRoot.querySelector('x-child');
@@ -125,8 +128,8 @@ describe('if:true directive', () => {
                 .then(() => {
                     expect(child.querySelector('.content')).not.toBeNull();
                 });
-        });
-    }
+        }
+    );
 
     it('should continue rendering content for nested slots after multiple rehydrations', () => {
         const elm = createElement('x-multiple-slot', { is: MultipleSlot });


### PR DESCRIPTION
## Details

Currently the karma tests use if/else statements to decide which tests to run under various conditions.

The problem with this approach is that the total number of tests is not consistent and the number of tests executed and skipped is not accurate:

[]
```
Executed 3369 of 3695 (skipped 326) SUCCESS (19.83 secs / 17.888 secs)
```
[DISABLE_SYNTHETIC=1]
```
Executed 3205 of 3531 (skipped 326) SUCCESS (5.412 secs / 4.206 secs)
```
[API_VERSION=60]
```
Executed 3335 of 3661 (skipped 326) SUCCESS (20.422 secs / 18.118 secs)
```
[DISABLE_SYNTHETIC=1, API_VERSION=60]
```
Executed 3156 of 3482 (skipped 326) SUCCESS (5.118 secs / 3.999 secs)
```

This makes it hard to reason about the effects of the various flags and their combinations in dev and CI.

Knowing how many tests exist in total and how many are skipped under certain conditions will be especially important when migrating from karma (#3589)  to a different tool.

This PR proposes using the `vitest/no-conditional-tests` rule in karma tests.

It also adds an implementation of `{describe/it}.{runIf/skipIf}` inspired by vitest to be used instead of if/else.

After these changes:

[]
```
Executed 3369 of 4683 (skipped 1314) SUCCESS (19.35 secs / 17.499 secs)
```
[DISABLE_SYNTHETIC=1]
```
Executed 3205 of 4683 (skipped 1478) SUCCESS (5.689 secs / 4.24 secs)
```
[API_VERSION=60]
```
Executed 3335 of 4683 (skipped 1348) SUCCESS (20.269 secs / 17.862 secs)
```
[DISABLE_SYNTHETIC=1, API_VERSION=60]
```
Executed 3156 of 4683 (skipped 1527) SUCCESS (5.669 secs / 4.183 secs)
```

I wrote a script to run every non-hydration command used in the karma.yml workflow file and all reported 4683 total tests. The hydration tests don't have this issue as it always runs a single test per file (136 total).

I expected a downside of increased test duration, but thankfully I can't see anything noticeable.

I tried to keep the diff small with some indentation / formatting effort, but it still came up a bit large.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
