### PR TITLE
feat: allow passing default export to `renderComponent`

### DIFF
--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table-render-10k.benchmark.js
@@ -7,7 +7,7 @@
 
 import { renderComponent } from '@lwc/ssr-runtime';
 
-import { generateMarkup } from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/table/table.js';
+import Table from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/table/table.js';
 import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
 
 const SSR_MODE = 'asyncYield';
@@ -19,7 +19,7 @@ benchmark(`ssr/table-v2/render/10k`, () => {
 
         return renderComponent(
             'benchmark-table',
-            generateMarkup,
+            Table,
             {
                 rows: store.data,
             },

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/tablecmp-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/tablecmp-render-10k.benchmark.js
@@ -7,7 +7,7 @@
 
 import { renderComponent } from '@lwc/ssr-runtime';
 
-import { generateMarkup } from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/tableComponent/tableComponent.js';
+import Table from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/tableComponent/tableComponent.js';
 import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
 
 const SSR_MODE = 'asyncYield';
@@ -19,7 +19,7 @@ benchmark(`ssr/table-component/render/10k`, () => {
 
         return renderComponent(
             'benchmark-table',
-            generateMarkup,
+            Table,
             {
                 rows: store.data,
             },

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -17,7 +17,6 @@ import type { CompilationMode } from '../index';
 interface FixtureModule {
     tagName: string;
     default: any;
-    generateMarkup: any;
     props?: { [key: string]: any };
     features?: FeatureFlagName[];
 }
@@ -88,7 +87,7 @@ function testFixtures() {
             try {
                 result = await serverSideRenderComponent(
                     module!.tagName,
-                    module!.generateMarkup,
+                    module!.default,
                     config?.props ?? {},
                     SSR_MODE
                 );

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -13,7 +13,7 @@ import { transmogrify } from '../transmogrify';
 import { replaceLwcImport } from './lwc-import';
 import { catalogTmplImport } from './catalog-tmpls';
 import { catalogStaticStylesheets, catalogAndReplaceStyleImports } from './stylesheets';
-import { addGenerateMarkupExport } from './generate-markup';
+import { addGenerateMarkupExport, assignGenerateMarkupToComponent } from './generate-markup';
 
 import type { Identifier as EsIdentifier, Program as EsProgram } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
@@ -140,6 +140,7 @@ export default function compileJS(src: string, filename: string, compilationMode
     }
 
     addGenerateMarkupExport(ast, state, filename);
+    assignGenerateMarkupToComponent(ast, state);
 
     if (compilationMode === 'async' || compilationMode === 'sync') {
         ast = transmogrify(ast, compilationMode);

--- a/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
@@ -1,0 +1,94 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { rollup } from 'rollup';
+import lwcRollupPlugin from '@lwc/rollup-plugin';
+import { renderComponent } from '../index';
+
+interface ComponentModule {
+    default: any;
+    generateMarkup: any;
+}
+
+async function compileComponent({
+    input,
+    files,
+}: {
+    input: string;
+    files: { [name: string]: string };
+}) {
+    const dirname = path.resolve(__dirname, 'dist/render-component');
+    const modulesDir = path.resolve(dirname, './src');
+    const outputFile = path.resolve(dirname, './dist/index.js');
+
+    for (const [name, content] of Object.entries(files)) {
+        const filename = path.join(modulesDir, name);
+        await fs.mkdir(path.dirname(filename), { recursive: true });
+        await fs.writeFile(filename, content, 'utf-8');
+    }
+
+    const bundle = await rollup({
+        input: path.resolve(modulesDir, input),
+        external: ['lwc', '@lwc/ssr-runtime'],
+        plugins: [
+            lwcRollupPlugin({
+                targetSSR: true,
+                modules: [{ dir: modulesDir }],
+            }),
+        ],
+    });
+
+    await bundle.write({
+        file: outputFile,
+        format: 'esm',
+        exports: 'named',
+    });
+
+    return outputFile;
+}
+
+describe('renderCompponent', () => {
+    let module;
+
+    beforeAll(async () => {
+        const files = {
+            'x/component/component.js': `
+                import { LightningElement } from 'lwc';
+                export default class extends LightningElement {}
+            `,
+            'x/component/component.html': `
+                <template><h1>Hello world</h1></template>
+            `,
+        };
+        const outputFile = await compileComponent({
+            input: 'x/component/component.js',
+            files,
+        });
+
+        module = (await import(outputFile)) as ComponentModule;
+    });
+
+    // TODO [#4726]: remove `generateMarkup` export
+    test('can call `renderComponent()` on `generateMarkup`', async () => {
+        const result = await renderComponent('x-component', module!.generateMarkup, {});
+
+        expect(result).toContain('<h1>Hello world</h1>');
+    });
+
+    test('can call `renderComponent()` on the default export', async () => {
+        const result = await renderComponent('x-component', module!.default, {});
+
+        expect(result).toContain('<h1>Hello world</h1>');
+    });
+
+    test('does not throw if props are not provided', async () => {
+        const result = await renderComponent('x-component', module!.default);
+
+        expect(result).toContain('<h1>Hello world</h1>');
+    });
+
+    test('throws if tagName is not provided', async () => {
+        await expect(() => renderComponent(undefined as any, module!.default, {})).rejects.toThrow(
+            'tagName must be a string, found: undefined'
+        );
+    });
+});

--- a/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
@@ -46,7 +46,7 @@ async function compileComponent({
     return outputFile;
 }
 
-describe('renderCompponent', () => {
+describe('renderComponent', () => {
     let module;
 
     beforeAll(async () => {

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -10,6 +10,7 @@ export {
     LightningElement,
     LightningElementConstructor,
     SYMBOL__SET_INTERNALS,
+    SYMBOL__GENERATE_MARKUP,
 } from './lightning-element';
 export { mutationTracker } from './mutation-tracker';
 // renderComponent is an alias for serverSideRenderComponent

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -40,6 +40,7 @@ interface PropsAvailableAtConstruction {
 }
 
 export const SYMBOL__SET_INTERNALS = Symbol('set-internals');
+export const SYMBOL__GENERATE_MARKUP = Symbol('generate-markup');
 
 export class LightningElement implements PropsAvailableAtConstruction {
     static renderMode?: 'light' | 'shadow';

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -6,7 +6,11 @@
  */
 
 import { mutationTracker } from './mutation-tracker';
-import type { LightningElement, LightningElementConstructor } from './lightning-element';
+import {
+    LightningElement,
+    LightningElementConstructor,
+    SYMBOL__GENERATE_MARKUP,
+} from './lightning-element';
 import type { Attributes, Properties } from './types';
 
 const escapeAttrVal = (attrVal: string) =>
@@ -99,19 +103,31 @@ type GenerateMarkupFnVariants =
     | GenerateMarkupFnAsyncNoGen
     | GenerateMarkupFnSyncNoGen;
 
+interface ComponentWithGenerateMarkup {
+    [SYMBOL__GENERATE_MARKUP]: GenerateMarkupFnVariants;
+}
+
 export async function serverSideRenderComponent(
     tagName: string,
-    compiledGenerateMarkup: GenerateMarkupFnVariants,
-    props: Properties,
+    Component: GenerateMarkupFnVariants | ComponentWithGenerateMarkup,
+    props: Properties = {},
     mode: 'asyncYield' | 'async' | 'sync' = 'asyncYield'
 ): Promise<string> {
+    if (typeof tagName !== 'string') {
+        throw new Error(`tagName must be a string, found: ${tagName}`);
+    }
+
+    // TODO [#4726]: remove `generateMarkup` export
+    const generateMarkup =
+        (Component as ComponentWithGenerateMarkup)[SYMBOL__GENERATE_MARKUP] ?? Component;
+
     let markup = '';
     const emit = (segment: string) => {
         markup += segment;
     };
 
     if (mode === 'asyncYield') {
-        for await (const segment of (compiledGenerateMarkup as GenerateMarkupFn)(
+        for await (const segment of (generateMarkup as GenerateMarkupFn)(
             tagName,
             props,
             null,
@@ -120,15 +136,9 @@ export async function serverSideRenderComponent(
             markup += segment;
         }
     } else if (mode === 'async') {
-        await (compiledGenerateMarkup as GenerateMarkupFnAsyncNoGen)(
-            emit,
-            tagName,
-            props,
-            null,
-            null
-        );
+        await (generateMarkup as GenerateMarkupFnAsyncNoGen)(emit, tagName, props, null, null);
     } else if (mode === 'sync') {
-        (compiledGenerateMarkup as GenerateMarkupFnSyncNoGen)(emit, tagName, props, null, null);
+        (generateMarkup as GenerateMarkupFnSyncNoGen)(emit, tagName, props, null, null);
     } else {
         throw new Error(`Invalid mode: ${mode}`);
     }

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -119,7 +119,7 @@ export async function serverSideRenderComponent(
 
     // TODO [#4726]: remove `generateMarkup` export
     const generateMarkup =
-        (Component as ComponentWithGenerateMarkup)[SYMBOL__GENERATE_MARKUP] ?? Component;
+        SYMBOL__GENERATE_MARKUP in Component ? Component[SYMBOL__GENERATE_MARKUP] : Component;
 
     let markup = '';
     const emit = (segment: string) => {


### PR DESCRIPTION
## Details

Fixes #4719 

Allows `renderComponent` in `@lwc/ssr-runtime` to accept the `default` export from a Component (i.e. the `Component` constructor) as well as the `generateMarkup` export.

The way I'm accomplishing this is by just attaching `generateMarkup` to the `Component` constructor as a symbol. This doesn't prevent all forms of monkeying but it does communicate "hey, don't mess with this."

Eventually I think we should remove the `generateMarkup` export entirely: #4726. For now I'm keeping it to avoid a breaking change.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
