### PR TITLE
test(ssr): test global html literals on components

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/expected.html
@@ -1,0 +1,256 @@
+<x-component>
+  <template shadowrootmode="open">
+    <x-child tabindex="0">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child tabindex="-1">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="   ">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="   ">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="   ">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="   ">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="   ">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="false">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="FALSE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="TRUE">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child accesskey="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child dir="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child draggable="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child hidden>
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child id="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child lang="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child spellcheck="true">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+    <x-child title="yolo">
+      <template shadowrootmode="open">
+      </template>
+    </x-child>
+  </template>
+</x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-component';
+export { default } from 'x/component';
+export * from 'x/component';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/child/child.js
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/component/component.html
@@ -1,0 +1,79 @@
+<template>
+
+    <x-child tabindex="0"></x-child>
+    <x-child tabindex="-1"></x-child>
+
+    <!-- LWC1061: The attribute "tabindex" can only be set to "0" or "-1". -->
+
+    <x-child accesskey></x-child>
+    <x-child dir></x-child>
+    <x-child draggable></x-child>
+    <x-child hidden></x-child>
+    <x-child id></x-child>
+    <x-child lang></x-child>
+    <x-child spellcheck></x-child>
+    <x-child title></x-child>
+
+    <x-child accesskey=""></x-child>
+    <x-child dir=""></x-child>
+    <x-child draggable=""></x-child>
+    <x-child hidden=""></x-child>
+    <x-child id=""></x-child>
+    <x-child lang=""></x-child>
+    <x-child spellcheck=""></x-child>
+    <x-child title=""></x-child>
+
+    <x-child accesskey="   "></x-child>
+    <x-child dir="   "></x-child>
+    <x-child draggable="   "></x-child>
+    <x-child hidden="   "></x-child>
+    <!--  LWC1040: Invalid id value "   ". Id values must not contain any whitespace -->
+    <x-child lang="   "></x-child>
+    <x-child spellcheck="   "></x-child>
+    <x-child title="   "></x-child>
+
+    <x-child accesskey="false"></x-child>
+    <x-child dir="false"></x-child>
+    <x-child draggable="false"></x-child>
+    <!--  LWC1036: To not set a boolean attribute, try <x-child> instead of <x-child hidden="false">. [...] -->
+    <x-child id="false"></x-child>
+    <x-child lang="false"></x-child>
+    <x-child spellcheck="false"></x-child>
+    <x-child title="false"></x-child>
+
+    <x-child accesskey="true"></x-child>
+    <x-child dir="true"></x-child>
+    <x-child draggable="true"></x-child>
+    <!-- LWC1037: To set a boolean attributes, try <x-child hidden> instead of <x-child hidden="true">. [...] -->
+    <x-child id="true"></x-child>
+    <x-child lang="true"></x-child>
+    <x-child spellcheck="true"></x-child>
+    <x-child title="true"></x-child>
+
+    <x-child accesskey="FALSE"></x-child>
+    <x-child dir="FALSE"></x-child>
+    <x-child draggable="FALSE"></x-child>
+    <x-child hidden="FALSE"></x-child>
+    <x-child id="FALSE"></x-child>
+    <x-child lang="FALSE"></x-child>
+    <x-child spellcheck="FALSE"></x-child>
+    <x-child title="FALSE"></x-child>
+
+    <x-child accesskey="TRUE"></x-child>
+    <x-child dir="TRUE"></x-child>
+    <x-child draggable="TRUE"></x-child>
+    <x-child hidden="TRUE"></x-child>
+    <x-child id="TRUE"></x-child>
+    <x-child lang="TRUE"></x-child>
+    <x-child spellcheck="TRUE"></x-child>
+    <x-child title="TRUE"></x-child>
+
+    <x-child accesskey="yolo"></x-child>
+    <x-child dir="yolo"></x-child>
+    <x-child draggable="yolo"></x-child>
+    <x-child hidden="yolo"></x-child>
+    <x-child id="yolo"></x-child>
+    <x-child lang="yolo"></x-child>
+    <x-child spellcheck="yolo"></x-child>
+    <x-child title="yolo"></x-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/component/component.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/known-boolean-attributes/default-def-html-attributes/static-on-component/modules/x/component/component.js
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -34,6 +34,7 @@ export const expectedFailures = new Set([
     'empty-text-with-comments-non-static-optimized/index.js',
     'global-html-attributes/index.js',
     'if-conditional-slot-content/index.js',
+    'known-boolean-attributes/default-def-html-attributes/static-on-component/index.js',
     'rehydration/index.js',
     'render-dynamic-value/index.js',
     'scoped-slots/advanced/index.js',


### PR DESCRIPTION
## Details

More tests for things we weren't covering before!

Adds tests for string/boolean literals of known global HTML attributes when applied to components (rather than elements).

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.


<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
