### PR TITLE
fix(signals): add symbol check for signals in engine

### DIFF
--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isFunction, isNull, isObject } from '@lwc/shared';
+import { hasOwnProperty, isNull, isObject, SIGNAL_SYMBOL } from '@lwc/shared';
 import { Signal } from '@lwc/signals';
 import {
     JobFunction,
@@ -46,9 +46,7 @@ export function componentValueObserved(vm: VM, key: PropertyKey, target: any = {
         lwcRuntimeFlags.ENABLE_EXPERIMENTAL_SIGNALS &&
         isObject(target) &&
         !isNull(target) &&
-        'value' in target &&
-        'subscribe' in target &&
-        isFunction(target.subscribe) &&
+        hasOwnProperty.call(target, SIGNAL_SYMBOL) &&
         // Only subscribe if a template is being rendered by the engine
         tro.isObserving()
     ) {

--- a/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
@@ -183,18 +183,6 @@ describe('signal protocol', () => {
         expect(elm.getSignalRemovedSubscriberCount()).toBe(2);
     });
 
-    it('does not subscribe if the signal shape is incorrect', async () => {
-        const elm = createElement('x-child', { is: Child });
-        const subscribe = jasmine.createSpy();
-        // Note the signals property is value's' and not value
-        const signal = { values: 'initial value', subscribe };
-        elm.signal = signal;
-        document.body.appendChild(elm);
-        await Promise.resolve();
-
-        expect(subscribe).not.toHaveBeenCalled();
-    });
-
     it(`does not subscribe if the signal shape has no Symbol.for('experimental-signal') key as own property`, async () => {
         const elm = createElement('x-child', { is: Child });
         const subscribe = jasmine.createSpy().and.callFake(() => () => {});

--- a/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
@@ -194,6 +194,24 @@ describe('signal protocol', () => {
 
         expect(subscribe).not.toHaveBeenCalled();
     });
+
+    it(`does not subscribe if the signal shape has no Symbol.for('experimental-signal') key as own property`, async () => {
+        const elm = createElement('x-child', { is: Child });
+        const subscribe = jasmine.createSpy().and.callFake(() => () => {});
+        // Note this follows the shape of the signal implementation
+        // but does not have the required Symbol.for('experimental-signal') key as own property.
+        const signal = {
+            get value() {
+                return 'initial value';
+            },
+            subscribe,
+        };
+        elm.signal = signal;
+        document.body.appendChild(elm);
+        await Promise.resolve();
+
+        expect(subscribe).not.toHaveBeenCalled();
+    });
 });
 
 describe('ENABLE_EXPERIMENTAL_SIGNALS not set', () => {

--- a/packages/@lwc/integration-karma/test/signal/protocol/x/signal/signal.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/x/signal/signal.js
@@ -1,6 +1,7 @@
 // Note for testing purposes the signal implementation uses LWC module resolution to simplify things.
 // In production the signal will come from a 3rd party library.
 export class Signal {
+    [Symbol.for('experimental-signal')] = undefined;
     subscribers = new Set();
     removedSubscribers = [];
 

--- a/packages/@lwc/integration-karma/test/signal/reactivity/x/signal/signal.js
+++ b/packages/@lwc/integration-karma/test/signal/reactivity/x/signal/signal.js
@@ -1,6 +1,7 @@
 // Note for testing purposes the signal implementation uses LWC module resolution to simplify things.
 // In production the signal will come from a 3rd party library.
 export class Signal {
+    [Symbol.for('experimental-signal')] = undefined;
     subscribers = new Set();
 
     constructor(initialValue) {

--- a/packages/@lwc/shared/src/index.ts
+++ b/packages/@lwc/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from './html-attributes';
 export * from './html-escape';
 export * from './namespaces';
 export * from './meta';
+export * from './signals';
 export * from './static-part-tokens';
 export * from './style';
 

--- a/packages/@lwc/shared/src/signals.ts
+++ b/packages/@lwc/shared/src/signals.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+export const SIGNAL_SYMBOL = Symbol.for('experimental-signal');

--- a/packages/@lwc/signals/package.json
+++ b/packages/@lwc/signals/package.json
@@ -40,5 +40,8 @@
                 ]
             }
         }
+    },
+    "dependencies": {
+        "@lwc/shared": "8.2.0"
     }
 }

--- a/packages/@lwc/signals/src/index.ts
+++ b/packages/@lwc/signals/src/index.ts
@@ -1,19 +1,24 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+
+import { SIGNAL_SYMBOL } from '@lwc/shared';
+
 export type OnUpdate = () => void;
 export type Unsubscribe = () => void;
 
 export interface Signal<T> {
+    [SIGNAL_SYMBOL]: undefined;
     get value(): T;
     subscribe(onUpdate: OnUpdate): Unsubscribe;
 }
 
 export abstract class SignalBaseClass<T> implements Signal<T> {
     abstract get value(): T;
+    readonly [SIGNAL_SYMBOL] = undefined;
 
     private subscribers: Set<OnUpdate> = new Set();
 


### PR DESCRIPTION
## Details
This adds a mechanism to restrict any signal-like property to be able to leverage experimental lwc signal reactivity. The ideal way to lock down usages is for the lwc-engine and signals to share a [SUPER_SECRET_SYMBOL](https://github.com/salesforce/lwc/pull/3963/files#r1472318703). 

Although that approach has some limitations, the lwc-engine (`aura_*`) in core has no dependencies and is one of the first modules to load hence, essentially meaning if we have to share a symbol then the symbol has to live there, if we export the `SUPER_SECRET_SYMBOL` from lwc-engine or from `aura_*` then it means whoever has access to aura has access to the symbol unless prevented through other mechanisms (lint, etc). 

`Symbol.for` provides an explicit way for the symbol to be shared across files but at the same time warn the consumer about our intent that they aren't supposed to do that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item
W-16994654
<!-- Work ID in text, if applicable. -->
