### PR TITLE
[DO NOT MERGE] Trigger CI for #4806: fix(ssr-compiler): conflicting type definitions for estree

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -57,7 +57,7 @@ const visitors: Visitors = {
         }
 
         // TODO [#4773]: Why do we get conflicting PropertyDefinition types when removing "vitest/globals"?
-        const decorators = (node as any).decorators;
+        const decorators = node.decorators;
         if (is.identifier(decorators[0]?.expression) && decorators[0].expression.name === 'api') {
             state.publicFields.push(node.key.name);
         } else {

--- a/packages/@lwc/ssr-compiler/tsconfig.json
+++ b/packages/@lwc/ssr-compiler/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../../tsconfig.json",
-
+    "compilerOptions": {
+        "types": ["rollup", "node"]
+    },
     "include": ["src/"]
 }


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4806.