### PR TITLE
feat(ssr): implement lwc:inner-html @W-16872197

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-inner-html/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-inner-html/expected.html
@@ -6,5 +6,13 @@
         World
       </b>
     </div>
+    <div>
+      <p>
+        <b>
+          static
+        </b>
+         content
+      </p>
+    </div>
   </template>
 </x-lwc-inner-html>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-inner-html/modules/x/lwc-inner-html/lwc-inner-html.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/lwc-inner-html/modules/x/lwc-inner-html/lwc-inner-html.html
@@ -1,3 +1,4 @@
 <template>
     <div lwc:inner-html={content}></div>
+    <div lwc:inner-html="<p><b>static</b> content</p>"></div>
 </template>

--- a/packages/@lwc/ssr-compiler/src/compile-template/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/element.ts
@@ -151,6 +151,8 @@ export const Element: Transformer<IrElement | IrExternalComponent | IrSlot> = fu
     }
 
     let childContent: EsStatement[];
+    // An element can have children or lwc:inner-html, but not both
+    // If it has both, the template compiler will throw an error before reaching here
     if (node.children.length) {
         childContent = irChildrenToEs(node.children, cxt);
     } else if (innerHtmlDirective) {


### PR DESCRIPTION
## Details

This PR implements `lwc:inner-html` in `@lwc/ssr-compiler`. It does not currently do any input sanitization on the HTML content.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-16872197
