### PR TITLE
chore(integration-karma): provide filename for ssr code in hydration tests

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -130,18 +130,24 @@ function throwOnUnexpectedConsoleCalls(runnable) {
     }
 }
 
-function getSsrCode(moduleCode, testConfig) {
+/**
+ * @param {string} moduleCode
+ * @param {string} testConfig
+ * @param {string} filename
+ */
+function getSsrCode(moduleCode, testConfig, filename) {
     const script = new vm.Script(
         `
         ${testConfig};
         config = config || {};
         ${moduleCode};
-        moduleOutput = LWC.renderComponent('x-${COMPONENT_UNDER_TEST}-${guid++}', Main, config.props || {});`
+        moduleOutput = LWC.renderComponent('x-${COMPONENT_UNDER_TEST}-${guid++}', Main, config.props || {});`,
+        { filename }
     );
 
     throwOnUnexpectedConsoleCalls(() => {
         vm.createContext(context);
-        script.runInContext(context);
+        script.runInContext(context, { filename });
     });
 
     return context.moduleOutput;
@@ -189,7 +195,7 @@ function createHCONFIG2JSPreprocessor(config, logger, emitter) {
             // You can add an `.only` file alongside an `index.spec.js` file to make it `fdescribe()`
             const onlyFileExists = await exists(path.join(suiteDir, '.only'));
 
-            const ssrOutput = getSsrCode(componentDef, testCode);
+            const ssrOutput = getSsrCode(componentDef, testCode, path.join(suiteDir, 'ssr.js'));
 
             watcher.watchSuite(filePath, testWatchFiles.concat(componentWatchFiles));
             const newContent = format(

--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -147,7 +147,7 @@ function getSsrCode(moduleCode, testConfig, filename) {
 
     throwOnUnexpectedConsoleCalls(() => {
         vm.createContext(context);
-        script.runInContext(context, { filename });
+        script.runInContext(context);
     });
 
     return context.moduleOutput;


### PR DESCRIPTION
## Details

I was having trouble debugging the ssr code generated in hydration tests. With this change, it shows up in stack traces and the code is highlighted. In VSCode it also persists break points between sessions.

<img width="918" alt="Screenshot 2024-10-22 at 16 48 12" src="https://github.com/user-attachments/assets/b77f12d1-4dde-4c5b-bd46-36eb3ec460ec">

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
