### PR TITLE
[DO NOT MERGE] Trigger CI for #4795: fix(tests): timeout in debug should not exceed max signed 32 bit int

### DIFF
--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -5,7 +5,7 @@ import pkg from './package.json';
 export default defineConfig({
     test: {
         // Don't time out if we detect a debugger attached
-        testTimeout: inspector.url() ? Number.MAX_SAFE_INTEGER : undefined,
+        testTimeout: inspector.url() ? 2147483647 : undefined,
         include: ['**/*.{test,spec}.{mjs,js,ts}'],
         snapshotFormat: {
             printBasicPrototype: true,


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4795.