### PR TITLE
chore(tests): disable usage of vitest globals

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -6,7 +6,6 @@
  */
 import path from 'node:path';
 import { describe } from 'vitest';
-
 import { transformSync } from '@babel/core';
 import { LWC_VERSION, HIGHEST_API_VERSION } from '@lwc/shared';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';

--- a/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/index.spec.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import path from 'node:path';
+import { describe } from 'vitest';
+
 import { transformSync } from '@babel/core';
 import { LWC_VERSION, HIGHEST_API_VERSION } from '@lwc/shared';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, expect, it } from 'vitest';
 import { TransformOptions } from '../../options';
 import { transform } from '../transformer';
 

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { APIVersion, noop } from '@lwc/shared';
 import { TransformOptions } from '../../options';
 import { transformSync } from '../transformer';

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { noop } from '@lwc/shared';
 import { TransformOptions } from '../../options';
 import { transform, transformSync } from '../transformer';

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { transform, transformSync } from '../../transformers/transformer';
 
 function testValidateOptions(methodName: string, method: any) {

--- a/packages/@lwc/engine-core/src/libs/mutation-tracker/__tests__/index.spec.ts
+++ b/packages/@lwc/engine-core/src/libs/mutation-tracker/__tests__/index.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { ReactiveObserver, valueMutated, valueObserved } from '../index';
 
 describe('reactive-service', () => {

--- a/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
+++ b/packages/@lwc/engine-dom/src/formatters/__tests__/component.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import {
     createElement,
     LightningElement,

--- a/packages/@lwc/engine-server/src/__tests__/create-element.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/create-element.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { createElement } from '../index';
 
 describe('createElement', () => {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -5,11 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import path from 'path';
-
+import path from 'node:path';
+import { vi, describe } from 'vitest';
 import { rollup } from 'rollup';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
-import { vi } from 'vitest';
 import { testFixtureDir, formatHTML } from '@lwc/test-utils-lwc-internals';
 import type * as lwc from '../index';
 
@@ -42,7 +41,7 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
 
     const bundle = await rollup({
         input,
-        external: ['lwc'],
+        external: ['lwc', 'vitest'],
         plugins: [
             lwcRollupPlugin({
                 enableDynamicComponents: true,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list-noop/modules/x/getter-class-list-noop/getter-class-list-noop.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list-noop/modules/x/getter-class-list-noop/getter-class-list-noop.js
@@ -1,3 +1,4 @@
+import { expect } from  'vitest';
 import { LightningElement } from 'lwc';
 
 export default class GetterClassListNoop extends LightningElement{

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list/modules/x/getter-class-list/getter-class-list.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/getter-class-list/modules/x/getter-class-list/getter-class-list.js
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { LightningElement } from 'lwc';
 
 export default class GetterClassList extends LightningElement{

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/methods-noop/modules/x/methods-noop/methods-noop.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/methods-noop/modules/x/methods-noop/methods-noop.js
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { LightningElement } from 'lwc';
 
 export default class MethodsNoop extends LightningElement {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/methods-unsupported/modules/x/methods-unsupported/methods-unsupported.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/methods-unsupported/modules/x/methods-unsupported/methods-unsupported.js
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { LightningElement } from 'lwc';
 
 export default class MethodsUnsupported extends LightningElement {

--- a/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
@@ -5,14 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import path from 'path';
-import vm from 'vm';
+import path from 'node:path';
+import vm from 'node:vm';
+import { vi, describe, it, expect } from 'vitest';
 import { parseFragment, serialize } from 'parse5';
 import { rollup, RollupLog } from 'rollup';
 import replace from '@rollup/plugin-replace';
 import virtual from '@rollup/plugin-virtual';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
-import { vi } from 'vitest';
 import * as engineServer from '../index';
 
 /**

--- a/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/render-component.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { renderComponent, LightningElement } from '../index';
 
 class Test extends LightningElement {}

--- a/packages/@lwc/engine-server/src/__tests__/unsupported-apis.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/unsupported-apis.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { it, expect } from 'vitest';
 import { swapComponent, swapStyle, swapTemplate } from '../index';
 
 it('throws error for swapComponent', () => {

--- a/packages/@lwc/engine-server/src/__tests__/validate-style-text-contents.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/validate-style-text-contents.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { validateStyleTextContents } from '../utils/validate-style-text-contents';
 
 // See https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -7,7 +7,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { describe, it, expect } from 'vitest';
-
 import { hasOwnProperty } from '@lwc/shared';
 import * as CompilerErrors from '../compiler/error-info';
 import { LWCErrorInfo } from '../shared/types';

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import 'vitest';
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
 import { hasOwnProperty } from '@lwc/shared';
 import * as CompilerErrors from '../compiler/error-info';
 import { LWCErrorInfo } from '../shared/types';

--- a/packages/@lwc/errors/src/compiler/__tests__/compiler-errors.spec.ts
+++ b/packages/@lwc/errors/src/compiler/__tests__/compiler-errors.spec.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { describe, it, expect } from 'vitest';
-
 import {
     CompilerError,
     generateCompilerError,

--- a/packages/@lwc/errors/src/compiler/__tests__/compiler-errors.spec.ts
+++ b/packages/@lwc/errors/src/compiler/__tests__/compiler-errors.spec.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
+
 import {
     CompilerError,
     generateCompilerError,

--- a/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
+++ b/packages/@lwc/errors/src/compiler/__tests__/error-info.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, expect, it } from 'vitest';
 import * as errorInfo from '../error-info';
 // All exported objects are maps of label/error info, except for GENERIC_COMPILER_ERROR,
 // which is a top-level error info object

--- a/packages/@lwc/features/src/__tests__/features.spec.ts
+++ b/packages/@lwc/features/src/__tests__/features.spec.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { describe, it, expect } from 'vitest';
 import features from '../index';
 
 describe('features', () => {

--- a/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
+++ b/packages/@lwc/features/src/__tests__/lwcRuntimeFlags.spec.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { describe, it, expect } from 'vitest';
 import { lwcRuntimeFlags } from '../index';
 
 describe('lwcRuntimeFlags', () => {

--- a/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
+++ b/packages/@lwc/features/src/__tests__/setFeatureFlag.spec.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { MockInstance, vi } from 'vitest';
+import { vi, describe, afterEach, beforeEach, expect, it, type MockInstance } from 'vitest';
 import { lwcRuntimeFlags, setFeatureFlag } from '../index';
 
 describe('setFeatureFlag', () => {

--- a/packages/@lwc/module-resolver/scripts/test/setup-test.ts
+++ b/packages/@lwc/module-resolver/scripts/test/setup-test.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { expect } from 'vitest';
 import { toThrowErrorWithType } from './matchers/to-throw-error-with-type';
 import { toThrowErrorWithCode } from './matchers/to-throw-error-with-code';
 

--- a/packages/@lwc/module-resolver/src/__tests__/mapping.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/mapping.spec.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { describe, test, expect } from 'vitest';
 import '../../scripts/test/types';
 import { resolveModule } from '../index';
 import { RegistryType } from '../types';

--- a/packages/@lwc/module-resolver/src/__tests__/module-errors.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/module-errors.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, test, expect } from 'vitest';
 import '../../scripts/test/types';
 import { resolveModule } from '../index';
 import { fixture, NO_LWC_MODULE_FOUND_CODE, LWC_CONFIG_ERROR_CODE } from './test-utils';

--- a/packages/@lwc/module-resolver/src/__tests__/multi-version.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/multi-version.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, test, expect } from 'vitest';
 import '../../scripts/test/types';
 import { resolveModule } from '../index';
 import { RegistryType } from '../types';

--- a/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
+++ b/packages/@lwc/module-resolver/src/__tests__/resolve.modules.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, test, expect } from 'vitest';
 import '../../scripts/test/types';
 import { resolveModule } from '../index';
 import { RegistryType } from '../types';

--- a/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
@@ -6,7 +6,6 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-
 import { rollup, RollupLog } from 'rollup';
 import { APIVersion, HIGHEST_API_VERSION, LOWEST_API_VERSION } from '@lwc/shared';
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
 import { rollup, RollupLog } from 'rollup';
 import { APIVersion, HIGHEST_API_VERSION, LOWEST_API_VERSION } from '@lwc/shared';
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
 import { rollup, type RollupLog, type RollupBuild } from 'rollup';
 
 import lwc, { type RollupLwcOptions } from '../../index';

--- a/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
 import { rollup, RollupLog } from 'rollup';
 import lwc, { RollupLwcOptions } from '../../index';
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
@@ -6,7 +6,6 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-
 import { rollup, RollupLog } from 'rollup';
 import lwc, { RollupLwcOptions } from '../../index';
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/integrations/integrations.spec.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
 import { rollup } from 'rollup';
 
 import lwc from '../../index';

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
+import { describe, it, expect } from 'vitest';
 import { rollup, type RollupLog, type Plugin, type RollupBuild } from 'rollup';
 import nodeResolve from '@rollup/plugin-node-resolve';
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/rootDir/rootDir.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/rootDir/rootDir.spec.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
-import { rollup } from 'rollup';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
 
+import { rollup, type RollupLog } from 'rollup';
 import lwc from '../../index';
 
 describe('rootDir', () => {
@@ -35,7 +36,7 @@ describe('rootDir', () => {
     });
 
     it('warns if an "input" object is passed and when "rootDir" is not set', async () => {
-        const warnings: any = [];
+        const warnings: RollupLog[] = [];
 
         await rollup({
             input: {

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
@@ -6,7 +6,6 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-
 import { rollup, RollupLog } from 'rollup';
 import { APIVersion } from '@lwc/shared';
 import lwc from '../../index';

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
 import { rollup, RollupLog } from 'rollup';
 import { APIVersion } from '@lwc/shared';
 import lwc from '../../index';

--- a/packages/@lwc/shared/src/__tests__/assert.spec.ts
+++ b/packages/@lwc/shared/src/__tests__/assert.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { assert } from '../index';
 
 describe('assert', () => {

--- a/packages/@lwc/shared/src/__tests__/html-attributes.spec.ts
+++ b/packages/@lwc/shared/src/__tests__/html-attributes.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, test, expect } from 'vitest';
 import { htmlPropertyToAttribute, kebabCaseToCamelCase } from '../html-attributes';
 
 type StringPair = [prop: string, attr: string];

--- a/packages/@lwc/shared/src/__tests__/signals.spec.ts
+++ b/packages/@lwc/shared/src/__tests__/signals.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { vi } from 'vitest';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
 
 describe('signals', () => {
     let setTrustedSignalSet: (signals: WeakSet<object>) => void;

--- a/packages/@lwc/signals/src/__tests__/index.spec.ts
+++ b/packages/@lwc/signals/src/__tests__/index.spec.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { Signal } from './signal';
 
 describe('signal protocol', () => {

--- a/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { describe, test, expect } from 'vitest';
 import { compileComponentForSSR } from '../index';
 
 describe('component compilation', () => {

--- a/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { is, builders as b } from 'estree-toolkit';
+import { describe, test, expect } from 'vitest';
 import { esTemplate, esTemplateWithYield } from '../estemplate';
 
 describe.each(
@@ -54,7 +55,7 @@ describe.each(
             const tmpl = topLevelFn`
                     const ${is.identifier} = 'foo';
                 `;
-            const doReplacement = () => tmpl(b.literal('I am not an identifier'));
+            const doReplacement = () => tmpl(b.literal('I am not an identifier') as any);
             expect(doReplacement).toThrow(
                 'Validation failed for templated node of type Identifier'
             );

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import path from 'node:path';
-import { vi } from 'vitest';
+import { vi, describe } from 'vitest';
 import { rollup, RollupLog } from 'rollup';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
 import { FeatureFlagName } from '@lwc/features/dist/types';

--- a/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
@@ -1,6 +1,6 @@
 import { parseModule } from 'meriyah';
 import { generate } from 'astring';
-import { beforeAll } from 'vitest';
+import { describe, beforeAll, test, expect } from 'vitest';
 import { transmogrify } from '../transmogrify';
 import type { Program as EsProgram } from 'estree';
 

--- a/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { describe, beforeAll, test, expect } from 'vitest';
 import { rollup } from 'rollup';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
 import { renderComponent } from '../index';

--- a/packages/@lwc/ssr-runtime/src/__tests__/server-side-render-component-alias.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/server-side-render-component-alias.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { renderComponent, serverSideRenderComponent } from '../index';
 
 describe('renderComponent as alias of serverSideRenderComponent', () => {

--- a/packages/@lwc/ssr-runtime/src/__tests__/to-iterator-directive.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/to-iterator-directive.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { toIteratorDirective } from '../to-iterator-directive';
 
 describe('toIteratorDirective', () => {

--- a/packages/@lwc/ssr-runtime/src/__tests__/validate-style-text-contents.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/validate-style-text-contents.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { validateStyleTextContents } from '../validate-style-text-contents';
 
 // See https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions

--- a/packages/@lwc/style-compiler/src/__tests__/index.spec.ts
+++ b/packages/@lwc/style-compiler/src/__tests__/index.spec.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
+import path from 'node:path';
+import { describe } from 'vitest';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';
 import { LWC_VERSION } from '@lwc/shared';
 

--- a/packages/@lwc/style-compiler/src/__tests__/inline.spec.ts
+++ b/packages/@lwc/style-compiler/src/__tests__/inline.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { transform } from '../index';
 
 describe('playground test for debugging', () => {

--- a/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { HIGHEST_API_VERSION } from '@lwc/shared';
 import { normalizeConfig } from '../config';
 

--- a/packages/@lwc/template-compiler/src/__tests__/error-codes.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/error-codes.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { ErrorCodes } from 'parse5';
 import { errorCodesToErrorOn, errorCodesToWarnOnInOlderAPIVersions } from '../parser/parse5Errors';
 

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures.spec.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'path';
+import path from 'node:path';
+import { describe } from 'vitest';
 import { LWC_VERSION } from '@lwc/shared';
 import prettier from 'prettier';
 import { testFixtureDir } from '@lwc/test-utils-lwc-internals';

--- a/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, it, expect } from 'vitest';
 import { DiagnosticLevel } from '@lwc/errors';
 import compile, { Config, parse } from '../index';
 

--- a/packages/@lwc/wire-service/src/__tests__/index.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/index.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { register, WireEventTarget, ValueChangedEvent } from '../index';
 
 describe('WireEventTarget from register', () => {

--- a/packages/lwc/__tests__/default-exports.spec.ts
+++ b/packages/lwc/__tests__/default-exports.spec.ts
@@ -6,6 +6,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { describe, beforeAll, test, expect } from 'vitest';
 
 const PACKAGE_ROOT = path.join(__dirname, '..');
 

--- a/packages/lwc/__tests__/isomorphic-exports.spec.ts
+++ b/packages/lwc/__tests__/isomorphic-exports.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { describe, test, expect } from 'vitest';
 import * as engineDom from '@lwc/engine-dom';
 import * as engineServer from '@lwc/engine-server';
 import * as ssrRuntime from '@lwc/ssr-runtime';

--- a/packages/lwc/__tests__/package-exports.spec.ts
+++ b/packages/lwc/__tests__/package-exports.spec.ts
@@ -6,6 +6,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, test, expect } from 'vitest';
 
 /** Packages that only contain type definitions, no JavaScript. */
 const tsPackages = ['@lwc/types'];

--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -7,6 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { test } from 'vitest';
 import * as glob from 'glob';
 import type { Config as StyleCompilerConfig } from '@lwc/style-compiler';
 const { globSync } = glob;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "lib": ["es2021"],
 
         // Disable automatic inclusion of @types packages
-        "types": ["node", "vitest/globals"],
+        "types": ["node"],
 
         // @rollup/plugin-typescript is actually responsible for writing dist files. Using "." as the declarationDir
         // ensures that .d.ts files are co-located with JS files, e.g. `dist/index.js` and `dist/index.d.ts`.

--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -6,7 +6,6 @@ export default defineConfig({
     test: {
         // Don't time out if we detect a debugger attached
         testTimeout: inspector.url() ? Number.MAX_SAFE_INTEGER : undefined,
-        globals: true,
         include: ['**/*.{test,spec}.{mjs,js,ts}'],
         snapshotFormat: {
             printBasicPrototype: true,


### PR DESCRIPTION
## Details

This was suggested in #4396, and actually improves the IDE experience as the vitest extension is more accurate this way.

Another advantage is that non-test files won't have these globals in the namespace. It's not possible to restrict the types option in tsconfig.json to only test files.

Vitest globals are mostly a convenience option when migrating from jest and not the recommended way.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
