### PR TITLE
fix(ssr-compiler): unused htmlEscape import

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -56,14 +56,15 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
                 modules: [{ dir: modulesDir }],
             }),
         ],
-        onwarn({ message, code }) {
+        onwarn({ message, code, names = [] }) {
             if (
-                code !== 'CIRCULAR_DEPENDENCY' &&
+                code === 'CIRCULAR_DEPENDENCY' ||
                 // TODO [#4793]: fix unused imports
-                code !== 'UNUSED_EXTERNAL_IMPORT'
+                (code === 'UNUSED_EXTERNAL_IMPORT' && !names.includes('htmlEscape'))
             ) {
-                throw new Error(message);
+                return;
             }
+            throw new Error(message);
         },
     });
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -133,9 +133,9 @@ function yieldAttrOrPropLiveValue(
     value: IrExpression | BinaryExpression,
     cxt: TransformerContext
 ): EsStatement[] {
+    cxt.hoist(bImportHtmlEscape(), importHtmlEscapeKey);
     const isHtmlBooleanAttr = isBooleanAttribute(name, elementName);
     const scopedExpression = getScopedExpression(value as EsExpression, cxt);
-
     return [bConditionalLiveYield(b.literal(name), scopedExpression, b.literal(isHtmlBooleanAttr))];
 }
 
@@ -196,7 +196,6 @@ export const Element: Transformer<IrElement | IrExternalComponent | IrSlot> = fu
                 }
             }
 
-            cxt.hoist(bImportHtmlEscape(), importHtmlEscapeKey);
             if (value.type === 'Literal') {
                 return yieldAttrOrPropLiteralValue(name, value);
             } else {


### PR DESCRIPTION
## Details

Partially addresses #4793

'htmlEscape'

## Before
```
  Snapshots  77 failed
 Test Files  1 failed | 3 passed (4)
      Tests  84 failed | 136 passed (220)
```

## After
```
  Snapshots  38 failed
 Test Files  1 failed | 3 passed (4)
      Tests  45 failed | 175 passed (220)
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
