### PR TITLE
fix(engine): fix mutation tracking when getter throws

### DIFF
--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'lwc';
 import Parent from 'x/parent';
 import Child from 'x/child';
+import GetterThrows from 'x/getterThrows';
 
 const arr = jasmine.arrayWithExactContents;
 const obj = jasmine.objectContaining;
@@ -301,4 +302,13 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             );
         });
     });
+});
+
+it('handles case where the getter throws an error', async () => {
+    const elm = createElement('x-getter-throws', { is: GetterThrows });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expect(elm.shadowRoot.querySelector('div').textContent).toBe('hello');
 });

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/getterThrows/getterThrows.html
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/getterThrows/getterThrows.html
@@ -1,0 +1,3 @@
+<template>
+    <div>{trackMe.doesNotThrow}</div>
+</template>

--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/getterThrows/getterThrows.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/x/getterThrows/getterThrows.js
@@ -1,0 +1,26 @@
+import { LightningElement, track } from 'lwc';
+
+const evilArray = [{}];
+Object.defineProperty(evilArray, '0', {
+    get() {
+        throw new Error('evil!');
+    },
+});
+
+export default class extends LightningElement {
+    @track trackMe = {
+        doesNotThrow: 'hello',
+        get throws() {
+            throw new Error('haha!');
+        },
+        get [Symbol('throws')]() {
+            throw new Error('woot!');
+        },
+        array: evilArray,
+        deep: {
+            get throws() {
+                throw new Error('yolo!');
+            },
+        },
+    };
+}


### PR DESCRIPTION
## Details

#4544 introduced a bug. If an `@track`ed object has any getters that throw, and if those errors are not normally encountered during component rendering (e.g. because the template only checks `deep.foo` and not `deep.bar`, and `deep.bar` throws), then we will actually start throwing errors in dev mode because `trackTargetForMutationLogging` will invoke the getter. This PR fixes that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

## GUS work item

W-16911163