### PR TITLE
Revert "fix(ssr-compiler): update estemplate spec (#4749)"

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
@@ -57,7 +57,7 @@ describe.each(
                 `;
             const doReplacement = () => tmpl(b.literal('I am not an identifier') as any);
             expect(doReplacement).toThrow(
-                "Validation failed for template. Expected node of type 'Identifier' but received node of type 'Literal'."
+                'Validation failed for templated node of type Identifier'
             );
         });
     });

--- a/packages/@lwc/ssr-compiler/src/estemplate.ts
+++ b/packages/@lwc/ssr-compiler/src/estemplate.ts
@@ -73,8 +73,7 @@ interface TraversalState {
 
 const getReplacementNode = (
     state: TraversalState,
-    placeholderId: string,
-    placeholderType: string
+    placeholderId: string
 ): EsNode | EsNode[] | null => {
     const key = Number(placeholderId.slice(PLACEHOLDER_PREFIX.length));
     const nodeCount = state.replacementNodes.length;
@@ -95,9 +94,7 @@ const getReplacementNode = (
         const nodeType = Array.isArray(replacementNode)
             ? `[${replacementNode.map((n) => n.type)}.join(', ')]`
             : replacementNode?.type;
-        throw new Error(
-            `Validation failed for template. Expected node of type '${placeholderType}' but received node of type '${nodeType}'.`
-        );
+        throw new Error(`Validation failed for templated node of type ${nodeType}`);
     }
 
     return replacementNode;
@@ -106,7 +103,7 @@ const getReplacementNode = (
 const visitors: Visitors<TraversalState> = {
     Identifier(path, state) {
         if (path.node?.name.startsWith(PLACEHOLDER_PREFIX)) {
-            const replacementNode = getReplacementNode(state, path.node.name, path.node.type);
+            const replacementNode = getReplacementNode(state, path.node.name);
 
             if (replacementNode === null) {
                 path.remove();
@@ -131,11 +128,7 @@ const visitors: Visitors<TraversalState> = {
             path.node.value.startsWith(PLACEHOLDER_PREFIX)
         ) {
             // A literal can only be replaced with a single node
-            const replacementNode = getReplacementNode(
-                state,
-                path.node.value,
-                path.node.type
-            ) as EsNode;
+            const replacementNode = getReplacementNode(state, path.node.value) as EsNode;
 
             path.replaceWith(replacementNode);
         }


### PR DESCRIPTION
This reverts commit d47b442aa3fc4c1f9100d317b30311e3bb6def9c.

The `placeholderType` being used is always `Identifier`, because the placeholder is always an identifier that looks like `__ESTEMPLATE_123456_PLACEHOLDER__0`. That's not particularly interesting information to include in the error message.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
