### PR TITLE
feat(ssr): add SSR compilation mode

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -33,8 +33,8 @@ const DEFAULT_OPTIONS = {
     disableSyntheticShadowSupport: false,
     enableLightningWebSecurityTransforms: false,
     targetSSR: false,
-    ssrMode: 'sync' as CompilationMode,
-};
+    ssrMode: 'sync',
+} as const;
 
 const DEFAULT_DYNAMIC_IMPORT_CONFIG: Required<DynamicImportConfig> = {
     loader: '',

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -6,6 +6,7 @@
  */
 import { InstrumentationObject, CompilerValidationErrors, invariant } from '@lwc/errors';
 import { isUndefined, isBoolean, getAPIVersionFromNumber } from '@lwc/shared';
+import { CompilationMode } from '@lwc/ssr-compiler';
 import type { CustomRendererConfig } from '@lwc/template-compiler';
 
 /**
@@ -128,7 +129,7 @@ export interface TransformOptions {
     instrumentation?: InstrumentationObject;
     /** API version to associate with the compiled module. Values correspond to Salesforce platform releases. */
     apiVersion?: number;
-    targetSSR?: boolean;
+    targetSSR?: CompilationMode | null;
 }
 
 type OptionalTransformKeys =
@@ -237,6 +238,6 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         outputConfig,
         experimentalDynamicComponent,
         apiVersion,
-        targetSSR: !!options.targetSSR,
+        targetSSR: options.targetSSR ?? null,
     };
 }

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -32,6 +32,8 @@ const DEFAULT_OPTIONS = {
     experimentalComplexExpressions: false,
     disableSyntheticShadowSupport: false,
     enableLightningWebSecurityTransforms: false,
+    targetSSR: false,
+    ssrMode: 'sync' as CompilationMode,
 };
 
 const DEFAULT_DYNAMIC_IMPORT_CONFIG: Required<DynamicImportConfig> = {
@@ -129,7 +131,8 @@ export interface TransformOptions {
     instrumentation?: InstrumentationObject;
     /** API version to associate with the compiled module. Values correspond to Salesforce platform releases. */
     apiVersion?: number;
-    targetSSR?: CompilationMode | null;
+    targetSSR?: boolean;
+    ssrMode?: CompilationMode;
 }
 
 type OptionalTransformKeys =
@@ -238,6 +241,5 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         outputConfig,
         experimentalDynamicComponent,
         apiVersion,
-        targetSSR: options.targetSSR ?? null,
     };
 }

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -8,11 +8,7 @@ import * as path from 'path';
 
 import { isString } from '@lwc/shared';
 import { TransformerErrors, generateCompilerError, invariant } from '@lwc/errors';
-import {
-    compileComponentForSSR,
-    compileTemplateForSSR,
-    type CompilationMode,
-} from '@lwc/ssr-compiler';
+import { compileComponentForSSR, compileTemplateForSSR } from '@lwc/ssr-compiler';
 
 import { NormalizedTransformOptions, TransformOptions, validateTransformOptions } from '../options';
 import styleTransform from './style';
@@ -81,10 +77,9 @@ export function transformSync(
     filename: string,
     options: TransformOptions
 ): TransformResult {
-    const ssrCompilationMode = options?.targetSSR ?? null;
     validateArguments(src, filename);
     const normalizedOptions = validateTransformOptions(options);
-    return transformFile(src, filename, normalizedOptions, ssrCompilationMode);
+    return transformFile(src, filename, normalizedOptions);
 }
 
 function validateArguments(src: string, filename: string) {
@@ -95,13 +90,12 @@ function validateArguments(src: string, filename: string) {
 function transformFile(
     src: string,
     filename: string,
-    options: NormalizedTransformOptions,
-    ssrCompilationMode: CompilationMode | null
+    options: NormalizedTransformOptions
 ): TransformResult {
     switch (path.extname(filename)) {
         case '.html':
-            if (ssrCompilationMode) {
-                return compileTemplateForSSR(src, filename, options, ssrCompilationMode);
+            if (options.targetSSR) {
+                return compileTemplateForSSR(src, filename, options, options.ssrMode);
             }
             return templateTransformer(src, filename, options);
 
@@ -114,8 +108,8 @@ function transformFile(
         case '.js':
         case '.mts':
         case '.mjs':
-            if (ssrCompilationMode) {
-                return compileComponentForSSR(src, filename, options, ssrCompilationMode);
+            if (options.targetSSR) {
+                return compileComponentForSSR(src, filename, options, options.ssrMode);
             }
             return scriptTransformer(src, filename, options);
 

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -14,10 +14,11 @@ import { transformSync, StylesheetConfig, DynamicImportConfig } from '@lwc/compi
 import { resolveModule, ModuleRecord, RegistryType } from '@lwc/module-resolver';
 import { APIVersion, getAPIVersionFromNumber } from '@lwc/shared';
 import type { CompilerDiagnostic } from '@lwc/errors';
+import type { CompilationMode } from '@lwc/ssr-compiler';
 
 export interface RollupLwcOptions {
     /** A boolean indicating whether to compile for SSR runtime target. */
-    targetSSR?: boolean;
+    targetSSR?: CompilationMode;
     /** A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should transform on. By default all files are targeted. */
     include?: FilterPattern;
     /** A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should not transform. By default no files are ignored. */

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -18,7 +18,9 @@ import type { CompilationMode } from '@lwc/ssr-compiler';
 
 export interface RollupLwcOptions {
     /** A boolean indicating whether to compile for SSR runtime target. */
-    targetSSR?: CompilationMode;
+    targetSSR?: boolean;
+    /** The variety of SSR code that should be generated, one of 'sync', 'async', or 'asyncYield' */
+    ssrMode?: CompilationMode;
     /** A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should transform on. By default all files are targeted. */
     include?: FilterPattern;
     /** A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should not transform. By default no files are ignored. */

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -12,6 +12,7 @@ import lwcRollupPlugin from '@lwc/rollup-plugin';
 import { FeatureFlagName } from '@lwc/features/dist/types';
 import { testFixtureDir, formatHTML } from '@lwc/test-utils-lwc-internals';
 import { serverSideRenderComponent } from '@lwc/ssr-runtime';
+import type { CompilationMode } from '../index';
 
 interface FixtureModule {
     tagName: string;
@@ -22,6 +23,8 @@ interface FixtureModule {
 }
 
 vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
+
+const SSR_MODE: CompilationMode = 'sync';
 
 async function compileFixture({ input, dirname }: { input: string; dirname: string }) {
     const modulesDir = path.resolve(dirname, './modules');
@@ -34,7 +37,7 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
         external: ['lwc'],
         plugins: [
             lwcRollupPlugin({
-                targetSSR: true,
+                targetSSR: SSR_MODE,
                 enableDynamicComponents: true,
                 // TODO [#3331]: remove usage of lwc:dynamic in 246
                 experimentalDynamicDirective: true,
@@ -85,7 +88,8 @@ function testFixtures() {
                 result = await serverSideRenderComponent(
                     module!.tagName,
                     module!.generateMarkup,
-                    config?.props ?? {}
+                    config?.props ?? {},
+                    SSR_MODE
                 );
             } catch (err: any) {
                 return {

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -37,7 +37,8 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
         external: ['lwc'],
         plugins: [
             lwcRollupPlugin({
-                targetSSR: SSR_MODE,
+                targetSSR: true,
+                ssrMode: SSR_MODE,
                 enableDynamicComponents: true,
                 // TODO [#3331]: remove usage of lwc:dynamic in 246
                 experimentalDynamicDirective: true,

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -10,6 +10,7 @@ import { traverse, builders as b, is } from 'estree-toolkit';
 import { parseModule } from 'meriyah';
 import { AriaPropNameToAttrNameMap } from '@lwc/shared';
 
+import { transmogrify } from '../transmogrify';
 import { replaceLwcImport } from './lwc-import';
 import { catalogTmplImport } from './catalog-tmpls';
 import { catalogStaticStylesheets, catalogStyleImport } from './stylesheets';
@@ -17,6 +18,7 @@ import { addGenerateMarkupExport } from './generate-markup';
 
 import type { Identifier as EsIdentifier, Program as EsProgram } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
+import type { CompilationMode } from '../shared';
 
 const visitors: Visitors = {
     $: { scope: true },
@@ -112,8 +114,8 @@ const visitors: Visitors = {
     },
 };
 
-export default function compileJS(src: string, filename: string) {
-    const ast = parseModule(src, {
+export default function compileJS(src: string, filename: string, compilationMode: CompilationMode) {
+    let ast = parseModule(src, {
         module: true,
         next: true,
     }) as EsProgram;
@@ -154,6 +156,10 @@ export default function compileJS(src: string, filename: string) {
     }
 
     addGenerateMarkupExport(ast, state, filename);
+
+    if (compilationMode === 'async' || compilationMode === 'sync') {
+        ast = transmogrify(ast, compilationMode);
+    }
 
     return {
         code: generate(ast, {}),

--- a/packages/@lwc/ssr-compiler/src/index.ts
+++ b/packages/@lwc/ssr-compiler/src/index.ts
@@ -7,27 +7,31 @@
 
 import compileJS from './compile-js';
 import compileTemplate from './compile-template';
-import { TransformOptions } from './shared';
+import type { CompilationMode, TransformOptions } from './shared';
 
 export interface CompilationResult {
     code: string;
     map: unknown;
 }
 
+export type { CompilationMode };
+
 export function compileComponentForSSR(
     src: string,
     filename: string,
-    _options: TransformOptions
+    _options: TransformOptions,
+    mode: CompilationMode = 'asyncYield'
 ): CompilationResult {
-    const { code } = compileJS(src, filename);
+    const { code } = compileJS(src, filename, mode);
     return { code, map: undefined };
 }
 
 export function compileTemplateForSSR(
     src: string,
     filename: string,
-    options: TransformOptions
+    options: TransformOptions,
+    mode: CompilationMode = 'asyncYield'
 ): CompilationResult {
-    const { code } = compileTemplate(src, filename, options);
+    const { code } = compileTemplate(src, filename, options, mode);
     return { code, map: undefined };
 }

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -59,3 +59,5 @@ export interface IHoistInstantiation {
 }
 
 export type TransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
+
+export type CompilationMode = 'asyncYield' | 'async' | 'sync';

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -60,4 +60,5 @@ export interface IHoistInstantiation {
 
 export type TransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
 
+/* SSR compilation mode. `async` refers to async functions, `sync` to sync functions, and `asyncYield` to async generator functions. */
 export type CompilationMode = 'asyncYield' | 'async' | 'sync';

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { traverse, builders as b } from 'estree-toolkit';
+import { produce } from 'immer';
+import type { Node } from 'estree';
+import type { Program as EsProgram } from 'estree';
+
+export type TransmogrificationMode = 'sync' | 'async';
+
+interface TransmogrificationState {
+    mode: TransmogrificationMode;
+}
+
+export type Visitors = Parameters<typeof traverse<Node, TransmogrificationState>>[1];
+
+const EMIT_IDENT = b.identifier('$$emit');
+
+const visitors: Visitors = {
+    $: { scope: true },
+    FunctionDeclaration(path, state) {
+        const { node } = path;
+        if (!node?.async || !node?.generator) {
+            return;
+        }
+        node.generator = false;
+        node.async = state.mode === 'async';
+        node.params.unshift(EMIT_IDENT);
+    },
+    YieldExpression(path, state) {
+        const { node } = path;
+        if (!node) {
+            return;
+        }
+
+        if (node.delegate) {
+            // transform `yield* foo(arg)` into `foo($$emit, arg)` or `await foo($$emit, arg)`
+            if (node.argument?.type !== 'CallExpression') {
+                throw new Error(
+                    'Implementation error: cannot transmogrify complex yield-from expressions'
+                );
+            }
+
+            const callExpr = node.argument;
+            callExpr.arguments.unshift(EMIT_IDENT);
+
+            if (state.mode === 'sync') {
+                path.replaceWith(callExpr);
+            } else {
+                path.replaceWith(b.awaitExpression(callExpr));
+            }
+        } else {
+            // transform `yield foo` into `$$emit(foo)`
+            const emittedExpression = node.argument;
+            if (!emittedExpression) {
+                throw new Error(
+                    'Implementation error: cannot transform a yield expression that yields nothing'
+                );
+            }
+
+            path.replaceWith(b.callExpression(EMIT_IDENT, [emittedExpression]));
+        }
+    },
+    ImportSpecifier(path, _state) {
+        // @lwc/ssr-runtime has a couple of helper functions that need to conform to either the generator or
+        // no-generator compilation mode/paradigm. Since these are simple helper functions, we can maintain
+        // two implementations of each helper method:
+        //
+        // - renderAttrs vs renderAttrsNoYield
+        // - fallbackTmpl vs fallbackTmplNoYield
+        //
+        // If this becomes too burdensome to maintain, we can officially deprecate the generator-based approach
+        // and switch the @lwc/ssr-runtime implementation wholesale over to the no-generator paradigm.
+
+        const { node } = path;
+        if (!node || node.imported.type !== 'Identifier') {
+            throw new Error(
+                'Implementation error: unexpected missing identifier in import specifier'
+            );
+        }
+
+        if (
+            path.parent?.type !== 'ImportDeclaration' ||
+            path.parent.source.value !== '@lwc/ssr-runtime'
+        ) {
+            return;
+        }
+
+        if (node.imported.name === 'fallbackTmpl') {
+            node.imported.name = 'fallbackTmplNoYield';
+        } else if (node.imported.name === 'renderAttrs') {
+            node.imported.name = 'renderAttrsNoYield';
+        }
+    },
+};
+
+/**
+ * Transforms async-generator code into either the async or synchronous alternatives that are
+ * ~semantically equivalent. For example, this template:
+ *
+ *   <template>
+ *       <div>foobar</div>
+ *       <x-child></x-child>
+ *   </template>
+ *
+ * Is compiled into the following JavaScript, intended for execution during SSR & stripped down
+ * for the purposes of this example:
+ *
+ *   async function* tmpl(props, attrs, slottedContent, Cmp, instance) {
+ *       yield '<div>foobar</div>';
+ *       const childProps = {};
+ *       const childAttrs = {};
+ *       yield* generateChildMarkup("x-child", childProps, childAttrs, childSlottedContentGenerator);
+ *   }
+ *
+ * When transmogrified in async-mode, the above generated template function becomes the following:
+ *
+ *   async function tmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
+ *       $$emit('<div>foobar</div>');
+ *       const childProps = {};
+ *       const childAttrs = {};
+ *       await generateChildMarkup($$emit, "x-child", childProps, childAttrs, childSlottedContentGenerator);
+ *   }
+ *
+ * When transmogrified in sync-mode, the template function becomes the following:
+ *
+ *   function tmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
+ *       $$emit('<div>foobar</div>');
+ *       const childProps = {};
+ *       const childAttrs = {};
+ *       generateChildMarkup($$emit, "x-child", childProps, childAttrs, childSlottedContentGenerator);
+ *   }
+ *
+ * There are tradeoffs for each of these modes. Notably, the async-yield variety is the easiest to transform
+ * into either of the other varieties and, for that reason, is the variety that is "authored" by the SSR compiler.
+ */
+export function transmogrify(
+    compiledComponentAst: EsProgram,
+    mode: TransmogrificationMode = 'sync'
+): EsProgram {
+    const state: TransmogrificationState = {
+        mode,
+    };
+
+    return produce(compiledComponentAst, (astDraft) => traverse(astDraft, visitors, state));
+}

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -18,6 +18,7 @@ interface TransmogrificationState {
 export type Visitors = Parameters<typeof traverse<Node, TransmogrificationState>>[1];
 
 const EMIT_IDENT = b.identifier('$$emit');
+// Rollup may rename variables to prevent shadowing. When it does, it uses the format `foo$0`, `foo$1`, etc.
 const TMPL_FN_PATTERN = /tmpl($\d+)?/;
 const GEN_MARKUP_PATTERN = /generateMarkup.*/;
 

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -20,7 +20,7 @@ export type Visitors = Parameters<typeof traverse<Node, TransmogrificationState>
 const EMIT_IDENT = b.identifier('$$emit');
 // Rollup may rename variables to prevent shadowing. When it does, it uses the format `foo$0`, `foo$1`, etc.
 const TMPL_FN_PATTERN = /tmpl($\d+)?/;
-const GEN_MARKUP_PATTERN = /generateMarkup.*/;
+const GEN_MARKUP_PATTERN = /generateMarkup($\d+)?/;
 
 const isWithinFn = (pattern: RegExp, nodePath: NodePath): boolean => {
     const { node } = nodePath;

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -77,11 +77,7 @@ const visitors: Visitors = {
             const callExpr = node.argument;
             callExpr.arguments.unshift(EMIT_IDENT);
 
-            if (state.mode === 'sync') {
-                path.replaceWith(callExpr);
-            } else {
-                path.replaceWith(b.awaitExpression(callExpr));
-            }
+            path.replaceWith(state.mode === 'sync' ? callExpr : b.awaitExpression(callExpr));
         } else {
             // transform `yield foo` into `$$emit(foo)`
             const emittedExpression = node.argument;

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -47,11 +47,7 @@ const visitors: Visitors = {
         // Component authors might conceivably use async generator functions in their own code. Therefore,
         // when traversing & transforming written+generated code, we need to disambiguate generated async
         // generator functions from those that were written by the component author.
-        if (
-            // !isGeneratedAsyncGenFn(node.id.name) &&
-            !isWithinFn(GEN_MARKUP_PATTERN, path) &&
-            !isWithinFn(TMPL_FN_PATTERN, path)
-        ) {
+        if (!isWithinFn(GEN_MARKUP_PATTERN, path) && !isWithinFn(TMPL_FN_PATTERN, path)) {
             return;
         }
         node.generator = false;

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -37,7 +37,6 @@ const isWithinFn = (pattern: RegExp, nodePath: NodePath): boolean => {
 };
 
 const visitors: Visitors = {
-    $: { scope: true },
     FunctionDeclaration(path, state) {
         const { node } = path;
         if (!node?.async || !node?.generator) {

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -11,8 +11,10 @@ export { MutationTracker } from './mutation-tracker';
 // renderComponent is an alias for serverSideRenderComponent
 export {
     fallbackTmpl,
+    fallbackTmplNoYield,
     GenerateMarkupFn,
     renderAttrs,
+    renderAttrsNoYield,
     serverSideRenderComponent,
     serverSideRenderComponent as renderComponent,
 } from './render';

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -133,7 +133,7 @@ export async function serverSideRenderComponent(
         };
         (compiledGenerateMarkup as GenerateMarkupFnSyncNoGen)(emit, tagName, props, null, null);
     } else {
-      throw new Error(`Invalid mode: ${mode}`);
+        throw new Error(`Invalid mode: ${mode}`);
     }
 
     return markup;

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { LightningElement, type LightningElementConstructor } from './lightning-element';
 import { mutationTracker } from './mutation-tracker';
+import type { LightningElement, LightningElementConstructor } from './lightning-element';
 import type { Attributes } from './types';
 
 const escapeAttrVal = (attrVal: string) =>
@@ -27,6 +27,25 @@ export function* renderAttrs(instance: LightningElement, attrs: Attributes) {
     yield mutationTracker.renderMutatedAttrs(instance);
 }
 
+export function renderAttrsNoYield(
+    emit: (segment: string) => void,
+    instance: LightningElement,
+    attrs: Attributes
+) {
+    if (!attrs) {
+        return;
+    }
+    for (const attrName of Object.getOwnPropertyNames(attrs)) {
+        const attrVal = attrs[attrName];
+        if (typeof attrVal === 'string') {
+            emit(attrVal === '' ? ` ${attrName}` : ` ${attrName}="${escapeAttrVal(attrVal)}"`);
+        } else if (attrVal === null) {
+            emit('');
+        }
+    }
+    emit(mutationTracker.renderMutatedAttrs(instance));
+}
+
 export function* fallbackTmpl(
     _props: unknown,
     _attrs: unknown,
@@ -39,6 +58,19 @@ export function* fallbackTmpl(
     }
 }
 
+export function fallbackTmplNoYield(
+    emit: (segment: string) => void,
+    _props: unknown,
+    _attrs: unknown,
+    _slotted: unknown,
+    Cmp: LightningElementConstructor,
+    _instance: unknown
+) {
+    if (Cmp.renderMode !== 'light') {
+        emit('<template shadowrootmode="open"></template>');
+    }
+}
+
 export type GenerateMarkupFn = (
     tagName: string,
     props: Record<string, any> | null,
@@ -46,15 +78,60 @@ export type GenerateMarkupFn = (
     slotted: Record<number | string, AsyncGenerator<string>> | null
 ) => AsyncGenerator<string>;
 
+export type GenerateMarkupFnAsyncNoGen = (
+    emit: (segment: string) => void,
+    tagName: string,
+    props: Record<string, any> | null,
+    attrs: Attributes | null,
+    slotted: Record<number | string, AsyncGenerator<string>> | null
+) => Promise<void>;
+
+export type GenerateMarkupFnSyncNoGen = (
+    emit: (segment: string) => void,
+    tagName: string,
+    props: Record<string, any> | null,
+    attrs: Attributes | null,
+    slotted: Record<number | string, AsyncGenerator<string>> | null
+) => void;
+
+type GenerateMarkupFnVariants =
+    | GenerateMarkupFn
+    | GenerateMarkupFnAsyncNoGen
+    | GenerateMarkupFnSyncNoGen;
+
 export async function serverSideRenderComponent(
     tagName: string,
-    compiledGenerateMarkup: GenerateMarkupFn,
-    props: Record<string, any>
+    compiledGenerateMarkup: GenerateMarkupFnVariants,
+    props: Record<string, any>,
+    mode: 'asyncYield' | 'async' | 'sync' = 'asyncYield'
 ): Promise<string> {
     let markup = '';
 
-    for await (const segment of compiledGenerateMarkup(tagName, props, null, null)) {
-        markup += segment;
+    if (mode === 'asyncYield') {
+        for await (const segment of (compiledGenerateMarkup as GenerateMarkupFn)(
+            tagName,
+            props,
+            null,
+            null
+        )) {
+            markup += segment;
+        }
+    } else if (mode === 'async') {
+        const emit = (segment: string) => {
+            markup += segment;
+        };
+        await (compiledGenerateMarkup as GenerateMarkupFnAsyncNoGen)(
+            emit,
+            tagName,
+            props,
+            null,
+            null
+        );
+    } else if (mode === 'sync') {
+        const emit = (segment: string) => {
+            markup += segment;
+        };
+        (compiledGenerateMarkup as GenerateMarkupFnSyncNoGen)(emit, tagName, props, null, null);
     }
 
     return markup;

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -132,6 +132,8 @@ export async function serverSideRenderComponent(
             markup += segment;
         };
         (compiledGenerateMarkup as GenerateMarkupFnSyncNoGen)(emit, tagName, props, null, null);
+    } else {
+      throw new Error(`Invalid mode: ${mode}`);
     }
 
     return markup;


### PR DESCRIPTION
## Details

This PR adds a final step to component compilation when targeting SSR. This final step optionally transforms the async-generator variety of generated code into one of two other varieties: async or sync (without generators).

These two alternate modes are provided primarily for performance reasons; the synchronous SSR compilation mode is at least an order of magnitude faster than generated code that relies on async generators.

A few additional notes:

- There are two helper functions in `@lwc/ssr-runtime` that are paradigm-dependent and (prior to this PR) were implemented as generator functions.
- Alternatives to these helper functions are provided, and are used if either the `sync` or `async` compilation mode is selected.
- Both the compiler _and_ the runtime have to know what mode they're running in
    - the runtime mode has to be the same as whatever was selected during compilation
    - the tests are wired up such that you can change the mode in one place, driving the behavior of both compilation and runtime
- In the future, we may want to just pick the compilation mode that we prefer and not allow other modes to be selected.
    - this would simplify the codebase
    - however, I've gone in this direction so that we have flexibility to accommodate any of the paths forward that have been discussed so far

## Does this pull request introduce a breaking change?

-   😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

-   🤞 No, it does not introduce an observable change.

## GUS work item

W-17029474
