### PR TITLE
[DO NOT MERGE] Trigger CI for #4804: fix(ssr-compiler): unused htmlEscape import

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -56,14 +56,15 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
                 modules: [{ dir: modulesDir }],
             }),
         ],
-        onwarn({ message, code }) {
+        onwarn({ message, code, names = [] }) {
             if (
-                code !== 'CIRCULAR_DEPENDENCY' &&
+                code === 'CIRCULAR_DEPENDENCY' ||
                 // TODO [#4793]: fix unused imports
-                code !== 'UNUSED_EXTERNAL_IMPORT'
+                (code === 'UNUSED_EXTERNAL_IMPORT' && !names.includes('htmlEscape'))
             ) {
-                throw new Error(message);
+                return;
             }
+            throw new Error(message);
         },
     });
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -133,9 +133,9 @@ function yieldAttrOrPropLiveValue(
     value: IrExpression | BinaryExpression,
     cxt: TransformerContext
 ): EsStatement[] {
+    cxt.hoist(bImportHtmlEscape(), importHtmlEscapeKey);
     const isHtmlBooleanAttr = isBooleanAttribute(name, elementName);
     const scopedExpression = getScopedExpression(value as EsExpression, cxt);
-
     return [bConditionalLiveYield(b.literal(name), scopedExpression, b.literal(isHtmlBooleanAttr))];
 }
 
@@ -196,7 +196,6 @@ export const Element: Transformer<IrElement | IrExternalComponent | IrSlot> = fu
                 }
             }
 
-            cxt.hoist(bImportHtmlEscape(), importHtmlEscapeKey);
             if (value.type === 'Literal') {
                 return yieldAttrOrPropLiteralValue(name, value);
             } else {


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4804.