### PR TITLE
[DO NOT MERGE] Trigger CI for #4690: chore(engine-server): run test fixtures concurrently

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -24,11 +24,15 @@ vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
 
 vi.mock('lwc', async () => {
     const lwcEngineServer = await import('../index');
-    lwcEngineServer!.setHooks({
-        sanitizeHtmlContent(content: unknown) {
-            return content as string;
-        },
-    });
+    try {
+        lwcEngineServer!.setHooks({
+            sanitizeHtmlContent(content: unknown) {
+                return content as string;
+            },
+        });
+    } catch (_err) {
+        // Ignore error if the hook is already overridden
+    }
     return lwcEngineServer;
 });
 
@@ -120,6 +124,6 @@ function testFixtures() {
     );
 }
 
-describe('fixtures', () => {
+describe.concurrent('fixtures', () => {
     testFixtures();
 });


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4690.