### PR TITLE
chore: remove fixture copy

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/expected.html
@@ -1,5 +1,0 @@
-<x-attribute-boolean>
-  <template shadowrootmode="open">
-    <input checked readonly required type="checkbox">
-  </template>
-</x-attribute-boolean>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/index.js
@@ -1,3 +1,0 @@
-export const tagName = 'x-attribute-boolean';
-export { default } from 'x/attribute-boolean';
-export * from 'x/attribute-boolean';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/modules/x/attribute-boolean/attribute-boolean.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/modules/x/attribute-boolean/attribute-boolean.html
@@ -1,3 +1,0 @@
-<template>
-    <input type="checkbox" required readonly checked />
-</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/modules/x/attribute-boolean/attribute-boolean.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean copy/modules/x/attribute-boolean/attribute-boolean.js
@@ -1,3 +1,0 @@
-import { LightningElement } from 'lwc';
-
-export default class AttributeBoolean extends LightningElement {}


### PR DESCRIPTION
## Details

This fixture snuck in in 849d5cae66e9e69e0d6c18841866b8a88bbb408e and appears to be an exact copy of the non-copy folder.

```shell
$ diff -r \
    packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean\ copy \
    packages/@lwc/engine-server/src/__tests__/fixtures/attribute-boolean
# no differences
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
