### PR TITLE
chore(ssr-compiler): aria loose ends

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
@@ -90,21 +90,6 @@ function getChildAttrsOrProps(
     return b.objectExpression(objectAttrsOrProps);
 }
 
-function reflectAriaPropsAsAttrs(props: IrProperty[]): IrAttribute[] {
-    return props
-        .map((prop) => {
-            if (prop.attributeName.startsWith('aria-') || prop.attributeName === 'role') {
-                return {
-                    type: 'Attribute',
-                    name: prop.attributeName,
-                    value: prop.value,
-                } as IrAttribute;
-            }
-            return null;
-        })
-        .filter((el): el is NonNullable<IrAttribute> => el !== null);
-}
-
 export const Component: Transformer<IrComponent> = function Component(node, cxt) {
     // Import the custom component's generateMarkup export.
     const childGeneratorLocalName = `generateMarkup_${toPropertyName(node.name)}`;
@@ -112,8 +97,6 @@ export const Component: Transformer<IrComponent> = function Component(node, cxt)
     const componentImport = bImportGenerateMarkup(childGeneratorLocalName, importPath);
     cxt.hoist(componentImport, childGeneratorLocalName);
     const childTagName = node.name;
-
-    const attributes = [...node.attributes, ...reflectAriaPropsAsAttrs(node.properties)];
 
     const shadowSlotContent = optimizeAdjacentYieldStmts(irChildrenToEs(node.children, cxt));
 
@@ -135,7 +118,7 @@ export const Component: Transformer<IrComponent> = function Component(node, cxt)
     return [
         bYieldFromChildGenerator(
             getChildAttrsOrProps(node.properties, cxt),
-            getChildAttrsOrProps(attributes, cxt),
+            getChildAttrsOrProps(node.attributes, cxt),
             shadowSlotContent,
             lightSlotContent,
             b.identifier(childGeneratorLocalName),

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -214,6 +214,60 @@ export class LightningElement implements PropsAvailableAtConstruction {
     setAttributeNS(_namespace: string | null, _qualifiedName: string, _value: string): void {
         throw new Error('Method "setAttributeNS" not implemented.');
     }
+
+    // ARIA properties
+    ariaActiveDescendant!: string | null;
+    ariaAtomic!: string | null;
+    ariaAutoComplete!: string | null;
+    ariaBusy!: string | null;
+    ariaChecked!: string | null;
+    ariaColCount!: string | null;
+    ariaColIndex!: string | null;
+    ariaColIndexText!: string | null;
+    ariaColSpan!: string | null;
+    ariaControls!: string | null;
+    ariaCurrent!: string | null;
+    ariaDescribedBy!: string | null;
+    ariaDescription!: string | null;
+    ariaDetails!: string | null;
+    ariaDisabled!: string | null;
+    ariaErrorMessage!: string | null;
+    ariaExpanded!: string | null;
+    ariaFlowTo!: string | null;
+    ariaHasPopup!: string | null;
+    ariaHidden!: string | null;
+    ariaInvalid!: string | null;
+    ariaKeyShortcuts!: string | null;
+    ariaLabel!: string | null;
+    ariaLabelledBy!: string | null;
+    ariaLevel!: string | null;
+    ariaLive!: string | null;
+    ariaModal!: string | null;
+    ariaMultiLine!: string | null;
+    ariaMultiSelectable!: string | null;
+    ariaOrientation!: string | null;
+    ariaOwns!: string | null;
+    ariaPlaceholder!: string | null;
+    ariaPosInSet!: string | null;
+    ariaPressed!: string | null;
+    ariaReadOnly!: string | null;
+    ariaRelevant!: string | null;
+    ariaRequired!: string | null;
+    ariaRoleDescription!: string | null;
+    ariaRowCount!: string | null;
+    ariaRowIndex!: string | null;
+    ariaRowIndexText!: string | null;
+    ariaRowSpan!: string | null;
+    ariaSelected!: string | null;
+    ariaSetSize!: string | null;
+    ariaSort!: string | null;
+    ariaValueMax!: string | null;
+    ariaValueMin!: string | null;
+    ariaValueNow!: string | null;
+    ariaValueText!: string | null;
+    ariaBrailleLabel!: string | null;
+    ariaBrailleRoleDescription!: string | null;
+    role!: string | null;
 }
 
 defineProperties(LightningElement.prototype, reflectionDescriptors);


### PR DESCRIPTION
Would eventually like to remove the use of `any` [here](https://github.com/salesforce/lwc/blob/e3f50fcaff8630ec623626a4ec1cf1a34e45dd23/packages/%40lwc/ssr-runtime/src/reflection.ts#L132).