### PR TITLE
test(ssr-compiler): enable all tests and skip fixtures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -76,7 +76,9 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
     return outputFile;
 }
 
-function testFixtures() {
+// We will enable this for realsies once all the tests are passing, but for now having the env var avoids
+// running these tests in CI while still allowing for local testing.
+describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
     testFixtureDir(
         {
             root: path.resolve(__dirname, '../../../engine-server/src/__tests__/fixtures'),
@@ -129,8 +131,4 @@ function testFixtures() {
             }
         }
     );
-}
-
-describe('fixtures', () => {
-    testFixtures();
 });

--- a/vitest.workspace.mjs
+++ b/vitest.workspace.mjs
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import { defineWorkspace } from 'vitest/config';
 
 export default defineWorkspace([
@@ -13,9 +12,7 @@ export default defineWorkspace([
     'packages/@lwc/rollup-plugin',
     'packages/@lwc/shared',
     'packages/@lwc/signals',
-    // We will enable this for realsies once all the tests are passing, but for now having the env var avoids
-    // running these tests in CI while still allowing for local testing.
-    ...(process.env.TEST_SSR_COMPILER ? ['packages/@lwc/ssr-compiler'] : []),
+    'packages/@lwc/ssr-compiler',
     'packages/@lwc/ssr-runtime',
     'packages/@lwc/style-compiler',
     'packages/@lwc/template-compiler',


### PR DESCRIPTION
## Details

Rather than skipping all the ssr tests, I think it makes more sense to skip just the fixtures instead, since all the others are passing.

To run the fixtures, the approach hasn't changed: `TEST_SSR_COMPILER=1 yarn test`.

```
 ✓ |lwc-ssr-compiler| src/__tests__/compilation.spec.ts (3)
 ✓ |lwc-ssr-compiler| src/__tests__/estemplate.spec.ts (12)
 ↓ |lwc-ssr-compiler| src/__tests__/fixtures.spec.ts (199) [skipped]
 ✓ |lwc-ssr-compiler| src/__tests__/transmogrify.spec.ts (6)

 Test Files  3 passed | 1 skipped (4)
      Tests  21 passed | 199 skipped (220)
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
