### PR TITLE
test(ssr): add test for dynamic imports

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -57,6 +57,10 @@ async function compileFixture({
         plugins: [
             lwcRollupPlugin({
                 enableDynamicComponents: true,
+                experimentalDynamicComponent: {
+                    loader: path.join(__dirname, './utils/custom-loader.js'),
+                    strictSpecifier: false,
+                },
                 modules: [
                     {
                         dir: modulesDir,

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/expected.html
@@ -1,0 +1,5 @@
+<x-dynamic-component>
+  <template shadowrootmode="open">
+    Importee: 
+  </template>
+</x-dynamic-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-dynamic-component';
+export { default } from 'x/dynamic';
+export * from 'x/dynamic';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/dynamic/dynamic.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/dynamic/dynamic.html
@@ -1,0 +1,3 @@
+<template>
+    Importee: {importee}
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/dynamic/dynamic.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/dynamic/dynamic.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc';
+
+export default class DynamicCtor extends LightningElement {
+    importee
+
+    constructor() {
+        super()
+        import('x/fake').then(result => {
+            this.importee = result
+        })
+    }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/fake/fake.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/dynamic-imports/basic/modules/x/fake/fake.js
@@ -1,0 +1,1 @@
+export default "do not actually import me"

--- a/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
+++ b/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
@@ -1,3 +1,3 @@
 export function load() {
-    return Promise.resolve(); // stub
+    return Promise.resolve("stub");
 }

--- a/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
+++ b/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
@@ -1,3 +1,3 @@
 export function load() {
-    return Promise.resolve("stub");
+    return Promise.resolve('stub');
 }

--- a/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
+++ b/packages/@lwc/engine-server/src/__tests__/utils/custom-loader.js
@@ -1,0 +1,3 @@
+export function load() {
+    return Promise.resolve(); // stub
+}

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -30,6 +30,7 @@ export const expectedFailures = new Set([
     'comments-text-preserve-off/index.js',
     'dynamic-components/slots/shadow/index.js',
     'dynamic-components/slots/light/index.js',
+    'dynamic-imports/basic/index.js',
     'dynamic-slots/index.js',
     'empty-text-with-comments-non-static-optimized/index.js',
     'if-conditional-slot-content/index.js',


### PR DESCRIPTION
## Details

Add a test to demonstrate the issue with #4875

I would like to test more cases here (like `import()`ing a non-literal), but that causes the SSR tests to crash with an unhandled rejection.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
