### PR TITLE
fix(engine): do not render empty string attr values

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/expected.html
@@ -1,0 +1,10 @@
+<x-test>
+  <template shadowrootmode="open">
+    <div data-foo>
+    </div>
+    <div data-foo>
+    </div>
+    <div data-foo>
+    </div>
+  </template>
+</x-test>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-test';
+export { default } from 'x/test';
+export * from 'x/test';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/modules/x/test/test.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/modules/x/test/test.html
@@ -1,0 +1,5 @@
+<template>
+    <div data-foo></div>
+    <div data-foo=''></div>
+    <div data-foo=""></div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/modules/x/test/test.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-empty-string/modules/x/test/test.js
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/correct-tag-attr-pair/empty-string/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/correct-tag-attr-pair/empty-string/expected.html
@@ -1,57 +1,57 @@
 <x-component>
   <template shadowrootmode="open">
-    <button autofocus="">
+    <button autofocus>
     </button>
-    <input autofocus="">
-    <keygen autofocus="">
-    <select autofocus="">
+    <input autofocus>
+    <keygen autofocus>
+    <select autofocus>
     </select>
-    <textarea autofocus="">
+    <textarea autofocus>
     </textarea>
-    <audio autoplay="">
+    <audio autoplay>
     </audio>
-    <video autoplay="">
+    <video autoplay>
     </video>
-    <input checked="">
-    <button disabled="">
+    <input checked>
+    <button disabled>
     </button>
-    <fieldset disabled="">
+    <fieldset disabled>
     </fieldset>
-    <input disabled="">
-    <optgroup disabled="">
+    <input disabled>
+    <optgroup disabled>
     </optgroup>
-    <select disabled="">
+    <select disabled>
     </select>
-    <textarea disabled="">
+    <textarea disabled>
     </textarea>
-    <button formnovalidate="">
+    <button formnovalidate>
     </button>
-    <audio loop="">
+    <audio loop>
     </audio>
-    <video loop="">
+    <video loop>
     </video>
-    <input multiple="">
-    <select multiple="">
+    <input multiple>
+    <select multiple>
     </select>
-    <audio muted="">
+    <audio muted>
     </audio>
-    <video muted="">
+    <video muted>
     </video>
-    <form novalidate="">
+    <form novalidate>
     </form>
-    <details open="">
+    <details open>
     </details>
-    <input readonly="">
-    <textarea readonly="">
+    <input readonly>
+    <textarea readonly>
     </textarea>
-    <input required="">
-    <select required="">
+    <input required>
+    <select required>
     </select>
-    <textarea required="">
+    <textarea required>
     </textarea>
-    <ol reversed="">
+    <ol reversed>
     </ol>
-    <option selected="">
+    <option selected>
     </option>
   </template>
 </x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static/expected.html
@@ -20,21 +20,21 @@
     </div>
     <div title>
     </div>
-    <div accesskey="">
+    <div accesskey>
     </div>
-    <div dir="">
+    <div dir>
     </div>
-    <div draggable="">
+    <div draggable>
     </div>
-    <div hidden="">
+    <div hidden>
     </div>
     <div id>
     </div>
-    <div lang="">
+    <div lang>
     </div>
     <div spellcheck="true">
     </div>
-    <div title="">
+    <div title>
     </div>
     <div accesskey="   ">
     </div>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/incorrect-tag-attr-pair/static/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/incorrect-tag-attr-pair/static/expected.html
@@ -4,9 +4,9 @@
     </div>
     <div formnovalidate>
     </div>
-    <div autofocus="">
+    <div autofocus>
     </div>
-    <div formnovalidate="">
+    <div formnovalidate>
     </div>
     <div autofocus="   ">
     </div>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -3,7 +3,7 @@ import _implicitScopedStylesheets from "./hidden-global-attr.scoped.css?scoped=t
 import _xFoo from "x/foo";
 import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<p hidden${3}>boolean present</p>`;
-const $fragment2 = parseFragment`<p hidden=""${3}>empty string, should be true</p>`;
+const $fragment2 = parseFragment`<p hidden${3}>empty string, should be true</p>`;
 const $fragment3 = parseFragment`<p hidden="other than true"${3}>string value, should be true</p>`;
 const $fragment4 = parseFragment`<p${"a0:hidden"}${3}>computed value, should be resolved in component</p>`;
 const $fragment5 = parseFragment`<p hidden="3"${3}>integer value, should be true</p>`;

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -3,7 +3,7 @@ import _implicitScopedStylesheets from "./required.scoped.css?scoped=true";
 import _xFoo from "x/foo";
 import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
 const $fragment1 = parseFragment`<input required value="boolean present"${3}>`;
-const $fragment2 = parseFragment`<input required="" value="empty string"${3}>`;
+const $fragment2 = parseFragment`<input required value="empty string"${3}>`;
 const $fragment3 = parseFragment`<input required="other than true" value="string value"${3}>`;
 const $fragment4 = parseFragment`<input${"a0:required"} value="computed value"${3}>`;
 const $fragment5 = parseFragment`<input required="3" value="integer value"${3}>`;

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -2,7 +2,7 @@ import _implicitStylesheets from "./error-empty-value.css";
 import _implicitScopedStylesheets from "./error-empty-value.scoped.css?scoped=true";
 import _fooBar from "foo/bar";
 import { freezeTemplate, parseFragment, registerTemplate } from "lwc";
-const $fragment1 = parseFragment`<p title=""${3}></p>`;
+const $fragment1 = parseFragment`<p title${3}></p>`;
 const stc0 = {
   props: {
     content: "",


### PR DESCRIPTION
## Details

Currently, we have an inconsistency between the static content optimization and non-static-content optimization in how the HTML is rendered for the empty string attribute value:

```html
<input required>    <!-- non-static-optimized -->
<input required=""> <!-- static-optimized -->
```

We should emit the same thing in both cases, since they are [equivalent](https://html.spec.whatwg.org/multipage/introduction.html#a-quick-introduction-to-html:syntax-attributes):

> The value, along with the "=" character, can be omitted altogether if the value is the empty string.

Here I am preferring the shorter format (for slightly better HTML file size), which means changing the static-optimized variant.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🔬 Yes, it does include an observable change.

Technically your Jest snapshots may break. But we haven't typically considered this a "breaking" change in the past.

## GUS work item

[W-17100402](https://gus.lightning.force.com/a07EE000024S78iYAC)
