### PR TITLE
fix(engine-core): dynamic class with empty string results in hydration mismatch

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -667,7 +667,7 @@ function validateClassAttr(
     if (
         !isUndefined(className) &&
         String(className) !== elmClassName &&
-        // No mismatch if SSR className is empty and the client-side class is null
+        // No mismatch if SSR `class` attribute is missing and CSR `class` is the empty string
         !(className === '' && isNull(elmClassName))
     ) {
         // className is used when class is bound to an expr.

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -664,7 +664,12 @@ function validateClassAttr(
 
     const elmClassName = getAttribute(elm, 'class');
 
-    if (!isUndefined(className) && String(className) !== elmClassName && className !== '') {
+    if (
+        !isUndefined(className) &&
+        String(className) !== elmClassName &&
+        // No mismatch if SSR className is empty and the client-side class is null
+        !(className === '' && isNull(elmClassName))
+    ) {
         // className is used when class is bound to an expr.
         nodesAreCompatible = false;
         // stringify for pretty-printing

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -664,7 +664,7 @@ function validateClassAttr(
 
     const elmClassName = getAttribute(elm, 'class');
 
-    if (!isUndefined(className) && String(className) !== elmClassName) {
+    if (!isUndefined(className) && String(className) !== elmClassName && className !== '') {
         // className is used when class is bound to an expr.
         nodesAreCompatible = false;
         // stringify for pretty-printing

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/index.spec.js
@@ -1,0 +1,17 @@
+export default {
+    props: {
+        classes: '',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.className).toBe(snapshots.classes);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p class={classes}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api classes;
+}


### PR DESCRIPTION
## Details

Hopefully this is right, but if not there should be some test that fails.

Closes #4661

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

No hydration mismatch on dynamic class with empty string 😄 

## GUS work item

<!-- Work ID in text, if applicable. -->
