### PR TITLE
chore: remove unnecessary block statements

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -13,13 +13,13 @@ import { bImportDeclaration } from '../estree/builders';
 import { bWireAdaptersPlumbing } from './wire';
 
 import type {
-    BlockStatement,
     ExportNamedDeclaration,
     Program,
     SimpleCallExpression,
     Identifier,
     MemberExpression,
     Statement,
+    ExpressionStatement,
 } from 'estree';
 import type { ComponentMetaState } from './types';
 
@@ -68,10 +68,8 @@ const bGenerateMarkup = esTemplate`
 `<ExportNamedDeclaration>;
 
 const bAssignGenerateMarkupToComponentClass = esTemplate`
-    {
-        ${/* lwcClassName */ is.identifier}[__SYMBOL__GENERATE_MARKUP] = generateMarkup;
-    }
-`<BlockStatement>;
+${/* lwcClassName */ is.identifier}[__SYMBOL__GENERATE_MARKUP] = generateMarkup;
+`<ExpressionStatement>;
 
 /**
  * This builds a generator function `generateMarkup` and adds it to the component JS's

--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
@@ -9,7 +9,7 @@ import { is } from 'estree-toolkit';
 import { generateScopeTokens } from '@lwc/template-compiler';
 import { builders as b } from 'estree-toolkit/dist/builders';
 import { esTemplate } from '../estemplate';
-import type { BlockStatement, Program, VariableDeclaration } from 'estree';
+import type { ExpressionStatement, Program, VariableDeclaration } from 'estree';
 
 const bStylesheetTokenDeclaration = esTemplate`
     const stylesheetScopeToken = '${is.literal}';
@@ -23,11 +23,9 @@ const bHasScopedStylesheetsDeclaration = esTemplate`
 // We also need to keep track of whether the template has any scoped styles or not so that we can render (or not) the
 // scope token.
 const tmplAssignmentBlock = esTemplate`
-  {
-    ${/* template */ is.identifier}.hasScopedStylesheets = hasScopedStylesheets;
-    ${/* template */ 0}.stylesheetScopeToken = stylesheetScopeToken;
-  }
-`<BlockStatement>;
+${/* template */ is.identifier}.hasScopedStylesheets = hasScopedStylesheets;
+${/* template */ 0}.stylesheetScopeToken = stylesheetScopeToken;
+`<ExpressionStatement[]>;
 
 export function addScopeTokenDeclarations(
     program: Program,
@@ -42,5 +40,5 @@ export function addScopeTokenDeclarations(
         bHasScopedStylesheetsDeclaration()
     );
 
-    program.body.push(tmplAssignmentBlock(b.identifier('tmpl')));
+    program.body.push(...tmplAssignmentBlock(b.identifier('tmpl')));
 }

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -31,6 +31,7 @@ import type {
     BlockStatement as EsBlockStatement,
     Expression as EsExpression,
     Statement as EsStatement,
+    IfStatement as EsIfStatement,
 } from 'estree';
 import type { Transformer, TransformerContext } from '../types';
 
@@ -89,13 +90,10 @@ const bStringLiteralYield = esTemplateWithYield`
 `<EsBlockStatement>;
 
 const bConditionallyYieldScopeTokenClass = esTemplateWithYield`
-    {
-        const shouldRenderScopeToken = hasScopedStylesheets || hasScopedStaticStylesheets(Cmp);
-        if (shouldRenderScopeToken) {
-            yield \` class="\${stylesheetScopeToken}"\`;
-        }
+    if (hasScopedStylesheets || hasScopedStaticStylesheets(Cmp)) {
+        yield \` class="\${stylesheetScopeToken}"\`;
     }
-`<EsBlockStatement>;
+`<EsIfStatement>;
 
 const bYieldSanitizedHtml = esTemplateWithYield`
     yield sanitizeHtmlContent(${/* lwc:inner-html content */ is.expression})


### PR DESCRIPTION
## Details

Block statements are helpful when you have a repeated pattern and don't want to deal with tracking variable names.

```py
const arr = []
{
  const tmp = 1
  arr.push(tmp)
}
{
  const tmp = 2
  arr.push(tmp)
}
{
  const tmp = 3
  arr.push(tmp)
}
```

They're not necessary in other cases, as there aren't collisions to worry about.

```go
const arr = []
{
  arr.push(1)
}
{
  arr.push(2)
}
{
  arr.push(3)
}
// 👆 is the same as 👇
const arr = []
arr.push(1)
arr.push(2)
arr.push(3)
```

This PR just tidies up some unnecessary block statements.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
