### PR TITLE
[DO NOT MERGE] Trigger CI for #4684: fix(engine-core): dynamic class with empty string results in hydration mismatch

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -664,7 +664,7 @@ function validateClassAttr(
 
     const elmClassName = getAttribute(elm, 'class');
 
-    if (!isUndefined(className) && String(className) !== elmClassName) {
+    if (!isUndefined(className) && String(className) !== elmClassName && className !== '') {
         // className is used when class is bound to an expr.
         nodesAreCompatible = false;
         // stringify for pretty-printing

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/index.spec.js
@@ -1,0 +1,17 @@
+export default {
+    props: {
+        classes: '',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).toBe(snapshots.p);
+        expect(p.className).toBe(snapshots.classes);
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p class={classes}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api classes;
+}


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4684.