### PR TITLE
[DO NOT MERGE] Trigger CI for #4755: test(engine-server): rethrow assertion errors

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -111,8 +111,12 @@ function testFixtures() {
                     config?.props ?? {}
                 );
             } catch (_err: any) {
+                if (_err.name === 'AssertionError') {
+                    throw _err;
+                }
                 err = _err.message;
             }
+
             features.forEach((flag) => {
                 lwcEngineServer!.setFeatureFlagForTest(flag, false);
             });


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4755.