### PR TITLE
feat: implement wire + context for SSR compiler

### DIFF
--- a/packages/@lwc/engine-core/src/framework/main.ts
+++ b/packages/@lwc/engine-core/src/framework/main.ts
@@ -52,6 +52,7 @@ export type {
     ConfigValue as WireConfigValue,
     ContextConsumer as WireContextConsumer,
     ContextProvider as WireContextProvider,
+    ContextProviderOptions as WireContextProviderOptions,
     ContextValue as WireContextValue,
     DataCallback as WireDataCallback,
     WireAdapter,

--- a/packages/@lwc/engine-core/src/framework/wiring/index.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/index.ts
@@ -12,6 +12,7 @@ export {
     ConfigValue,
     ContextConsumer,
     ContextProvider,
+    ContextProviderOptions,
     ContextValue,
     DataCallback,
     ReplaceReactiveValues,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/expected.html
@@ -1,0 +1,11 @@
+<x-provider>
+  <template shadowrootmode="open">
+    <x-consumer>
+      <template shadowrootmode="open">
+        <div>
+          some context
+        </div>
+      </template>
+    </x-consumer>
+  </template>
+</x-provider>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-provider';
+export { default } from 'x/provider';
+export * from 'x/provider';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/consumer/consumer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/consumer/consumer.html
@@ -1,0 +1,3 @@
+<template>
+    <div>{foo}</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/consumer/consumer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/consumer/consumer.js
@@ -2,5 +2,10 @@ import { LightningElement, wire } from 'lwc';
 import { WireAdapter } from '../../../wire-adapter';
 
 export default class ConsumerComponent extends LightningElement {
-  @wire(WireAdapter, { unused: '$definitelyUnused' }) foo;
+  foo;
+
+  @wire(WireAdapter, { unused: '$definitelyUnused' })
+  calledWithWireInfo(newValue) {
+    this.foo = newValue;
+  }
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/provider/provider.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/provider/provider.html
@@ -1,0 +1,3 @@
+<template>
+    <x-consumer></x-consumer>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/provider/provider.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/modules/x/provider/provider.js
@@ -1,0 +1,14 @@
+import { LightningElement } from 'lwc';
+import { contextualizer } from '../../../wire-adapter';
+
+export default class ProviderComponent extends LightningElement {
+    connectedCallback() {
+        contextualizer(this, {
+            consumerConnectedCallback(consumer) {
+                consumer.provide({
+                    value: 'some context'
+                });
+            }
+        });
+    }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/wire-adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-method/wire-adapter.js
@@ -1,0 +1,31 @@
+import { createContextProvider } from 'lwc';
+
+export class WireAdapter {
+    contextValue = { value: 'missing' };
+    static contextSchema = { value: 'required' };
+
+    constructor(callback) {
+        this._callback = callback;
+    }
+
+    connect() {
+        // noop
+    }
+
+    disconnect() {
+        // noop
+    }
+
+    update(_config, context) {
+        if (context) {
+            if (!context.hasOwnProperty('value')) {
+                throw new Error(`Invalid context provided`);
+            }
+            this.contextValue = context.value;
+            this._callback(this.contextValue);
+        }
+    }
+
+}
+
+export const contextualizer = createContextProvider(WireAdapter);

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/expected.html
@@ -1,0 +1,11 @@
+<x-provider>
+  <template shadowrootmode="open">
+    <x-consumer>
+      <template shadowrootmode="open">
+        <div>
+          some context
+        </div>
+      </template>
+    </x-consumer>
+  </template>
+</x-provider>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-provider';
+export { default } from 'x/provider';
+export * from 'x/provider';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/consumer/consumer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/consumer/consumer.html
@@ -1,0 +1,3 @@
+<template>
+    <div>{foo}</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/consumer/consumer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/consumer/consumer.js
@@ -2,5 +2,13 @@ import { LightningElement, wire } from 'lwc';
 import { WireAdapter } from '../../../wire-adapter';
 
 export default class ConsumerComponent extends LightningElement {
-  @wire(WireAdapter, { unused: '$definitelyUnused' }) foo;
+  _foo;
+
+  @wire(WireAdapter, { unused: '$definitelyUnused' })
+  set foo(newFoo) {
+    this._foo = newFoo;
+  }
+  get foo() {
+    return this._foo
+  };
 }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/provider/provider.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/provider/provider.html
@@ -1,0 +1,3 @@
+<template>
+    <x-consumer></x-consumer>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/provider/provider.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/modules/x/provider/provider.js
@@ -1,0 +1,14 @@
+import { LightningElement } from 'lwc';
+import { contextualizer } from '../../../wire-adapter';
+
+export default class ProviderComponent extends LightningElement {
+    connectedCallback() {
+        contextualizer(this, {
+            consumerConnectedCallback(consumer) {
+                consumer.provide({
+                    value: 'some context'
+                });
+            }
+        });
+    }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/wire-adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-simple-setter/wire-adapter.js
@@ -1,0 +1,31 @@
+import { createContextProvider } from 'lwc';
+
+export class WireAdapter {
+    contextValue = { value: 'missing' };
+    static contextSchema = { value: 'required' };
+
+    constructor(callback) {
+        this._callback = callback;
+    }
+
+    connect() {
+        // noop
+    }
+
+    disconnect() {
+        // noop
+    }
+
+    update(_config, context) {
+        if (context) {
+            if (!context.hasOwnProperty('value')) {
+                throw new Error(`Invalid context provided`);
+            }
+            this.contextValue = context.value;
+            this._callback(this.contextValue);
+        }
+    }
+
+}
+
+export const contextualizer = createContextProvider(WireAdapter);

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/context-slotted/modules/x/consumer/consumer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/context-slotted/modules/x/consumer/consumer.js
@@ -1,6 +1,6 @@
 import { LightningElement, wire } from 'lwc';
 import { WireAdapter } from '../../../wire-adapter';
 
-export default class Component extends LightningElement {
+export default class SlottedConsumerComponent extends LightningElement {
   @wire(WireAdapter) foo;
 }

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -53,6 +53,7 @@
         "meriyah": "^5.0.0"
     },
     "devDependencies": {
+        "@types/babel__helper-validator-identifier": "^7.15.2",
         "@types/estree": "^1.0.6"
     }
 }

--- a/packages/@lwc/ssr-compiler/src/compile-js/catalog-tmpls.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/catalog-tmpls.ts
@@ -11,7 +11,7 @@ import type { ComponentMetaState } from './types';
 
 /**
  * While traversing the component JS, this takes note of any .html files that are
- * explicitly imported..
+ * explicitly imported.
  */
 export function catalogTmplImport(path: NodePath<ImportDeclaration>, state: ComponentMetaState) {
     if (!path.node) {

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -14,10 +14,15 @@ import { replaceLwcImport } from './lwc-import';
 import { catalogTmplImport } from './catalog-tmpls';
 import { catalogStaticStylesheets, catalogAndReplaceStyleImports } from './stylesheets';
 import { addGenerateMarkupExport, assignGenerateMarkupToComponent } from './generate-markup';
+import { catalogWireAdapters } from './wire';
 
-import type { Identifier as EsIdentifier, Program as EsProgram } from 'estree';
+import type { Identifier as EsIdentifier, Program as EsProgram, Expression } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
 import type { CompilationMode } from '../shared';
+import type {
+    PropertyDefinition as DecoratatedPropertyDefinition,
+    MethodDefinition as DecoratatedMethodDefinition,
+} from 'meriyah/dist/src/estree';
 
 const visitors: Visitors = {
     $: { scope: true },
@@ -56,9 +61,17 @@ const visitors: Visitors = {
             return;
         }
 
-        const decorators = node.decorators;
-        if (is.identifier(decorators[0]?.expression) && decorators[0].expression.name === 'api') {
+        const decorators = (node as DecoratatedPropertyDefinition).decorators;
+        const decoratedExpression = decorators?.[0]?.expression as Expression;
+        if (is.identifier(decoratedExpression) && decoratedExpression.name === 'api') {
             state.publicFields.push(node.key.name);
+        } else if (
+            is.callExpression(decoratedExpression) &&
+            is.identifier(decoratedExpression.callee) &&
+            decoratedExpression.callee.name === 'wire'
+        ) {
+            catalogWireAdapters(state, node);
+            state.privateFields.push(node.key.name);
         } else {
             state.privateFields.push(node.key.name);
         }
@@ -76,13 +89,30 @@ const visitors: Visitors = {
         }
     },
     MethodDefinition(path, state) {
-        if (path.node?.key.type !== 'Identifier') {
+        const node = path.node;
+        if (!is.identifier(node?.key)) {
             return;
         }
 
-        switch (path.node.key.name) {
+        // If we mutate any class-methods that are piped through this compiler, then we'll be
+        // inadvertently mutating things like Wire adapters.
+        if (!state.isLWC) {
+            return;
+        }
+
+        const decorators = (node as DecoratatedMethodDefinition).decorators;
+        const decoratedExpression = decorators?.[0]?.expression as Expression;
+        if (
+            is.callExpression(decoratedExpression) &&
+            is.identifier(decoratedExpression.callee) &&
+            decoratedExpression.callee.name === 'wire'
+        ) {
+            catalogWireAdapters(state, node);
+        }
+
+        switch (node.key.name) {
             case 'constructor':
-                path.node.value.params = [b.identifier('propsAvailableAtConstruction')];
+                node.value.params = [b.identifier('propsAvailableAtConstruction')];
                 break;
             case 'connectedCallback':
                 state.hasConnectedCallback = true;
@@ -139,6 +169,7 @@ export default function compileJS(src: string, filename: string, compilationMode
         staticStylesheetIds: null,
         publicFields: [],
         privateFields: [],
+        wireAdapters: [],
     };
 
     traverse(ast, visitors, state);

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -10,6 +10,16 @@ import type { Node } from 'estree';
 
 export type Visitors = Parameters<typeof traverse<Node, ComponentMetaState>>[1];
 
+export interface WireAdapter {
+    fieldName: string;
+    adapterConstructorId: string;
+    config: Array<{
+        configKey: string;
+        referencedField: string;
+    }>;
+    fieldType: 'property' | 'method';
+}
+
 export interface ComponentMetaState {
     // indicates whether the LightningElement subclass is found in the JS being traversed
     isLWC: boolean;
@@ -39,4 +49,6 @@ export interface ComponentMetaState {
     publicFields: Array<string>;
     // the private fields of the component class
     privateFields: Array<string>;
+    // indicates whether the LightningElement has any wired props
+    wireAdapters: WireAdapter[];
 }

--- a/packages/@lwc/ssr-compiler/src/compile-js/wire.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/wire.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { is, builders as b } from 'estree-toolkit';
+import { esTemplate } from '../estemplate';
+import { isValidIdentifier } from '../shared';
+
+import type { PropertyDefinition as EsPropertyDefinitionWithDecorators } from 'meriyah/dist/src/estree';
+import type {
+    Expression,
+    PropertyDefinition,
+    ObjectExpression,
+    Statement,
+    MethodDefinition,
+    ExpressionStatement,
+} from 'estree';
+import type { ComponentMetaState, WireAdapter } from './types';
+
+function extractWireConfig(
+    fieldName: string,
+    adapterConstructorId: string,
+    fieldType: 'method' | 'property',
+    config?: ObjectExpression
+): WireAdapter {
+    const extractedConfig =
+        config?.properties?.map?.((objProp) => {
+            if (!is.property(objProp)) {
+                throw new Error('Object spread syntax is disallowed in @wire config.');
+            }
+            const { key, value } = objProp;
+
+            if (!is.identifier(key)) {
+                throw new Error(`@wire config entry key must be an identifer; found ${key.type}`);
+            }
+            if (!is.literal(value) || typeof value.value !== 'string' || value.value[0] !== '$') {
+                throw new Error('@wire config entry values must be strings starting with a $');
+            }
+            const referencedField = value.value.slice(1);
+            if (!isValidIdentifier(referencedField)) {
+                throw new Error(`@wire config referenced invalid field: ${referencedField}`);
+            }
+
+            return {
+                configKey: key.name,
+                referencedField,
+            };
+        }) ?? [];
+
+    return {
+        fieldName,
+        fieldType,
+        adapterConstructorId,
+        config: extractedConfig,
+    };
+}
+
+export function catalogWireAdapters(
+    state: ComponentMetaState,
+    node: PropertyDefinition | MethodDefinition
+) {
+    if (!is.identifier(node.key)) {
+        throw new Error(
+            'Unimplemented: wires that decorate non-identifiers are not currently supported.'
+        );
+    }
+    const { name } = node.key;
+
+    const { decorators } = node as EsPropertyDefinitionWithDecorators;
+    if (decorators?.length !== 1) {
+        throw new Error('Only one decorator can be applied to a single field.');
+    }
+
+    const expression = decorators[0].expression as Expression;
+    if (!is.callExpression(expression)) {
+        throw new Error('The @wire decorator must be called.');
+    }
+
+    const { arguments: args } = expression;
+    const [adapterConstructorId, config] = args;
+    if (!is.identifier(adapterConstructorId)) {
+        throw new Error('The @wire decorator must reference a wire adapter class.');
+    }
+    if (config && !is.objectExpression(config)) {
+        throw new Error('Invalid config provided to @wire decorator; expected an object literal.');
+    }
+
+    const fieldtype =
+        node.type === 'MethodDefinition' && node.kind === 'method' ? 'method' : 'property';
+
+    state.wireAdapters = [
+        ...state.wireAdapters,
+        extractWireConfig(name, adapterConstructorId.name, fieldtype, config),
+    ];
+}
+
+function bWireConfigObj(adapter: WireAdapter) {
+    return b.objectExpression(
+        adapter.config.map(({ configKey, referencedField }) =>
+            b.property(
+                'init',
+                b.identifier(configKey),
+                b.memberExpression(b.identifier('instance'), b.identifier(referencedField))
+            )
+        )
+    );
+}
+
+const bSetWiredProp = esTemplate`
+    instance.${/*wire-decorated property*/ is.identifier} = newValue
+`<ExpressionStatement>;
+
+const bCallWiredMethod = esTemplate`
+    instance.${/*wire-decorated method*/ is.identifier}(newValue)
+`<ExpressionStatement>;
+
+const bWireAdapterPlumbing = esTemplate`
+    const wireInstance = new ${/*wire adapter constructor*/ is.identifier}((newValue) => {
+        ${/*update the decorated property or call the decorated method*/ is.expressionStatement};
+    });
+    wireInstance.connect?.();
+    if (wireInstance.update) {
+        const wireConfigObj = ${/*mapping from lwc fields to wire config keys*/ is.objectExpression};
+
+        // This may look a bit weird, in that the 'update' function is called twice: once with
+        // an 'undefined' value and possibly again with a context-provided value. While weird,
+        // this preserves the behavior of the browser-side wire implementation as well as the
+        // original SSR implementation.
+        wireInstance.update(wireConfigObj, undefined);
+        __connectContext(${/*wire adapter constructor*/ 0}, instance, (newContextValue) => {
+            const wireConfigObj = ${/*mapping from lwc fields to wire config keys*/ 2};
+            wireInstance.update(wireConfigObj, newContextValue);
+        });
+    }
+`<Statement[]>;
+
+export function bWireAdaptersPlumbing(adapters: WireAdapter[]): Statement[] {
+    return adapters.map((adapter) => {
+        const { adapterConstructorId, fieldName } = adapter;
+
+        const actionUponNewValue =
+            adapter.fieldType === 'method'
+                ? bCallWiredMethod(b.identifier(fieldName))
+                : bSetWiredProp(b.identifier(fieldName));
+
+        return b.blockStatement(
+            bWireAdapterPlumbing(
+                b.identifier(adapterConstructorId),
+                actionUponNewValue,
+                bWireConfigObj(adapter)
+            )
+        );
+    });
+}

--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -43,7 +43,9 @@ const bExportTemplate = esTemplate`
         if (!isLightDom) {
             yield '</template>';
             if (slottedContent?.shadow) {
-                yield* slottedContent.shadow();
+                // instance must be passed in; this is used to establish the contextful relationship
+                // between context provider (aka parent component) and context consumer (aka slotted content)
+                yield* slottedContent.shadow(instance);
             }
         }
     }

--- a/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
@@ -6,7 +6,6 @@
  */
 
 import { builders as b, is } from 'estree-toolkit';
-import { reservedKeywords } from '@lwc/shared';
 import { Node as IrNode } from '@lwc/template-compiler';
 
 import { bImportDeclaration } from '../estree/builders';
@@ -20,16 +19,6 @@ import type {
 
 export const bImportHtmlEscape = () => bImportDeclaration(['htmlEscape']);
 export const importHtmlEscapeKey = 'import:htmlEscape';
-
-// This is a mostly-correct regular expression will only match if the entire string
-// provided is a valid ECMAScript identifier. Its imperfections lie in the fact that
-// it will match strings like "export" when "export" is actually a reserved keyword
-// and therefore not a valid identifier. When combined with a check against reserved
-// keywords, it is a reliable test for whether a provided string is a valid identifier.
-const imperfectIdentifierMatcher = /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*$/;
-
-export const isValidIdentifier = (str: string) =>
-    !reservedKeywords.has(str) && imperfectIdentifierMatcher.test(str);
 
 export function optimizeAdjacentYieldStmts(statements: EsStatement[]): EsStatement[] {
     let prevStmt: EsStatement | null = null;

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
@@ -32,7 +32,7 @@ const bYieldEscapedString = esTemplateWithYield`
             yield String(${0});
             break;
         default:
-            yield ${0} ? htmlEscape(${0}.toString()) : '\\u200D';
+            yield ${0} ? htmlEscape(${0}.toString()) : ${2} ? '\\u200D' : '';
     }
 `<EsStatement[]>;
 

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-import { Config as TemplateCompilerConfig } from '@lwc/template-compiler';
+import { reservedKeywords } from '@lwc/shared';
+import type { Config as TemplateCompilerConfig } from '@lwc/template-compiler';
 
 export type Expression = string;
 
@@ -62,3 +62,13 @@ export type TransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'
 
 /* SSR compilation mode. `async` refers to async functions, `sync` to sync functions, and `asyncYield` to async generator functions. */
 export type CompilationMode = 'asyncYield' | 'async' | 'sync';
+
+// This is a mostly-correct regular expression will only match if the entire string
+// provided is a valid ECMAScript identifier. Its imperfections lie in the fact that
+// it will match strings like "export" when "export" is actually a reserved keyword
+// and therefore not a valid identifier. When combined with a check against reserved
+// keywords, it is a reliable test for whether a provided string is a valid identifier.
+const imperfectIdentifierMatcher = /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*$/;
+
+export const isValidIdentifier = (str: string) =>
+    !reservedKeywords.has(str) && imperfectIdentifierMatcher.test(str);

--- a/packages/@lwc/ssr-runtime/package.json
+++ b/packages/@lwc/ssr-runtime/package.json
@@ -45,6 +45,7 @@
     },
     "devDependencies": {
         "@lwc/shared": "8.7.0",
+        "@lwc/engine-core": "8.7.0",
         "observable-membrane": "2.0.0"
     }
 }

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -33,3 +33,4 @@ export { hasScopedStaticStylesheets, renderStylesheets } from './styles';
 export { toIteratorDirective } from './to-iterator-directive';
 export { validateStyleTextContents } from './validate-style-text-contents';
 export { getReadOnlyProxy } from './get-read-only-proxy';
+export { createContextProvider, establishContextfulRelationship, connectContext } from './wire';

--- a/packages/@lwc/ssr-runtime/src/stubs.ts
+++ b/packages/@lwc/ssr-runtime/src/stubs.ts
@@ -10,9 +10,6 @@
 export function api(..._: unknown[]): never {
     throw new Error('@api cannot be used in SSR context.');
 }
-export function createContextProvider(..._: unknown[]): never {
-    throw new Error('createContextProvider cannot be used in SSR context.');
-}
 export function createElement(..._: unknown[]): never {
     throw new Error('createElement cannot be used in SSR context.');
 }

--- a/packages/@lwc/ssr-runtime/src/wire.ts
+++ b/packages/@lwc/ssr-runtime/src/wire.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from './lightning-element';
+import type {
+    WireAdapterConstructor,
+    WireContextConsumer,
+    WireContextProviderOptions,
+} from '@lwc/engine-core';
+
+type SsrContextProvider = (le: LightningElement, options?: WireContextProviderOptions) => void;
+
+const contextfulRelationships = new WeakMap<LightningElement, LightningElement>();
+export function establishContextfulRelationship(
+    parentLe: LightningElement,
+    childLe: LightningElement
+): void {
+    contextfulRelationships.set(childLe, parentLe);
+}
+
+export function getContextfulStack(le: LightningElement): LightningElement[] {
+    const contextfulParent = contextfulRelationships.get(le);
+    if (!contextfulParent) {
+        return [];
+    }
+    return [contextfulParent, ...getContextfulStack(contextfulParent)];
+}
+
+const contextProviders = new WeakMap<
+    WireAdapterConstructor,
+    WeakMap<LightningElement, OnConsumerConnected>
+>();
+type OnConsumerConnected = (consumer: WireContextConsumer) => void;
+
+function registerContextProvider(
+    adapter: WireAdapterConstructor,
+    attachedLe: LightningElement,
+    consumerCallback: OnConsumerConnected
+) {
+    let elementMap = contextProviders.get(adapter);
+    if (!elementMap) {
+        elementMap = new WeakMap();
+        contextProviders.set(adapter, elementMap);
+    }
+    elementMap.set(attachedLe, consumerCallback);
+}
+
+export function connectContext(
+    adapter: WireAdapterConstructor,
+    contextConsumer: LightningElement,
+    onNewValue: (newValue: any) => void
+): void {
+    const elementMap = contextProviders.get(adapter);
+    if (!elementMap) {
+        return;
+    }
+    const contextfulStack = getContextfulStack(contextConsumer);
+    for (const ancestor of contextfulStack) {
+        const onConsumerConnected = elementMap.get(ancestor);
+        if (onConsumerConnected) {
+            onConsumerConnected({
+                provide(newContextValue) {
+                    onNewValue(newContextValue);
+                },
+            });
+            return;
+        }
+    }
+}
+
+export function createContextProvider(adapter: WireAdapterConstructor): SsrContextProvider {
+    return (le, options) => {
+        if (!(le instanceof LightningElement)) {
+            throw new Error('Unable to register context provider on provided `elm`.');
+        }
+        if (!le.isConnected || !options?.consumerConnectedCallback) {
+            return;
+        }
+        const { consumerConnectedCallback } = options;
+
+        registerContextProvider(adapter, le, (consumer: WireContextConsumer) =>
+            consumerConnectedCallback(consumer)
+        );
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,6 +2904,11 @@
     "@types/babel__core" "*"
     "@types/babel__traverse" "*"
 
+"@types/babel__helper-validator-identifier@^7.15.2":
+  version "7.15.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__helper-validator-identifier/-/babel__helper-validator-identifier-7.15.2.tgz#e75af42eb71d7f91a4f2805dca331f776a7d6241"
+  integrity sha512-l3dkwCt890NFhMwPKXbxsWXC0Por0/+KaFIiQP1j38/vWSH2P3Tn6m+IuJHkx2SBI3VLFqincFe9JtBk2NFHOw==
+
 "@types/babel__template@*":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"


### PR DESCRIPTION
## Details

This implements both the normal & contextful varieties of `@wire` for the new SSR compiler. The `wire` and `context-*` fixture tests are now passing (down to 39 total failures).

## Does this pull request introduce a breaking change?

-   😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

-   🤞 No, it does not introduce an observable change.

## GUS work item

W-14631064
