### PR TITLE
refactor(ssr-compiler): remove setter attribute reflection

### DIFF
--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -25,7 +25,7 @@ import {
 import { ClassList } from './class-list';
 import { Attributes, Properties } from './types';
 import { mutationTracker } from './mutation-tracker';
-import { reflectAttrToProp, descriptors as reflectionDescriptors } from './reflection';
+import { descriptors as reflectionDescriptors } from './reflection';
 import type { Stylesheets } from '@lwc/shared';
 
 type EventListenerOrEventListenerObject = unknown;
@@ -97,7 +97,6 @@ export class LightningElement implements PropsAvailableAtConstruction {
         const normalizedName = StringToLowerCase.call(toString(attrName));
         const normalizedValue = String(attrValue);
         this.#attrs[normalizedName] = normalizedValue;
-        reflectAttrToProp(this, normalizedName, normalizedValue);
         mutationTracker.add(this, normalizedName);
     }
 
@@ -117,7 +116,6 @@ export class LightningElement implements PropsAvailableAtConstruction {
     removeAttribute(attrName: string): void {
         const normalizedName = StringToLowerCase.call(toString(attrName));
         delete this.#attrs[normalizedName];
-        reflectAttrToProp(this, normalizedName, null);
         // Track mutations for removal of non-existing attributes
         mutationTracker.add(this, normalizedName);
     }

--- a/packages/@lwc/ssr-runtime/src/reflection.ts
+++ b/packages/@lwc/ssr-runtime/src/reflection.ts
@@ -5,34 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import {
-    AriaAttrNameToPropNameMap,
-    assign,
-    create,
-    entries,
-    hasOwnProperty,
-    isNull,
-    toString,
-} from '@lwc/shared';
+import { AriaAttrNameToPropNameMap, entries, isNull, toString } from '@lwc/shared';
 
 import type { LightningElement } from './lightning-element';
-
-/**
- * Map of global attribute or ARIA attribute to the corresponding property name.
- * Not all global attributes are included, just those from `HTMLElementTheGoodParts`.
- */
-const attrsToProps = assign(create(null), {
-    accesskey: 'accessKey',
-    dir: 'dir',
-    draggable: 'draggable',
-    hidden: 'hidden',
-    id: 'id',
-    lang: 'lang',
-    spellcheck: 'spellcheck',
-    tabindex: 'tabIndex',
-    title: 'title',
-    ...AriaAttrNameToPropNameMap,
-});
 
 /**
  * Descriptor for IDL attribute reflections that merely reflect the string, e.g. `title`.
@@ -118,21 +93,6 @@ const ariaDescriptor = (attrName: string): TypedPropertyDescriptor<string | null
         }
     },
 });
-
-export function reflectAttrToProp(
-    instance: LightningElement,
-    attrName: string,
-    attrValue: string | null
-) {
-    const reflectedPropName = attrsToProps[attrName as keyof typeof attrsToProps];
-    // If it is a reflected property and it was not overridden by the instance
-    if (reflectedPropName && !hasOwnProperty.call(instance, reflectedPropName)) {
-        const currentValue = (instance as any)[reflectedPropName];
-        if (currentValue !== attrValue) {
-            (instance as any)[reflectedPropName] = attrValue;
-        }
-    }
-}
 
 export const descriptors: Record<string, PropertyDescriptor> = {
     accessKey: stringDescriptor('accesskey'),


### PR DESCRIPTION
We don't need this anymore because we now handle attribute-to-property reflection through property get descriptors.