### PR TITLE
fix: revert "fix(ssr): infer the SSR mode in `renderComponent`"

### DIFF
--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/slots/slot-create-container-5k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/slots/slot-create-container-5k.benchmark.js
@@ -2,6 +2,7 @@ import { renderComponent } from '@lwc/ssr-runtime';
 import SlotUsage from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/slotUsageComponent/slotUsageComponent.js';
 import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
 
+const SSR_MODE = 'asyncYield';
 const NUMBER_OF_ROWS = 5000;
 
 benchmark(`ssr/slot/shadow/create/5k`, () => {
@@ -23,6 +24,6 @@ benchmark(`ssr/slot/shadow/create/5k`, () => {
             titleOfComponentWithSlot: 'Component that receives a slot',
             rowsOfComponentWithSlot: rowsOfComponentWithSlot,
         };
-        return renderComponent('benchmark-slot-usage-component', SlotUsage, props);
+        return renderComponent('benchmark-slot-usage-component', SlotUsage, props, SSR_MODE);
     });
 });

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table/table-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table/table-render-10k.benchmark.js
@@ -10,13 +10,20 @@ import { renderComponent } from '@lwc/ssr-runtime';
 import Table from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/table/table.js';
 import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
 
+const SSR_MODE = 'asyncYield';
+
 benchmark(`ssr/table-v2/render/10k`, () => {
     run(() => {
         const store = new Store();
         store.runLots();
 
-        return renderComponent('benchmark-table', Table, {
-            rows: store.data,
-        });
+        return renderComponent(
+            'benchmark-table',
+            Table,
+            {
+                rows: store.data,
+            },
+            SSR_MODE
+        );
     });
 });

--- a/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table/tablecmp-render-10k.benchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/__benchmarks__/ssr/table/tablecmp-render-10k.benchmark.js
@@ -10,13 +10,20 @@ import { renderComponent } from '@lwc/ssr-runtime';
 import Table from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/tableComponent/tableComponent.js';
 import Store from '@lwc/perf-benchmarks-components/dist/ssr/benchmark/store/store.js';
 
+const SSR_MODE = 'asyncYield';
+
 benchmark(`ssr/table-component/render/10k`, () => {
     run(() => {
         const store = new Store();
         store.runLots();
 
-        return renderComponent('benchmark-table', Table, {
-            rows: store.data,
-        });
+        return renderComponent(
+            'benchmark-table',
+            Table,
+            {
+                rows: store.data,
+            },
+            SSR_MODE
+        );
     });
 });

--- a/packages/@lwc/perf-benchmarks/src/utils/styledComponentSsrBenchmark.js
+++ b/packages/@lwc/perf-benchmarks/src/utils/styledComponentSsrBenchmark.js
@@ -1,5 +1,7 @@
 import { renderComponent } from '@lwc/ssr-runtime';
 
+const SSR_MODE = 'asyncYield';
+
 // Generic benchmark for styled components, SSR-flavored!
 export function styledComponentSsrBenchmark(
     name,
@@ -15,7 +17,8 @@ export function styledComponentSsrBenchmark(
                 await renderComponent(
                     isArray ? `styled-component${i}` : 'styled-component',
                     isArray ? componentOrComponents[i] : componentOrComponents,
-                    {}
+                    {},
+                    SSR_MODE
                 );
             }
         });

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -121,7 +121,8 @@ describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
                 result = await serverSideRenderComponent(
                     module!.tagName,
                     module!.default,
-                    config?.props ?? {}
+                    config?.props ?? {},
+                    SSR_MODE
                 );
             } catch (err: any) {
                 return {

--- a/packages/@lwc/ssr-runtime/package.json
+++ b/packages/@lwc/ssr-runtime/package.json
@@ -45,7 +45,6 @@
     },
     "devDependencies": {
         "@lwc/shared": "8.7.0",
-        "@lwc/ssr-compiler": "8.7.0",
         "@lwc/engine-core": "8.7.0",
         "observable-membrane": "2.0.0"
     }

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isGeneratorFunction, isAsyncFunction } from 'node:util/types';
+
 import { mutationTracker } from './mutation-tracker';
 import {
     LightningElement,
@@ -12,7 +12,6 @@ import {
     SYMBOL__GENERATE_MARKUP,
 } from './lightning-element';
 import type { Attributes, Properties } from './types';
-import type { CompilationMode } from '@lwc/ssr-compiler';
 
 const escapeAttrVal = (attrVal: string) =>
     attrVal.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
@@ -111,7 +110,8 @@ interface ComponentWithGenerateMarkup {
 export async function serverSideRenderComponent(
     tagName: string,
     Component: GenerateMarkupFnVariants | ComponentWithGenerateMarkup,
-    props: Properties = {}
+    props: Properties = {},
+    mode: 'asyncYield' | 'async' | 'sync' = 'asyncYield'
 ): Promise<string> {
     if (typeof tagName !== 'string') {
         throw new Error(`tagName must be a string, found: ${tagName}`);
@@ -120,11 +120,6 @@ export async function serverSideRenderComponent(
     // TODO [#4726]: remove `generateMarkup` export
     const generateMarkup =
         SYMBOL__GENERATE_MARKUP in Component ? Component[SYMBOL__GENERATE_MARKUP] : Component;
-    const mode: CompilationMode = isAsyncFunction(generateMarkup)
-        ? isGeneratorFunction(generateMarkup)
-            ? 'asyncYield'
-            : 'async'
-        : 'sync';
 
     let markup = '';
     const emit = (segment: string) => {


### PR DESCRIPTION
## Details

This reverts commit d47c56c7fbd6b4f891d3398109a8b975dab897b7 (#4820).

It turns out we broke the Best tests with this PR (due to `node:utils/types` not being Rollupified correctly), and plus it seems like it doesn't accurately detect `async` mode for some reason (it sometimes determines `sync`)?

This PR was not super important so let's just revert it for now.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
