### PR TITLE
refactor(ssr): use import helpers

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheets.ts
@@ -5,20 +5,12 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { builders as b, is } from 'estree-toolkit';
-import { esTemplate } from '../estemplate';
+import { builders as b } from 'estree-toolkit';
 
+import { bImportDefaultDeclaration } from '../estree/builders';
 import type { NodePath } from 'estree-toolkit';
 import type { ImportDeclaration } from 'estree';
 import type { ComponentMetaState } from './types';
-
-const bDefaultStyleImport = esTemplate`
-    import defaultStylesheets from '${is.literal}';
-`<ImportDeclaration>;
-
-const bDefaultScopedStyleImport = esTemplate`
-    import defaultScopedStylesheets from '${is.literal}';
-`<ImportDeclaration>;
 
 export function catalogAndReplaceStyleImports(
     path: NodePath<ImportDeclaration>,
@@ -63,8 +55,11 @@ export function getStylesheetImports(filepath: string) {
     }
 
     return [
-        bDefaultStyleImport(b.literal(`./${moduleName}.css`)),
-        bDefaultScopedStyleImport(b.literal(`./${moduleName}.scoped.css?scoped=true`)),
+        bImportDefaultDeclaration('defaultStylesheets', `./${moduleName}.css`),
+        bImportDefaultDeclaration(
+            'defaultScopedStylesheets',
+            `./${moduleName}.scoped.css?scoped=true`
+        ),
     ];
 }
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -13,17 +13,11 @@ import { esTemplate } from '../estemplate';
 import { getStylesheetImports } from '../compile-js/stylesheets';
 import { addScopeTokenDeclarations } from '../compile-js/stylesheet-scope-token';
 import { transmogrify } from '../transmogrify';
+import { bImportDeclaration } from '../estree/builders';
 import { optimizeAdjacentYieldStmts } from './shared';
 import { templateIrToEsTree } from './ir-to-es';
-import type {
-    ExportDefaultDeclaration as EsExportDefaultDeclaration,
-    ImportDeclaration as EsImportDeclaration,
-} from 'estree';
+import type { ExportDefaultDeclaration as EsExportDefaultDeclaration } from 'estree';
 import type { CompilationMode } from '../shared';
-
-const bStylesheetUtilitiesImport = esTemplate`
-    import { renderStylesheets, hasScopedStaticStylesheets } from '@lwc/ssr-runtime';
-`<EsImportDeclaration>;
 
 // TODO [#4663]: Render mode mismatch between template and compiler should throw.
 const bExportTemplate = esTemplate`
@@ -104,7 +98,7 @@ export default function compileTemplate(
 
     const moduleBody = [
         ...hoisted,
-        bStylesheetUtilitiesImport(),
+        bImportDeclaration(['renderStylesheets', 'hasScopedStaticStylesheets']),
         bExportTemplate(optimizeAdjacentYieldStmts(statements)),
     ];
     let program = b.program(moduleBody, 'module');

--- a/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
@@ -8,20 +8,17 @@
 import { builders as b, is } from 'estree-toolkit';
 import { reservedKeywords } from '@lwc/shared';
 import { Node as IrNode } from '@lwc/template-compiler';
-import { esTemplate } from '../estemplate';
 
+import { bImportDeclaration } from '../estree/builders';
 import { TransformerContext } from './types';
 import type {
-    ImportDeclaration as EsImportDeclaration,
     Statement as EsStatement,
     Expression as EsExpression,
     MemberExpression as EsMemberExpression,
     Identifier as EsIdentifier,
 } from 'estree';
 
-export const bImportHtmlEscape = esTemplate`
-    import { htmlEscape } from '@lwc/ssr-runtime';
-`<EsImportDeclaration>;
+export const bImportHtmlEscape = () => bImportDeclaration(['htmlEscape']);
 export const importHtmlEscapeKey = 'import:htmlEscape';
 
 // This is a mostly-correct regular expression will only match if the entire string

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/for-of.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/for-of.ts
@@ -51,7 +51,7 @@ export const ForOf: Transformer<IrForOf> = function ForEach(node, cxt): EsForOfS
         ? (node.expression as EsExpression)
         : b.memberExpression(b.identifier('instance'), node.expression as EsExpression);
 
-    cxt.hoist(bImportDeclaration(['toIteratorDirective']), 'toIteratorDirective');
+    cxt.hoist(bImportDeclaration(['toIteratorDirective']), 'import:toIteratorDirective');
 
     return [
         bForOfYieldFrom(b.identifier(id), iterable, optimizeAdjacentYieldStmts(forEachStatements)),

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/for-of.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/for-of.ts
@@ -10,13 +10,13 @@ import { esTemplate } from '../../estemplate';
 import { irToEs } from '../ir-to-es';
 import { optimizeAdjacentYieldStmts } from '../shared';
 
+import { bImportDeclaration } from '../../estree/builders';
 import type { ForOf as IrForOf } from '@lwc/template-compiler';
 import type {
     Expression as EsExpression,
     ForOfStatement as EsForOfStatement,
     Identifier as EsIdentifier,
     MemberExpression as EsMemberExpression,
-    ImportDeclaration as EsImportDeclaration,
 } from 'estree';
 import type { Transformer } from '../types';
 
@@ -35,10 +35,6 @@ const bForOfYieldFrom = esTemplate`
     }
 `<EsForOfStatement>;
 
-const bToIteratorDirectiveImport = esTemplate`
-    import { toIteratorDirective } from '@lwc/ssr-runtime';
-`<EsImportDeclaration>;
-
 export const ForOf: Transformer<IrForOf> = function ForEach(node, cxt): EsForOfStatement[] {
     const id = node.iterator.name;
     cxt.pushLocalVars([id]);
@@ -55,7 +51,7 @@ export const ForOf: Transformer<IrForOf> = function ForEach(node, cxt): EsForOfS
         ? (node.expression as EsExpression)
         : b.memberExpression(b.identifier('instance'), node.expression as EsExpression);
 
-    cxt.hoist(bToIteratorDirectiveImport(), 'toIteratorDirective');
+    cxt.hoist(bImportDeclaration(['toIteratorDirective']), 'toIteratorDirective');
 
     return [
         bForOfYieldFrom(b.identifier(id), iterable, optimizeAdjacentYieldStmts(forEachStatements)),

--- a/packages/@lwc/ssr-compiler/src/estree/builders.ts
+++ b/packages/@lwc/ssr-compiler/src/estree/builders.ts
@@ -5,12 +5,26 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { is } from 'estree-toolkit';
-import { esTemplate } from '../estemplate';
-import { isStringLiteral } from './validators';
+import { builders as b } from 'estree-toolkit';
 
 import type { ImportDeclaration } from 'estree';
 
-export const bImportDeclaration = esTemplate`
-    import ${is.identifier} from "${isStringLiteral}";
-`<ImportDeclaration>;
+/** Creates a default import statement, e.g. `import pkg from "pkg"` */
+export const bImportDefaultDeclaration = (name: string, source: string): ImportDeclaration =>
+    b.importDeclaration([b.importDefaultSpecifier(b.identifier(name))], b.literal(source));
+
+/**
+ * Creates an import statement, e.g. `import { foo, bar as $bar$ } from "pkg"`.
+ * Does not support default or namespace imports (`import pkg` or `import * as pkg`).
+ * @param imports names to be imported; values can be a string (plain import) or object (aliased)
+ * @param source source location to import from; defaults to @lwc/ssr-runtime
+ */
+export const bImportDeclaration = (
+    imports: (string | Record<string, string>)[],
+    source = '@lwc/ssr-runtime'
+): ImportDeclaration => {
+    const specifiers = imports
+        .flatMap((imp) => (typeof imp === 'string' ? ([[imp, imp]] as const) : Object.entries(imp)))
+        .map(([imported, local]) => b.importSpecifier(b.identifier(imported), b.identifier(local)));
+    return b.importDeclaration(specifiers, b.literal(source));
+};

--- a/packages/@lwc/ssr-compiler/src/estree/validators.ts
+++ b/packages/@lwc/ssr-compiler/src/estree/validators.ts
@@ -11,7 +11,7 @@ import type { Checker } from 'estree-toolkit/dist/generated/is-type';
 import type { Node } from 'estree-toolkit/dist/helpers'; // estree's `Node` is not compatible?
 
 /** Node representing a string literal. */
-type StringLiteral = SimpleLiteral & { value: string };
+export type StringLiteral = SimpleLiteral & { value: string };
 
 export const isStringLiteral = (node: Node | null | undefined): node is StringLiteral => {
     return is.literal(node) && typeof node.value === 'string';

--- a/packages/@lwc/ssr-compiler/src/estree/validators.ts
+++ b/packages/@lwc/ssr-compiler/src/estree/validators.ts
@@ -6,16 +6,9 @@
  */
 
 import { is } from 'estree-toolkit';
-import type { CallExpression, Identifier, MemberExpression, SimpleLiteral } from 'estree';
+import type { CallExpression, Identifier, MemberExpression } from 'estree';
 import type { Checker } from 'estree-toolkit/dist/generated/is-type';
 import type { Node } from 'estree-toolkit/dist/helpers'; // estree's `Node` is not compatible?
-
-/** Node representing a string literal. */
-export type StringLiteral = SimpleLiteral & { value: string };
-
-export const isStringLiteral = (node: Node | null | undefined): node is StringLiteral => {
-    return is.literal(node) && typeof node.value === 'string';
-};
 
 /** Node representing an identifier named "render". */
 type RenderIdentifier = Identifier & { name: 'render' };


### PR DESCRIPTION
## Details

Doing unrelated work, I noticed that we have an import helper that we don't use! So I used it. I also gave it an easier to use signature.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
