### PR TITLE
fix(ssr): fix rendering of `spellcheck` attribute

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -32,7 +32,6 @@ export const expectedFailures = new Set([
     'dynamic-components/index.js',
     'dynamic-slots/index.js',
     'empty-text-with-comments-non-static-optimized/index.js',
-    'global-html-attributes/index.js',
     'if-conditional-slot-content/index.js',
     'rehydration/index.js',
     'render-dynamic-value/index.js',

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
@@ -101,7 +101,7 @@ function getChildAttrsOrProps(
         .map(({ name, value, type }) => {
             const key = isValidIdentifier(name) ? b.identifier(name) : b.literal(name);
             if (value.type === 'Literal' && typeof value.value === 'string') {
-                let literalValue = value.value;
+                let literalValue: string | boolean = value.value;
                 if (name === 'style') {
                     literalValue = normalizeStyleAttributeValue(literalValue);
                 } else if (name === 'class') {
@@ -109,6 +109,10 @@ function getChildAttrsOrProps(
                     if (literalValue === '') {
                         return; // do not render empty `class=""`
                     }
+                } else if (name === 'spellcheck') {
+                    // `spellcheck` string values are specially handled to massage them into booleans:
+                    // https://github.com/salesforce/lwc/blob/574ffbd/packages/%40lwc/template-compiler/src/codegen/index.ts#L445-L448
+                    literalValue = literalValue.toLowerCase() !== 'false';
                 }
                 return b.property('init', key, b.literal(literalValue));
             } else if (value.type === 'Literal' && typeof value.value === 'boolean') {


### PR DESCRIPTION
## Details

Does what it says on the tin.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
