### PR TITLE
fix(ssr): fix duplicate styles in same template

### DIFF
--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -443,7 +443,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 if (!isNull(styleVNodes)) {
                     // It's important here not to mutate the underlying `vnodes` returned from `html.call()`.
                     // The reason for this is because, due to the static content optimization, the vnodes array
-                    // may be a static array shared across multiple templates. This occurs for example in the
+                    // may be a static array shared across multiple component instances. E.g. this occurs in the
                     // case of an empty `<template></template>` in a `component.html` file.
                     vnodes = [...styleVNodes, ...vnodes];
                 }

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -444,7 +444,9 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                     // It's important here not to mutate the underlying `vnodes` returned from `html.call()`.
                     // The reason for this is because, due to the static content optimization, the vnodes array
                     // may be a static array shared across multiple component instances. E.g. this occurs in the
-                    // case of an empty `<template></template>` in a `component.html` file.
+                    // case of an empty `<template></template>` in a `component.html` file, due to the underlying
+                    // children being `[]` (no children). If we append the `<style>` vnode to this array, then the same
+                    // array will be reused for every component instance, i.e. whenever `tmpl()` is called.
                     vnodes = [...styleVNodes, ...vnodes];
                 }
             });

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/expected.html
@@ -1,0 +1,18 @@
+<x-parent>
+  <template shadowrootmode="open">
+    <x-child>
+      <template shadowrootmode="open">
+        <style type="text/css">
+          :host {color: chocolate;}
+        </style>
+      </template>
+    </x-child>
+    <x-child>
+      <template shadowrootmode="open">
+        <style type="text/css">
+          :host {color: chocolate;}
+        </style>
+      </template>
+    </x-child>
+  </template>
+</x-parent>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-parent';
+export { default } from 'x/parent';
+export * from 'x/parent';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.css
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.css
@@ -1,0 +1,3 @@
+:host {
+    color: chocolate;
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/child/child.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/parent/parent.html
@@ -1,0 +1,4 @@
+<template>
+    <x-child></x-child>
+    <x-child></x-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/parent/parent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/no-dup-styles/modules/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {}


### PR DESCRIPTION
## Details

Fixes #4790

Turns out we had a simple programming error here where we were using `MutableVNodes` when it should have been the immutable `VNodes`. Tricky bug!

Related: #4789

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## Gus WI

W-17151345
