### PR TITLE
chore(deps): remove @eslint/compat

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,10 +6,8 @@
  */
 import jest from 'eslint-plugin-jest';
 import lwcInternal from '@lwc/eslint-plugin-lwc-internal';
-// @ts-expect-error CJS module; TS can't detect that it has a default export
 import _import from 'eslint-plugin-import';
 import header from 'eslint-plugin-header';
-import { fixupPluginRules } from '@eslint/compat';
 import globals from 'globals';
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
@@ -37,7 +35,7 @@ export default tseslint.config(
     {
         plugins: {
             '@lwc/lwc-internal': lwcInternal,
-            import: fixupPluginRules(_import),
+            import: _import,
             header,
             vitest,
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     },
     "devDependencies": {
         "@commitlint/cli": "^19.5.0",
-        "@eslint/compat": "^1.2.2",
         "@eslint/js": "^9.14.0",
         "@lwc/eslint-plugin-lwc-internal": "link:./scripts/eslint-plugin",
         "@lwc/test-utils-lwc-internals": "link:./scripts/test-utils",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,7 +1725,7 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
   integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
 
-"@eslint/compat@^1.1.1", "@eslint/compat@^1.2.2":
+"@eslint/compat@^1.1.1":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/compat/-/compat-1.2.2.tgz#46d02898df7e32ccc04166b6ea2689c52dee10da"
   integrity sha512-jhgiIrsw+tRfcBQ4BFl2C3vCrIUw2trCY0cnDvGZpwTtKCEDmZhAtMfrEUP/KpnwM6PrO0T+Ltm+ccW74olG3Q==
@@ -2060,9 +2060,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4", "@napi-rs/wasm-runtime@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
## Details

This was only used for `eslint-plugin-import` which supports eslint v9 since [v2.31.0](https://github.com/import-js/eslint-plugin-import/releases/tag/v2.31.0)

Annoyingly, an older version of it still gets pulled in by `eslint-config-flat-gitignore`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
