### PR TITLE
[DO NOT MERGE] Trigger CI for #4854: chore(ssr): remove as-component-prop/with-@api from expected failures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -23,7 +23,6 @@ export const expectedFailures = new Set([
     'attribute-class/with-scoped-styles/dynamic/index.js',
     'attribute-component-global-html/index.js',
     'attribute-global-html/as-component-prop/undeclared/index.js',
-    'attribute-global-html/as-component-prop/with-@api/index.js',
     'attribute-global-html/as-component-prop/without-@api/index.js',
     'attribute-namespace/index.js',
     'attribute-style/basic/index.js',


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4854.