### PR TITLE
feat(engine-dom): native-only styles

### DIFF
--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -19,6 +19,8 @@ import {
     getOwnPropertyDescriptor,
     isArray,
     isUndefined,
+    KEY__SCOPED_CSS,
+    KEY__NATIVE_ONLY_CSS,
 } from '@lwc/shared';
 import { logWarnOnce } from '../shared/logger';
 import { Template } from './template';
@@ -35,10 +37,7 @@ const TEMPLATE_PROPS = [
 ] as const;
 
 // Expandos that may be placed on a stylesheet factory function, and which are meaningful to LWC at runtime
-const STYLESHEET_PROPS = [
-    // SEE `KEY__SCOPED_CSS` in @lwc/style-compiler
-    '$scoped$',
-] as const;
+const STYLESHEET_PROPS = [KEY__SCOPED_CSS, KEY__NATIVE_ONLY_CSS] as const;
 
 // Via https://www.npmjs.com/package/object-observer
 const ARRAY_MUTATION_METHODS = [

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -9,6 +9,7 @@ import {
     ArrayPush,
     isArray,
     isNull,
+    isTrue,
     isUndefined,
     KEY__NATIVE_ONLY_CSS,
     KEY__SCOPED_CSS,
@@ -185,8 +186,8 @@ function evaluateStylesheetsContent(
                 // the stylesheet, while internally, we have a replacement for it.
                 stylesheet = getStyleOrSwappedStyle(stylesheet);
             }
-            const isScopedCss = stylesheet[KEY__SCOPED_CSS];
-            const isNativeOnlyCss = stylesheet[KEY__NATIVE_ONLY_CSS];
+            const isScopedCss = isTrue(stylesheet[KEY__SCOPED_CSS]);
+            const isNativeOnlyCss = isTrue(stylesheet[KEY__NATIVE_ONLY_CSS]);
             const { renderMode, shadowMode } = vm;
 
             if (

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayMap, ArrayPush, isArray, isNull, isUndefined, KEY__SCOPED_CSS } from '@lwc/shared';
+import {
+    ArrayMap,
+    ArrayPush,
+    isArray,
+    isNull,
+    isUndefined,
+    KEY__NATIVE_ONLY_CSS,
+    KEY__SCOPED_CSS,
+} from '@lwc/shared';
 
 import { logError } from '../shared/logger';
 
@@ -177,12 +185,14 @@ function evaluateStylesheetsContent(
                 // the stylesheet, while internally, we have a replacement for it.
                 stylesheet = getStyleOrSwappedStyle(stylesheet);
             }
-            const isScopedCss = (stylesheet as any)[KEY__SCOPED_CSS];
+            const isScopedCss = stylesheet[KEY__SCOPED_CSS];
+            const isNativeOnlyCss = stylesheet[KEY__NATIVE_ONLY_CSS];
+            const { renderMode, shadowMode } = vm;
 
             if (
                 lwcRuntimeFlags.DISABLE_LIGHT_DOM_UNSCOPED_CSS &&
                 !isScopedCss &&
-                vm.renderMode === RenderMode.Light
+                renderMode === RenderMode.Light
             ) {
                 logError(
                     'Unscoped CSS is not supported in Light DOM in this environment. Please use scoped CSS ' +
@@ -193,20 +203,18 @@ function evaluateStylesheetsContent(
             // Apply the scope token only if the stylesheet itself is scoped, or if we're rendering synthetic shadow.
             const scopeToken =
                 isScopedCss ||
-                (vm.shadowMode === ShadowMode.Synthetic && vm.renderMode === RenderMode.Shadow)
+                (shadowMode === ShadowMode.Synthetic && renderMode === RenderMode.Shadow)
                     ? stylesheetToken
                     : undefined;
             // Use the actual `:host` selector if we're rendering global CSS for light DOM, or if we're rendering
             // native shadow DOM. Synthetic shadow DOM never uses `:host`.
             const useActualHostSelector =
-                vm.renderMode === RenderMode.Light
-                    ? !isScopedCss
-                    : vm.shadowMode === ShadowMode.Native;
+                renderMode === RenderMode.Light ? !isScopedCss : shadowMode === ShadowMode.Native;
             // Use the native :dir() pseudoclass only in native shadow DOM. Otherwise, in synthetic shadow,
             // we use an attribute selector on the host to simulate :dir().
             let useNativeDirPseudoclass;
-            if (vm.renderMode === RenderMode.Shadow) {
-                useNativeDirPseudoclass = vm.shadowMode === ShadowMode.Native;
+            if (renderMode === RenderMode.Shadow) {
+                useNativeDirPseudoclass = shadowMode === ShadowMode.Native;
             } else {
                 // Light DOM components should only render `[dir]` if they're inside of a synthetic shadow root.
                 // At the top level (root is null) or inside of a native shadow root, they should use `:dir()`.
@@ -216,11 +224,20 @@ function evaluateStylesheetsContent(
                 }
                 useNativeDirPseudoclass = isNull(root) || root.shadowMode === ShadowMode.Native;
             }
-            const cssContent = stylesheet(
-                scopeToken,
-                useActualHostSelector,
-                useNativeDirPseudoclass
-            );
+
+            let cssContent;
+            if (
+                isNativeOnlyCss &&
+                renderMode === RenderMode.Shadow &&
+                shadowMode === ShadowMode.Synthetic
+            ) {
+                // Native-only (i.e. disableSyntheticShadowSupport) CSS should be ignored entirely
+                // in synthetic shadow. It's fine to use in either native shadow or light DOM, but in
+                // synthetic shadow it wouldn't be scoped properly and so should be ignored.
+                cssContent = '/* ignored native-only CSS */';
+            } else {
+                cssContent = stylesheet(scopeToken, useActualHostSelector, useNativeDirPseudoclass);
+            }
 
             if (process.env.NODE_ENV !== 'production') {
                 linkStylesheetToCssContentInDevMode(stylesheet, cssContent);

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
@@ -1,0 +1,61 @@
+import { createElement } from 'lwc';
+import Light from 'x/light';
+import Shadow from 'x/shadow';
+
+function getRelevantStyles(node) {
+    const props = [
+        '--chic',
+        '--implicit',
+        '--implicit-scoped',
+        '--glamorous',
+        '--hip',
+        '--snazzy',
+        '--bar',
+        '--foo',
+        '--style-library',
+    ];
+
+    const style = getComputedStyle(node);
+    return Object.fromEntries(props.map((prop) => [prop, style.getPropertyValue(prop)]));
+}
+
+const expectedSyntheticStyles = {
+    '--chic': '',
+    '--implicit': "'default'",
+    '--implicit-scoped': "'default'",
+    '--glamorous': "'default'",
+    '--hip': "'default'",
+    '--snazzy': '',
+    '--bar': "'default'",
+    '--foo': '',
+    '--style-library': "'default'",
+};
+
+const expectedNativeOrLightStyles = {
+    ...expectedSyntheticStyles,
+    '--chic': "'native'",
+    '--snazzy': "'native'",
+    '--foo': "'native'",
+};
+
+describe('skips native-only css in synthetic mode only', () => {
+    it('shadow', async () => {
+        const elm = createElement('x-shadow', { is: Shadow });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+
+        const div = elm.shadowRoot.querySelector('div');
+        expect(getRelevantStyles(div)).toEqual(
+            process.env.NATIVE_SHADOW ? expectedNativeOrLightStyles : expectedSyntheticStyles
+        );
+    });
+
+    it('light', async () => {
+        const elm = createElement('x-light', { is: Light });
+        document.body.appendChild(elm);
+        await Promise.resolve();
+
+        const div = elm.querySelector('div');
+        expect(getRelevantStyles(div)).toEqual(expectedNativeOrLightStyles);
+    });
+});

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
@@ -16,7 +16,14 @@ function getRelevantStyles(node) {
     ];
 
     const style = getComputedStyle(node);
-    return Object.fromEntries(props.map((prop) => [prop, style.getPropertyValue(prop)]));
+    return Object.fromEntries(
+        props.map((prop) => {
+            // The browsers disagree on whether this should be a single quote or double quote
+            // Safari 17 uses a double quote, Chrome 130 and Firefox 132 use a single quote
+            const value = style.getPropertyValue(prop).replace(/"/g, '');
+            return [prop, value];
+        })
+    );
 }
 
 const expectedSyntheticStyles = {

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
@@ -20,7 +20,8 @@ function getRelevantStyles(node) {
         props.map((prop) => {
             // The browsers disagree on whether this should be a single quote or double quote
             // Safari 17 uses a double quote, Chrome 130 and Firefox 132 use a single quote
-            const value = style.getPropertyValue(prop).replace(/"/g, "'");
+            // Safari 14 also adds whitespace around it
+            const value = style.getPropertyValue(prop).replace(/"/g, "'").trim();
             return [prop, value];
         })
     );

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/index.spec.js
@@ -20,7 +20,7 @@ function getRelevantStyles(node) {
         props.map((prop) => {
             // The browsers disagree on whether this should be a single quote or double quote
             // Safari 17 uses a double quote, Chrome 130 and Firefox 132 use a single quote
-            const value = style.getPropertyValue(prop).replace(/"/g, '');
+            const value = style.getPropertyValue(prop).replace(/"/g, "'");
             return [prop, value];
         })
     );

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/chic.native-only.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/chic.native-only.css
@@ -1,0 +1,3 @@
+div {
+    --chic: 'native';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/glamorous.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/glamorous.css
@@ -1,0 +1,3 @@
+div {
+    --glamorous: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/hip.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/hip.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --hip: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.css
@@ -1,0 +1,5 @@
+@import 'x/styleLibrary';
+
+div {
+    --implicit: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.html
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <div></div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.js
@@ -1,0 +1,10 @@
+import { LightningElement } from 'lwc';
+import chic from './chic.native-only.css';
+import glamorous from './glamorous.css';
+import hip from './hip.scoped.css';
+import snazzy from './snazzy.native-only.scoped.css';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    static stylesheets = [chic, glamorous, hip, snazzy];
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/light.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --implicit-scoped: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/snazzy.native-only.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/light/snazzy.native-only.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --snazzy: 'native';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/chic.native-only.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/chic.native-only.css
@@ -1,0 +1,3 @@
+div {
+    --chic: 'native';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/glamorous.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/glamorous.css
@@ -1,0 +1,3 @@
+div {
+    --glamorous: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/hip.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/hip.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --hip: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.css
@@ -1,0 +1,5 @@
+@import 'x/styleLibrary';
+
+div {
+    --implicit: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.html
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.js
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+import chic from './chic.native-only.css';
+import glamorous from './glamorous.css';
+import hip from './hip.scoped.css';
+import snazzy from './snazzy.native-only.scoped.css';
+
+export default class extends LightningElement {
+    static stylesheets = [chic, glamorous, hip, snazzy];
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/shadow.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --implicit-scoped: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/snazzy.native-only.scoped.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/shadow/snazzy.native-only.scoped.css
@@ -1,0 +1,3 @@
+div {
+    --snazzy: 'native';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/bar.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/bar.css
@@ -1,0 +1,3 @@
+div {
+    --bar: 'default';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/foo.native-only.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/foo.native-only.css
@@ -1,0 +1,3 @@
+div {
+    --foo: 'native';
+}

--- a/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/styleLibrary.css
+++ b/packages/@lwc/integration-karma/test/rendering/native-only-css/x/styleLibrary/styleLibrary.css
@@ -1,0 +1,6 @@
+@import './bar.css';
+@import './foo.native-only.css';
+
+div {
+    --style-library: 'default';
+}

--- a/packages/@lwc/shared/src/keys.ts
+++ b/packages/@lwc/shared/src/keys.ts
@@ -16,5 +16,6 @@ export const KEY__LEGACY_SHADOW_TOKEN = '$legacyShadowToken$';
 export const KEY__LEGACY_SHADOW_TOKEN_PRIVATE = '$$LegacyShadowTokenKey$$';
 export const KEY__SYNTHETIC_MODE = '$$lwc-synthetic-mode';
 export const KEY__SCOPED_CSS = '$scoped$';
+export const KEY__NATIVE_ONLY_CSS = '$nativeOnly$';
 export const KEY__NATIVE_GET_ELEMENT_BY_ID = '$nativeGetElementById$';
 export const KEY__NATIVE_QUERY_SELECTOR_ALL = '$nativeQuerySelectorAll$';

--- a/packages/@lwc/shared/src/style.ts
+++ b/packages/@lwc/shared/src/style.ts
@@ -6,6 +6,7 @@
  */
 
 import { isArray } from './language';
+import { KEY__NATIVE_ONLY_CSS, KEY__SCOPED_CSS } from './keys';
 
 export const IMPORTANT_FLAG = /\s*!\s*important\s*$/i;
 const DECLARATION_DELIMITER = /;(?![^(]*\))/g;
@@ -29,7 +30,11 @@ export type Stylesheet = {
     /**
      * True if this is a scoped style (e.g. `foo.scoped.css`)
      */
-    $scoped$?: boolean;
+    [KEY__SCOPED_CSS]?: boolean;
+    /**
+     * True if this is a native-only style (i.e. compiled with `disableSyntheticShadowSupport`).
+     */
+    [KEY__NATIVE_ONLY_CSS]?: boolean;
 };
 
 /**

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/disable-synthetic-shadow-support-keyframes/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/disable-synthetic-shadow-support-keyframes/expected.js
@@ -8,4 +8,5 @@ function stylesheet() {
   return ".foo" + shadowSelector + " {animation-name: fadeIn" + suffixToken + ";}@keyframes fadeIn" + suffixToken + " {0% {opacity: 0;}100% {opacity: 1;}}";
   /*LWC compiler vX.X.X*/
 }
+stylesheet.$nativeOnly$ = true;
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/__tests__/fixtures/disable-synthetic-shadow-support/expected.js
+++ b/packages/@lwc/style-compiler/src/__tests__/fixtures/disable-synthetic-shadow-support/expected.js
@@ -8,4 +8,5 @@ function stylesheet() {
   return ((useActualHostSelector ? (useNativeDirPseudoclass ? '' : '[dir="rtl"]') + " :host(.foo) " : (useNativeDirPseudoclass ? '' : '[dir="rtl"]') + " " + hostSelector + ".foo ")) + (useNativeDirPseudoclass ? ':dir(rtl)' : '') + " {}";
   /*LWC compiler vX.X.X*/
 }
+stylesheet.$nativeOnly$ = true;
 export default [stylesheet];

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import postcss, { Result } from 'postcss';
-import { KEY__SCOPED_CSS, LWC_VERSION_COMMENT } from '@lwc/shared';
+import { KEY__SCOPED_CSS, LWC_VERSION_COMMENT, KEY__NATIVE_ONLY_CSS } from '@lwc/shared';
 import { Config } from './index';
 import { isImportMessage } from './utils/message';
 import { HOST_ATTRIBUTE, SHADOW_ATTRIBUTE } from './utils/selectors-scoping';
@@ -92,6 +92,10 @@ export default function serialize(result: Result, config: Config): string {
         if (scoped) {
             // Mark the stylesheet as scoped so that we can distinguish it later at runtime
             buffer += `${STYLESHEET_IDENTIFIER}.${KEY__SCOPED_CSS} = true;\n`;
+        }
+        if (disableSyntheticShadow) {
+            // Mark the stylesheet as $nativeOnly$ so it can be ignored in synthetic shadow mode
+            buffer += `${STYLESHEET_IDENTIFIER}.${KEY__NATIVE_ONLY_CSS} = true;\n`;
         }
 
         // add import at the end


### PR DESCRIPTION
## Details

If you are using a custom Rollup plugin (or similar) to conditionally set `disableSyntheticShadowSupport` for certain files (e.g. `foo.native-only.css`), then those CSS files will get compiled in a way that is fundamentally incompatible with synthetic shadow: https://github.com/salesforce/lwc/pull/3229

If, for whatever reason, you then take those stylesheets and try to render them in synthetic shadow anyway, you'll get a broken experience because the styles will not be scoped, or have the proper `:host`/`:dir` transformations, and (worse) will be hoisted to the top-level `<head>` where they might affect other unrelated components.

To fix this, this PR adds a special expando, `stylesheet.$nativeOnly`, to the `style-compiler` to indicate that a stylesheet function is intended not to be used with synthetic shadow. If the expando is true, and if the template being rendered is synthetic shadow, then no styles will be rendered at all.

Light DOM is unaffected. This is targeted at synthetic shadow only.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

On platform, nobody is doing the zany thing I describe above except for our own first-party components.

<!-- If yes, please describe the anticipated observable changes. -->
