### PR TITLE
chore(integration-karma): replace done callback with async/await

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -256,6 +256,7 @@ export default tseslint.config(
         files: ['packages/@lwc/integration-karma/**'],
         rules: {
             'vitest/no-conditional-tests': 'error',
+            'vitest/no-done-callback': 'error',
         },
     },
     {

--- a/packages/@lwc/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -138,7 +138,7 @@ describe('error boundary', () => {
         });
     });
 
-    it('should render alternative view if child throws during self rehydration cycle', (done) => {
+    it('should render alternative view if child throws during self rehydration cycle', async () => {
         const elm = createElement('x-boundary-child-self-rehydrate-throw', {
             is: XBoundaryChildSelfRehydrateThrow,
         });
@@ -149,14 +149,12 @@ describe('error boundary', () => {
 
         // Using a setTimeout instead of a Promise here because it takes multiple microtasks for the engine to render
         // the alternative view
-        setTimeout(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.self-rehydrate-alternative');
+        await new Promise(setTimeout);
 
-            expect(alternativeView.textContent).toEqual('self rehydrate alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-self-rehydrate-throw')).toBe(null);
+        const alternativeView = elm.shadowRoot.querySelector('.self-rehydrate-alternative');
 
-            done();
-        });
+        expect(alternativeView.textContent).toEqual('self rehydrate alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-self-rehydrate-throw')).toBe(null);
     });
 
     it('should fail to unmount alternative offender when root element is not a boundary', () => {

--- a/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
+++ b/packages/@lwc/integration-karma/test/native-shadow/Event-methods/Event.composedPath.spec.js
@@ -1,6 +1,23 @@
 import { createElement } from 'lwc';
 import Synthetic from 'x/synthetic';
 
+/**
+ * Returns a promise that resolves with the composed path of an event dispatched from `fromTarget` to `toTarget`.
+ *
+ * @param {EventTarget} toTarget - The target element where the event listener is added.
+ * @param {EventTarget} fromTarget - The target element from which the event is dispatched.
+ * @returns {Promise<EventTarget[]>} A promise that resolves with the composed path of the event.
+ */
+function getComposedPath(toTarget, fromTarget) {
+    return new Promise((resolve) => {
+        toTarget.addEventListener('test', (event) => {
+            resolve(event.composedPath());
+        });
+
+        fromTarget.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+    });
+}
+
 describe('[W-9846457] event access when using native shadow dom', () => {
     let nativeParent;
     let nativeChild;
@@ -25,47 +42,37 @@ describe('[W-9846457] event access when using native shadow dom', () => {
         document.removeEventListener('test', noop, true);
     });
 
-    it('should handle composed bubbling events (nested child)', (done) => {
-        nativeChild.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                nativeChild.shadowRoot,
-                nativeChild,
-                nativeParent.shadowRoot,
-                nativeParent,
-                document.body,
-                document.documentElement,
-                document,
-                window,
-            ]);
-            done();
-        });
+    it('should handle composed bubbling events (nested child)', async () => {
+        const composedPath = await getComposedPath(nativeChild, nativeChild.shadowRoot);
 
-        nativeChild.shadowRoot.dispatchEvent(
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
+        expect(composedPath).toEqual([
+            nativeChild.shadowRoot,
+            nativeChild,
+            nativeParent.shadowRoot,
+            nativeParent,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
     });
 
-    it('should handle composed bubbling events (root parent)', (done) => {
-        nativeParent.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                nativeChild.shadowRoot,
-                nativeChild,
-                nativeParent.shadowRoot,
-                nativeParent,
-                document.body,
-                document.documentElement,
-                document,
-                window,
-            ]);
-            done();
-        });
+    it('should handle composed bubbling events (root parent)', async () => {
+        const composedPath = await getComposedPath(nativeParent, nativeChild.shadowRoot);
 
-        nativeChild.shadowRoot.dispatchEvent(
-            new CustomEvent('test', { composed: true, bubbles: true })
-        );
+        expect(composedPath).toEqual([
+            nativeChild.shadowRoot,
+            nativeChild,
+            nativeParent.shadowRoot,
+            nativeParent,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
     });
 
-    it('should handle composed bubbling events (native element)', (done) => {
+    it('should handle composed bubbling events (native element)', async () => {
         const div = document.createElement('div');
         const span = document.createElement('span');
 
@@ -73,23 +80,20 @@ describe('[W-9846457] event access when using native shadow dom', () => {
         shadowRoot.appendChild(span);
         document.body.appendChild(div);
 
-        div.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                span,
-                div.shadowRoot,
-                div,
-                document.body,
-                document.documentElement,
-                document,
-                window,
-            ]);
-            done();
-        });
+        const composedPath = await getComposedPath(div, span);
 
-        span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        expect(composedPath).toEqual([
+            span,
+            div.shadowRoot,
+            div,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
     });
 
-    it('should handle composed bubbling events (synthetic above native)', (done) => {
+    it('should handle composed bubbling events (synthetic above native)', async () => {
         const synthetic = createElement('x-synthetic', { is: Synthetic });
         const div = document.createElement('div');
 
@@ -125,15 +129,12 @@ describe('[W-9846457] event access when using native shadow dom', () => {
             ];
         }
 
-        synthetic.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual(expected);
-            done();
-        });
+        const composedPath = await getComposedPath(synthetic, div.shadowRoot);
 
-        div.shadowRoot.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        expect(composedPath).toEqual(expected);
     });
 
-    it('should handle composed bubbling events (native above synthetic)', (done) => {
+    it('should handle composed bubbling events (native above synthetic)', async () => {
         const synthetic = createElement('x-synthetic', { is: Synthetic });
         const native = document.createElement('div');
 
@@ -151,10 +152,31 @@ describe('[W-9846457] event access when using native shadow dom', () => {
 
         document.body.appendChild(native);
 
-        synthetic.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                synthetic.shadowRoot,
-                synthetic,
+        const composedPath = await getComposedPath(synthetic, synthetic.shadowRoot);
+
+        expect(composedPath).toEqual([
+            synthetic.shadowRoot,
+            synthetic,
+            native.shadowRoot,
+            native,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
+    });
+});
+
+describe('Event.composedPath() method', () => {
+    describe('dispatched on shadow root', () => {
+        it('{bubbles: true, composed: true}', async () => {
+            const native = document.createElement('x-native-name-unique-to-this-test-1');
+            native.attachShadow({ mode: 'open' });
+            document.body.appendChild(native);
+
+            const composedPath = await getComposedPath(native.shadowRoot, native.shadowRoot);
+
+            expect(composedPath).toEqual([
                 native.shadowRoot,
                 native,
                 document.body,
@@ -162,61 +184,27 @@ describe('[W-9846457] event access when using native shadow dom', () => {
                 document,
                 window,
             ]);
-            done();
-        });
-
-        synthetic.shadowRoot.dispatchEvent(
-            new CustomEvent('test', { bubbles: true, composed: true })
-        );
-    });
-});
-
-describe('Event.composedPath() method', () => {
-    describe('dispatched on shadow root', () => {
-        it('{bubbles: true, composed: true}', (done) => {
-            const native = document.createElement('x-native-name-unique-to-this-test-1');
-            native.attachShadow({ mode: 'open' });
-            document.body.appendChild(native);
-
-            native.shadowRoot.addEventListener('test', (event) => {
-                expect(event.composedPath()).toEqual([
-                    native.shadowRoot,
-                    native,
-                    document.body,
-                    document.documentElement,
-                    document,
-                    window,
-                ]);
-                done();
-            });
-
-            native.shadowRoot.dispatchEvent(
-                new CustomEvent('test', { bubbles: true, composed: true })
-            );
         });
     });
     describe('dispatched on shadowed element', () => {
-        it('{bubbles: true, composed: true}', (done) => {
+        it('{bubbles: true, composed: true}', async () => {
             const native = document.createElement('x-native-name-unique-to-this-test-2');
             const span = document.createElement('span');
             const sr = native.attachShadow({ mode: 'open' });
             sr.appendChild(span);
             document.body.appendChild(native);
 
-            native.shadowRoot.addEventListener('test', (event) => {
-                expect(event.composedPath()).toEqual([
-                    span,
-                    native.shadowRoot,
-                    native,
-                    document.body,
-                    document.documentElement,
-                    document,
-                    window,
-                ]);
-                done();
-            });
+            const composedPath = await getComposedPath(native.shadowRoot, span);
 
-            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            expect(composedPath).toEqual([
+                span,
+                native.shadowRoot,
+                native,
+                document.body,
+                document.documentElement,
+                document,
+                window,
+            ]);
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/polyfills/event-composed/index.spec.js
+++ b/packages/@lwc/integration-karma/test/polyfills/event-composed/index.spec.js
@@ -11,14 +11,16 @@ it('should respect when the event composed flag is set during construction', () 
     expect(notComposedClickEvent.composed).toBe(false);
 });
 
-it('should set composed to true for click events dispatched by the user agent', (done) => {
+it('should set composed to true for click events dispatched by the user agent', async () => {
     const elm = document.createElement('div');
     document.body.appendChild(elm);
 
-    elm.addEventListener('click', (evt) => {
-        expect(evt.composed).toBe(true);
-        done();
+    const composed = await new Promise((resolve) => {
+        elm.addEventListener('click', (evt) => {
+            resolve(evt.composed);
+        });
+        elm.click();
     });
 
-    elm.click();
+    expect(composed).toBe(true);
 });

--- a/packages/@lwc/integration-karma/test/rendering/slotting/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slotting/index.spec.js
@@ -56,29 +56,25 @@ xit('should not render if the slotted content changes', () => {
     });
 });
 
-it('should not throw error when updating slotted content triggers next tick re-render in component receiving the slotted content', (done) => {
+it('should not throw error when updating slotted content triggers next tick re-render in component receiving the slotted content', async () => {
     // Regression introduced in #1617 refactor(engine): improving the diffing algo for slotted elements
     const elm = createElement('x-regression-container', {
         is: RegressionContainer,
     });
     document.body.appendChild(elm);
 
-    requestAnimationFrame(() => {
-        const results = elm.shadowRoot.querySelectorAll('.text-result');
+    await new Promise(requestAnimationFrame);
 
-        expect(results.length).toBe(1);
-        expect(results[0].textContent).toBe('Inner visible truetoggle');
-        elm.shadowRoot.querySelector('button').click();
+    let results = elm.shadowRoot.querySelectorAll('.text-result');
+    expect(results.length).toBe(1);
+    expect(results[0].textContent).toBe('Inner visible truetoggle');
+    elm.shadowRoot.querySelector('button').click();
 
-        requestAnimationFrame(() => {
-            const results = elm.shadowRoot.querySelectorAll('.text-result');
+    await new Promise(requestAnimationFrame);
 
-            expect(results.length).toBe(1);
-            expect(results[0].textContent).toBe('Inner visible falsetoggle');
-
-            done();
-        });
-    });
+    results = elm.shadowRoot.querySelectorAll('.text-result');
+    expect(results.length).toBe(1);
+    expect(results[0].textContent).toBe('Inner visible falsetoggle');
 });
 
 describe('does not log an error/warning on unknown slot name', () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-methods/index.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-methods/index.spec.js
@@ -143,33 +143,31 @@ describe('Event.composedPath', () => {
         expect(_event.composedPath()).toHaveSize(0);
     });
 
-    it('should not throw when invoked on an event with a target that is not an instance of Node', (done) => {
+    it('should not throw when invoked on an event with a target that is not an instance of Node', async () => {
         const req = new XMLHttpRequest();
-        req.addEventListener('test', (event) => {
-            // Not looking at return value because browsers have different implementations.
-            expect(() => {
-                event.composedPath();
-            }).not.toThrowError();
-            done();
+        const event = await new Promise((resolve) => {
+            req.addEventListener('test', resolve);
+            req.dispatchEvent(new CustomEvent('test'));
         });
-        req.dispatchEvent(new CustomEvent('test'));
+        // Not looking at return value because browsers have different implementations.
+        expect(() => {
+            event.composedPath();
+        }).not.toThrowError();
     });
 
-    it('should return expected composed path when the target is a text node', (done) => {
+    it('should return expected composed path when the target is a text node', async () => {
         const nodes = createTestElement();
         const event = new CustomEvent('test', { bubbles: true, composed: false });
 
         const textNode = nodes.child_div.childNodes[0];
 
-        textNode.addEventListener('test', (event) => {
-            expect(event.composedPath()).toEqual([
-                textNode,
-                nodes.child_div,
-                nodes['x-child.shadowRoot'],
-            ]);
-            done();
+        const composedPath = await new Promise((resolve) => {
+            textNode.addEventListener('test', (event) => {
+                resolve(event.composedPath());
+            });
+            textNode.dispatchEvent(event);
         });
 
-        textNode.dispatchEvent(event);
+        expect(composedPath).toEqual([textNode, nodes.child_div, nodes['x-child.shadowRoot']]);
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -52,6 +52,6 @@ describe('Event.currentTarget', () => {
             child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        expect(currentTarget).toEqual(container.shadowRoot);
+        expect(currentTarget).toBe(container.shadowRoot);
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -36,7 +36,7 @@ describe('Event.currentTarget', () => {
             child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        expect(currentTarget).toEqual(container);
+        expect(currentTarget).ToBe(container);
     });
 
     it('should reference the shadow root', async () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -19,7 +19,7 @@ describe('Event.currentTarget', () => {
             div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        expect(first).toEqual(container);
+        expect(first).toBe(container);
         expect(second).toBeNull();
     });
 

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -3,44 +3,55 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event.currentTarget', () => {
-    it('should be null when accessed asynchronously', function (done) {
+    it('should be null when accessed asynchronously', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
-        container.addEventListener('test', (event) => {
-            expect(event.currentTarget).toEqual(container);
-            setTimeout(() => {
-                expect(event.currentTarget).toBeNull();
-                done();
+        const [first, second] = await new Promise((resolve) => {
+            container.addEventListener('test', (event) => {
+                const first = event.currentTarget;
+                setTimeout(() => {
+                    const second = event.currentTarget;
+                    resolve([first, second]);
+                });
             });
+            const div = container.shadowRoot.querySelector('div');
+            div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
-        const div = container.shadowRoot.querySelector('div');
-        div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+
+        expect(first).toEqual(container);
+        expect(second).toBeNull();
     });
 
-    it('should reference the host element', (done) => {
+    it('should reference the host element', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
-        container.addEventListener('test', (event) => {
-            expect(event.currentTarget).toEqual(container);
-            done();
+        const currentTarget = await new Promise((resolve) => {
+            container.addEventListener('test', (event) => {
+                resolve(event.currentTarget);
+            });
+
+            const child = container.shadowRoot.querySelector('x-child');
+            child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        const child = container.shadowRoot.querySelector('x-child');
-        child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        expect(currentTarget).toEqual(container);
     });
 
-    it('should reference the shadow root', (done) => {
+    it('should reference the shadow root', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
-        container.shadowRoot.addEventListener('test', (event) => {
-            expect(event.currentTarget).toEqual(container.shadowRoot);
-            done();
+        const currentTarget = await new Promise((resolve) => {
+            container.shadowRoot.addEventListener('test', (event) => {
+                resolve(event.currentTarget);
+            });
+
+            const child = container.shadowRoot.querySelector('x-child');
+            child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        const child = container.shadowRoot.querySelector('x-child');
-        child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        expect(currentTarget).toEqual(container.shadowRoot);
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.currentTarget.spec.js
@@ -36,7 +36,7 @@ describe('Event.currentTarget', () => {
             child.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        expect(currentTarget).ToBe(container);
+        expect(currentTarget).toBe(container);
     });
 
     it('should reference the shadow root', async () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.defaultPrevented.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.defaultPrevented.spec.js
@@ -3,66 +3,77 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Event.defaultPrevented', () => {
-    it('should return true if cancelable and preventDefault() was invoked', (done) => {
+    it('should return true if cancelable and preventDefault() was invoked', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
         container.shadowRoot.addEventListener('test', (event) => {
             event.preventDefault();
         });
-        container.addEventListener('test', (event) => {
-            expect(event.defaultPrevented).toBeTrue();
-            done();
+
+        const defaultPrevented = await new Promise((resolve) => {
+            container.addEventListener('test', (event) => {
+                resolve(event.defaultPrevented);
+            });
+
+            const div = container.shadowRoot.querySelector('div');
+            div.dispatchEvent(
+                new CustomEvent('test', {
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true,
+                })
+            );
         });
 
-        const div = container.shadowRoot.querySelector('div');
-        div.dispatchEvent(
-            new CustomEvent('test', {
-                bubbles: true,
-                cancelable: true,
-                composed: true,
-            })
-        );
+        expect(defaultPrevented).toBeTrue();
     });
 
-    it('should return false if cancelable and preventDefault() was not invoked', (done) => {
+    it('should return false if cancelable and preventDefault() was not invoked', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
-        container.addEventListener('test', (event) => {
-            expect(event.defaultPrevented).toBeFalse();
-            done();
+        const defaultPrevented = await new Promise((resolve) => {
+            container.addEventListener('test', (event) => {
+                resolve(event.defaultPrevented);
+            });
+
+            const div = container.shadowRoot.querySelector('div');
+            div.dispatchEvent(
+                new CustomEvent('test', {
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true,
+                })
+            );
         });
 
-        const div = container.shadowRoot.querySelector('div');
-        div.dispatchEvent(
-            new CustomEvent('test', {
-                bubbles: true,
-                cancelable: true,
-                composed: true,
-            })
-        );
+        expect(defaultPrevented).toBeFalse();
     });
 
-    it('should return false if not cancelable and preventDefault() was invoked', (done) => {
+    it('should return false if not cancelable and preventDefault() was invoked', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
         container.shadowRoot.addEventListener('test', (event) => {
             event.preventDefault();
         });
-        container.addEventListener('test', (event) => {
-            expect(event.defaultPrevented).toBeFalse();
-            done();
+
+        const defaultPrevented = await new Promise((resolve) => {
+            container.addEventListener('test', (event) => {
+                resolve(event.defaultPrevented);
+            });
+
+            const div = container.shadowRoot.querySelector('div');
+            div.dispatchEvent(
+                new CustomEvent('test', {
+                    bubbles: true,
+                    cancelable: false,
+                    composed: true,
+                })
+            );
         });
 
-        const div = container.shadowRoot.querySelector('div');
-        div.dispatchEvent(
-            new CustomEvent('test', {
-                bubbles: true,
-                cancelable: false,
-                composed: true,
-            })
-        );
+        expect(defaultPrevented).toBeFalse();
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -123,7 +123,7 @@ describe('Event.target', () => {
                 span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
             });
 
-            expect(target).toEqual(span);
+            expect(target).toBe(span);
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -8,18 +8,20 @@ describe('Event.target', () => {
         document.removeEventListener('test', globalListener);
     });
 
-    it('should retarget', (done) => {
+    it('should retarget', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
         const child = container.shadowRoot.querySelector('x-child');
-        child.addEventListener('test', (event) => {
-            expect(event.target).toEqual(child);
-            done();
-        });
+        const target = await new Promise((resolve) => {
+            child.addEventListener('test', (event) => {
+                resolve(event.target);
+            });
 
-        const div = child.shadowRoot.querySelector('div');
-        div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            const div = child.shadowRoot.querySelector('div');
+            div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        });
+        expect(target).toEqual(child);
     });
 
     it('should patch the prototype instead of the instance', () => {
@@ -59,19 +61,22 @@ describe('Event.target', () => {
         expect(event.target).toEqual(container);
     });
 
-    it('should retarget when accessed in a document event listener', (done) => {
+    it('should retarget when accessed in a document event listener', async () => {
         const container = createElement('x-container', { is: Container });
         document.body.appendChild(container);
 
-        globalListener = (event) => {
-            expect(event.target).toEqual(container);
-            done();
-        };
-        document.addEventListener('test', globalListener);
+        const target = await new Promise((resolve) => {
+            globalListener = (event) => {
+                resolve(event.target);
+            };
+            document.addEventListener('test', globalListener);
 
-        const child = container.shadowRoot.querySelector('x-child');
-        const div = child.shadowRoot.querySelector('div');
-        div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            const child = container.shadowRoot.querySelector('x-child');
+            const div = child.shadowRoot.querySelector('div');
+            div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+        });
+
+        expect(target).toEqual(container);
     });
 
     describe.skipIf(process.env.NATIVE_SHADOW)('legacy behavior', () => {
@@ -80,38 +85,45 @@ describe('Event.target', () => {
             spyOn(console, 'warn');
         });
 
-        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed asynchronously [W-6626752]', (done) => {
+        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed asynchronously [W-6626752]', async () => {
             const container = createElement('x-container', { is: Container });
             document.body.appendChild(container);
 
             const child = container.shadowRoot.querySelector('x-child');
             const span = child.appendSpanAndReturn();
 
-            container.addEventListener('test', (event) => {
-                expect(event.target).toEqual(container);
-                setTimeout(() => {
-                    expect(event.target).toEqual(span);
-                    done();
+            const [first, second] = await new Promise((resolve) => {
+                container.addEventListener('test', (event) => {
+                    const first = event.target;
+                    setTimeout(() => {
+                        resolve([first, event.target]);
+                    });
                 });
+
+                span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
             });
 
-            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            expect(first).toEqual(container);
+            expect(second).toEqual(span);
         });
 
-        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed in a document event listener [W-6626752]', (done) => {
+        it('should not retarget when the target was manually added without lwc:dom="manual" and accessed in a document event listener [W-6626752]', async () => {
             const container = createElement('x-container', { is: Container });
             document.body.appendChild(container);
 
             const child = container.shadowRoot.querySelector('x-child');
             const span = child.appendSpanAndReturn();
 
-            globalListener = (event) => {
-                expect(event.target).toEqual(span);
-                done();
-            };
-            document.addEventListener('test', globalListener);
+            const target = await new Promise((resolve) => {
+                globalListener = (event) => {
+                    resolve(event.target);
+                };
+                document.addEventListener('test', globalListener);
 
-            span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+                span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
+            });
+
+            expect(target).toEqual(span);
         });
     });
 });

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -103,8 +103,8 @@ describe('Event.target', () => {
                 span.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
             });
 
-            expect(first).toEqual(container);
-            expect(second).toEqual(span);
+            expect(first).toBe(container);
+            expect(second).toBe(span);
         });
 
         it('should not retarget when the target was manually added without lwc:dom="manual" and accessed in a document event listener [W-6626752]', async () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -76,7 +76,7 @@ describe('Event.target', () => {
             div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
 
-        expect(target).toEqual(container);
+        expect(target).toBe(container);
     });
 
     describe.skipIf(process.env.NATIVE_SHADOW)('legacy behavior', () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -21,7 +21,7 @@ describe('Event.target', () => {
             const div = child.shadowRoot.querySelector('div');
             div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
         });
-        expect(target).toEqual(child);
+        expect(target).toBe(child);
     });
 
     it('should patch the prototype instead of the instance', () => {

--- a/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
+++ b/packages/@lwc/integration-karma/test/shadow-dom/Event-properties/Event.target.spec.js
@@ -58,7 +58,7 @@ describe('Event.target', () => {
         const div = child.shadowRoot.querySelector('div');
         div.dispatchEvent(new CustomEvent('test', { bubbles: true, composed: true }));
 
-        expect(event.target).toEqual(container);
+        expect(event.target).toBe(container);
     });
 
     it('should retarget when accessed in a document event listener', async () => {

--- a/packages/@lwc/integration-karma/test/template/directive-lwc-inner-html/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-lwc-inner-html/index.spec.js
@@ -74,7 +74,7 @@ it('applies styles to injected content', async () => {
     document.body.appendChild(elm);
 
     // When running with synthetic shadow a micro task is needed to for the MutationObserver to add
-    // the styling tokens. For IE11 specifically, we need to wait for a full task.
+    // the styling tokens.
     await Promise.resolve();
 
     const b = elm.shadowRoot.querySelector('b');

--- a/packages/@lwc/integration-karma/test/template/directive-lwc-inner-html/index.spec.js
+++ b/packages/@lwc/integration-karma/test/template/directive-lwc-inner-html/index.spec.js
@@ -68,18 +68,16 @@ describe('type conversion', () => {
     });
 });
 
-it('applies styles to injected content', (done) => {
+it('applies styles to injected content', async () => {
     const elm = createElement('x-inner-html', { is: XInnerHtml });
     elm.content = '<b>Test</b>';
     document.body.appendChild(elm);
 
     // When running with synthetic shadow a micro task is needed to for the MutationObserver to add
     // the styling tokens. For IE11 specifically, we need to wait for a full task.
-    setTimeout(() => {
-        const b = elm.shadowRoot.querySelector('b');
-        const styles = window.getComputedStyle(b);
-        expect(styles.borderBottomStyle).toContain('dashed');
+    await Promise.resolve();
 
-        done();
-    });
+    const b = elm.shadowRoot.querySelector('b');
+    const styles = window.getComputedStyle(b);
+    expect(styles.borderBottomStyle).toContain('dashed');
 });

--- a/packages/@lwc/integration-karma/test/wire/legacy-adapters/index.spec.js
+++ b/packages/@lwc/integration-karma/test/wire/legacy-adapters/index.spec.js
@@ -44,80 +44,74 @@ describe('legacy wire adapters (register call)', () => {
     });
 
     describe('with dynamic config', () => {
-        it('should not call config when all initially all props of config are undefined', (done) => {
+        it('should not call config when all initially all props of config are undefined', async () => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const calls = elm.allUndefinedConfigCalls;
-                expect(calls.length).toBe(0);
-                done();
-            }, 0);
+            await new Promise(setTimeout);
+
+            const calls = elm.allUndefinedConfigCalls;
+            expect(calls.length).toBe(0);
         });
 
-        it('should call config when at least one prop in config is defined', (done) => {
+        it('should call config when at least one prop in config is defined', async () => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const calls = elm.someDefinedConfigCalls;
-                expect(calls.length).toBe(1);
-                expect(calls[0]).toEqual({ p1: undefined, p3: 'test' });
+            await new Promise(setTimeout);
 
-                done();
-            }, 0);
+            const calls = elm.someDefinedConfigCalls;
+            expect(calls.length).toBe(1);
+            expect(calls[0]).toEqual({ p1: undefined, p3: 'test' });
         });
 
-        it('should call config when all props become undefined after initialization', (done) => {
+        it('should call config when all props become undefined after initialization', async () => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const calls = elm.someDefinedConfigCalls;
-                expect(calls.length).toBe(1);
-                expect(calls[0]).toEqual({ p1: undefined, p3: 'test' });
+            await new Promise(setTimeout);
 
-                elm.setParam('p3', undefined);
+            let calls = elm.someDefinedConfigCalls;
+            expect(calls.length).toBe(1);
+            expect(calls[0]).toEqual({ p1: undefined, p3: 'test' });
 
-                setTimeout(() => {
-                    const calls = elm.someDefinedConfigCalls;
-                    expect(calls.length).toBe(2);
-                    expect(calls[1]).toEqual({ p1: undefined, p3: undefined });
-                    done();
-                }, 0);
-            }, 0);
+            elm.setParam('p3', undefined);
+
+            await new Promise(setTimeout);
+
+            calls = elm.someDefinedConfigCalls;
+            expect(calls.length).toBe(2);
+            expect(calls[1]).toEqual({ p1: undefined, p3: undefined });
         });
 
-        it('should call config when initially all props of config are undefined and some change', (done) => {
+        it('should call config when initially all props of config are undefined and some change', async () => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const calls = elm.allUndefinedConfigCalls;
-                expect(calls.length).toBe(0);
+            await new Promise(setTimeout);
 
-                elm.setParam('p2', 'test');
+            let calls = elm.allUndefinedConfigCalls;
+            expect(calls.length).toBe(0);
 
-                setTimeout(() => {
-                    const calls = elm.allUndefinedConfigCalls;
-                    expect(calls.length).toBe(1);
-                    expect(calls[0]).toEqual({ p1: undefined, p2: 'test' });
-                    done();
-                }, 0);
-            }, 0);
+            elm.setParam('p2', 'test');
+
+            await new Promise(setTimeout);
+
+            calls = elm.allUndefinedConfigCalls;
+            expect(calls.length).toBe(1);
+            expect(calls[0]).toEqual({ p1: undefined, p2: 'test' });
         });
     });
 
     describe('with dynamic and static config', () => {
-        it('should not call config when initially all props from params in config are undefined', (done) => {
+        it('should not call config when initially all props from params in config are undefined', async () => {
             const elm = createElement('x-simple-d-wire', { is: DynamicWiredProps });
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const calls = elm.mixedAllParamsUndefinedCalls;
-                expect(calls.length).toBe(0);
-                done();
-            }, 0);
+            await new Promise(setTimeout);
+
+            const calls = elm.mixedAllParamsUndefinedCalls;
+            expect(calls.length).toBe(0);
         });
 
         // This following 2 test cases can occur in two scenarios:
@@ -133,51 +127,47 @@ describe('legacy wire adapters (register call)', () => {
         // 1) was not possible to reproduce, a config param could only depend on one property from the component, and since
         //    now is possible, existing adapters may behave incorrectly.
         // 2) was handled at the wire-protocol level and existing adapters may behave incorrectly.
-        it('should not call config when the generated config is the same as the last one (case 1)', (done) => {
+        it('should not call config when the generated config is the same as the last one (case 1)', async () => {
             const elm = createElement('x-same-config', { is: SameConfigCase });
             elm.a = 3;
             elm.b = 2;
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const firstResult = elm.resultMultipleDependenciesForConfig;
-                expect(firstResult.sum).toBe(5);
+            await new Promise(setTimeout);
 
-                elm.a = 1;
-                elm.b = 4;
+            const firstResult = elm.resultMultipleDependenciesForConfig;
+            expect(firstResult.sum).toBe(5);
 
-                setTimeout(() => {
-                    const secondResult = elm.resultMultipleDependenciesForConfig;
+            elm.a = 1;
+            elm.b = 4;
 
-                    // Based on the RFC: every time that `adapter.update()` is invoked, a new config object will
-                    // be provided as a first argument, no identity is preserved in this case.
-                    expect(firstResult).toBe(secondResult);
+            await new Promise(setTimeout);
 
-                    done();
-                });
-            });
+            const secondResult = elm.resultMultipleDependenciesForConfig;
+
+            // Based on the RFC: every time that `adapter.update()` is invoked, a new config object will
+            // be provided as a first argument, no identity is preserved in this case.
+            expect(firstResult).toBe(secondResult);
         });
 
-        it('should not call config when the generated config is the same as the last one (case 2)', (done) => {
+        it('should not call config when the generated config is the same as the last one (case 2)', async () => {
             const elm = createElement('x-same-config', { is: SameConfigCase });
             elm.a = 3;
             document.body.appendChild(elm);
 
-            setTimeout(() => {
-                const firstResult = elm.resultApiValueDependency;
-                expect(firstResult.a).toBe(3);
+            await new Promise(setTimeout);
 
-                // setting same api value
-                elm.a = 3;
+            const firstResult = elm.resultApiValueDependency;
+            expect(firstResult.a).toBe(3);
 
-                setTimeout(() => {
-                    const secondResult = elm.resultApiValueDependency;
+            // setting same api value
+            elm.a = 3;
 
-                    expect(firstResult).toBe(secondResult);
+            await new Promise(setTimeout);
 
-                    done();
-                }, 0);
-            }, 0);
+            const secondResult = elm.resultApiValueDependency;
+
+            expect(firstResult).toBe(secondResult);
         });
     });
 

--- a/packages/@lwc/integration-karma/test/wire/reactive-params.spec.js
+++ b/packages/@lwc/integration-karma/test/wire/reactive-params.spec.js
@@ -3,16 +3,17 @@ import { createElement } from 'lwc';
 import CascadeWiredProps from 'x/cascadeWiredProps';
 
 describe('@wire reactive parameters', () => {
-    it('should provide complete configuration to dependent adapter', (done) => {
+    it('should provide complete configuration to dependent adapter', async () => {
         const elm = createElement('x-cascade-wire', { is: CascadeWiredProps });
-        elm.addEventListener('dependantwirevalue', (evt) => {
-            const secondWireValue = evt.detail.providedValue;
+        document.body.appendChild(elm);
 
-            expect(secondWireValue.firstParam).toBe('first-param-value');
-            expect(secondWireValue.secondParam).toBe('second-param-value');
-            done();
+        const secondWireValue = await new Promise((resolve) => {
+            elm.addEventListener('dependantwirevalue', (evt) => {
+                resolve(evt.detail.providedValue);
+            });
         });
 
-        document.body.appendChild(elm);
+        expect(secondWireValue.firstParam).toBe('first-param-value');
+        expect(secondWireValue.secondParam).toBe('second-param-value');
     });
 });

--- a/packages/@lwc/integration-karma/test/wire/wiring/index.spec.js
+++ b/packages/@lwc/integration-karma/test/wire/wiring/index.spec.js
@@ -233,32 +233,26 @@ describe('wiring', () => {
                 });
         });
 
-        it('should trigger component rerender when field is updated', (done) => {
+        it('should trigger component rerender when field is updated', async () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
-            void Promise.resolve()
-                .then(() => Promise.resolve()) // In this tick, the config is injected.
-                .then(() => {
-                    // Now the component have re-rendered.
-                    const staticValue = elm.shadowRoot.querySelector('.static');
-                    const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
+            await Promise.resolve();
+            await Promise.resolve(); // In this tick, the config is injected.
 
-                    expect(staticValue.textContent).toBe('1,2,3');
-                    expect(dynamicValue.textContent).toBe('');
+            // Now the component has re-rendered.
+            const staticValue = elm.shadowRoot.querySelector('.static');
+            const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
 
-                    elm.setDynamicParamSource('modified value');
+            expect(staticValue.textContent).toBe('1,2,3');
+            expect(dynamicValue.textContent).toBe('');
 
-                    setTimeout(() => {
-                        const staticValue = elm.shadowRoot.querySelector('.static');
-                        const dynamicValue = elm.shadowRoot.querySelector('.dynamic');
+            elm.setDynamicParamSource('modified value');
 
-                        expect(staticValue.textContent).toBe('1,2,3');
-                        expect(dynamicValue.textContent).toBe('modified value');
+            await new Promise((resolve) => setTimeout(resolve, 5));
 
-                        done();
-                    }, 5);
-                });
+            expect(staticValue.textContent).toBe('1,2,3');
+            expect(dynamicValue.textContent).toBe('modified value');
         });
 
         it('should not call update when component is disconnected.', () => {


### PR DESCRIPTION
## Details

This PR enables the `vitest/no-done-callback` lint for karma tests and replaces all usages of it with async / await.

This rule is [recommended by jest](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-done-callback.md), and in [vitest the support for done was removed](https://vitest.dev/guide/migration.html#done-callback) years ago in favor of [test context](https://vitest.dev/guide/test-context.html#built-in-test-context).

The [jasmine docs also recommend using async/await](https://vitest.dev/guide/test-context.html#built-in-test-context) over the done callback.

I also noticed most of the tests which use the callback were written ~5 years ago.

This should make debugging easier, as well as transitioning to a different framework if needed.

This PR does not touch tests which are returning promises without the async/await syntax, as it's perfectly valid in some cases.

The majority of the changes were 'manually' transpiled, with no expected change in behavior, but went a bit further than just wrapping the each test in a single promise (something the eslint plugin can do automatically).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
