### PR TITLE
fix(ssr): support `.ts` files

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
@@ -21,4 +21,13 @@ describe('component compilation', () => {
         const { code } = compileComponentForSSR(src, filename, {});
         expect(code).toContain('import explicit from "./explicit.html"');
     });
+    test('supports .ts file imports', () => {
+        const src = `
+            import { LightningElement } from 'lwc';
+            export default class extends LightningElement {}
+        `;
+        const filename = path.resolve('component.ts');
+        const { code } = compileComponentForSSR(src, filename, {});
+        expect(code).toContain('import tmpl from "./component.html"');
+    });
 });

--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { basename } from 'node:path';
+import { parse as pathParse } from 'node:path';
 import { is, builders as b } from 'estree-toolkit';
 import { AriaPropNameToAttrNameMap } from '@lwc/shared';
 import { esTemplate } from '../estemplate';
@@ -164,7 +164,7 @@ export function addGenerateMarkupExport(
         : b.identifier('tmpl');
 
     if (!tmplExplicitImports) {
-        const defaultTmplPath = `./${basename(filename, 'js')}html`;
+        const defaultTmplPath = `./${pathParse(filename).name}.html`;
         program.body.unshift(
             bImportDeclaration(b.identifier('tmpl'), b.literal(defaultTmplPath) as StringLiteral)
         );


### PR DESCRIPTION
## Details

See https://github.com/salesforce/lwc/pull/4681#issuecomment-2436286589

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
