### PR TITLE
chore: remove deprecated contextmenu html global attribute

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/constants.ts
+++ b/packages/@lwc/babel-plugin-component/src/constants.ts
@@ -14,7 +14,6 @@ const AMBIGUOUS_PROP_SET = new Map([
     ['bgcolor', 'bgColor'],
     ['accesskey', 'accessKey'],
     ['contenteditable', 'contentEditable'],
-    ['contextmenu', 'contextMenu'],
     ['tabindex', 'tabIndex'],
     ['maxlength', 'maxLength'],
     ['maxvalue', 'maxValue'],

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/expected.html
@@ -1,6 +1,6 @@
 <x-component>
   <template shadowrootmode="open">
-    <x-child accesskey="foo" aria-activedescendant="foo" aria-atomic="foo" aria-autocomplete="foo" aria-busy="foo" aria-checked="foo" aria-colcount="foo" aria-colindex="foo" aria-colspan="foo" aria-controls="foo" aria-current="foo" aria-describedby="foo" aria-details="foo" aria-disabled="foo" aria-errormessage="foo" aria-expanded="foo" aria-flowto="foo" aria-haspopup="foo" aria-hidden="foo" aria-invalid="foo" aria-keyshortcuts="foo" aria-label="foo" aria-labelledby="foo" aria-level="foo" aria-live="foo" aria-modal="foo" aria-multiline="foo" aria-multiselectable="foo" aria-orientation="foo" aria-owns="foo" aria-placeholder="foo" aria-posinset="foo" aria-pressed="foo" aria-readonly="foo" aria-relevant="foo" aria-required="foo" aria-roledescription="foo" aria-rowcount="foo" aria-rowindex="foo" aria-rowspan="foo" aria-selected="foo" aria-setsize="foo" aria-sort="foo" aria-valuemax="foo" aria-valuemin="foo" aria-valuenow="foo" aria-valuetext="foo" autocapitalize="foo" autofocus="foo" contenteditable="foo" contextmenu="foo" dir="foo" draggable="foo" enterkeyhint="foo" exportparts="foo" id="foo" inputmode="foo" itemid="foo" itemprop="foo" itemref="foo" itemscope="foo" itemtype="foo" lang="foo" nonce="foo" role="foo" spellcheck="foo" tabindex="foo" title="foo" translate="foo">
+    <x-child accesskey="foo" aria-activedescendant="foo" aria-atomic="foo" aria-autocomplete="foo" aria-busy="foo" aria-checked="foo" aria-colcount="foo" aria-colindex="foo" aria-colspan="foo" aria-controls="foo" aria-current="foo" aria-describedby="foo" aria-details="foo" aria-disabled="foo" aria-errormessage="foo" aria-expanded="foo" aria-flowto="foo" aria-haspopup="foo" aria-hidden="foo" aria-invalid="foo" aria-keyshortcuts="foo" aria-label="foo" aria-labelledby="foo" aria-level="foo" aria-live="foo" aria-modal="foo" aria-multiline="foo" aria-multiselectable="foo" aria-orientation="foo" aria-owns="foo" aria-placeholder="foo" aria-posinset="foo" aria-pressed="foo" aria-readonly="foo" aria-relevant="foo" aria-required="foo" aria-roledescription="foo" aria-rowcount="foo" aria-rowindex="foo" aria-rowspan="foo" aria-selected="foo" aria-setsize="foo" aria-sort="foo" aria-valuemax="foo" aria-valuemin="foo" aria-valuenow="foo" aria-valuetext="foo" autocapitalize="foo" autofocus="foo" contenteditable="foo" dir="foo" draggable="foo" enterkeyhint="foo" exportparts="foo" id="foo" inputmode="foo" itemid="foo" itemprop="foo" itemref="foo" itemscope="foo" itemtype="foo" lang="foo" nonce="foo" role="foo" spellcheck="foo" tabindex="foo" title="foo" translate="foo">
       <template shadowrootmode="open">
         <span>
           accessKey: 
@@ -175,9 +175,6 @@
         </span>
         <span>
           contentEditable: 
-        </span>
-        <span>
-          contextMenu: 
         </span>
         <span>
           crossorigin: 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/modules/x/child/child.html
@@ -57,7 +57,6 @@
     <span>colSpan: {colSpan}</span>
     <span>command: {command}</span>
     <span>contentEditable: {contentEditable}</span>
-    <span>contextMenu: {contextMenu}</span>
     <span>crossorigin: {crossorigin}</span>
     <span>datetime: {datetime}</span>
     <span>details: {details}</span>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/undeclared/modules/x/component/component.html
@@ -57,7 +57,6 @@
         colspan={dynamic}
         command={dynamic}
         contenteditable={dynamic}
-        contextmenu={dynamic}
         crossorigin={dynamic}
         datetime={dynamic}
         details={dynamic}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/expected.html
@@ -1,6 +1,6 @@
 <x-component>
   <template shadowrootmode="open">
-    <x-child contextmenu="foo" exportparts="foo">
+    <x-child exportparts="foo">
       <template shadowrootmode="open">
         <span>
           accessKey: foo
@@ -175,9 +175,6 @@
         </span>
         <span>
           contentEditable: foo
-        </span>
-        <span>
-          contextMenu: 
         </span>
         <span>
           crossorigin: 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/child/child.html
@@ -57,7 +57,6 @@
     <span>colSpan: {colSpan}</span>
     <span>command: {command}</span>
     <span>contentEditable: {contentEditable}</span>
-    <span>contextMenu: {contextMenu}</span>
     <span>crossorigin: {crossorigin}</span>
     <span>datetime: {datetime}</span>
     <span>details: {details}</span>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/child/child.js
@@ -59,7 +59,6 @@ export default class extends LightningElement {
     @api colSpan
     @api command
     @api contentEditable
-    @api contextMenu
     @api crossorigin
     @api datetime
     @api details

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/with-@api/modules/x/component/component.html
@@ -57,7 +57,6 @@
         colspan={dynamic}
         command={dynamic}
         contenteditable={dynamic}
-        contextmenu={dynamic}
         crossorigin={dynamic}
         datetime={dynamic}
         details={dynamic}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/expected.html
@@ -1,6 +1,6 @@
 <x-component>
   <template shadowrootmode="open">
-    <x-child aria-activedescendant="foo" aria-atomic="foo" aria-autocomplete="foo" aria-busy="foo" aria-checked="foo" aria-colcount="foo" aria-colindex="foo" aria-colspan="foo" aria-controls="foo" aria-current="foo" aria-describedby="foo" aria-details="foo" aria-disabled="foo" aria-errormessage="foo" aria-expanded="foo" aria-flowto="foo" aria-haspopup="foo" aria-hidden="foo" aria-invalid="foo" aria-keyshortcuts="foo" aria-label="foo" aria-labelledby="foo" aria-level="foo" aria-live="foo" aria-modal="foo" aria-multiline="foo" aria-multiselectable="foo" aria-orientation="foo" aria-owns="foo" aria-placeholder="foo" aria-posinset="foo" aria-pressed="foo" aria-readonly="foo" aria-relevant="foo" aria-required="foo" aria-roledescription="foo" aria-rowcount="foo" aria-rowindex="foo" aria-rowspan="foo" aria-selected="foo" aria-setsize="foo" aria-sort="foo" aria-valuemax="foo" aria-valuemin="foo" aria-valuenow="foo" aria-valuetext="foo" contextmenu="foo" exportparts="foo" role="foo">
+    <x-child aria-activedescendant="foo" aria-atomic="foo" aria-autocomplete="foo" aria-busy="foo" aria-checked="foo" aria-colcount="foo" aria-colindex="foo" aria-colspan="foo" aria-controls="foo" aria-current="foo" aria-describedby="foo" aria-details="foo" aria-disabled="foo" aria-errormessage="foo" aria-expanded="foo" aria-flowto="foo" aria-haspopup="foo" aria-hidden="foo" aria-invalid="foo" aria-keyshortcuts="foo" aria-label="foo" aria-labelledby="foo" aria-level="foo" aria-live="foo" aria-modal="foo" aria-multiline="foo" aria-multiselectable="foo" aria-orientation="foo" aria-owns="foo" aria-placeholder="foo" aria-posinset="foo" aria-pressed="foo" aria-readonly="foo" aria-relevant="foo" aria-required="foo" aria-roledescription="foo" aria-rowcount="foo" aria-rowindex="foo" aria-rowspan="foo" aria-selected="foo" aria-setsize="foo" aria-sort="foo" aria-valuemax="foo" aria-valuemin="foo" aria-valuenow="foo" aria-valuetext="foo" exportparts="foo" role="foo">
       <template shadowrootmode="open">
         <span>
           accessKey: 
@@ -175,9 +175,6 @@
         </span>
         <span>
           contentEditable: 
-        </span>
-        <span>
-          contextMenu: 
         </span>
         <span>
           crossorigin: 

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/child/child.html
@@ -57,7 +57,6 @@
     <span>colSpan: {colSpan}</span>
     <span>command: {command}</span>
     <span>contentEditable: {contentEditable}</span>
-    <span>contextMenu: {contextMenu}</span>
     <span>crossorigin: {crossorigin}</span>
     <span>datetime: {datetime}</span>
     <span>details: {details}</span>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/child/child.js
@@ -59,7 +59,6 @@ export default class extends LightningElement {
     colSpan
     command
     contentEditable
-    contextMenu
     crossorigin
     datetime
     details

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/attribute-global-html/as-component-prop/without-@api/modules/x/component/component.html
@@ -57,7 +57,6 @@
         colspan={dynamic}
         command={dynamic}
         contenteditable={dynamic}
-        contextmenu={dynamic}
         crossorigin={dynamic}
         datetime={dynamic}
         details={dynamic}

--- a/packages/@lwc/shared/src/html-attributes.ts
+++ b/packages/@lwc/shared/src/html-attributes.ts
@@ -64,7 +64,6 @@ const GLOBAL_ATTRIBUTE = /*@__PURE__*/ new Set([
     'autofocus',
     'class',
     'contenteditable',
-    'contextmenu',
     'dir',
     'draggable',
     'enterkeyhint',


### PR DESCRIPTION
## Details

Remove support for `contextmenu` global html attribute that was only ever implemented in Firefox and has since been removed from Firefox.

## Does this pull request introduce a breaking change?

Unlikely, as there isn't a single browser that does anything with this attribute. Even when it was implemented, it was only supported by Firefox.