### PR TITLE
test(integration-karma): fix flaky `PerformanceObserver` test

### DIFF
--- a/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
+++ b/packages/@lwc/integration-karma/test/profiler/mutation-logging/index.spec.js
@@ -5,38 +5,25 @@ import Child from 'x/child';
 const arr = jasmine.arrayWithExactContents;
 const obj = jasmine.objectContaining;
 
-const sentinelObserver = new EventTarget();
-
 let entries = [];
-let observer;
 
 beforeEach(() => {
-    observer = new PerformanceObserver((list) => {
-        const newEntries = list.getEntries();
-        entries.push(
-            ...newEntries.filter((_) => ['lwc-hydrate', 'lwc-rehydrate'].includes(_.name))
-        );
-        if (newEntries.some((_) => _.name === 'sentinel')) {
-            sentinelObserver.dispatchEvent(new CustomEvent('sentinel'));
+    const perfMeasure = performance.measure.bind(performance);
+
+    // We could use PerformanceObserver for this, but it's awkward and unreliable for unit testing
+    // See: https://github.com/salesforce/lwc/issues/4600
+    spyOn(performance, 'measure').and.callFake((...args) => {
+        const entry = perfMeasure(...args);
+        if (['lwc-hydrate', 'lwc-rehydrate'].includes(entry.name)) {
+            entries.push(entry);
         }
+        return entry;
     });
-    observer.observe({ entryTypes: ['measure'] });
 });
 
 afterEach(() => {
     entries = [];
-    observer.disconnect();
 });
-
-// We have to wait for a "sentinel" measure because the PerformanceObserver doesn't guarantee when it's
-// going to be called.
-async function waitForSentinelMeasure() {
-    await Promise.resolve(); // wait a tick for the component itself to render
-    await new Promise((resolve) => {
-        sentinelObserver.addEventListener('sentinel', resolve, { once: true });
-        performance.measure('sentinel');
-    });
-}
 
 function rehydrationEntry(tagName, propString) {
     return obj({
@@ -60,10 +47,10 @@ it.runIf(process.env.NODE_ENV === 'production')('No perf measures in prod mode',
     const elm = createElement('x-child', { is: Child });
     document.body.appendChild(elm);
 
-    await waitForSentinelMeasure();
+    await Promise.resolve();
     elm.firstName = 'Ferdinand';
 
-    await waitForSentinelMeasure();
+    await Promise.resolve();
     expect(entries).toEqual([]);
 });
 
@@ -76,7 +63,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             elm = createElement('x-child', { is: Child });
             document.body.appendChild(elm);
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expect(entries).toEqual(arr([obj({ name: 'lwc-hydrate' })]));
             entries = []; // reset
         });
@@ -84,62 +71,62 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
         it('Does basic mutation logging', async () => {
             elm.firstName = 'Ferdinand';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'firstName');
         });
 
         it('Logs subsequent mutations on the same component', async () => {
             elm.firstName = 'Ferdinand';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'firstName');
             entries = []; // reset
 
             elm.lastName = 'Magellan';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'lastName');
             entries = []; // reset
 
             elm.firstName = 'Vasco';
             elm.lastName = 'da Gama';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'firstName, lastName');
         });
 
         it('Logs deep mutation on an object', async () => {
             elm.setPreviousName('first', 'Vancouver');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'previousName.first');
         });
 
         it('Logs deep mutation on an object - characters requiring bracket member notation', async () => {
             elm.setPreviousNameFullName('George Vancouver');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'previousName["full name"]');
         });
 
         it('Logs doubly-deep mutation on an object', async () => {
             elm.setPreviousNameSuffix('short', 'Jr.');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'previousName.suffix.short');
         });
 
         it('Logs deep mutation on an array', async () => {
             elm.addAlias('Magellan');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'aliases.length');
         });
 
         it('Logs deep mutation on an object within an array', async () => {
             elm.setFavoriteIceCreamFlavor('vanilla');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'favoriteFlavors[0].flavor');
         });
 
@@ -148,7 +135,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             elm.setPreviousNameSuffix('short', 'Jr.');
             elm.setFavoriteIceCreamFlavor('vanilla');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry(
                 'x-child',
                 'favoriteFlavors[0].flavor, firstName, previousName.suffix.short'
@@ -160,7 +147,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             document.body.appendChild(elm2);
             elm.firstName = 'Ferdinand';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expect(entries).toEqual(
                 arr([
                     obj({
@@ -175,7 +162,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             const elm2 = createElement('x-child', { is: Child });
             document.body.appendChild(elm2);
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expect(entries).toEqual(
                 arr([
                     obj({
@@ -188,7 +175,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             elm.firstName = 'Marco';
             elm2.lastName = 'Polo';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
 
             expect(entries).toEqual(
                 arr([
@@ -216,28 +203,28 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
         it('Logs for deep non-enumerable prop mutation', async () => {
             elm.setWackyAccessorDeepValue('yolo');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'wackyAccessors.foo.bar');
         });
 
         it('Logs for deep symbol prop mutation', async () => {
             elm.setWackyAccessorSymbol('haha');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(yolo)]');
         });
 
         it('Logs for doubly deep symbol prop mutation', async () => {
             elm.setWackyAccessorDoublyDeepSymbol('wahoo');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'wackyAccessors[Symbol(whoa)].baz');
         });
 
         it('Logs for mutation on deeply-recursive object', async () => {
             elm.setOnRecursiveObject('woohoo');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'recursiveObject.foo');
         });
     });
@@ -252,7 +239,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             await Promise.resolve();
             child = elm.shadowRoot.querySelector('x-child');
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expect(entries).toEqual(
                 arr(
                     // synthetic lifecycle considers this one hydration event rather than two
@@ -267,14 +254,14 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
         it('Logs a mutation on the parent only', async () => {
             elm.firstName = 'Ferdinand';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-parent', 'firstName');
         });
 
         it('Logs a mutation on the child only', async () => {
             child.lastName = 'Magellan';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expectRehydrationEntry('x-child', 'lastName');
         });
 
@@ -282,7 +269,7 @@ describe.skipIf(process.env.NODE_ENV === 'production')('Perf measures in dev mod
             elm.firstName = 'Ferdinand';
             child.lastName = 'Magellan';
 
-            await waitForSentinelMeasure();
+            await Promise.resolve();
             expect(entries).toEqual(
                 arr([
                     obj({


### PR DESCRIPTION
## Details

Fixes #4600.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
