### PR TITLE
test(ssr): add ssr benchmarks

### DIFF
--- a/packages/@lwc/perf-benchmarks-components/rollup.config.mjs
+++ b/packages/@lwc/perf-benchmarks-components/rollup.config.mjs
@@ -16,24 +16,34 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { tmpDir, styledComponents } = generateStyledComponents();
 
+const SSR_MODE = 'asyncYield';
+
+const ENGINE_TYPE_TO_LWC_IMPORT = {
+    dom: '@lwc/engine-dom',
+    server: '@lwc/engine-server',
+    ssr: '@lwc/ssr-runtime',
+};
+
 function createConfig(componentFile, engineType) {
     const rootDir = componentFile.includes(tmpDir)
         ? path.join(tmpDir, 'src')
         : path.join(__dirname, 'src');
-    const lwcImportModule = engineType === 'server' ? '@lwc/engine-server' : '@lwc/engine-dom';
+    const lwcImportModule = ENGINE_TYPE_TO_LWC_IMPORT[engineType];
     return {
         input: componentFile,
         plugins: [
             lwc({
                 rootDir,
                 experimentalComplexExpressions: true,
+                targetSSR: engineType === 'ssr',
+                ssrMode: SSR_MODE,
             }),
             replace({
                 preventAssignment: true,
                 // always run perf tests in prod mode
                 'process.env.NODE_ENV': JSON.stringify('production'),
             }),
-            // Replace `import { foo } from 'lwc'` with '@lwc/engine-server' or '@lwc/engine-dom'
+            // Replace `import { ... } from 'lwc'` with '@lwc/engine-server' / '@lwc/engine-dom' / '@lwc/ssr-runtime'
             replace({
                 preventAssignment: true,
                 delimiters: ['', ''],
@@ -49,13 +59,22 @@ function createConfig(componentFile, engineType) {
         },
         // These packages need to be external so that @lwc/perf-benchmarks can potentially swap them out
         // (e.g. to allow them to run in server mode or DOM mode), and so that Tachometer can swap them out.
-        external: ['lwc', '@lwc/engine-server', '@lwc/engine-dom'],
+        external: ['lwc', '@lwc/engine-server', '@lwc/engine-dom', '@lwc/ssr-runtime'],
+        onwarn({ message, code }) {
+            // We have circular dependencies due to the `tree` component recursively rendering itself.
+            // We have unused imports because the `@lwc/ssr-compiler` currently imports `wire`/`api` from `'lwc'`
+            // regardless of whether it's used or not.
+            // For all other warnings, throw an error out of caution.
+            if (!['CIRCULAR_DEPENDENCY', 'UNUSED_EXTERNAL_IMPORT'].includes(code)) {
+                throw new Error(message);
+            }
+        },
     };
 }
 
 const components = [...globSync(path.join(__dirname, 'src/**/*.js')), ...styledComponents];
 
-const config = ['server', 'dom']
+const config = ['server', 'dom', 'ssr']
     .map((engineType) => components.map((component) => createConfig(component, engineType)))
     .flat();
 

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -11,12 +11,14 @@
         "test:best:ci": "best src --runner remote"
     },
     "//": [
-        "Note it's important for Tachometer that any deps it needs to swap out are dependencies, not devDependencies."
+        "Note it's important for Tachometer that any deps it needs to swap out are dependencies, not devDependencies.",
+        "Don't forget to add these to fix-deps.sh as well."
     ],
     "dependencies": {
         "@lwc/engine-dom": "8.3.0",
         "@lwc/engine-server": "8.3.0",
         "@lwc/perf-benchmarks-components": "8.3.0",
+        "@lwc/ssr-runtime": "8.3.0",
         "@lwc/synthetic-shadow": "8.3.0"
     },
     "devDependencies": {

--- a/packages/@lwc/perf-benchmarks/rollup.config.mjs
+++ b/packages/@lwc/perf-benchmarks/rollup.config.mjs
@@ -7,10 +7,17 @@
 
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { readFileSync } from 'node:fs';
 import { globSync } from 'glob';
 import inject from '@rollup/plugin-inject';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(path.join(__dirname, './package.json'), 'utf-8'));
+
+// lwc packages that need to be swapped in when comparing the current code to the latest tip-of-tree code.
+const swappablePackages = Object.keys(packageJson.dependencies).filter((_) =>
+    _.startsWith('@lwc/')
+);
 
 // Figure out all the packages we might be importing from @lwc/perf-benchmarks-components
 // so that we can tell Rollup that those are `external`.
@@ -40,12 +47,7 @@ function createConfig(benchmarkFile) {
         },
         // These packages need to be external so that Tachometer can dynamically swap them out
         // when comparing the current PR to the tip-of-tree
-        external: [
-            '@lwc/engine-server',
-            '@lwc/engine-dom',
-            '@lwc/synthetic-shadow',
-            ...componentModules,
-        ],
+        external: [...swappablePackages, ...componentModules],
     };
 }
 

--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -11,6 +11,7 @@
 
 const path = require('node:path');
 const { readFile, writeFile } = require('node:fs/promises');
+const { readFileSync } = require('node:fs');
 const { glob } = require('glob');
 const { hashElement } = require('folder-hash');
 
@@ -38,14 +39,12 @@ BENCHMARK_CPU_THROTTLING_RATE =
 
 const benchmarkComponentsDir = path.join(__dirname, '../../../@lwc/perf-benchmarks-components');
 const packageRootDir = path.resolve(__dirname, '..');
+const packageJson = JSON.parse(readFileSync(path.resolve(packageRootDir, 'package.json'), 'utf-8'));
 
 // lwc packages that need to be swapped in when comparing the current code to the latest tip-of-tree code.
-const swappablePackages = [
-    '@lwc/engine-dom',
-    '@lwc/engine-server',
-    '@lwc/synthetic-shadow',
-    '@lwc/perf-benchmarks-components',
-];
+const swappablePackages = Object.keys(packageJson.dependencies).filter((_) =>
+    _.startsWith('@lwc/')
+);
 
 function createHtml(benchmarkFile) {
     return `

--- a/packages/@lwc/perf-benchmarks/scripts/fix-deps.sh
+++ b/packages/@lwc/perf-benchmarks/scripts/fix-deps.sh
@@ -14,7 +14,7 @@ set -e
 
 mkdir -p ./node_modules/@lwc
 
-for pkg in @lwc/engine-dom @lwc/engine-server @lwc/synthetic-shadow @lwc/perf-benchmarks-components; do
+for pkg in @lwc/engine-dom @lwc/engine-server @lwc/perf-benchmarks-components @lwc/ssr-runtime @lwc/synthetic-shadow; do
   if [ ! -L "./node_modules/$pkg" ]; then
     ln -s "../../../../../packages/$pkg" "./node_modules/$pkg"
   fi

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/table-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-server/table-render-10k.benchmark.js
@@ -7,10 +7,10 @@
 
 import { renderComponent } from '@lwc/engine-server';
 
-import Table from '@lwc/perf-benchmarks-components/dist/server/benchmark/cardComponent/cardComponent.js';
+import Table from '@lwc/perf-benchmarks-components/dist/server/benchmark/table/table.js';
 import Store from '@lwc/perf-benchmarks-components/dist/server/benchmark/store/store.js';
 
-benchmark(`server/table/render/10k`, () => {
+benchmark(`server/table-v2/render/10k`, () => {
     run(() => {
         const store = new Store();
         store.runLots();

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table-render-10k.benchmark.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { renderComponent } from '@lwc/ssr-runtime';
+
+import { generateMarkup } from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/table/table.js';
+import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
+
+const SSR_MODE = 'asyncYield';
+
+benchmark(`ssr/table-v2/render/10k`, () => {
+    run(() => {
+        const store = new Store();
+        store.runLots();
+
+        return renderComponent(
+            'benchmark-table',
+            generateMarkup,
+            {
+                rows: store.data,
+            },
+            SSR_MODE
+        );
+    });
+});

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/tablecmp-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/tablecmp-render-10k.benchmark.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { renderComponent } from '@lwc/ssr-runtime';
+
+import { generateMarkup } from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/tableComponent/tableComponent.js';
+import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
+
+const SSR_MODE = 'asyncYield';
+
+benchmark(`ssr/table-component/render/10k`, () => {
+    run(() => {
+        const store = new Store();
+        store.runLots();
+
+        return renderComponent(
+            'benchmark-table',
+            generateMarkup,
+            {
+                rows: store.data,
+            },
+            SSR_MODE
+        );
+    });
+});


### PR DESCRIPTION
## Details

~~This will fail until #4702 is merged, but I wanted to get the PR ready.~~ (_Edit: merged!_)

This adds SSR Tachometer/Best benchmarks. For now I'm merely reusing the existing `engine-server` ones so we can compare them.

Interestingly we have some work to do! Running one iteration only (so not statistically significant), I got:

- `tablecmp-render-10k`: 70ms -> 101ms
- `table-render-10k`: 210ms -> 295ms

Probably this is mostly due to the `asyncYield`, but that's fine. We will be able to hopefully see the improvement later when we switch to a no-yield variant. Plus there are probably other optimizations to do.

**Edit:** yep it is due to `asyncYield`! `sync` is way faster:

- `tablecmp-render-10k`: 19ms
- `table-render-10k`: 47ms

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.