### PR TITLE
chore(forks): auto trigger nucleus tests

### DIFF
--- a/scripts/tasks/unsafe-external-contributor-ci-workaround.sh
+++ b/scripts/tasks/unsafe-external-contributor-ci-workaround.sh
@@ -79,5 +79,9 @@ gh pr create \
   --body "External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #$NUMBER."
 git switch -
 gh pr close "$INTERNAL_BRANCH" --delete-branch
+
+# Trigger nucleus tests
+gh pr comment "$NUMBER" -b '/nucleus test'
+
 # Open the original PR in browser to validate that CI is running correctly
 gh pr view --web "$NUMBER"


### PR DESCRIPTION
Script to run CI for forks doesn't include triggering nucleus tests; now it does!

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
