### PR TITLE
feat(ssr): forbid scary attributes

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/inner-outer-html/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/inner-outer-html/config.json
@@ -1,0 +1,6 @@
+{
+  "ssrFiles": {
+    "error": "ssr-error.txt",
+    "expected": "ssr-expected"
+  }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/inner-outer-html/ssr-error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/inner-outer-html/ssr-error.txt
@@ -1,0 +1,1 @@
+Cannot set attribute "inner-h-t-m-l" on <div>.

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -151,10 +151,14 @@ export const Element: Transformer<IrElement | IrExternalComponent | IrSlot> = fu
     const yieldAttrsAndProps = attrsAndProps.flatMap((attr) => {
         const { name, value, type } = attr;
 
-        // For classes, these may need to be prefixed with the scope token
-        const isClass = type === 'Attribute' && name === 'class';
-        if (isClass) {
-            hasClassAttribute = true;
+        let isClass = false;
+        if (type === 'Attribute') {
+            if (name === 'inner-h-t-m-l' || name === 'outer-h-t-m-l') {
+                throw new Error(`Cannot set attribute "${name}" on <${node.name}>.`);
+            } else if (name === 'class') {
+                isClass = true;
+                hasClassAttribute = true;
+            }
         }
 
         cxt.hoist(bImportHtmlEscape(), importHtmlEscapeKey);

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -42,8 +42,6 @@ interface PropsAvailableAtConstruction {
 export const SYMBOL__SET_INTERNALS = Symbol('set-internals');
 export const SYMBOL__GENERATE_MARKUP = Symbol('generate-markup');
 
-const FORBIDDEN_ATTRIBUTES = new Set(['inner-h-t-m-l', 'outer-h-t-m-l']);
-
 export class LightningElement implements PropsAvailableAtConstruction {
     static renderMode?: 'light' | 'shadow';
     static stylesheets?: Stylesheets;
@@ -97,9 +95,6 @@ export class LightningElement implements PropsAvailableAtConstruction {
 
     setAttribute(attrName: string, attrValue: string): void {
         const normalizedName = StringToLowerCase.call(toString(attrName));
-        if (FORBIDDEN_ATTRIBUTES.has(normalizedName)) {
-            throw new Error(`Cannot set attribute "${attrName}" on <${this.tagName}>.`);
-        }
         const normalizedValue = String(attrValue);
         this.#attrs[normalizedName] = normalizedValue;
         reflectAttrToProp(this, normalizedName, normalizedValue);

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -42,6 +42,8 @@ interface PropsAvailableAtConstruction {
 export const SYMBOL__SET_INTERNALS = Symbol('set-internals');
 export const SYMBOL__GENERATE_MARKUP = Symbol('generate-markup');
 
+const FORBIDDEN_ATTRIBUTES = new Set(['inner-h-t-m-l', 'outer-h-t-m-l']);
+
 export class LightningElement implements PropsAvailableAtConstruction {
     static renderMode?: 'light' | 'shadow';
     static stylesheets?: Stylesheets;
@@ -95,6 +97,9 @@ export class LightningElement implements PropsAvailableAtConstruction {
 
     setAttribute(attrName: string, attrValue: string): void {
         const normalizedName = StringToLowerCase.call(toString(attrName));
+        if (FORBIDDEN_ATTRIBUTES.has(normalizedName)) {
+            throw new Error(`Cannot set attribute "${attrName}" on <${this.tagName}>.`);
+        }
         const normalizedValue = String(attrValue);
         this.#attrs[normalizedName] = normalizedValue;
         reflectAttrToProp(this, normalizedName, normalizedValue);


### PR DESCRIPTION
## Details

This is technically divergent behavior from `@lwc/engine-server`, but we want to discourage use of these attributes.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
