### PR TITLE
test: test slots not at top level

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/expected.html
@@ -1,0 +1,22 @@
+<x-outer>
+  <x-inner>
+    a
+    <!---->
+    <div>
+      <div slot="foo">
+        I am the foo slot
+      </div>
+    </div>
+    <div>
+      <div slot="foo">
+        I am also the foo slot
+      </div>
+    </div>
+    <!---->
+    b
+    <!---->
+    fallback for foo
+    <!---->
+    c
+  </x-inner>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <div>
+            <div slot="foo">I am the foo slot</div>
+        </div>
+        <div>
+            <div slot="foo">I am also the foo slot</div>
+        </div>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/light/modules/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/expected.html
@@ -1,0 +1,27 @@
+<x-outer>
+  <template shadowrootmode="open">
+    <x-inner>
+      <template shadowrootmode="open">
+        a
+        <slot>
+          fallback for default
+        </slot>
+        b
+        <slot name="foo">
+          fallback for foo
+        </slot>
+        c
+      </template>
+      <div>
+        <div slot="foo">
+          I am the foo slot
+        </div>
+      </div>
+      <div>
+        <div slot="foo">
+          I am also the foo slot
+        </div>
+      </div>
+    </x-inner>
+  </template>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/inner/inner.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <div>
+            <div slot="foo">I am the foo slot</div>
+        </div>
+        <div>
+            <div slot="foo">I am also the foo slot</div>
+        </div>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/element/shadow/modules/x/outer/outer.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/expected.html
@@ -1,0 +1,22 @@
+<x-outer>
+  <x-inner>
+    a
+    <!---->
+    <x-external>
+      <div slot="foo">
+        I am the foo slot
+      </div>
+    </x-external>
+    <x-external>
+      <div slot="foo">
+        I am also the foo slot
+      </div>
+    </x-external>
+    <!---->
+    b
+    <!---->
+    fallback for foo
+    <!---->
+    c
+  </x-inner>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <x-external lwc:external>
+            <div slot="foo">I am the foo slot</div>
+        </x-external>
+        <x-external lwc:external>
+            <div slot="foo">I am also the foo slot</div>
+        </x-external>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/light/modules/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/expected.html
@@ -1,0 +1,27 @@
+<x-outer>
+  <template shadowrootmode="open">
+    <x-inner>
+      <template shadowrootmode="open">
+        a
+        <slot>
+          fallback for default
+        </slot>
+        b
+        <slot name="foo">
+          fallback for foo
+        </slot>
+        c
+      </template>
+      <x-external>
+        <div slot="foo">
+          I am the foo slot
+        </div>
+      </x-external>
+      <x-external>
+        <div slot="foo">
+          I am also the foo slot
+        </div>
+      </x-external>
+    </x-inner>
+  </template>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/inner/inner.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <x-external lwc:external>
+            <div slot="foo">I am the foo slot</div>
+        </x-external>
+        <x-external lwc:external>
+            <div slot="foo">I am also the foo slot</div>
+        </x-external>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/external/shadow/modules/x/outer/outer.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/expected.html
@@ -1,0 +1,18 @@
+<x-outer>
+  <x-inner>
+    a
+    <!---->
+    fallback for default
+    <!---->
+    b
+    <!---->
+    <div>
+      I am the foo slot
+    </div>
+    <div>
+      I am also the foo slot
+    </div>
+    <!---->
+    c
+  </x-inner>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <template if:true={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template if:true={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/light/modules/x/outer/outer.js
@@ -1,0 +1,6 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+  isTrue = true
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/expected.html
@@ -1,0 +1,23 @@
+<x-outer>
+  <template shadowrootmode="open">
+    <x-inner>
+      <template shadowrootmode="open">
+        a
+        <slot>
+          fallback for default
+        </slot>
+        b
+        <slot name="foo">
+          fallback for foo
+        </slot>
+        c
+      </template>
+      <div slot="foo">
+        I am the foo slot
+      </div>
+      <div slot="foo">
+        I am also the foo slot
+      </div>
+    </x-inner>
+  </template>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/inner/inner.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <template if:true={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template if:true={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/ifTrue/shadow/modules/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  isTrue = true
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/expected.html
@@ -1,0 +1,18 @@
+<x-outer>
+  <x-inner>
+    a
+    <!---->
+    fallback for default
+    <!---->
+    b
+    <!---->
+    <div>
+      I am the foo slot
+    </div>
+    <div>
+      I am also the foo slot
+    </div>
+    <!---->
+    c
+  </x-inner>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/light/modules/x/outer/outer.js
@@ -1,0 +1,6 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  static renderMode = 'light'
+  isTrue = true
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/expected.html
@@ -1,0 +1,23 @@
+<x-outer>
+  <template shadowrootmode="open">
+    <x-inner>
+      <template shadowrootmode="open">
+        a
+        <slot>
+          fallback for default
+        </slot>
+        b
+        <slot name="foo">
+          fallback for foo
+        </slot>
+        c
+      </template>
+      <div slot="foo">
+        I am the foo slot
+      </div>
+      <div slot="foo">
+        I am also the foo slot
+      </div>
+    </x-inner>
+  </template>
+</x-outer>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-outer';
+export { default } from 'x/outer';
+export * from 'x/outer';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/inner/inner.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/inner/inner.js
@@ -1,0 +1,4 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slot-not-at-top-level/lwcIf/shadow/modules/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement} from 'lwc';
+
+export default class extends LightningElement {
+  isTrue = true
+}

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -632,12 +632,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
     // Succeeds if the given DOM element is equivalent to the given HTML in terms of nodes and elements. This is
     // basically the same as `expect(element.outerHTML).toBe(html)` except that it works despite bugs in synthetic shadow.
     function expectEquivalentDOM(element, html) {
-        // parseHTMLUnsafe landed in Chrome 124 https://caniuse.com/mdn-api_document_parsehtmlunsafe_static
-        const fragment = Document.parseHTMLUnsafe
-            ? Document.parseHTMLUnsafe(html)
-            : new DOMParser().parseFromString(html, 'text/html', {
-                  includeShadowRoots: true,
-              });
+        const fragment = Document.parseHTMLUnsafe(html);
 
         function expectEquivalent(a, b) {
             if (!a || !b) {

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -629,8 +629,8 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         });
     }
 
-    // Return true if the given DOM element is equivalent to the given HTML in terms of nodes and elements This is
-    // basically the same as `expect(element.outerHTML).toBe((html)` except that it works despite bugs in synthetic shadow.
+    // Succeeds if the given DOM element is equivalent to the given HTML in terms of nodes and elements. This is
+    // basically the same as `expect(element.outerHTML).toBe(html)` except that it works despite bugs in synthetic shadow.
     function expectEquivalentDOM(element, html) {
         // parseHTMLUnsafe landed in Chrome 124 https://caniuse.com/mdn-api_document_parsehtmlunsafe_static
         const fragment = Document.parseHTMLUnsafe

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -642,7 +642,10 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
         function expectEquivalent(a, b) {
             expect(a.tagName).toBe(b.tagName);
             expect(a.nodeType).toBe(b.nodeType);
-            expect(a.textContent).toBe(b.textContent);
+
+            if (a.nodeType === Node.TEXT_NODE || a.nodeType === Node.COMMENT_NODE) {
+                expect(a.textContent).toBe(b.textContent);
+            }
 
             // attrs
             if (a.nodeType === Node.ELEMENT_NODE && b.nodeType === Node.ELEMENT_NODE) {
@@ -658,6 +661,13 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
             expect(aChildNodes.length).toBe(bChildNodes.length);
             for (let i = 0; i < aChildNodes.length; i++) {
                 expectEquivalent(aChildNodes[i], bChildNodes[i]);
+            }
+
+            // shadow root (recursive)
+            if (a.shadowRoot) {
+                expectEquivalent(a.shadowRoot, b.shadowRoot);
+            } else {
+                expect(a.shadowRoot).toBe(b.shadowRoot);
             }
         }
 

--- a/packages/@lwc/integration-karma/helpers/test-utils.js
+++ b/packages/@lwc/integration-karma/helpers/test-utils.js
@@ -640,9 +640,14 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
               });
 
         function expectEquivalent(a, b) {
+            if (!a || !b) {
+                // null/undefined
+                expect(a).toBe(b);
+                return;
+            }
+
             expect(a.tagName).toBe(b.tagName);
             expect(a.nodeType).toBe(b.nodeType);
-
             if (a.nodeType === Node.TEXT_NODE || a.nodeType === Node.COMMENT_NODE) {
                 expect(a.textContent).toBe(b.textContent);
             }
@@ -664,11 +669,7 @@ window.TestUtils = (function (lwc, jasmine, beforeAll) {
             }
 
             // shadow root (recursive)
-            if (a.shadowRoot) {
-                expectEquivalent(a.shadowRoot, b.shadowRoot);
-            } else {
-                expect(a.shadowRoot).toBe(b.shadowRoot);
-            }
+            expectEquivalent(a.shadowRoot, b.shadowRoot);
         }
 
         expect(fragment.body.childNodes.length).toBe(1); // only supports one top-level element

--- a/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/shared/browsers.js
@@ -21,7 +21,7 @@ exports.STANDARD_SAUCE_BROWSERS = [
         label: 'sl_safari_latest',
         browserName: 'safari',
         browserVersion: 'latest',
-        platformName: 'macOS 12', // Note: this must be updated when macOS releases new updates
+        platformName: 'macOS 13', // Note: this must be updated when macOS releases new updates
     },
 ];
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
@@ -1,20 +1,26 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
+import {
+    expectEquivalentDOM,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+} from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
-it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
-    'renders slots not at the top level',
-    async () => {
-        const elm = createElement('x-outer', { is: Outer });
-        document.body.appendChild(elm);
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
 
-        await Promise.resolve();
+    await Promise.resolve();
 
-        expectEquivalentDOM(
-            elm,
-            `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
-        );
+    let expected;
+    if (USE_LIGHT_DOM_SLOT_FORWARDING) {
+        expected = `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`;
+    } else if (USE_COMMENTS_FOR_FRAGMENT_BOOKENDS) {
+        expected = `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`;
+    } else {
+        expected = `<x-outer><x-inner>a<div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div>bfallback for fooc</x-inner></x-outer>`;
     }
-);
+
+    expectEquivalentDOM(elm, expected);
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/index.spec.js
@@ -1,16 +1,20 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM } from 'test-utils';
+import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
-    const elm = createElement('x-outer', { is: Outer });
-    document.body.appendChild(elm);
+// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
+it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
+    'renders slots not at the top level',
+    async () => {
+        const elm = createElement('x-outer', { is: Outer });
+        document.body.appendChild(elm);
 
-    await Promise.resolve();
+        await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
-    );
-});
+        expectEquivalentDOM(
+            elm,
+            `<x-outer><x-inner>a<!----><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
+        );
+    }
+);

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <div>
+            <div slot="foo">I am the foo slot</div>
+        </div>
+        <div>
+            <div slot="foo">I am also the foo slot</div>
+        </div>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/light/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
@@ -8,8 +8,13 @@ it('renders slots not at the top level', async () => {
 
     await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        `<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div></x-inner></template></x-outer>`
-    );
+    let expected;
+    if (process.env.NATIVE_SHADOW) {
+        expected = `<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div></x-inner></template></x-outer>`;
+    } else {
+        // synthetic shadow does not render the fallback for the default slot
+        expected = `<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot></slot>b<slot name="foo">fallback for foo</slot>c</template><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div></x-inner></template></x-outer>`;
+    }
+
+    expectEquivalentDOM(elm, expected);
 });

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        `<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div><div slot="foo">I am the foo slot</div></div><div><div slot="foo">I am also the foo slot</div></div></x-inner></template></x-outer>`
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/inner/inner.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <div>
+            <div slot="foo">I am the foo slot</div>
+        </div>
+        <div>
+            <div slot="foo">I am also the foo slot</div>
+        </div>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/element/shadow/x/outer/outer.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
@@ -1,5 +1,5 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM } from 'test-utils';
+import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 import Outer from 'x/outer';
 
 beforeAll(() => {
@@ -7,14 +7,18 @@ beforeAll(() => {
 });
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
-    const elm = createElement('x-outer', { is: Outer });
-    document.body.appendChild(elm);
+// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
+it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
+    'renders slots not at the top level',
+    async () => {
+        const elm = createElement('x-outer', { is: Outer });
+        document.body.appendChild(elm);
 
-    await Promise.resolve();
+        await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
-    );
-});
+        expectEquivalentDOM(
+            elm,
+            `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
+        );
+    }
+);

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
@@ -1,0 +1,19 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+beforeAll(() => {
+    customElements.define('x-external-light', class extends HTMLElement {});
+});
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
@@ -6,7 +6,8 @@ beforeAll(() => {
     customElements.define('x-external-light', class extends HTMLElement {});
 });
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/index.spec.js
@@ -1,5 +1,9 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
+import {
+    expectEquivalentDOM,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+} from 'test-utils';
 import Outer from 'x/outer';
 
 beforeAll(() => {
@@ -7,18 +11,20 @@ beforeAll(() => {
 });
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
-it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
-    'renders slots not at the top level',
-    async () => {
-        const elm = createElement('x-outer', { is: Outer });
-        document.body.appendChild(elm);
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
 
-        await Promise.resolve();
+    await Promise.resolve();
 
-        expectEquivalentDOM(
-            elm,
-            `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`
-        );
+    let expected;
+    if (USE_LIGHT_DOM_SLOT_FORWARDING) {
+        expected = `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`;
+    } else if (USE_COMMENTS_FOR_FRAGMENT_BOOKENDS) {
+        expected = `<x-outer><x-inner>a<!----><x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light><!---->b<!---->fallback for foo<!---->c</x-inner></x-outer>`;
+    } else {
+        expected = `<x-outer><x-inner>a<x-external-light><div slot="foo">I am the foo slot</div></x-external-light><x-external-light><div slot="foo">I am also the foo slot</div></x-external-light>bfallback for fooc</x-inner></x-outer>`;
     }
-);
+
+    expectEquivalentDOM(elm, expected);
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <x-external-light lwc:external>
+            <div slot="foo">I am the foo slot</div>
+        </x-external-light>
+        <x-external-light lwc:external>
+            <div slot="foo">I am also the foo slot</div>
+        </x-external-light>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/light/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
@@ -1,0 +1,19 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+beforeAll(() => {
+    customElements.define('x-external-shadow', class extends HTMLElement {});
+});
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><x-external-shadow><div slot="foo">I am the foo slot</div></x-external-shadow><x-external-shadow><div slot="foo">I am also the foo slot</div></x-external-shadow></x-inner></template></x-outer>'
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
@@ -12,8 +12,15 @@ it('renders slots not at the top level', async () => {
 
     await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><x-external-shadow><div slot="foo">I am the foo slot</div></x-external-shadow><x-external-shadow><div slot="foo">I am also the foo slot</div></x-external-shadow></x-inner></template></x-outer>'
-    );
+    let expected;
+    if (process.env.NATIVE_SHADOW) {
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><x-external-shadow><div slot="foo">I am the foo slot</div></x-external-shadow><x-external-shadow><div slot="foo">I am also the foo slot</div></x-external-shadow></x-inner></template></x-outer>';
+    } else {
+        // synthetic shadow does not render the fallback for the default slot
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot></slot>b<slot name="foo">fallback for foo</slot>c</template><x-external-shadow><div slot="foo">I am the foo slot</div></x-external-shadow><x-external-shadow><div slot="foo">I am also the foo slot</div></x-external-shadow></x-inner></template></x-outer>';
+    }
+
+    expectEquivalentDOM(elm, expected);
 });

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/index.spec.js
@@ -6,7 +6,8 @@ beforeAll(() => {
     customElements.define('x-external-shadow', class extends HTMLElement {});
 });
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/inner/inner.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <x-external-shadow lwc:external>
+            <div slot="foo">I am the foo slot</div>
+        </x-external-shadow>
+        <x-external-shadow lwc:external>
+            <div slot="foo">I am also the foo slot</div>
+        </x-external-shadow>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/external/shadow/x/outer/outer.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
@@ -1,16 +1,20 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM } from 'test-utils';
+import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
-    const elm = createElement('x-outer', { is: Outer });
-    document.body.appendChild(elm);
+// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
+it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
+    'renders slots not at the top level',
+    async () => {
+        const elm = createElement('x-outer', { is: Outer });
+        document.body.appendChild(elm);
 
-    await Promise.resolve();
+        await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
-    );
-});
+        expectEquivalentDOM(
+            elm,
+            '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
+        );
+    }
+);

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/index.spec.js
@@ -1,20 +1,28 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
+import {
+    expectEquivalentDOM,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+} from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
-it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
-    'renders slots not at the top level',
-    async () => {
-        const elm = createElement('x-outer', { is: Outer });
-        document.body.appendChild(elm);
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
 
-        await Promise.resolve();
+    await Promise.resolve();
 
-        expectEquivalentDOM(
-            elm,
-            '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
-        );
+    let expected;
+    if (USE_LIGHT_DOM_SLOT_FORWARDING) {
+        expected =
+            '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>';
+    } else if (USE_COMMENTS_FOR_FRAGMENT_BOOKENDS) {
+        expected = `<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div><!---->c</x-inner></x-outer>`;
+    } else {
+        expected =
+            '<x-outer><x-inner>afallback for defaultb<div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div>c</x-inner></x-outer>';
     }
-);
+
+    expectEquivalentDOM(elm, expected);
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <template if:true={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template if:true={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/light/x/outer/outer.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    isTrue = true;
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
@@ -8,8 +8,15 @@ it('renders slots not at the top level', async () => {
 
     await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>'
-    );
+    let expected;
+    if (process.env.NATIVE_SHADOW) {
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>';
+    } else {
+        // synthetic shadow does not render the fallback for the foo slot
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo"></slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>';
+    }
+
+    expectEquivalentDOM(elm, expected);
 });

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>'
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/inner/inner.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <template if:true={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template if:true={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/ifTrue/shadow/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    isTrue = true;
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
@@ -1,20 +1,28 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
+import {
+    expectEquivalentDOM,
+    USE_LIGHT_DOM_SLOT_FORWARDING,
+    USE_COMMENTS_FOR_FRAGMENT_BOOKENDS,
+} from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
-it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
-    'renders slots not at the top level',
-    async () => {
-        const elm = createElement('x-outer', { is: Outer });
-        document.body.appendChild(elm);
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
 
-        await Promise.resolve();
+    await Promise.resolve();
 
-        expectEquivalentDOM(
-            elm,
-            `<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>`
-        );
+    let expected;
+    if (USE_LIGHT_DOM_SLOT_FORWARDING) {
+        expected =
+            '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>';
+    } else if (USE_COMMENTS_FOR_FRAGMENT_BOOKENDS) {
+        expected = `<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div><!---->c</x-inner></x-outer>`;
+    } else {
+        expected =
+            '<x-outer><x-inner>afallback for defaultb<div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div>c</x-inner></x-outer>';
     }
-);
+
+    expectEquivalentDOM(elm, expected);
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/index.spec.js
@@ -1,16 +1,20 @@
 import { createElement } from 'lwc';
-import { expectEquivalentDOM } from 'test-utils';
+import { expectEquivalentDOM, USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from 'test-utils';
 import Outer from 'x/outer';
 
 // `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
-it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
-    const elm = createElement('x-outer', { is: Outer });
-    document.body.appendChild(elm);
+// USE_COMMENTS_FOR_FRAGMENT_BOOKENDS is needed because otherwise we end up with adjacent text nodes which parse as one
+it.runIf(Document.parseHTMLUnsafe && USE_COMMENTS_FOR_FRAGMENT_BOOKENDS)(
+    'renders slots not at the top level',
+    async () => {
+        const elm = createElement('x-outer', { is: Outer });
+        document.body.appendChild(elm);
 
-    await Promise.resolve();
+        await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        '<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>'
-    );
-});
+        expectEquivalentDOM(
+            elm,
+            `<x-outer><x-inner>a<!---->fallback for default<!---->b<!----><div>I am the foo slot</div><div>I am also the foo slot</div><!---->c</x-inner></x-outer>`
+        );
+    }
+);

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/inner/inner.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template lwc:render-mode="light">
+    <x-inner>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/light/x/outer/outer.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    isTrue = true;
+}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
@@ -8,8 +8,15 @@ it('renders slots not at the top level', async () => {
 
     await Promise.resolve();
 
-    expectEquivalentDOM(
-        elm,
-        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>'
-    );
+    let expected;
+    if (process.env.NATIVE_SHADOW) {
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>';
+    } else {
+        // synthetic shadow does not render the fallback for the foo slot
+        expected =
+            '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo"></slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>';
+    }
+
+    expectEquivalentDOM(elm, expected);
 });

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
@@ -2,7 +2,8 @@ import { createElement } from 'lwc';
 import { expectEquivalentDOM } from 'test-utils';
 import Outer from 'x/outer';
 
-it('renders slots not at the top level', async () => {
+// `expectEquivalentDOM` requires `Document.parseHTMLUnsafe`
+it.runIf(Document.parseHTMLUnsafe)('renders slots not at the top level', async () => {
     const elm = createElement('x-outer', { is: Outer });
     document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/index.spec.js
@@ -1,0 +1,15 @@
+import { createElement } from 'lwc';
+import { expectEquivalentDOM } from 'test-utils';
+import Outer from 'x/outer';
+
+it('renders slots not at the top level', async () => {
+    const elm = createElement('x-outer', { is: Outer });
+    document.body.appendChild(elm);
+
+    await Promise.resolve();
+
+    expectEquivalentDOM(
+        elm,
+        '<x-outer><template shadowrootmode="open"><x-inner><template shadowrootmode="open">a<slot>fallback for default</slot>b<slot name="foo">fallback for foo</slot>c</template><div slot="foo">I am the foo slot</div><div slot="foo">I am also the foo slot</div></x-inner></template></x-outer>'
+    );
+});

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/inner/inner.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/inner/inner.html
@@ -1,0 +1,7 @@
+<template>
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/inner/inner.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/inner/inner.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/outer/outer.html
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/outer/outer.html
@@ -1,0 +1,10 @@
+<template>
+    <x-inner>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am the foo slot</div>
+        </template>
+        <template lwc:if={isTrue}>
+            <div slot="foo">I am also the foo slot</div>
+        </template>
+    </x-inner>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/outer/outer.js
+++ b/packages/@lwc/integration-karma/test/rendering/slot-not-at-top-level/lwcIf/shadow/x/outer/outer.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    isTrue = true;
+}


### PR DESCRIPTION
## Details

When working on the SSR compiler, the question came up of how `slot` attributes work when not at the top level, e.g.:

```html
<x-foo>
  <div>
    <span slot="does-this-work"></span>
  </div>
</x-foo>
```

The answer seems to be that our behavior for light DOM slots is correct insofar as it matches native shadow DOM behavior (which is that only `slot` attributes at the true top level – just elements, not including our framework directives like `<template lwc:if>`). Synthetic shadow also seems to behave correctly.

This PR is just asserting the existing behavior.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
