### PR TITLE
fix(ssr-compiler): conflicting type definitions for estree

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -57,7 +57,7 @@ const visitors: Visitors = {
         }
 
         // TODO [#4773]: Why do we get conflicting PropertyDefinition types when removing "vitest/globals"?
-        const decorators = (node as any).decorators;
+        const decorators = node.decorators;
         if (is.identifier(decorators[0]?.expression) && decorators[0].expression.name === 'api') {
             state.publicFields.push(node.key.name);
         } else {

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -56,7 +56,6 @@ const visitors: Visitors = {
             return;
         }
 
-        // TODO [#4773]: Why do we get conflicting PropertyDefinition types when removing "vitest/globals"?
         const decorators = node.decorators;
         if (is.identifier(decorators[0]?.expression) && decorators[0].expression.name === 'api') {
             state.publicFields.push(node.key.name);

--- a/packages/@lwc/ssr-compiler/tsconfig.json
+++ b/packages/@lwc/ssr-compiler/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../../tsconfig.json",
-
+    "compilerOptions": {
+        "types": ["rollup", "node"]
+    },
     "include": ["src/"]
 }


### PR DESCRIPTION
## Details

Closes #4773

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
