### PR TITLE
test: add benchmark for light dom slots

### DIFF
--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/cardComponentLight/cardComponentLight.html
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/cardComponentLight/cardComponentLight.html
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template lwc:render-mode="light">
+    <h1>{title}</h1>
+    <template for:each={rows} for:item="row">
+        <benchmark-table-component-row-light
+                key={row.id}
+                class={row.className}
+                row={row}
+        >
+        </benchmark-table-component-row-light>
+    </template>
+    <div>
+        <slot></slot>
+    </div>
+</template>

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/cardComponentLight/cardComponentLight.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/cardComponentLight/cardComponentLight.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class CardComponentLight extends LightningElement {
+    static renderMode = 'light';
+    @api title;
+    // Note: This is only to give volume to the rehydration process.
+    @api rows;
+}

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/slotUsageComponentLight/slotUsageComponentLight.html
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/slotUsageComponentLight/slotUsageComponentLight.html
@@ -1,0 +1,21 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template lwc:render-mode="light">
+    <h1>{componentContent}</h1>
+    <benchmark-card-component-light title={titleOfComponentWithSlot} rows={rowsOfComponentWithSlot}>
+
+        <template for:each={rowsOfSlottedContent} for:item="row">
+            <benchmark-table-component-row-light
+                    key={row.id}
+                    class={row.className}
+                    row={row}
+            >
+            </benchmark-table-component-row-light>
+        </template>
+
+    </benchmark-card-component-light>
+</template>

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/slotUsageComponentLight/slotUsageComponentLight.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/slotUsageComponentLight/slotUsageComponentLight.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class SlotUsageComponentLight extends LightningElement {
+    static renderMode = 'light';
+    @api componentContent;
+    @api rowsOfSlottedContent;
+    @api titleOfComponentWithSlot;
+    @api rowsOfComponentWithSlot;
+}

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/tableComponentRowLight/tableComponentRowLight.html
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/tableComponentRowLight/tableComponentRowLight.html
@@ -1,0 +1,11 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template lwc:render-mode="light">
+    <span>{row.id}</span>
+    <div><a onclick={handleSelect} data-id={row.id}>{row.label}</a></div>
+    <div><a onclick={handleRemove} data-id={row.id}>Remove</a></div>
+</template>

--- a/packages/@lwc/perf-benchmarks-components/src/benchmark/tableComponentRowLight/tableComponentRowLight.js
+++ b/packages/@lwc/perf-benchmarks-components/src/benchmark/tableComponentRowLight/tableComponentRowLight.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class TableComponentRowLight extends LightningElement {
+    static renderMode = 'light';
+    @api row;
+
+    handleSelect() {
+        this.dispatchEvent(new CustomEvent('select'));
+    }
+
+    handleRemove() {
+        this.dispatchEvent(new CustomEvent('remove'));
+    }
+}

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-light/light-slot-create-container-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-light/light-slot-create-container-5k.benchmark.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from '@lwc/engine-dom';
+
+import SlotUsage from '@lwc/perf-benchmarks-components/dist/dom/benchmark/slotUsageComponentLight/slotUsageComponentLight.js';
+import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+const NUMBER_OF_ROWS = 5000;
+
+benchmark(`dom/slot/light/create/5k`, () => {
+    let slottingComponent;
+    let rowsOfComponentWithSlot;
+    let rowsOfSlottedContent;
+
+    before(() => {
+        slottingComponent = createElement('benchmark-slot-usage-component-light', {
+            is: SlotUsage,
+        });
+        const store = new Store();
+
+        rowsOfComponentWithSlot = store.buildData(NUMBER_OF_ROWS);
+        rowsOfSlottedContent = store.buildData(NUMBER_OF_ROWS);
+        return insertComponent(slottingComponent);
+    });
+
+    run(() => {
+        slottingComponent.componentContent = 'Parent component slotting content to child cmp';
+        slottingComponent.rowsOfSlottedContent = rowsOfSlottedContent;
+        slottingComponent.titleOfComponentWithSlot = 'Component that receives a slot';
+        slottingComponent.rowsOfComponentWithSlot = rowsOfComponentWithSlot;
+    });
+
+    after(() => {
+        destroyComponent(slottingComponent);
+    });
+});

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-light/light-slot-update-slotted-content-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/engine-dom/benchmark-slot-light/light-slot-update-slotted-content-5k.benchmark.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from '@lwc/engine-dom';
+
+import SlotUsage from '@lwc/perf-benchmarks-components/dist/dom/benchmark/slotUsageComponentLight/slotUsageComponentLight.js';
+import Store from '@lwc/perf-benchmarks-components/dist/dom/benchmark/store/store.js';
+import { insertComponent, destroyComponent } from '../../../utils/utils.js';
+
+const NUMBER_OF_ROWS = 5000;
+
+benchmark(`dom/slot/light/update-slotted-content/5k`, () => {
+    let slottingComponent;
+    let nextData;
+
+    before(async () => {
+        slottingComponent = createElement('benchmark-slot-usage-component-light', {
+            is: SlotUsage,
+        });
+
+        const store = new Store();
+
+        slottingComponent.componentContent = 'Parent component slotting content to child cmp';
+        slottingComponent.titleOfComponentWithSlot = 'Component that receives a slot';
+        slottingComponent.rowsOfSlottedContent = store.buildData(NUMBER_OF_ROWS);
+        slottingComponent.rowsOfComponentWithSlot = store.buildData(NUMBER_OF_ROWS);
+
+        nextData = store.buildData(NUMBER_OF_ROWS);
+
+        await insertComponent(slottingComponent);
+    });
+
+    run(() => {
+        slottingComponent.rowsOfSlottedContent = nextData;
+    });
+
+    after(() => {
+        destroyComponent(slottingComponent);
+    });
+});

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/slots/light-slot-create-container-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/slots/light-slot-create-container-5k.benchmark.js
@@ -1,0 +1,29 @@
+import { renderComponent } from '@lwc/ssr-runtime';
+import SlotUsage from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/slotUsageComponentLight/slotUsageComponentLight.js';
+import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
+
+const SSR_MODE = 'asyncYield';
+const NUMBER_OF_ROWS = 5000;
+
+benchmark(`ssr/slot/light/create/5k`, () => {
+    let store;
+    let rowsOfComponentWithSlot;
+    let rowsOfSlottedContent;
+
+    before(() => {
+        store = new Store();
+        rowsOfComponentWithSlot = store.buildData(NUMBER_OF_ROWS);
+        rowsOfSlottedContent = store.buildData(NUMBER_OF_ROWS);
+    });
+
+    run(() => {
+        const props = {
+            rows: store.data,
+            componentContent: 'Parent component slotting content to child cmp',
+            rowsOfSlottedContent: rowsOfSlottedContent,
+            titleOfComponentWithSlot: 'Component that receives a slot',
+            rowsOfComponentWithSlot: rowsOfComponentWithSlot,
+        };
+        return renderComponent('benchmark-slot-usage-component-light', SlotUsage, props, SSR_MODE);
+    });
+});


### PR DESCRIPTION
## Details

Adds benchmarks for light dom slots for both `engine-dom` and SSR.

Not familiar with the benchmarking here yet. I initially wrote a script to convert the components to light dom instead of copying, but thought it might be better to validate if I kept it simple.

Closes #4784

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
