### PR TITLE
chore(ci): bump node/chrome/gha versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,12 +19,12 @@ jobs:
         runs-on: salesforce-Ubuntu
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: '20.12.2'
+                  node-version: '20.18.0'
                   cache: 'yarn'
 
             - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,10 +38,10 @@ jobs:
 
             # Needed for local browser integration tests
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v130
+            - name: Setup chrome v131
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 130
+                  chrome-version: 131
               id: setup-chrome
 
             - name: Install dependencies
@@ -49,8 +49,8 @@ jobs:
               working-directory: ./
 
             # Pin chromedriver to the same version as Chrome above
-            - name: Install chromedriver v130
-              run: yarn add -W chromedriver@^130
+            - name: Install chromedriver v131
+              run: yarn add -W chromedriver@^131
               working-directory: ./
 
             - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,5 +53,5 @@ jobs:
               run: yarn add -W chromedriver@^131
               working-directory: ./
 
-            - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod
-            - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:dev
+            - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod:ci
+            - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:dev:ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,10 +38,10 @@ jobs:
 
             # Needed for local browser integration tests
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v131
+            - name: Setup chrome v130
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 131
+                  chrome-version: 130
               id: setup-chrome
 
             - name: Install dependencies
@@ -49,8 +49,8 @@ jobs:
               working-directory: ./
 
             # Pin chromedriver to the same version as Chrome above
-            - name: Install chromedriver v131
-              run: yarn add -W chromedriver@^131
+            - name: Install chromedriver v130
+              run: yarn add -W chromedriver@^130
               working-directory: ./
 
             - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod:ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,20 +28,20 @@ jobs:
                 working-directory: ./packages/@lwc/integration-tests
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: '20.12.2'
+                  node-version: '20.18.0'
                   cache: 'yarn'
 
             # Needed for local browser integration tests
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v127
+            - name: Setup chrome v130
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 127
+                  chrome-version: 130
               id: setup-chrome
 
             - name: Install dependencies
@@ -49,8 +49,8 @@ jobs:
               working-directory: ./
 
             # Pin chromedriver to the same version as Chrome above
-            - name: Install chromedriver v127
-              run: yarn add -W chromedriver@^127
+            - name: Install chromedriver v130
+              run: yarn add -W chromedriver@^130
               working-directory: ./
 
             - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,10 +38,10 @@ jobs:
 
             # Needed for local browser integration tests
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v130
+            - name: Setup chrome v128
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 130
+                  chrome-version: 128
               id: setup-chrome
 
             - name: Install dependencies
@@ -49,8 +49,8 @@ jobs:
               working-directory: ./
 
             # Pin chromedriver to the same version as Chrome above
-            - name: Install chromedriver v130
-              run: yarn add -W chromedriver@^130
+            - name: Install chromedriver v128
+              run: yarn add -W chromedriver@^128
               working-directory: ./
 
             - run: CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }} yarn local:prod:ci

--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -22,7 +22,7 @@ env:
     PUPPETEER_SKIP_DOWNLOAD: 'true' # only needed for @best/runner-local, unused here
     GITHUB_RUN_ID: ${{github.run_id}}
     COVERAGE: '1'
-    NODE_VERSION: '20.12.2'
+    NODE_VERSION: '20.18.0'
 
 jobs:
     run-karma-tests-group-1:
@@ -34,10 +34,10 @@ jobs:
                 working-directory: ./packages/@lwc/integration-karma
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: 'yarn'
@@ -74,10 +74,10 @@ jobs:
                 working-directory: ./packages/@lwc/integration-karma
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: 'yarn'
@@ -114,10 +114,10 @@ jobs:
                 working-directory: ./packages/@lwc/integration-karma
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: 'yarn'
@@ -156,10 +156,10 @@ jobs:
                 working-directory: ./packages/@lwc/integration-karma
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: 'yarn'
@@ -202,10 +202,10 @@ jobs:
             - run-karma-tests-group-4
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: 'yarn'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,20 +24,20 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: '20.12.2'
+                  node-version: '20.18.0'
                   cache: 'yarn'
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v126
+            - name: Setup chrome v130
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 126
+                  chrome-version: 130
               id: setup-chrome
 
             - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
             # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
             # See: https://github.com/google/tachometer#on-demand-dependencies
-            - name: Install chromedriver v126
-              run: yarn add -W chromedriver@^126
+            - name: Install chromedriver v130
+              run: yarn add -W chromedriver@^130
 
             - name: Check package.json integrity
               run: node ./scripts/tasks/check-and-rewrite-package-json.js --test
@@ -67,7 +67,7 @@ jobs:
             - name: Run unit tests
               run: yarn test:ci
             - name: Upload unit test coverage report
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: test-coverage-report
                   path: coverage/

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,10 +34,10 @@ jobs:
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v131
+            - name: Setup chrome v130
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 131
+                  chrome-version: 130
               id: setup-chrome
 
             - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
             # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
             # See: https://github.com/google/tachometer#on-demand-dependencies
-            - name: Install chromedriver v131
-              run: yarn add -W chromedriver@^131
+            - name: Install chromedriver v130
+              run: yarn add -W chromedriver@^130
 
             - name: Check package.json integrity
               run: node ./scripts/tasks/check-and-rewrite-package-json.js --test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,10 +34,10 @@ jobs:
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v130
+            - name: Setup chrome v131
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 130
+                  chrome-version: 131
               id: setup-chrome
 
             - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
             # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
             # See: https://github.com/google/tachometer#on-demand-dependencies
-            - name: Install chromedriver v130
-              run: yarn add -W chromedriver@^130
+            - name: Install chromedriver v131
+              run: yarn add -W chromedriver@^131
 
             - name: Check package.json integrity
               run: node ./scripts/tasks/check-and-rewrite-package-json.js --test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,10 +34,10 @@ jobs:
 
             # Needed for perf smoke tests, matches the chromedriver version installed by tachometer (https://github.com/google/tachometer/blob/main/README.md#on-demand-dependencies)
             # chrome-version documentation can be found here: https://github.com/browser-actions/setup-chrome?tab=readme-ov-file#usage
-            - name: Setup chrome v130
+            - name: Setup chrome v128
               uses: browser-actions/setup-chrome@v1
               with:
-                  chrome-version: 130
+                  chrome-version: 128
               id: setup-chrome
 
             - name: Install dependencies
@@ -45,8 +45,8 @@ jobs:
 
             # Pin chromedriver to the same version as Chrome above, so Tachometer uses this version.
             # See: https://github.com/google/tachometer#on-demand-dependencies
-            - name: Install chromedriver v130
-              run: yarn add -W chromedriver@^130
+            - name: Install chromedriver v128
+              run: yarn add -W chromedriver@^128
 
             - name: Check package.json integrity
               run: node ./scripts/tasks/check-and-rewrite-package-json.js --test

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -9,6 +9,8 @@
         "local": "yarn local:prod",
         "local:dev": "yarn build:dev && MODE=dev wdio ./scripts/wdio.local.conf.js",
         "local:prod": "yarn build:prod && MODE=prod wdio ./scripts/wdio.local.conf.js",
+        "local:dev:ci": "yarn build:dev && MODE=dev ../../../scripts/ci/retry.sh wdio ./scripts/wdio.local.conf.js",
+        "local:prod:ci": "yarn build:prod && MODE=prod ../../../scripts/ci/retry.sh wdio ./scripts/wdio.local.conf.js",
         "sauce": "yarn sauce:prod",
         "sauce:dev": "MODE=dev yarn build:dev && MODE=dev wdio ./scripts/wdio.sauce.conf.js",
         "sauce:prod": "MODE=prod yarn build:prod && MODE=prod wdio ./scripts/wdio.sauce.conf.js",


### PR DESCRIPTION
## Details

Updating in case this is related to the WDIO failures in #4717

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
