### PR TITLE
test: fix Symbol error in fixture

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/error.txt
@@ -1,1 +1,0 @@
-Cannot convert a Symbol value to a number

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/expected.html
@@ -1,0 +1,268 @@
+<x-component>
+  <template shadowrootmode="open">
+    <x-child>
+      <template shadowrootmode="open">
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+        <div>
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="false">
+        </div>
+        <div dir="false">
+        </div>
+        <div draggable="false">
+        </div>
+        <div>
+        </div>
+        <div id="false">
+        </div>
+        <div lang="false">
+        </div>
+        <div spellcheck="false">
+        </div>
+        <div tabindex="false">
+        </div>
+        <div title="false">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="true">
+        </div>
+        <div dir="true">
+        </div>
+        <div draggable="true">
+        </div>
+        <div hidden>
+        </div>
+        <div id="true">
+        </div>
+        <div lang="true">
+        </div>
+        <div spellcheck="true">
+        </div>
+        <div tabindex="true">
+        </div>
+        <div title="true">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="0">
+        </div>
+        <div dir="0">
+        </div>
+        <div draggable="0">
+        </div>
+        <div>
+        </div>
+        <div id="0">
+        </div>
+        <div lang="0">
+        </div>
+        <div spellcheck="0">
+        </div>
+        <div tabindex="0">
+        </div>
+        <div title="0">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="0">
+        </div>
+        <div dir="0">
+        </div>
+        <div draggable="0">
+        </div>
+        <div>
+        </div>
+        <div id="0">
+        </div>
+        <div lang="0">
+        </div>
+        <div spellcheck="0">
+        </div>
+        <div tabindex="0">
+        </div>
+        <div title="0">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="NaN">
+        </div>
+        <div dir="NaN">
+        </div>
+        <div draggable="NaN">
+        </div>
+        <div>
+        </div>
+        <div id="NaN">
+        </div>
+        <div lang="NaN">
+        </div>
+        <div spellcheck="NaN">
+        </div>
+        <div tabindex="NaN">
+        </div>
+        <div title="NaN">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="Infinity">
+        </div>
+        <div dir="Infinity">
+        </div>
+        <div draggable="Infinity">
+        </div>
+        <div hidden>
+        </div>
+        <div id="Infinity">
+        </div>
+        <div lang="Infinity">
+        </div>
+        <div spellcheck="Infinity">
+        </div>
+        <div tabindex="0">
+        </div>
+        <div title="Infinity">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="-Infinity">
+        </div>
+        <div dir="-Infinity">
+        </div>
+        <div draggable="-Infinity">
+        </div>
+        <div hidden>
+        </div>
+        <div id="-Infinity">
+        </div>
+        <div lang="-Infinity">
+        </div>
+        <div spellcheck="-Infinity">
+        </div>
+        <div tabindex="-Infinity">
+        </div>
+        <div title="-Infinity">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey>
+        </div>
+        <div dir>
+        </div>
+        <div draggable>
+        </div>
+        <div>
+        </div>
+        <div id>
+        </div>
+        <div lang>
+        </div>
+        <div spellcheck>
+        </div>
+        <div tabindex>
+        </div>
+        <div title>
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="foo,bar">
+        </div>
+        <div dir="foo,bar">
+        </div>
+        <div draggable="foo,bar">
+        </div>
+        <div hidden>
+        </div>
+        <div id="foo,bar">
+        </div>
+        <div lang="foo,bar">
+        </div>
+        <div spellcheck="foo,bar">
+        </div>
+        <div tabindex="foo,bar">
+        </div>
+        <div title="foo,bar">
+        </div>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <div accesskey="[object Object]">
+        </div>
+        <div dir="[object Object]">
+        </div>
+        <div draggable="[object Object]">
+        </div>
+        <div hidden>
+        </div>
+        <div id="[object Object]">
+        </div>
+        <div lang="[object Object]">
+        </div>
+        <div spellcheck="[object Object]">
+        </div>
+        <div tabindex="[object Object]">
+        </div>
+        <div title="[object Object]">
+        </div>
+      </template>
+    </x-child>
+  </template>
+</x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/modules/x/component/component.html
@@ -9,7 +9,6 @@
   <x-child dynamic={isInfinity}></x-child>
   <x-child dynamic={isNegInfinity}></x-child>
   <x-child dynamic={isEmptyString}></x-child>
-  <x-child dynamic={isSymbol}></x-child>
   <x-child dynamic={isArray}></x-child>
   <x-child dynamic={isObject}></x-child>
 </template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/modules/x/component/component.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/dynamic/modules/x/component/component.js
@@ -11,7 +11,6 @@ export default class extends LightningElement {
   isInfinity = Infinity;
   isNegInfinity = -Infinity;
   isEmptyString = '';
-  isSymbol = Symbol('yolo')
   isArray = ['foo', 'bar']
   isObject = {foo: 'bar', baz: 'quux'}
 }


### PR DESCRIPTION
## Details

I didn't notice in #4730 that we introduced an `error.txt` caused by an attempt to convert a `Symbol` to a string. Since using `Symbols` in this case is a super-rare edge case, and because it reduces the value of the test to just have an error message, I say we remove the `Symbol`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
