### PR TITLE
fix(ssr): make child props immutable

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/expected.html
@@ -1,0 +1,15 @@
+<x-parent>
+  <template shadowrootmode="open">
+    <x-child>
+      <template shadowrootmode="open">
+        <div>
+          
+array(disabled): error hit during mutation
+object(title): error hit during mutation
+deep(spellcheck): error hit during mutation
+object(title): error hit during deletion
+        </div>
+      </template>
+    </x-child>
+  </template>
+</x-parent>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-parent';
+export { default } from 'x/parent';
+export * from 'x/parent';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/child/child.html
@@ -1,0 +1,3 @@
+<template>
+  <div>{result}</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/child/child.js
@@ -1,0 +1,40 @@
+import { LightningElement, api } from "lwc";
+
+export default class extends LightningElement {
+  // Intentionally using the HTML global attribute names disabled/title/spellcheck here
+  @api disabled // array
+  @api title // object
+  @api spellcheck // deep
+
+  result
+
+  connectedCallback() {
+    const results = []
+    
+    try {
+      this.disabled.push('bar')
+    } catch (err) {
+      results.push('array(disabled): error hit during mutation')
+    }
+
+    try {
+      this.title.foo = 'baz'
+    } catch (err) {
+      results.push('object(title): error hit during mutation')
+    }
+    
+    try {
+      this.spellcheck.foo[0].quux = 'quux'
+    } catch (err) {
+      results.push('deep(spellcheck): error hit during mutation')
+    }
+
+    try {
+      delete this.title.foo
+    } catch (err) {
+      results.push('object(title): error hit during deletion')
+    }
+
+    this.result = '\n' + results.join('\n')
+  }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/parent/parent.html
@@ -1,0 +1,8 @@
+<template>
+  <x-child
+    disabled={array}
+    title={object}
+    spellcheck={deep}
+  >
+  </x-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/parent/parent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/parent-child-read-only-pseudo-attr/modules/x/parent/parent.js
@@ -1,0 +1,7 @@
+import { LightningElement } from "lwc";
+
+export default class extends LightningElement {
+  array = [1, 2, 3]
+  object = { foo: 'bar '}
+  deep = { foo: [{ bar: 'baz' }]}
+}

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { freeze, entries, isObject, isArray, create, isNull, ArrayMap } from '@lwc/shared';
+import { freeze, entries, isObject, isArray, create, isNull, ArrayPush } from '@lwc/shared';
 
 // Deep freeze and clone an object. Designed for cloning/freezing child props when passed from a parent to a child so
 // that they are immutable. This is one of the normal guarantees of both engine-dom and engine-server that we want to
@@ -13,9 +13,12 @@ import { freeze, entries, isObject, isArray, create, isNull, ArrayMap } from '@l
 // the parent's rendering, which would lead to bidirectional reactivity and mischief.
 export function cloneAndDeepFreeze<T>(obj: T): T {
     if (isArray(obj)) {
-        const res = ArrayMap.call(obj, cloneAndDeepFreeze);
+        const res: any[] = [];
+        for (const item of obj) {
+            ArrayPush.call(res, item);
+        }
         freeze(res);
-        return res;
+        return res as T;
     } else if (isObject(obj) && !isNull(obj)) {
         const res = create(null);
         for (const [key, value] of entries(obj)) {

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -19,9 +19,9 @@ export function cloneAndDeepFreeze(obj: any): any {
         }
         freeze(res);
         return res;
-    } else if (!isNull(obj) && isObject(obj)) {
+    } else if (isObject(obj) && !isNull(obj)) {
         const res = create(null);
-        for (const [key, value] of entries(obj as any)) {
+        for (const [key, value] of entries(obj)) {
             (res as any)[key] = cloneAndDeepFreeze(value);
         }
         freeze(res);

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -11,7 +11,7 @@ import { freeze, entries, isObject, isArray, create, isNull } from '@lwc/shared'
 // that they are immutable. This is one of the normal guarantees of both engine-dom and engine-server that we want to
 // emulate in ssr-runtime. The goal here is that a child cannot mutate the props of its parent and thus affect
 // the parent's rendering, which would lead to bidirectional reactivity and mischief.
-export function cloneAndDeepFreeze(obj: any): any {
+export function cloneAndDeepFreeze<T>(obj: T): T {
     if (isArray(obj)) {
         const res = [];
         for (let i = 0; i < obj.length; i++) {

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { freeze, entries, isObject, isArray, create, isNull } from '@lwc/shared';
+import { freeze, entries, isObject, isArray, create, isNull, ArrayMap } from '@lwc/shared';
 
 // Deep freeze and clone an object. Designed for cloning/freezing child props when passed from a parent to a child so
 // that they are immutable. This is one of the normal guarantees of both engine-dom and engine-server that we want to
@@ -13,10 +13,7 @@ import { freeze, entries, isObject, isArray, create, isNull } from '@lwc/shared'
 // the parent's rendering, which would lead to bidirectional reactivity and mischief.
 export function cloneAndDeepFreeze<T>(obj: T): T {
     if (isArray(obj)) {
-        const res = [];
-        for (let i = 0; i < obj.length; i++) {
-            res[i] = cloneAndDeepFreeze(obj[i]);
-        }
+        const res = ArrayMap.call(obj, cloneAndDeepFreeze);
         freeze(res);
         return res;
     } else if (isObject(obj) && !isNull(obj)) {

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { freeze, entries, isObject, isArray, create, isNull } from '@lwc/shared';
+
+// Deep freeze and clone an object. Designed for cloning/freezing child props when passed from a parent to a child so
+// that they are immutable. This is one of the normal guarantees of both engine-dom and engine-server that we want to
+// emulate in ssr-runtime. The goal here is that a child cannot mutate the props of its parent and thus affect
+// the parent's rendering, which would lead to bidirectional reactivity and mischief.
+export function cloneAndDeepFreeze(obj: any): any {
+    if (isArray(obj)) {
+        const res = [];
+        for (let i = 0; i < obj.length; i++) {
+            res[i] = cloneAndDeepFreeze(obj[i]);
+        }
+        freeze(res);
+        return res;
+    } else if (!isNull(obj) && isObject(obj)) {
+        const res = create(null);
+        for (const [key, value] of entries(obj as any)) {
+            (res as any)[key] = cloneAndDeepFreeze(value);
+        }
+        freeze(res);
+        return res;
+    } else {
+        // primitive
+        return obj;
+    }
+}

--- a/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
+++ b/packages/@lwc/ssr-runtime/src/clone-and-deep-freeze.ts
@@ -15,7 +15,7 @@ export function cloneAndDeepFreeze<T>(obj: T): T {
     if (isArray(obj)) {
         const res: any[] = [];
         for (const item of obj) {
-            ArrayPush.call(res, item);
+            ArrayPush.call(res, cloneAndDeepFreeze(item));
         }
         freeze(res);
         return res as T;

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -31,3 +31,4 @@ export {
 export { hasScopedStaticStylesheets, renderStylesheets } from './styles';
 export { toIteratorDirective } from './to-iterator-directive';
 export { validateStyleTextContents } from './validate-style-text-contents';
+export { cloneAndDeepFreeze } from './clone-and-deep-freeze';


### PR DESCRIPTION
## Details

This fixes the `parent-child-read-only-prop` by making props read-only when passed from the parent to the child.

Long-term, we can debate if this is worth it or not – it probably adds a perf overhead, but it is technically consistent with the current engine.

I also added a test to ensure this works correctly for props-that-kinda-look-like-attributes (e.g. `title`/`spellcheck`).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

## Gus WI

W-17150218
