### PR TITLE
test(engine-server): test scoped slot forwarding

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/expected.html
@@ -1,0 +1,17 @@
+<x-light-container>
+  <x-scoped-slot-parent>
+    <x-scoped-slot-child>
+      <x-leaf>
+        <template shadowrootmode="open">
+          <slot>
+          </slot>
+          <slot name="foo">
+          </slot>
+        </template>
+        <h2>
+          Hello world!
+        </h2>
+      </x-leaf>
+    </x-scoped-slot-child>
+  </x-scoped-slot-parent>
+</x-light-container>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/index.js
@@ -1,0 +1,4 @@
+export const tagName = 'x-light-container';
+export { default } from 'x/lightContainer';
+export * from 'x/lightContainer';
+export const features = [];

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/leaf/leaf.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/leaf/leaf.html
@@ -1,0 +1,4 @@
+<template>
+    <slot></slot>
+    <slot name="foo"></slot>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/leaf/leaf.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/leaf/leaf.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/lightContainer/lightContainer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/lightContainer/lightContainer.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <x-scoped-slot-parent></x-scoped-slot-parent>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/lightContainer/lightContainer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/lightContainer/lightContainer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotChild/scopedSlotChild.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotChild/scopedSlotChild.html
@@ -1,0 +1,6 @@
+<template lwc:render-mode="light">
+    <x-leaf>
+        <!-- Note the slot mapping does not work for scoped slots -->
+        <slot lwc:slot-bind={title} slot="foo"></slot>
+    </x-leaf>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotChild/scopedSlotChild.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotChild/scopedSlotChild.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+
+    title = 'Hello world!';
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotParent/scopedSlotParent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotParent/scopedSlotParent.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    <x-scoped-slot-child>
+        <template lwc:slot-data="title">
+            <h2>{title}</h2>
+        </template>
+    </x-scoped-slot-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotParent/scopedSlotParent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-forwarding/scoped-slots/modules/x/scopedSlotParent/scopedSlotParent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}


### PR DESCRIPTION
## Details

This is merely copied from the Karma tests.

Unlike normal light DOM slots, which throw an error (#4668), scoped light DOM slots do not throw an error when forwarded. So we can just add a test here and increase our test coverage in `engine-server`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
