### PR TITLE
test(ssr-compiler): narrow which unused imports are expected

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -57,14 +57,18 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
                 modules: [{ dir: modulesDir }],
             }),
         ],
-        onwarn({ message, code }) {
-            if (
-                code === 'CIRCULAR_DEPENDENCY' ||
-                // TODO [#4793]: fix unused imports
-                code === 'UNUSED_EXTERNAL_IMPORT'
-            ) {
+        onwarn({ message, code, names }) {
+            if (code === 'CIRCULAR_DEPENDENCY') {
                 return;
             }
+            // TODO [#4793]: fix unused imports
+            if (code === 'UNUSED_EXTERNAL_IMPORT') {
+                const unexpected = new Set(names);
+                const expected = ['connectContext', 'htmlEscape', 'track'];
+                expected.forEach((name) => unexpected.delete(name));
+                if (unexpected.size === 0) return;
+            }
+
             throw new Error(message);
         },
     });

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -23,7 +23,6 @@ export const expectedFailures = new Set([
     'attribute-class/with-scoped-styles/dynamic/index.js',
     'attribute-component-global-html/index.js',
     'attribute-global-html/as-component-prop/undeclared/index.js',
-    'attribute-global-html/as-component-prop/with-@api/index.js',
     'attribute-global-html/as-component-prop/without-@api/index.js',
     'attribute-namespace/index.js',
     'attribute-style/basic/index.js',


### PR DESCRIPTION
## Details

Incrementally building towards #4793 (and validating #4840), this reduces the allowed unused imports to a hard-coded list. Also includes the change in #4854 (thx @cardoso <3).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
