### PR TITLE
feat: remove decorator imports visitor

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -16,6 +16,7 @@ import { catalogStaticStylesheets, catalogAndReplaceStyleImports } from './style
 import { addGenerateMarkupExport, assignGenerateMarkupToComponent } from './generate-markup';
 import { catalogWireAdapters } from './wire';
 
+import { removeDecoratorImport } from './remove-decorator-import';
 import type { Identifier as EsIdentifier, Program as EsProgram, Expression } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
 import type { CompilationMode } from '../shared';
@@ -34,6 +35,7 @@ const visitors: Visitors = {
         replaceLwcImport(path, state);
         catalogTmplImport(path, state);
         catalogAndReplaceStyleImports(path, state);
+        removeDecoratorImport(path);
     },
     ClassDeclaration(path, state) {
         if (!path.node?.superClass) {

--- a/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { ImportDeclaration } from 'estree';
+import { NodePath, builders as b } from 'estree-toolkit';
+
+export function removeDecoratorImport(path: NodePath<ImportDeclaration>) {
+    if (!path.node || path.node.source.value !== '@lwc/ssr-runtime') {
+        return;
+    }
+
+    const filteredSpecifiers = path.node.specifiers.filter(
+        (specifier) =>
+            !(
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.type === 'Identifier' &&
+                (specifier.imported.name === 'api' || specifier.imported.name === 'wire')
+            )
+    );
+
+    if (filteredSpecifiers.length !== path.node.specifiers.length) {
+        path.replaceWith(b.importDeclaration(filteredSpecifiers, b.literal('@lwc/ssr-runtime')));
+    }
+}

--- a/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
@@ -18,6 +18,7 @@ export function removeDecoratorImport(path: NodePath<ImportDeclaration>) {
             !(
                 specifier.type === 'ImportSpecifier' &&
                 specifier.imported.type === 'Identifier' &&
+                // Excluding track because it also has a non-decorator signature that might be used
                 (specifier.imported.name === 'api' || specifier.imported.name === 'wire')
             )
     );


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

W-17152250
