### PR TITLE
fix(tests): timeout in debug should not exceed max signed 32 bit int

### DIFF
--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -5,7 +5,7 @@ import pkg from './package.json';
 export default defineConfig({
     test: {
         // Don't time out if we detect a debugger attached
-        testTimeout: inspector.url() ? Number.MAX_SAFE_INTEGER : undefined,
+        testTimeout: inspector.url() ? 2147483647 : undefined,
         include: ['**/*.{test,spec}.{mjs,js,ts}'],
         snapshotFormat: {
             printBasicPrototype: true,


### PR DESCRIPTION
## Details

This delay actually makes it rather impossible to run the tests in debug mode, as in Node.js any delay exceeding the maximum signed 32 bit integer will be treated as `1ms` instead. In the browser it would overflow. 🦶🔫 .

- [Window: setTimeout() method - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value)
- [Timers | Node.js Documentation](https://nodejs.org/docs/latest/api/timers.html#settimeoutcallback-delay-args:~:text=the%20time%20specified.-,When%20delay%20is%20larger%20than%202147483647%20or%20less%20than%201%20or%20NaN%2C%20the%20delay%20will%20be%20set%20to%201.%20Non%2Dinteger%20delays%20are%20truncated%20to%20an%20integer.,-If%20callback%20is)

It actually shows a red-colored warning in the console since Node.js 10:

```
(node:29434) TimeoutOverflowWarning: 9007199254740991 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
