### PR TITLE
test(hydration): add tests for empty string mismatch

### DIFF
--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/index.spec.js
@@ -1,0 +1,27 @@
+export default {
+    props: {
+        classes: 'yolo',
+    },
+    clientProps: {
+        classes: '',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).not.toBe(snapshots.p);
+        expect(p.className).toBe('');
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "" but found "yolo"',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p class={classes}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-client-nonempty-on-server/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api classes;
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/index.spec.js
@@ -1,0 +1,27 @@
+export default {
+    props: {
+        classes: '',
+    },
+    clientProps: {
+        classes: 'yolo',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            classes: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).not.toBe(snapshots.p);
+        expect(p.className).toBe('yolo');
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "class" has different values, expected "yolo" but found null',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p class={classes}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/class-attr/empty-string-on-server-nonempty-on-client/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api classes;
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/index.spec.js
@@ -1,0 +1,27 @@
+export default {
+    props: {
+        styles: 'color: burlywood;',
+    },
+    clientProps: {
+        styles: '',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            styles: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).not.toBe(snapshots.p);
+        expect(p.getAttribute('style')).toBe(null);
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "" but found "color: burlywood;"',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p style={styles}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-client-nonempty-on-server/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api styles;
+}

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/index.spec.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/index.spec.js
@@ -1,0 +1,27 @@
+export default {
+    props: {
+        styles: '',
+    },
+    clientProps: {
+        styles: 'color: burlywood;',
+    },
+    snapshot(target) {
+        const p = target.shadowRoot.querySelector('p');
+        return {
+            p,
+            styles: p.className,
+        };
+    },
+    test(target, snapshots, consoleCalls) {
+        const p = target.shadowRoot.querySelector('p');
+        expect(p).not.toBe(snapshots.p);
+        expect(p.getAttribute('style')).toBe('color: burlywood;');
+
+        TestUtils.expectConsoleCallsDev(consoleCalls, {
+            error: [
+                'Mismatch hydrating element <p>: attribute "style" has different values, expected "color: burlywood;" but found ""',
+                'Hydration completed with errors.',
+            ],
+        });
+    },
+};

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/x/main/main.html
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/x/main/main.html
@@ -1,0 +1,3 @@
+<template>
+    <p style={styles}>text</p>
+</template>

--- a/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/x/main/main.js
+++ b/packages/@lwc/integration-karma/test-hydration/mismatches/style-attr/empty-string/empty-on-server-nonempty-on-client/x/main/main.js
@@ -1,0 +1,4 @@
+import { LightningElement, api } from 'lwc';
+export default class Main extends LightningElement {
+    @api styles;
+}


### PR DESCRIPTION
## Details

Add tests for hydration mismatches where style/class has the empty string in one case (client/server) and a nonempty string in another. This would have caught this issue: https://github.com/salesforce/lwc/pull/4684/files#r1815784007

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
