### PR TITLE
[DO NOT MERGE] Trigger CI for #4809: test(ssr-compiler): enable all tests and skip fixtures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -76,7 +76,9 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
     return outputFile;
 }
 
-function testFixtures() {
+// We will enable this for realsies once all the tests are passing, but for now having the env var avoids
+// running these tests in CI while still allowing for local testing.
+describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
     testFixtureDir(
         {
             root: path.resolve(__dirname, '../../../engine-server/src/__tests__/fixtures'),
@@ -129,8 +131,4 @@ function testFixtures() {
             }
         }
     );
-}
-
-describe('fixtures', () => {
-    testFixtures();
 });

--- a/vitest.workspace.mjs
+++ b/vitest.workspace.mjs
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import { defineWorkspace } from 'vitest/config';
 
 export default defineWorkspace([
@@ -13,9 +12,7 @@ export default defineWorkspace([
     'packages/@lwc/rollup-plugin',
     'packages/@lwc/shared',
     'packages/@lwc/signals',
-    // We will enable this for realsies once all the tests are passing, but for now having the env var avoids
-    // running these tests in CI while still allowing for local testing.
-    ...(process.env.TEST_SSR_COMPILER ? ['packages/@lwc/ssr-compiler'] : []),
+    'packages/@lwc/ssr-compiler',
     'packages/@lwc/ssr-runtime',
     'packages/@lwc/style-compiler',
     'packages/@lwc/template-compiler',


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4809.