### PR TITLE
chore(engine-server): run test fixtures concurrently

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -24,11 +24,15 @@ vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
 
 vi.mock('lwc', async () => {
     const lwcEngineServer = await import('../index');
-    lwcEngineServer!.setHooks({
-        sanitizeHtmlContent(content: unknown) {
-            return content as string;
-        },
-    });
+    try {
+        lwcEngineServer!.setHooks({
+            sanitizeHtmlContent(content: unknown) {
+                return content as string;
+            },
+        });
+    } catch (_err) {
+        // Ignore error if the hook is already overridden
+    }
     return lwcEngineServer;
 });
 
@@ -120,6 +124,6 @@ function testFixtures() {
     );
 }
 
-describe('fixtures', () => {
+describe.concurrent('fixtures', () => {
     testFixtures();
 });


### PR DESCRIPTION
## Details

Small but easy improvement observed locally ~1.65s to ~1.25s.

This is still the longest-running test file (in subsequent runs), so this might help uncover other ways to improve.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
