### PR TITLE
fix(ssr): fix converting dynamic values to strings

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -50,7 +50,8 @@ const bConditionalLiveYield = esTemplateWithYield`
             (hasScopedStylesheets || hasScopedStaticStylesheets(Cmp));
         const prefix = shouldRenderScopeToken ? stylesheetScopeToken + ' ' : '';
 
-        // Global HTML attributes are specially coerced into booleans
+        // Global HTML boolean attributes are specially coerced into booleans
+        // https://github.com/salesforce/lwc/blob/f34a347/packages/%40lwc/template-compiler/src/codegen/index.ts#L450-L454
         if (isHtmlBooleanAttr) {
             attrValue = attrValue ? '' : undefined;
         }

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -115,6 +115,7 @@ function yieldAttrOrPropLiteralValue(name: string, valueNode: IrLiteral): EsStat
             yieldedValue = StringReplace.call(StringTrim.call(value), /\s+/g, ' ');
         } else if (name === 'spellcheck') {
             // `spellcheck` string values are specially handled to massage them into booleans.
+            // https://github.com/salesforce/lwc/blob/fe4e95f/packages/%40lwc/template-compiler/src/codegen/index.ts#L445-L448
             yieldedValue = String(value.toLowerCase() !== 'false');
         } else {
             yieldedValue = value;

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -60,7 +60,7 @@ const bConditionalLiveYield = esTemplateWithYield`
         // This follows the historical behavior in api.ts:
         // https://github.com/salesforce/lwc/blob/f34a347/packages/%40lwc/engine-core/src/framework/api.ts#L193-L211
         if (attrName === 'tabindex') {
-            const shouldNormalize = attrValue > 0 && !(attrValue === true || attrValue === false);
+            const shouldNormalize = attrValue > 0 && typeof attrValue !== 'boolean';
             attrValue = shouldNormalize ? 0 : attrValue;
         }
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
@@ -23,12 +23,16 @@ const bYield = (expr: EsExpression) => b.expressionStatement(b.yieldExpression(e
 
 const bYieldEscapedString = esTemplateWithYield`
     const ${is.identifier} = ${is.expression};
-    if (typeof ${0} === 'string') {
-        yield (${is.literal} && ${0} === '') ? '\\u200D' : htmlEscape(${0});
-    } else if (typeof ${0} === 'number') {
-        yield ${0}.toString();
-    } else {
-        yield ${0} ? htmlEscape(${0}.toString()) : '\\u200D';
+    switch (typeof ${0}) {
+        case 'string':
+            yield (${is.literal} && ${0} === '') ? '\\u200D' : htmlEscape(${0});
+            break;
+        case 'number':
+        case 'boolean':
+            yield ${0}.toString();
+            break;
+        default:
+            yield ${0} ? htmlEscape(${0}.toString()) : '\\u200D';
     }
 `<EsStatement[]>;
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
@@ -29,7 +29,7 @@ const bYieldEscapedString = esTemplateWithYield`
             break;
         case 'number':
         case 'boolean':
-            yield ${0}.toString();
+            yield String(${0});
             break;
         default:
             yield ${0} ? htmlEscape(${0}.toString()) : '\\u200D';


### PR DESCRIPTION
## Details

Once #4776 is merged, this PR will get us down to 29 total snapshot test failures.

This fixes how we render a variety of dynamic and literal values, in both text content and attribute values. There are lots of special rules here for e.g. `spellcheck`, `tabindex`, and HTML global attributes.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

## GUS work item

[W-17094417](https://gus.lightning.force.com/a07EE000024NyElYAK)
