### PR TITLE
chore(ssr): use test options for expected failures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -85,14 +85,12 @@ describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
         {
             root: path.resolve(__dirname, '../../../engine-server/src/__tests__/fixtures'),
             pattern: '**/index.js',
+            // TODO [#4815]: enable all SSR v2 tests
             expectedFailures,
         },
         async ({ filename, dirname, config }) => {
             const errorFile = config?.ssrFiles?.error ?? 'error.txt';
             const expectedFile = config?.ssrFiles?.expected ?? 'expected.html';
-            // TODO [#4815]: enable all SSR v2 tests
-            const shortFilename = filename.split('fixtures/')[1];
-            const expectedFailure = expectedFailures.has(shortFilename);
 
             let compiledFixturePath;
             try {
@@ -107,14 +105,7 @@ describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
                 };
             }
 
-            let module;
-            try {
-                module = (await import(compiledFixturePath)) as FixtureModule;
-            } catch (err: any) {
-                if (!expectedFailure) {
-                    throw err;
-                }
-            }
+            const module = (await import(compiledFixturePath)) as FixtureModule;
 
             let result;
             try {


### PR DESCRIPTION
## Details

Follow up to #4816.

Uses vitest's built-in support for expected failures.

I also removed `description` from `TestFixtureConfig` since it's unused.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
