### PR TITLE
chore: enforce consistent-type-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ export default tseslint.config(
         rules: {
             // Rules without config, sorted alphabetically by namespace, then rule
             '@lwc/lwc-internal/no-invalid-todo': 'error',
+            '@typescript-eslint/consistent-type-imports': 'error',
             '@typescript-eslint/no-base-to-string': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-redundant-type-constituents': 'off',

--- a/packages/@lwc/babel-plugin-component/src/compiler-version-number.ts
+++ b/packages/@lwc/babel-plugin-component/src/compiler-version-number.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { types, Visitor } from '@babel/core';
 import { LWC_VERSION_COMMENT } from '@lwc/shared';
-import { BabelAPI, LwcBabelPluginPass } from './types';
+import type { types, Visitor } from '@babel/core';
+import type { BabelAPI, LwcBabelPluginPass } from './types';
 
 export default function compilerVersionNumber({ types: t }: BabelAPI): Visitor<LwcBabelPluginPass> {
     return {

--- a/packages/@lwc/babel-plugin-component/src/component.ts
+++ b/packages/@lwc/babel-plugin-component/src/component.ts
@@ -5,10 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { basename, extname } from 'path';
-import * as types from '@babel/types';
 import { addDefault, addNamed } from '@babel/helper-module-imports';
-import { NodePath } from '@babel/traverse';
-import { Visitor } from '@babel/core';
 import { generateCustomElementTagName, getAPIVersionFromNumber } from '@lwc/shared';
 import {
     COMPONENT_NAME_KEY,
@@ -18,7 +15,10 @@ import {
     API_VERSION_KEY,
     COMPONENT_CLASS_ID,
 } from './constants';
-import { BabelAPI, BabelTypes, LwcBabelPluginPass } from './types';
+import type * as types from '@babel/types';
+import type { NodePath } from '@babel/traverse';
+import type { Visitor } from '@babel/core';
+import type { BabelAPI, BabelTypes, LwcBabelPluginPass } from './types';
 
 function getBaseName(classPath: string) {
     const ext = extname(classPath);

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/shared.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/shared.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { LWC_PACKAGE_EXPORTS } from '../../constants';
-import { DecoratorMeta } from '../index';
+import type { DecoratorMeta } from '../index';
 
 const { API_DECORATOR } = LWC_PACKAGE_EXPORTS;
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/transform.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/transform.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { types } from '@babel/core';
-import { NodePath } from '@babel/traverse';
 import { DECORATOR_TYPES, LWC_COMPONENT_PROPERTIES } from '../../constants';
-import { DecoratorMeta } from '../index';
-import { BabelTypes } from '../../types';
-import { ClassBodyItem } from '../types';
 import { isApiDecorator } from './shared';
+import type { types } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { DecoratorMeta } from '../index';
+import type { BabelTypes } from '../../types';
+import type { ClassBodyItem } from '../types';
 
 const { PUBLIC_PROPS, PUBLIC_METHODS } = LWC_COMPONENT_PROPERTIES;
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/validate.ts
@@ -5,18 +5,18 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { DecoratorErrors } from '@lwc/errors';
-import { NodePath } from '@babel/traverse';
-import { types } from '@babel/core';
 import { generateError } from '../../utils';
-import { LwcBabelPluginPass } from '../../types';
 import {
     AMBIGUOUS_PROP_SET,
     DECORATOR_TYPES,
     DISALLOWED_PROP_SET,
     LWC_PACKAGE_EXPORTS,
 } from '../../constants';
-import { DecoratorMeta } from '../index';
 import { isApiDecorator } from './shared';
+import type { NodePath } from '@babel/traverse';
+import type { types } from '@babel/core';
+import type { LwcBabelPluginPass } from '../../types';
+import type { DecoratorMeta } from '../index';
 
 const { TRACK_DECORATOR } = LWC_PACKAGE_EXPORTS;
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Node, types, Visitor } from '@babel/core';
-import { Binding, NodePath } from '@babel/traverse';
 import { addNamed } from '@babel/helper-module-imports';
 import { DecoratorErrors } from '@lwc/errors';
 import { APIFeature, getAPIVersionFromNumber, isAPIFeatureEnabled } from '@lwc/shared';
 import { DECORATOR_TYPES, LWC_PACKAGE_ALIAS, REGISTER_DECORATORS_ID } from '../constants';
 import { generateError, isClassMethod, isGetterClassMethod, isSetterClassMethod } from '../utils';
-import { BabelAPI, BabelTypes, LwcBabelPluginPass } from '../types';
 import api from './api';
 import wire from './wire';
 import track from './track';
-import { ClassBodyItem, ImportSpecifier, LwcDecoratorName } from './types';
+import type { BabelAPI, BabelTypes, LwcBabelPluginPass } from '../types';
+import type { Binding, NodePath } from '@babel/traverse';
+import type { Node, types, Visitor } from '@babel/core';
+import type { ClassBodyItem, ImportSpecifier, LwcDecoratorName } from './types';
 
 const DECORATOR_TRANSFORMS = [api, wire, track];
 const AVAILABLE_DECORATORS = DECORATOR_TRANSFORMS.map((transform) => transform.name).join(', ');

--- a/packages/@lwc/babel-plugin-component/src/decorators/track/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/track/index.ts
@@ -7,8 +7,8 @@
 import { DecoratorErrors } from '@lwc/errors';
 import { LWC_COMPONENT_PROPERTIES, LWC_PACKAGE_EXPORTS } from '../../constants';
 import { generateError } from '../../utils';
-import { BabelTypes, LwcBabelPluginPass } from '../../types';
-import { DecoratorMeta } from '../index';
+import type { BabelTypes, LwcBabelPluginPass } from '../../types';
+import type { DecoratorMeta } from '../index';
 
 const { TRACK_DECORATOR } = LWC_PACKAGE_EXPORTS;
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/types.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/types.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { NodePath } from '@babel/traverse';
-import { types } from '@babel/core';
-import { LWCErrorInfo } from '@lwc/errors';
-import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
+import type { types } from '@babel/core';
+import type { LWCErrorInfo } from '@lwc/errors';
+import type * as t from '@babel/types';
 
 export type ImportSpecifier = {
     name: string;

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/shared.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/shared.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { LWC_PACKAGE_EXPORTS } from '../../constants';
-import { DecoratorMeta } from '../index';
+import type { DecoratorMeta } from '../index';
 
 const { WIRE_DECORATOR } = LWC_PACKAGE_EXPORTS;
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/transform.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { types } from '@babel/core';
-import { NodePath, Scope } from '@babel/traverse';
 import { LWC_COMPONENT_PROPERTIES } from '../../constants';
-import { DecoratorMeta } from '../index';
-import { BabelTypes } from '../../types';
-import { BindingOptions } from '../types';
 import { isWireDecorator } from './shared';
+import type { types } from '@babel/core';
+import type { NodePath, Scope } from '@babel/traverse';
+import type { DecoratorMeta } from '../index';
+import type { BabelTypes } from '../../types';
+import type { BindingOptions } from '../types';
 
 const WIRE_PARAM_PREFIX = '$';
 const WIRE_CONFIG_ARG_NAME = '$cmp';

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { types } from '@babel/core';
-import { NodePath } from '@babel/traverse';
 import { DecoratorErrors } from '@lwc/errors';
 import { LWC_PACKAGE_EXPORTS } from '../../constants';
 import { generateError } from '../../utils';
-import { LwcBabelPluginPass } from '../../types';
-import { DecoratorMeta } from '../index';
 import { isWireDecorator } from './shared';
+import type { types } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { LwcBabelPluginPass } from '../../types';
+import type { DecoratorMeta } from '../index';
 
 const { TRACK_DECORATOR, WIRE_DECORATOR, API_DECORATOR } = LWC_PACKAGE_EXPORTS;
 

--- a/packages/@lwc/babel-plugin-component/src/dedupe-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dedupe-imports.ts
@@ -5,9 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { types } from '@babel/core';
-import { NodePath } from '@babel/traverse';
-import { BabelAPI, BabelTypes } from './types';
+import type { types } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { BabelAPI, BabelTypes } from './types';
 
 function defaultImport(
     t: BabelTypes,

--- a/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { NodePath } from '@babel/traverse';
-import { types, Visitor } from '@babel/core';
 import { addNamed } from '@babel/helper-module-imports';
 import { CompilerMetrics, LWCClassErrors } from '@lwc/errors';
 import { generateError, incrementMetricCounter } from './utils';
-import { LwcBabelPluginPass } from './types';
+import type { types, Visitor } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { LwcBabelPluginPass } from './types';
 
 function getImportSource(path: NodePath<types.Import>): NodePath<types.Node> {
     return path.parentPath.get('arguments.0') as NodePath<types.Node>;

--- a/packages/@lwc/babel-plugin-component/src/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/index.ts
@@ -16,7 +16,7 @@ import dynamicImports from './dynamic-imports';
 import scopeCssImports from './scope-css-imports';
 import compilerVersionNumber from './compiler-version-number';
 import { getEngineImportSpecifiers } from './utils';
-import { BabelAPI, LwcBabelPluginPass } from './types';
+import type { BabelAPI, LwcBabelPluginPass } from './types';
 import type { PluginObj } from '@babel/core';
 
 // This is useful for consumers of this package to define their options

--- a/packages/@lwc/babel-plugin-component/src/scope-css-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/scope-css-imports.ts
@@ -7,9 +7,9 @@
 
 // Add ?scoped=true to any imports ending with .scoped.css. This signals that the stylesheet
 // should be treated as "scoped".
-import { Node } from '@babel/core';
-import { NodePath } from '@babel/traverse';
-import { BabelAPI } from './types';
+import type { Node } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { BabelAPI } from './types';
 
 export default function ({ types: t }: BabelAPI, path: NodePath): void {
     const programPath = path.isProgram() ? path : path.findParent((node) => node.isProgram());

--- a/packages/@lwc/babel-plugin-component/src/types.ts
+++ b/packages/@lwc/babel-plugin-component/src/types.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as BabelCoreNamespace from '@babel/core';
-import { PluginPass, types } from '@babel/core';
-import { InstrumentationObject } from '@lwc/errors';
+import type * as BabelCoreNamespace from '@babel/core';
+import type { PluginPass, types } from '@babel/core';
+import type { InstrumentationObject } from '@lwc/errors';
 
 export type BabelAPI = typeof BabelCoreNamespace;
 export type BabelTypes = typeof types;

--- a/packages/@lwc/babel-plugin-component/src/utils.ts
+++ b/packages/@lwc/babel-plugin-component/src/utils.ts
@@ -5,12 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import lineColumn from 'line-column';
-import { types } from '@babel/core';
-import { NodePath } from '@babel/traverse';
-import { CompilerMetrics, generateErrorMessage } from '@lwc/errors';
+import { generateErrorMessage } from '@lwc/errors';
 import { LWC_PACKAGE_ALIAS } from './constants';
-import { DecoratorErrorOptions, ImportSpecifier } from './decorators/types';
-import { LwcBabelPluginPass } from './types';
+import type { types } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { CompilerMetrics } from '@lwc/errors';
+import type { DecoratorErrorOptions, ImportSpecifier } from './decorators/types';
+import type { LwcBabelPluginPass } from './types';
 
 function isClassMethod(
     classMethod: NodePath<types.Node>,

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { InstrumentationObject, CompilerValidationErrors, invariant } from '@lwc/errors';
+import { CompilerValidationErrors, invariant } from '@lwc/errors';
 import { isUndefined, isBoolean, getAPIVersionFromNumber, DEFAULT_SSR_MODE } from '@lwc/shared';
-import { CompilationMode } from '@lwc/ssr-compiler';
+import type { InstrumentationObject } from '@lwc/errors';
+import type { CompilationMode } from '@lwc/ssr-compiler';
 import type { CustomRendererConfig } from '@lwc/template-compiler';
 
 /**

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-css.spec.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { describe, expect, it } from 'vitest';
-import { TransformOptions } from '../../options';
 import { transform } from '../transformer';
+import type { TransformOptions } from '../../options';
 
 const TRANSFORMATION_OPTIONS: TransformOptions = {
     namespace: 'x',

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -6,8 +6,8 @@
  */
 import { vi, describe, it, expect } from 'vitest';
 import { APIVersion, noop } from '@lwc/shared';
-import { TransformOptions } from '../../options';
 import { transformSync } from '../transformer';
+import type { TransformOptions } from '../../options';
 
 const TRANSFORMATION_OPTIONS: TransformOptions = {
     namespace: 'x',

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -6,8 +6,8 @@
  */
 import { vi, describe, it, expect } from 'vitest';
 import { noop } from '@lwc/shared';
-import { TransformOptions } from '../../options';
 import { transform, transformSync } from '../transformer';
+import type { TransformOptions } from '../../options';
 
 const TRANSFORMATION_OPTIONS: TransformOptions = {
     namespace: 'x',

--- a/packages/@lwc/compiler/src/transformers/shared.ts
+++ b/packages/@lwc/compiler/src/transformers/shared.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { CompilerDiagnostic } from '@lwc/errors';
+import type { CompilerDiagnostic } from '@lwc/errors';
 
 /** The object returned after transforming code. */
 export interface TransformResult {

--- a/packages/@lwc/compiler/src/transformers/transformer.ts
+++ b/packages/@lwc/compiler/src/transformers/transformer.ts
@@ -10,10 +10,11 @@ import { isString } from '@lwc/shared';
 import { TransformerErrors, generateCompilerError, invariant } from '@lwc/errors';
 import { compileComponentForSSR, compileTemplateForSSR } from '@lwc/ssr-compiler';
 
-import { NormalizedTransformOptions, TransformOptions, validateTransformOptions } from '../options';
+import { validateTransformOptions } from '../options';
 import styleTransform from './style';
 import templateTransformer from './template';
 import scriptTransformer from './javascript';
+import type { NormalizedTransformOptions, TransformOptions } from '../options';
 import type { TransformResult } from './shared';
 
 /**

--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -34,14 +34,20 @@ import { invokeEventListener } from './invoker';
 import { getVMBeingRendered, setVMBeingRendered } from './template';
 import { EmptyArray } from './utils';
 import { isComponentConstructor } from './def';
-import { RenderMode, ShadowMode, SlotSet, VM } from './vm';
-import { LightningElementConstructor } from './base-lightning-element';
+import { RenderMode, ShadowMode } from './vm';
 import { markAsDynamicChildren } from './rendering';
 import {
     isVBaseElement,
     isVCustomElement,
     isVScopedSlotFragment,
     isVStatic,
+    VNodeType,
+    VStaticPartType,
+} from './vnodes';
+import { getComponentRegisteredName } from './component';
+import { createSanitizedHtmlContent } from './sanitized-html-content';
+import type { SanitizedHtmlContent } from './sanitized-html-content';
+import type {
     Key,
     MutableVNodes,
     VComment,
@@ -51,16 +57,14 @@ import {
     VFragment,
     VNode,
     VNodes,
-    VNodeType,
     VScopedSlotFragment,
     VStatic,
     VStaticPart,
     VStaticPartData,
-    VStaticPartType,
     VText,
 } from './vnodes';
-import { getComponentRegisteredName } from './component';
-import { createSanitizedHtmlContent, SanitizedHtmlContent } from './sanitized-html-content';
+import type { LightningElementConstructor } from './base-lightning-element';
+import type { SlotSet, VM } from './vm';
 
 const SymbolIterator: typeof Symbol.iterator = Symbol.iterator;
 

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -29,7 +29,7 @@ import { getAssociatedVM } from './vm';
 import { getReadOnlyProxy } from './membrane';
 import { HTMLElementConstructor, HTMLElementPrototype } from './html-element';
 import { HTMLElementOriginalDescriptors } from './html-properties';
-import { LightningElement } from './base-lightning-element';
+import type { LightningElement } from './base-lightning-element';
 
 // A bridge descriptor is a descriptor whose job is just to get the component instance
 // from the element instance, and get the value or set a new value on the component.

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -13,7 +13,6 @@
  * shape of a component. It is also used internally to apply extra optimizations.
  */
 import {
-    AccessibleElementProperties,
     create,
     defineProperties,
     defineProperty,
@@ -41,27 +40,21 @@ import {
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import { getComponentAPIVersion, getWrappedComponentsListener } from './component';
 import { isBeingConstructed, isInvokingRender, vmBeingConstructed } from './invoker';
-import {
-    associateVM,
-    getAssociatedVM,
-    RefVNodes,
-    RenderMode,
-    ShadowMode,
-    ShadowSupportMode,
-    VM,
-} from './vm';
+import { associateVM, getAssociatedVM, RenderMode, ShadowMode } from './vm';
 import { componentValueObserved } from './mutation-tracker';
 import {
     patchCustomElementWithRestrictions,
     patchShadowRootWithRestrictions,
 } from './restrictions';
-import { getVMBeingRendered, isUpdatingTemplate, Template } from './template';
-import { HTMLElementConstructor } from './base-bridge-element';
+import { getVMBeingRendered, isUpdatingTemplate } from './template';
 import { updateComponentValue } from './update-component-value';
 import { markLockerLiveObject } from './membrane';
 import { instrumentInstance } from './runtime-instrumentation';
 import { applyShadowMigrateMode } from './shadow-migration-mode';
-import type { Stylesheets } from '@lwc/shared';
+import type { HTMLElementConstructor } from './base-bridge-element';
+import type { Template } from './template';
+import type { RefVNodes, ShadowSupportMode, VM } from './vm';
+import type { Stylesheets, AccessibleElementProperties } from '@lwc/shared';
 
 /**
  * This operation is called with a descriptor of an standard html property

--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -8,9 +8,9 @@ import { isNull, LWC_VERSION, LWC_VERSION_COMMENT_REGEX } from '@lwc/shared';
 
 import { logError } from '../shared/logger';
 
-import { Template } from './template';
-import { LightningElementConstructor } from './base-lightning-element';
 import { report, ReportingEventId } from './reporting';
+import type { Template } from './template';
+import type { LightningElementConstructor } from './base-lightning-element';
 import type { Stylesheet } from '@lwc/shared';
 
 let warned = false;

--- a/packages/@lwc/engine-core/src/framework/component.ts
+++ b/packages/@lwc/engine-core/src/framework/component.ts
@@ -4,28 +4,21 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    assert,
-    isFalse,
-    isFunction,
-    isUndefined,
-    APIVersion,
-    LOWEST_API_VERSION,
-} from '@lwc/shared';
+import { assert, isFalse, isFunction, isUndefined, LOWEST_API_VERSION } from '@lwc/shared';
 
-import {
-    createReactiveObserver,
-    ReactiveObserver,
-    unsubscribeFromSignals,
-} from './mutation-tracker';
+import { createReactiveObserver, unsubscribeFromSignals } from './mutation-tracker';
 
 import { invokeComponentRenderMethod, isInvokingRender, invokeEventListener } from './invoker';
-import { VM, scheduleRehydration } from './vm';
-import { LightningElementConstructor } from './base-lightning-element';
-import { Template, isUpdatingTemplate, getVMBeingRendered } from './template';
-import { VNodes } from './vnodes';
+import { scheduleRehydration } from './vm';
+import { isUpdatingTemplate, getVMBeingRendered } from './template';
 import { checkVersionMismatch } from './check-version-mismatch';
 import { associateReactiveObserverWithVM } from './mutation-logger';
+import type { VM } from './vm';
+import type { LightningElementConstructor } from './base-lightning-element';
+import type { Template } from './template';
+import type { VNodes } from './vnodes';
+import type { ReactiveObserver } from './mutation-tracker';
+import type { APIVersion } from '@lwc/shared';
 
 type ComponentConstructorMetadata = {
     tmpl: Template;

--- a/packages/@lwc/engine-core/src/framework/decorators/register.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/register.ts
@@ -13,21 +13,17 @@ import {
     getOwnPropertyDescriptor,
     isFalse,
 } from '@lwc/shared';
-import { LightningElementConstructor } from '../base-lightning-element';
 
 import { assertNotProd, EmptyObject } from '../utils';
 import { logError } from '../../shared/logger';
 import { createObservedFieldPropertyDescriptor } from '../observed-fields';
-import {
-    WireAdapterConstructor,
-    storeWiredMethodMeta,
-    storeWiredFieldMeta,
-    ConfigCallback,
-} from '../wiring';
+import { storeWiredMethodMeta, storeWiredFieldMeta } from '../wiring';
 
 import { createPublicPropertyDescriptor, createPublicAccessorDescriptor } from './api';
 import { internalTrackDecorator } from './track';
 import { internalWireFieldDecorator } from './wire';
+import type { WireAdapterConstructor, ConfigCallback } from '../wiring';
+import type { LightningElementConstructor } from '../base-lightning-element';
 
 // data produced by compiler
 type WireCompilerMeta = Record<string, WireCompilerDef>;

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -26,7 +26,7 @@ import {
     keys,
 } from '@lwc/shared';
 
-import { RenderMode, ShadowSupportMode } from '../framework/vm';
+import { RenderMode } from '../framework/vm';
 import {
     isCircularModuleDependency,
     resolveCircularModuleDependency,
@@ -36,19 +36,19 @@ import { logError, logWarn } from '../shared/logger';
 import { instrumentDef } from './runtime-instrumentation';
 import { EmptyObject } from './utils';
 import { getComponentRegisteredTemplate } from './component';
-import { Template } from './template';
-import { LightningElement, LightningElementConstructor } from './base-lightning-element';
+import { LightningElement } from './base-lightning-element';
 import { lightningBasedDescriptors } from './base-lightning-element';
-import { PropType, getDecoratorsMeta } from './decorators/register';
+import { getDecoratorsMeta } from './decorators/register';
 import { defaultEmptyTemplate } from './secure-template';
 
-import {
-    BaseBridgeElement,
-    HTMLBridgeElementFactory,
-    HTMLElementConstructor,
-} from './base-bridge-element';
+import { BaseBridgeElement, HTMLBridgeElementFactory } from './base-bridge-element';
 import { getComponentOrSwappedComponent } from './hot-swaps';
 import { isReportingEnabled, report, ReportingEventId } from './reporting';
+import type { HTMLElementConstructor } from './base-bridge-element';
+import type { PropType } from './decorators/register';
+import type { LightningElementConstructor } from './base-lightning-element';
+import type { Template } from './template';
+import type { ShadowSupportMode } from '../framework/vm';
 
 export interface ComponentDef {
     name: string;

--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -23,8 +23,8 @@ import {
     KEY__NATIVE_ONLY_CSS,
 } from '@lwc/shared';
 import { logWarnOnce } from '../shared/logger';
-import { Template } from './template';
 import { onReportingEnabled, report, ReportingEventId } from './reporting';
+import type { Template } from './template';
 import type { Stylesheet, Stylesheets } from '@lwc/shared';
 
 // See @lwc/engine-core/src/framework/template.ts

--- a/packages/@lwc/engine-core/src/framework/get-component-constructor.ts
+++ b/packages/@lwc/engine-core/src/framework/get-component-constructor.ts
@@ -6,8 +6,8 @@
  */
 
 import { isUndefined } from '@lwc/shared';
-import { LightningElement } from './base-lightning-element';
 import { getAssociatedVMIfPresent } from './vm';
+import type { LightningElement } from './base-lightning-element';
 
 /**
  * EXPERIMENTAL: This function provides access to the component constructor, given an HTMLElement.

--- a/packages/@lwc/engine-core/src/framework/hot-swaps.ts
+++ b/packages/@lwc/engine-core/src/framework/hot-swaps.ts
@@ -6,15 +6,16 @@
  */
 
 import { isFalse, isNull, isUndefined, flattenStylesheets } from '@lwc/shared';
-import { VM, scheduleRehydration, forceRehydration } from './vm';
+import { scheduleRehydration, forceRehydration } from './vm';
 import { isComponentConstructor } from './def';
-import { LightningElementConstructor } from './base-lightning-element';
-import { Template } from './template';
 import { markComponentAsDirty } from './component';
 import { isTemplateRegistered } from './secure-template';
 import { unrenderStylesheet } from './stylesheet';
 import { assertNotProd } from './utils';
 import { WeakMultiMap } from './weak-multimap';
+import type { Template } from './template';
+import type { LightningElementConstructor } from './base-lightning-element';
+import type { VM } from './vm';
 import type { Stylesheet, Stylesheets } from '@lwc/shared';
 
 let swappedTemplateMap: WeakMap<Template, Template> = /*@__PURE__@*/ new WeakMap();

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -27,7 +27,6 @@ import {
 
 import { logWarn } from '../shared/logger';
 
-import { RendererAPI } from './renderer';
 import { cloneAndOmitKey, shouldBeFormAssociated } from './utils';
 import { allocateChildren, mount, removeNode } from './rendering';
 import {
@@ -35,15 +34,22 @@ import {
     runConnectedCallback,
     VMState,
     RenderMode,
-    VM,
     runRenderedCallback,
     resetRefVNodes,
 } from './vm';
-import {
+import { VNodeType, isVStaticPartElement } from './vnodes';
+
+import { patchProps } from './modules/props';
+import { applyEventListeners } from './modules/events';
+import { hydrateStaticParts, traverseAndSetElements } from './modules/static-parts';
+import { getScopeTokenClass } from './stylesheet';
+import { renderComponent } from './component';
+import { applyRefs } from './modules/refs';
+import { isSanitizedHtmlContentEqual } from './sanitized-html-content';
+import type {
     VNodes,
     VBaseElement,
     VNode,
-    VNodeType,
     VText,
     VComment,
     VElement,
@@ -53,16 +59,9 @@ import {
     VElementData,
     VStaticPartData,
     VStaticPartText,
-    isVStaticPartElement,
 } from './vnodes';
-
-import { patchProps } from './modules/props';
-import { applyEventListeners } from './modules/events';
-import { hydrateStaticParts, traverseAndSetElements } from './modules/static-parts';
-import { getScopeTokenClass } from './stylesheet';
-import { renderComponent } from './component';
-import { applyRefs } from './modules/refs';
-import { isSanitizedHtmlContentEqual } from './sanitized-html-content';
+import type { VM } from './vm';
+import type { RendererAPI } from './renderer';
 
 // These values are the ones from Node.nodeType (https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
 const enum EnvNodeTypes {

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -8,11 +8,13 @@ import { assert, isFunction, isUndefined, noop } from '@lwc/shared';
 
 import { addErrorComponentStack } from '../shared/error';
 
-import { evaluateTemplate, Template, setVMBeingRendered, getVMBeingRendered } from './template';
-import { VM, runWithBoundaryProtection } from './vm';
-import { LightningElement, LightningElementConstructor } from './base-lightning-element';
+import { evaluateTemplate, setVMBeingRendered, getVMBeingRendered } from './template';
+import { runWithBoundaryProtection } from './vm';
 import { logOperationStart, logOperationEnd, OperationId } from './profiler';
-import { VNodes } from './vnodes';
+import type { Template } from './template';
+import type { VM } from './vm';
+import type { LightningElement, LightningElementConstructor } from './base-lightning-element';
+import type { VNodes } from './vnodes';
 
 export let isInvokingRender: boolean = false;
 

--- a/packages/@lwc/engine-core/src/framework/modules/attrs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/attrs.ts
@@ -12,11 +12,11 @@ import {
     XLINK_NAMESPACE,
     kebabCaseToCamelCase,
 } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-
 import { EmptyObject } from '../utils';
-import { VBaseElement, VStatic, VStaticPartElement } from '../vnodes';
 import { safelySetProperty } from '../sanitized-html-content';
+import type { RendererAPI } from '../renderer';
+
+import type { VBaseElement, VStatic, VStaticPartElement } from '../vnodes';
 
 const ColonCharCode = 58;
 

--- a/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-class-attr.ts
@@ -13,10 +13,10 @@ import {
     StringCharCodeAt,
     StringSlice,
 } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-
 import { EmptyObject, SPACE_CHAR } from '../utils';
-import { VBaseElement, VStaticPartElement } from '../vnodes';
+import type { RendererAPI } from '../renderer';
+
+import type { VBaseElement, VStaticPartElement } from '../vnodes';
 
 const classNameToClassMap = create(null);
 

--- a/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/computed-style-attr.ts
@@ -5,10 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isNull, isString, isUndefined } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-import { VBaseElement, VStaticPartElement } from '../vnodes';
 import { logError } from '../../shared/logger';
-import { VM } from '../vm';
+import type { RendererAPI } from '../renderer';
+import type { VBaseElement, VStaticPartElement } from '../vnodes';
+import type { VM } from '../vm';
 
 // The style property is a string when defined via an expression in the template.
 export function patchStyleAttribute(

--- a/packages/@lwc/engine-core/src/framework/modules/events.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/events.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-import { VBaseElement, VStaticPartElement } from '../vnodes';
+import type { RendererAPI } from '../renderer';
+import type { VBaseElement, VStaticPartElement } from '../vnodes';
 
 export function applyEventListeners(
     vnode: VBaseElement | VStaticPartElement,

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -6,10 +6,10 @@
  */
 import { htmlPropertyToAttribute, isNull, isUndefined } from '@lwc/shared';
 import { logWarn } from '../../shared/logger';
-import { RendererAPI } from '../renderer';
 import { EmptyObject } from '../utils';
-import { VBaseElement } from '../vnodes';
 import { safelySetProperty } from '../sanitized-html-content';
+import type { RendererAPI } from '../renderer';
+import type { VBaseElement } from '../vnodes';
 
 function isLiveBindingProp(sel: string, key: string): boolean {
     // For properties with live bindings, we read values from the DOM element

--- a/packages/@lwc/engine-core/src/framework/modules/refs.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/refs.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { RefVNodes, VM } from '../vm';
-import { VBaseElement, VStaticPartElement } from '../vnodes';
+import type { RefVNodes, VM } from '../vm';
+import type { VBaseElement, VStaticPartElement } from '../vnodes';
 
 // Set a ref (lwc:ref) on a VM, from a template API
 export function applyRefs(vnode: VBaseElement | VStaticPartElement, owner: VM) {

--- a/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-class-attr.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-import { VBaseElement } from '../vnodes';
+import type { RendererAPI } from '../renderer';
+import type { VBaseElement } from '../vnodes';
 
 // The HTML class property becomes the vnode.data.classMap object when defined as a string in the template.
 // The compiler takes care of transforming the inline classnames into an object. It's faster to set the

--- a/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-parts.ts
@@ -6,21 +6,15 @@
  */
 
 import { isNull, isUndefined, assert } from '@lwc/shared';
-import {
-    VStatic,
-    VStaticPart,
-    VStaticPartElement,
-    VStaticPartText,
-    isVStaticPartElement,
-    isVStaticPartText,
-} from '../vnodes';
-import { RendererAPI } from '../renderer';
+import { isVStaticPartElement, isVStaticPartText } from '../vnodes';
 import { applyEventListeners } from './events';
 import { applyRefs } from './refs';
 import { patchAttributes } from './attrs';
 import { patchStyleAttribute } from './computed-style-attr';
 import { patchClassAttribute } from './computed-class-attr';
 import { patchTextVStaticPart } from './text';
+import type { RendererAPI } from '../renderer';
+import type { VStatic, VStaticPart, VStaticPartElement, VStaticPartText } from '../vnodes';
 
 /**
  * Given an array of static parts, mounts the DOM element to the part based on the staticPartId

--- a/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/static-style-attr.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
-import { VBaseElement } from '../vnodes';
+import type { RendererAPI } from '../renderer';
+import type { VBaseElement } from '../vnodes';
 
 // The HTML style property becomes the vnode.data.styleDecls object when defined as a string in the template.
 // The compiler takes care of transforming the inline style into an object. It's faster to set the

--- a/packages/@lwc/engine-core/src/framework/modules/text.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/text.ts
@@ -5,9 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isNull } from '@lwc/shared';
-import { RendererAPI } from '../renderer';
 import { lockDomMutation, unlockDomMutation } from '../restrictions';
-import { VComment, VStaticPartText, VText } from '../vnodes';
+import type { RendererAPI } from '../renderer';
+import type { VComment, VStaticPartText, VText } from '../vnodes';
 
 export function patchTextVNode(n1: VText, n2: VText, renderer: RendererAPI) {
     n2.elm = n1.elm;

--- a/packages/@lwc/engine-core/src/framework/mutation-logger.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-logger.ts
@@ -19,9 +19,9 @@ import {
     getOwnPropertySymbols,
     isString,
 } from '@lwc/shared';
-import { ReactiveObserver } from '../libs/mutation-tracker';
-import { VM } from './vm';
 import { assertNotProd } from './utils';
+import type { ReactiveObserver } from '../libs/mutation-tracker';
+import type { VM } from './vm';
 
 export interface MutationLog {
     vm: VM;

--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -5,16 +5,11 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isFunction, isNull, isObject, isTrustedSignal } from '@lwc/shared';
-import { Signal } from '@lwc/signals';
-import {
-    JobFunction,
-    CallbackFunction,
-    ReactiveObserver,
-    valueMutated,
-    valueObserved,
-} from '../libs/mutation-tracker';
+import { ReactiveObserver, valueMutated, valueObserved } from '../libs/mutation-tracker';
 import { subscribeToSignal } from '../libs/signal-tracker';
-import { VM } from './vm';
+import type { Signal } from '@lwc/signals';
+import type { JobFunction, CallbackFunction } from '../libs/mutation-tracker';
+import type { VM } from './vm';
 
 const DUMMY_REACTIVE_OBSERVER = {
     observe(job: JobFunction) {

--- a/packages/@lwc/engine-core/src/framework/observed-fields.ts
+++ b/packages/@lwc/engine-core/src/framework/observed-fields.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { LightningElement } from './base-lightning-element';
 import { getAssociatedVM } from './vm';
 import { componentValueObserved } from './mutation-tracker';
 import { updateComponentValue } from './update-component-value';
+import type { LightningElement } from './base-lightning-element';
 
 export function createObservedFieldPropertyDescriptor(key: string): PropertyDescriptor {
     return {

--- a/packages/@lwc/engine-core/src/framework/profiler.ts
+++ b/packages/@lwc/engine-core/src/framework/profiler.ts
@@ -7,8 +7,9 @@
 import { ArrayJoin, ArrayMap, ArrayPush, ArraySort, isUndefined, noop } from '@lwc/shared';
 
 import { getComponentTag } from '../shared/format';
-import { RenderMode, ShadowMode, VM } from './vm';
+import { RenderMode, ShadowMode } from './vm';
 import { EmptyArray } from './utils';
+import type { VM } from './vm';
 import type { MutationLog } from './mutation-logger';
 
 export const enum OperationId {

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -23,7 +23,6 @@ import {
 
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
-import { RendererAPI } from './renderer';
 import { EmptyArray, shouldBeFormAssociated } from './utils';
 import { markComponentAsDirty } from './component';
 import { getScopeTokenClass } from './stylesheet';
@@ -37,7 +36,6 @@ import {
     rerenderVM,
     runConnectedCallback,
     ShadowMode,
-    VM,
     VMState,
 } from './vm';
 import {
@@ -47,18 +45,7 @@ import {
     isVFragment,
     isVScopedSlotFragment,
     isVStatic,
-    Key,
-    MutableVNodes,
-    VBaseElement,
-    VComment,
-    VCustomElement,
-    VElement,
-    VFragment,
-    VNode,
-    VNodes,
     VNodeType,
-    VStatic,
-    VText,
 } from './vnodes';
 
 import { patchAttributes, patchSlotAssignment } from './modules/attrs';
@@ -71,6 +58,21 @@ import { applyStaticStyleAttribute } from './modules/static-style-attr';
 import { applyRefs } from './modules/refs';
 import { mountStaticParts, patchStaticParts } from './modules/static-parts';
 import { patchTextVNode, updateTextContent } from './modules/text';
+import type {
+    Key,
+    MutableVNodes,
+    VBaseElement,
+    VComment,
+    VCustomElement,
+    VElement,
+    VFragment,
+    VNode,
+    VNodes,
+    VStatic,
+    VText,
+} from './vnodes';
+import type { VM } from './vm';
+import type { RendererAPI } from './renderer';
 
 export function patchChildren(
     c1: VNodes,

--- a/packages/@lwc/engine-core/src/framework/reporting.ts
+++ b/packages/@lwc/engine-core/src/framework/reporting.ts
@@ -6,7 +6,7 @@
  */
 import { noop } from '@lwc/shared';
 
-import { RenderMode, ShadowMode, ShadowSupportMode } from './vm';
+import type { RenderMode, ShadowMode, ShadowSupportMode } from './vm';
 
 export const enum ReportingEventId {
     CrossRootAriaInSyntheticShadow = 'CrossRootAriaInSyntheticShadow',

--- a/packages/@lwc/engine-core/src/framework/secure-template.ts
+++ b/packages/@lwc/engine-core/src/framework/secure-template.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Template } from './template';
 import { checkVersionMismatch } from './check-version-mismatch';
+import type { Template } from './template';
 
 const signedTemplateSet: Set<Template> = new Set();
 

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -18,13 +18,15 @@ import {
 import { logError } from '../shared/logger';
 
 import api from './api';
-import { RenderMode, ShadowMode, VM } from './vm';
-import { computeHasScopedStyles, hasStyles, Template } from './template';
+import { RenderMode, ShadowMode } from './vm';
+import { computeHasScopedStyles, hasStyles } from './template';
 import { getStyleOrSwappedStyle } from './hot-swaps';
-import { VCustomElement, VNode } from './vnodes';
 import { checkVersionMismatch } from './check-version-mismatch';
 import { getComponentInternalDef } from './def';
 import { assertNotProd, EmptyArray } from './utils';
+import type { VCustomElement, VNode } from './vnodes';
+import type { Template } from './template';
+import type { VM } from './vm';
 import type { Stylesheet, Stylesheets } from '@lwc/shared';
 
 // These are only used for HMR in dev mode

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -22,26 +22,20 @@ import {
 
 import { logError } from '../shared/logger';
 import { getComponentTag } from '../shared/format';
-import api, { RenderAPI } from './api';
-import {
-    RenderMode,
-    resetComponentRoot,
-    runWithBoundaryProtection,
-    ShadowMode,
-    SlotSet,
-    TemplateCache,
-    VM,
-} from './vm';
+import api from './api';
+import { RenderMode, resetComponentRoot, runWithBoundaryProtection, ShadowMode } from './vm';
 import { assertNotProd, EmptyObject } from './utils';
 import { defaultEmptyTemplate, isTemplateRegistered } from './secure-template';
 import { createStylesheet, getStylesheetsContent, updateStylesheetToken } from './stylesheet';
 import { logOperationEnd, logOperationStart, OperationId } from './profiler';
 import { getTemplateOrSwappedTemplate, setActiveVM } from './hot-swaps';
-import { VNodes, VStaticPart, VStaticPartElement, VStaticPartText } from './vnodes';
-import { RendererAPI } from './renderer';
 import { getMapFromClassName } from './modules/computed-class-attr';
 import { FragmentCacheKey, getFromFragmentCache, setInFragmentCache } from './fragment-cache';
 import { isReportingEnabled, report, ReportingEventId } from './reporting';
+import type { RendererAPI } from './renderer';
+import type { VNodes, VStaticPart, VStaticPartElement, VStaticPartText } from './vnodes';
+import type { SlotSet, TemplateCache, VM } from './vm';
+import type { RenderAPI } from './api';
 import type { Stylesheets } from '@lwc/shared';
 
 export interface Template {

--- a/packages/@lwc/engine-core/src/framework/update-component-value.ts
+++ b/packages/@lwc/engine-core/src/framework/update-component-value.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { VM } from './vm';
 import { componentValueMutated } from './mutation-tracker';
+import type { VM } from './vm';
 
 export function updateComponentValue(vm: VM, key: string, newValue: any) {
     const { cmpFields } = vm;

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -15,7 +15,7 @@ import {
 } from '@lwc/shared';
 import { logWarnOnce } from '../shared/logger';
 import { getComponentAPIVersion, getComponentRegisteredName } from './component';
-import { LightningElementConstructor } from './base-lightning-element';
+import type { LightningElementConstructor } from './base-lightning-element';
 
 type Callback = () => void;
 

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
-    APIVersion,
     ArrayPush,
     ArraySlice,
     ArrayUnshift,
@@ -26,7 +25,6 @@ import {
 import { addErrorComponentStack } from '../shared/error';
 import { logError, logWarnOnce } from '../shared/logger';
 
-import { HostNode, HostElement, RendererAPI } from './renderer';
 import {
     renderComponent,
     markComponentAsDirty,
@@ -36,13 +34,7 @@ import {
 } from './component';
 import { addCallbackToNextTick, EmptyArray, EmptyObject } from './utils';
 import { invokeComponentCallback, invokeComponentConstructor } from './invoker';
-import { Template } from './template';
-import { ComponentDef, getComponentInternalDef } from './def';
-import {
-    LightningElement,
-    LightningElementConstructor,
-    LightningElementShadowRoot,
-} from './base-lightning-element';
+import { getComponentInternalDef } from './def';
 import {
     logOperationStart,
     logOperationEnd,
@@ -53,20 +45,21 @@ import {
     logGlobalOperationEndWithVM,
 } from './profiler';
 import { patchChildren } from './rendering';
-import { ReactiveObserver } from './mutation-tracker';
 import { flushMutationLogsForVM, getAndFlushMutationLogs } from './mutation-logger';
 import { connectWireAdapters, disconnectWireAdapters, installWireAdapters } from './wiring';
-import {
-    VNodes,
-    VCustomElement,
-    VNode,
-    VNodeType,
-    VBaseElement,
-    isVFragment,
-    VStaticPartElement,
-} from './vnodes';
+import { VNodeType, isVFragment } from './vnodes';
 import { isReportingEnabled, report, ReportingEventId } from './reporting';
-import type { Stylesheet, Stylesheets } from '@lwc/shared';
+import type { VNodes, VCustomElement, VNode, VBaseElement, VStaticPartElement } from './vnodes';
+import type { ReactiveObserver } from './mutation-tracker';
+import type {
+    LightningElement,
+    LightningElementConstructor,
+    LightningElementShadowRoot,
+} from './base-lightning-element';
+import type { ComponentDef } from './def';
+import type { Template } from './template';
+import type { HostNode, HostElement, RendererAPI } from './renderer';
+import type { Stylesheet, Stylesheets, APIVersion } from '@lwc/shared';
 
 type ShadowRootMode = 'open' | 'closed';
 

--- a/packages/@lwc/engine-core/src/framework/wiring/context.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/context.ts
@@ -6,8 +6,8 @@
  */
 import { isUndefined, ArrayPush } from '@lwc/shared';
 import { guid } from '../utils';
-import { VM } from '../vm';
-import {
+import type { VM } from '../vm';
+import type {
     ContextConsumer,
     ContextProvider,
     ContextProviderOptions,

--- a/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/wiring.ts
@@ -7,11 +7,13 @@
 
 import { assert, create, isUndefined, ArrayPush, defineProperty, noop } from '@lwc/shared';
 import { associateReactiveObserverWithVM } from '../mutation-logger';
-import { LightningElement } from '../base-lightning-element';
-import { createReactiveObserver, ReactiveObserver } from '../mutation-tracker';
-import { runWithBoundaryProtection, VMState, VM, getAssociatedVM } from '../vm';
+import { createReactiveObserver } from '../mutation-tracker';
+import { runWithBoundaryProtection, VMState, getAssociatedVM } from '../vm';
 import { updateComponentValue } from '../update-component-value';
 import { createContextWatcher } from './context';
+import type { VM } from '../vm';
+import type { ReactiveObserver } from '../mutation-tracker';
+import type { LightningElement } from '../base-lightning-element';
 import type {
     ConfigCallback,
     ConfigValue,

--- a/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-non-standard-aria.ts
@@ -8,8 +8,9 @@
 import { defineProperty, getOwnPropertyDescriptor, isNull, isUndefined } from '@lwc/shared';
 import { onReportingEnabled, report, ReportingEventId } from '../framework/reporting';
 import { logWarnOnce } from '../shared/logger';
-import { getAssociatedVMIfPresent, VM } from '../framework/vm';
+import { getAssociatedVMIfPresent } from '../framework/vm';
 import { BaseBridgeElement } from '../framework/base-bridge-element';
+import type { VM } from '../framework/vm';
 
 //
 // The goal of this code is to detect usages of non-standard reflected ARIA properties. These are caused by

--- a/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
+++ b/packages/@lwc/engine-core/src/patches/detect-synthetic-cross-root-aria.ts
@@ -22,8 +22,9 @@ import {
     KEY__SHADOW_TOKEN,
 } from '@lwc/shared';
 import { onReportingEnabled, report, ReportingEventId } from '../framework/reporting';
-import { getAssociatedVMIfPresent, VM } from '../framework/vm';
+import { getAssociatedVMIfPresent } from '../framework/vm';
 import { logWarnOnce } from '../shared/logger';
+import type { VM } from '../framework/vm';
 
 //
 // The goal of this code is to detect invalid cross-root ARIA references in synthetic shadow DOM.

--- a/packages/@lwc/engine-core/src/shared/error.ts
+++ b/packages/@lwc/engine-core/src/shared/error.ts
@@ -7,8 +7,8 @@
 
 import { defineProperty, isFrozen, isUndefined } from '@lwc/shared';
 
-import { VM } from '../framework/vm';
 import { getErrorComponentStack } from './format';
+import type { VM } from '../framework/vm';
 
 export function addErrorComponentStack(vm: VM, error: any): void {
     if (!isFrozen(error) && isUndefined(error.wcStack)) {

--- a/packages/@lwc/engine-core/src/shared/format.ts
+++ b/packages/@lwc/engine-core/src/shared/format.ts
@@ -6,7 +6,7 @@
  */
 import { isNull, ArrayJoin, ArrayPush, StringToLowerCase } from '@lwc/shared';
 
-import { VM } from '../framework/vm';
+import type { VM } from '../framework/vm';
 
 export function getComponentTag(vm: VM): string {
     return `<${StringToLowerCase.call(vm.tagName)}>`;

--- a/packages/@lwc/engine-core/src/shared/logger.ts
+++ b/packages/@lwc/engine-core/src/shared/logger.ts
@@ -6,8 +6,8 @@
  */
 import { isUndefined } from '@lwc/shared';
 
-import { VM } from '../framework/vm';
 import { getComponentStack } from './format';
+import type { VM } from '../framework/vm';
 
 const alreadyLoggedMessages = new Set();
 

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-    LightningElement,
     RenderMode,
     ShadowMode,
     computeShadowAndRenderMode,
@@ -18,11 +17,10 @@ import {
     runFormDisabledCallback,
     runFormResetCallback,
     runFormStateRestoreCallback,
-    FormRestoreState,
-    FormRestoreReason,
 } from '@lwc/engine-core';
 import { isNull } from '@lwc/shared';
 import { renderer } from '../renderer';
+import type { LightningElement, FormRestoreState, FormRestoreReason } from '@lwc/engine-core';
 
 type ComponentConstructor = typeof LightningElement;
 type HTMLElementConstructor = typeof HTMLElement;

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -18,10 +18,10 @@ import {
     createVM,
     connectRootElement,
     disconnectRootElement,
-    LightningElement,
     shouldBeFormAssociated,
 } from '@lwc/engine-core';
 import { renderer } from '../renderer';
+import type { LightningElement } from '@lwc/engine-core';
 
 // TODO [#2472]: Remove this workaround when appropriate.
 // eslint-disable-next-line @lwc/lwc-internal/no-global-node

--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -7,7 +7,6 @@
 
 import {
     createVM,
-    LightningElement,
     hydrateRoot,
     connectRootElement,
     getAssociatedVMIfPresent,
@@ -15,6 +14,7 @@ import {
 } from '@lwc/engine-core';
 import { StringToLowerCase, isFunction, isNull, isObject } from '@lwc/shared';
 import { renderer } from '../renderer';
+import type { LightningElement } from '@lwc/engine-core';
 
 function resetShadowRootAndLightDom(element: Element, Ctor: typeof LightningElement) {
     if (element.shadowRoot) {

--- a/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
+++ b/packages/@lwc/engine-dom/src/custom-elements/create-custom-element.ts
@@ -6,16 +6,14 @@
  */
 import { isUndefined, isTrue } from '@lwc/shared';
 import {
-    LifecycleCallback,
     connectRootElement,
     disconnectRootElement,
     runFormAssociatedCallback,
     runFormDisabledCallback,
     runFormResetCallback,
     runFormStateRestoreCallback,
-    FormRestoreState,
-    FormRestoreReason,
 } from '@lwc/engine-core';
+import type { LifecycleCallback, FormRestoreState, FormRestoreReason } from '@lwc/engine-core';
 
 const cachedConstructors = new Map<string, CustomElementConstructor>();
 const nativeLifecycleElementsToUpgradedByLWC = new WeakMap<HTMLElement, boolean>();

--- a/packages/@lwc/engine-dom/src/formatters/component.ts
+++ b/packages/@lwc/engine-dom/src/formatters/component.ts
@@ -5,8 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { getAssociatedVMIfPresent, LightningElement } from '@lwc/engine-core';
+import { getAssociatedVMIfPresent } from '@lwc/engine-core';
 import { isUndefined, keys } from '@lwc/shared';
+import type { LightningElement } from '@lwc/engine-core';
 
 /**
  * Displays the header for a custom element.

--- a/packages/@lwc/engine-dom/src/renderer/context.ts
+++ b/packages/@lwc/engine-dom/src/renderer/context.ts
@@ -5,14 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import {
-    createContextProviderWithRegister,
+import { createContextProviderWithRegister } from '@lwc/engine-core';
+import { addEventListener, dispatchEvent } from './index';
+import type {
     WireAdapterConstructor,
     WireContextValue,
     WireContextSubscriptionPayload,
     WireContextSubscriptionCallback,
 } from '@lwc/engine-core';
-import { addEventListener, dispatchEvent } from './index';
 
 export class WireContextSubscriptionEvent extends CustomEvent<undefined> {
     // These are initialized on the constructor via defineProperties.

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -8,8 +8,9 @@
 import path from 'node:path';
 import { vi, describe } from 'vitest';
 import { rollup } from 'rollup';
-import lwcRollupPlugin, { RollupLwcOptions } from '@lwc/rollup-plugin';
+import lwcRollupPlugin from '@lwc/rollup-plugin';
 import { testFixtureDir, formatHTML } from '@lwc/test-utils-lwc-internals';
+import type { RollupLwcOptions } from '@lwc/rollup-plugin';
 import type * as lwc from '../index';
 
 interface FixtureModule {

--- a/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
@@ -9,11 +9,12 @@ import path from 'node:path';
 import vm from 'node:vm';
 import { vi, describe, it, expect } from 'vitest';
 import { parseFragment, serialize } from 'parse5';
-import { rollup, RollupLog } from 'rollup';
+import { rollup } from 'rollup';
 import replace from '@rollup/plugin-replace';
 import virtual from '@rollup/plugin-virtual';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
 import * as engineServer from '../index';
+import type { RollupLog } from 'rollup';
 
 /**
  * The goal of these tests is to serialize the HTML, and then parse it with a real

--- a/packages/@lwc/engine-server/src/apis/render-component.ts
+++ b/packages/@lwc/engine-server/src/apis/render-component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { createVM, connectRootElement, LightningElement } from '@lwc/engine-core';
+import { createVM, connectRootElement } from '@lwc/engine-core';
 import { isString, isFunction, isObject, isNull, HTML_NAMESPACE } from '@lwc/shared';
 
 import { renderer } from '../renderer';
@@ -12,7 +12,6 @@ import { serializeElement } from '../serializer';
 import {
     HostAttributesKey,
     HostChildrenKey,
-    HostElement,
     HostNamespaceKey,
     HostNodeType,
     HostParentKey,
@@ -20,6 +19,8 @@ import {
     HostTypeKey,
     HostContextProvidersKey,
 } from '../types';
+import type { HostElement } from '../types';
+import type { LightningElement } from '@lwc/engine-core';
 
 const FakeRootElement: HostElement = {
     [HostTypeKey]: HostNodeType.Element,

--- a/packages/@lwc/engine-server/src/context.ts
+++ b/packages/@lwc/engine-server/src/context.ts
@@ -5,24 +5,22 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import { createContextProviderWithRegister, getAssociatedVMIfPresent } from '@lwc/engine-core';
+import { isUndefined, isNull } from '@lwc/shared';
 import {
-    createContextProviderWithRegister,
-    getAssociatedVMIfPresent,
+    HostNodeType,
+    HostTypeKey,
+    HostParentKey,
+    HostHostKey,
+    HostContextProvidersKey,
+} from './types';
+import type { HostElement, HostParentNode } from './types';
+import type {
     LightningElement,
     WireAdapterConstructor,
     WireContextSubscriptionPayload,
     WireContextSubscriptionCallback,
 } from '@lwc/engine-core';
-import { isUndefined, isNull } from '@lwc/shared';
-import {
-    HostElement,
-    HostNodeType,
-    HostTypeKey,
-    HostParentKey,
-    HostParentNode,
-    HostHostKey,
-    HostContextProvidersKey,
-} from './types';
 
 export function createContextProvider(adapter: WireAdapterConstructor) {
     return createContextProviderWithRegister(adapter, registerContextProvider);

--- a/packages/@lwc/engine-server/src/renderer.ts
+++ b/packages/@lwc/engine-server/src/renderer.ts
@@ -16,14 +16,9 @@ import {
     noop,
     StringToLowerCase,
 } from '@lwc/shared';
-import { LifecycleCallback } from '@lwc/engine-core';
 
 import {
-    HostNode,
-    HostElement,
-    HostAttribute,
     HostNodeType,
-    HostChildNode,
     HostTypeKey,
     HostNamespaceKey,
     HostParentKey,
@@ -41,6 +36,8 @@ import {
     stopTrackingMutations,
 } from './utils/mutation-tracking';
 import { registerContextConsumer } from './context';
+import type { HostNode, HostElement, HostAttribute, HostChildNode } from './types';
+import type { LifecycleCallback } from '@lwc/engine-core';
 
 function unsupportedMethod(name: string): () => never {
     return function () {

--- a/packages/@lwc/engine-server/src/serializer.ts
+++ b/packages/@lwc/engine-server/src/serializer.ts
@@ -8,10 +8,6 @@
 import { htmlEscape, HTML_NAMESPACE, isVoidElement } from '@lwc/shared';
 
 import {
-    HostElement,
-    HostShadowRoot,
-    HostAttribute,
-    HostChildNode,
     HostNodeType,
     HostTypeKey,
     HostNamespaceKey,
@@ -21,6 +17,7 @@ import {
     HostValueKey,
 } from './types';
 import { validateStyleTextContents } from './utils/validate-style-text-contents';
+import type { HostElement, HostShadowRoot, HostAttribute, HostChildNode } from './types';
 
 // Note that for statically optimized content the expression serialization is done in
 // buildParseFragmentFn in @lwc/engine-core. It takes the same logic used here.

--- a/packages/@lwc/engine-server/src/types.ts
+++ b/packages/@lwc/engine-server/src/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { WireContextSubscriptionCallback } from '@lwc/engine-core';
+import type { WireContextSubscriptionCallback } from '@lwc/engine-core';
 
 // We use Symbols as the keys for HostElement properties to avoid conflicting
 // with public component properties defined by a component author.

--- a/packages/@lwc/engine-server/src/utils/mutation-tracking.ts
+++ b/packages/@lwc/engine-server/src/utils/mutation-tracking.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { HostAttributesKey, HostElement, HostNamespaceKey } from '../types';
+import { HostAttributesKey, HostNamespaceKey } from '../types';
+import type { HostElement } from '../types';
 
 const elementsToTrackForMutations: WeakSet<HostElement> = new WeakSet();
 

--- a/packages/@lwc/errors/src/__tests__/errors.spec.ts
+++ b/packages/@lwc/errors/src/__tests__/errors.spec.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { hasOwnProperty } from '@lwc/shared';
 import * as CompilerErrors from '../compiler/error-info';
-import { LWCErrorInfo } from '../shared/types';
+import type { LWCErrorInfo } from '../shared/types';
 
 const ERROR_CODE_RANGES = {
     compiler: {

--- a/packages/@lwc/errors/src/compiler/errors.ts
+++ b/packages/@lwc/errors/src/compiler/errors.ts
@@ -5,15 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { templateString } from '../shared/utils';
-import { LWCErrorInfo } from '../shared/types';
-import {
-    CompilerDiagnosticOrigin,
-    CompilerDiagnostic,
-    CompilerError,
-    getCodeFromError,
-    getFilename,
-    getLocation,
-} from './utils';
+import { CompilerError, getCodeFromError, getFilename, getLocation } from './utils';
+import type { LWCErrorInfo } from '../shared/types';
+import type { CompilerDiagnosticOrigin, CompilerDiagnostic } from './utils';
 
 export { CompilerDiagnosticOrigin, CompilerDiagnostic, CompilerError } from './utils';
 

--- a/packages/@lwc/errors/src/compiler/instrumentation.ts
+++ b/packages/@lwc/errors/src/compiler/instrumentation.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { LWCErrorInfo } from '../shared/types';
-import { ErrorConfig } from './errors';
+import type { LWCErrorInfo } from '../shared/types';
+import type { ErrorConfig } from './errors';
 
 /**
  * Pattern modeled after @lwc/engine-core's reporting.ts system

--- a/packages/@lwc/errors/src/compiler/utils.ts
+++ b/packages/@lwc/errors/src/compiler/utils.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Location, DiagnosticLevel } from '../shared/types';
+import { DiagnosticLevel } from '../shared/types';
+import type { Location } from '../shared/types';
 
 export interface CompilerDiagnosticOrigin {
     filename?: string;

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { create, defineProperty, isUndefined, isBoolean } from '@lwc/shared';
-import { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
+import type { FeatureFlagMap, FeatureFlagName, FeatureFlagValue } from './types';
 
 // When deprecating a feature flag, ensure that it is also no longer set in the application. For
 // example, in core, the flag should be removed from LwcPermAndPrefUtilImpl.java

--- a/packages/@lwc/integration-types/src/decorators/wire.ts
+++ b/packages/@lwc/integration-types/src/decorators/wire.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { LightningElement, WireAdapterConstructor, wire } from 'lwc';
+import { LightningElement, wire } from 'lwc';
+import type { WireAdapterConstructor } from 'lwc';
 
 type TestConfig = { config: 'config' };
 type TestValue = { value: 'value' };

--- a/packages/@lwc/module-resolver/src/resolve-module.ts
+++ b/packages/@lwc/module-resolver/src/resolve-module.ts
@@ -26,7 +26,8 @@ import {
 } from './utils';
 import { NoLwcModuleFound, LwcConfigError } from './errors';
 
-import {
+import { RegistryType } from './types';
+import type {
     RegistryEntry,
     AliasModuleRecord,
     InnerResolverOptions,
@@ -34,7 +35,6 @@ import {
     DirModuleRecord,
     ModuleResolverConfig,
     NpmModuleRecord,
-    RegistryType,
 } from './types';
 
 function resolveModuleFromAlias(

--- a/packages/@lwc/module-resolver/src/utils.ts
+++ b/packages/@lwc/module-resolver/src/utils.ts
@@ -8,7 +8,8 @@ import path from 'path';
 import fs from 'fs';
 
 import { LwcConfigError } from './errors';
-import {
+import { isObject } from './shared';
+import type {
     LwcConfig,
     ModuleRecord,
     NpmModuleRecord,
@@ -19,7 +20,6 @@ import {
     InnerResolverOptions,
     RegistryType,
 } from './types';
-import { isObject } from './shared';
 
 const PACKAGE_JSON = 'package.json';
 const LWC_CONFIG_FILE = 'lwc.config.json';

--- a/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/apiVersion/apiVersion.spec.ts
@@ -6,10 +6,12 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { rollup, RollupLog } from 'rollup';
+import { rollup } from 'rollup';
 import { APIVersion, HIGHEST_API_VERSION, LOWEST_API_VERSION } from '@lwc/shared';
 
-import lwc, { RollupLwcOptions } from '../../index';
+import lwc from '../../index';
+import type { RollupLwcOptions } from '../../index';
+import type { RollupLog } from 'rollup';
 
 describe('API versioning', () => {
     async function runRollup(

--- a/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/enableStaticContentOptimization/enableStaticContentOptimization.spec.ts
@@ -6,8 +6,10 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { rollup, RollupLog } from 'rollup';
-import lwc, { RollupLwcOptions } from '../../index';
+import { rollup } from 'rollup';
+import lwc from '../../index';
+import type { RollupLog } from 'rollup';
+import type { RollupLwcOptions } from '../../index';
 
 describe('enableStaticContentOptimization:', () => {
     async function runRollup(

--- a/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/warnings/warnings.spec.ts
@@ -6,9 +6,10 @@
  */
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { rollup, RollupLog } from 'rollup';
+import { rollup } from 'rollup';
 import { APIVersion } from '@lwc/shared';
 import lwc from '../../index';
+import type { RollupLog } from 'rollup';
 
 function normalizeLog(log: RollupLog) {
     return {

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -8,11 +8,15 @@ import fs from 'fs';
 import path from 'path';
 import { URLSearchParams } from 'url';
 
-import { Plugin, SourceMapInput, RollupLog } from 'rollup';
-import pluginUtils, { FilterPattern } from '@rollup/pluginutils';
-import { transformSync, StylesheetConfig, DynamicImportConfig } from '@lwc/compiler';
-import { resolveModule, ModuleRecord, RegistryType } from '@lwc/module-resolver';
-import { APIVersion, getAPIVersionFromNumber } from '@lwc/shared';
+import pluginUtils from '@rollup/pluginutils';
+import { transformSync } from '@lwc/compiler';
+import { resolveModule, RegistryType } from '@lwc/module-resolver';
+import { getAPIVersionFromNumber } from '@lwc/shared';
+import type { Plugin, SourceMapInput, RollupLog } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { StylesheetConfig, DynamicImportConfig } from '@lwc/compiler';
+import type { ModuleRecord } from '@lwc/module-resolver';
+import type { APIVersion } from '@lwc/shared';
 import type { CompilerDiagnostic } from '@lwc/errors';
 import type { CompilationMode } from '@lwc/ssr-compiler';
 

--- a/packages/@lwc/shared/src/style.ts
+++ b/packages/@lwc/shared/src/style.ts
@@ -6,7 +6,7 @@
  */
 
 import { isArray } from './language';
-import { KEY__NATIVE_ONLY_CSS, KEY__SCOPED_CSS } from './keys';
+import type { KEY__NATIVE_ONLY_CSS, KEY__SCOPED_CSS } from './keys';
 
 export const IMPORTANT_FLAG = /\s*!\s*important\s*$/i;
 const DECLARATION_DELIMITER = /;(?![^(]*\))/g;

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -9,11 +9,11 @@ import path from 'node:path';
 import { vi, describe } from 'vitest';
 import { rollup } from 'rollup';
 import lwcRollupPlugin from '@lwc/rollup-plugin';
-import { FeatureFlagName } from '@lwc/features/dist/types';
 import { testFixtureDir, formatHTML } from '@lwc/test-utils-lwc-internals';
 import { serverSideRenderComponent } from '@lwc/ssr-runtime';
 import { DEFAULT_SSR_MODE } from '@lwc/shared';
 import { expectedFailures } from './utils/expected-failures';
+import type { FeatureFlagName } from '@lwc/features/dist/types';
 import type { CompilationMode } from '../index';
 
 interface FixtureModule {

--- a/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/remove-decorator-import.ts
@@ -5,8 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { ImportDeclaration } from 'estree';
-import { NodePath, builders as b } from 'estree-toolkit';
+import { builders as b } from 'estree-toolkit';
+import type { ImportDeclaration } from 'estree';
+import type { NodePath } from 'estree-toolkit';
 
 const decorators = new Set(['api', 'wire', 'track']);
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/shared.ts
@@ -6,16 +6,16 @@
  */
 
 import { builders as b, is } from 'estree-toolkit';
-import {
+import { normalizeStyleAttributeValue, StringReplace, StringTrim } from '@lwc/shared';
+
+import { isValidIdentifier } from '../shared';
+import { expressionIrToEs } from './expression';
+import type { TransformerContext } from './types';
+import type {
     Node as IrNode,
     Attribute as IrAttribute,
     Property as IrProperty,
 } from '@lwc/template-compiler';
-import { normalizeStyleAttributeValue, StringReplace, StringTrim } from '@lwc/shared';
-
-import { isValidIdentifier } from '../shared';
-import { TransformerContext } from './types';
-import { expressionIrToEs } from './expression';
 import type {
     Statement as EsStatement,
     Expression as EsExpression,

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component.ts
@@ -7,7 +7,7 @@
 
 import { produce } from 'immer';
 import { builders as b, is } from 'estree-toolkit';
-import { kebabcaseToCamelcase, ScopedSlotFragment, toPropertyName } from '@lwc/template-compiler';
+import { kebabcaseToCamelcase, toPropertyName } from '@lwc/template-compiler';
 import { bAttributeValue, getChildAttrsOrProps, optimizeAdjacentYieldStmts } from '../shared';
 import { esTemplate, esTemplateWithYield } from '../../estemplate';
 import { irChildrenToEs, irToEs } from '../ir-to-es';
@@ -15,7 +15,7 @@ import { isNullableOf } from '../../estree/validators';
 import type { CallExpression as EsCallExpression, Expression as EsExpression } from 'estree';
 
 import type { BlockStatement as EsBlockStatement } from 'estree';
-import type { Component as IrComponent } from '@lwc/template-compiler';
+import type { Component as IrComponent, ScopedSlotFragment } from '@lwc/template-compiler';
 import type { Transformer } from '../types';
 
 const bYieldFromChildGenerator = esTemplateWithYield`

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/element.ts
@@ -18,13 +18,15 @@ import {
     type Element as IrElement,
     type Literal as IrLiteral,
     type Property as IrProperty,
-    ExternalComponent as IrExternalComponent,
-    Slot as IrSlot,
 } from '@lwc/template-compiler';
 import { esTemplateWithYield } from '../../estemplate';
 import { expressionIrToEs } from '../expression';
 import { irChildrenToEs } from '../ir-to-es';
 import { getScopedExpression, normalizeClassAttributeValue } from '../shared';
+import type {
+    ExternalComponent as IrExternalComponent,
+    Slot as IrSlot,
+} from '@lwc/template-compiler';
 
 import type {
     BinaryExpression,

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/lwc-component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/lwc-component.ts
@@ -6,10 +6,10 @@
  */
 import { is } from 'estree-toolkit';
 import { isUndefined } from '@lwc/shared';
-import { Transformer } from '../types';
 import { expressionIrToEs } from '../expression';
 import { esTemplate, esTemplateWithYield } from '../../estemplate';
 import { getChildAttrsOrProps } from '../shared';
+import type { Transformer } from '../types';
 import type {
     LwcComponent as IrLwcComponent,
     Expression as IrExpression,

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
@@ -7,13 +7,13 @@
 
 import { is, builders as b } from 'estree-toolkit';
 
-import { Slot as IrSlot } from '@lwc/template-compiler';
 import { esTemplateWithYield } from '../../estemplate';
 
 import { irChildrenToEs } from '../ir-to-es';
 import { bAttributeValue, getScopedExpression } from '../shared';
 import { isNullableOf } from '../../estree/validators';
 import { Element } from './element';
+import type { Slot as IrSlot } from '@lwc/template-compiler';
 import type {
     Statement as EsStatement,
     IfStatement as EsIfStatement,

--- a/packages/@lwc/ssr-compiler/src/compile-template/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { Node as IrNode } from '@lwc/template-compiler';
+import type { Node as IrNode } from '@lwc/template-compiler';
 import type { Statement as EsStatement } from 'estree';
 
 export type Transformer<T extends IrNode = IrNode> = (

--- a/packages/@lwc/ssr-compiler/src/estemplate.ts
+++ b/packages/@lwc/ssr-compiler/src/estemplate.ts
@@ -5,9 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { traverse, Visitors } from 'estree-toolkit';
+import { traverse } from 'estree-toolkit';
 import { parse } from 'acorn';
 import { produce } from 'immer';
+import type { Visitors } from 'estree-toolkit';
 import type {
     Node as EsNode,
     Program as EsProgram,

--- a/packages/@lwc/ssr-runtime/src/class-list.ts
+++ b/packages/@lwc/ssr-runtime/src/class-list.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { LightningElement } from './lightning-element';
+import type { LightningElement } from './lightning-element';
 
 const MULTI_SPACE = /\s+/g;
 

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -23,9 +23,9 @@ import {
 } from '@lwc/shared';
 
 import { ClassList } from './class-list';
-import { Attributes, Properties } from './types';
 import { mutationTracker } from './mutation-tracker';
 import { descriptors as reflectionDescriptors } from './reflection';
+import type { Attributes, Properties } from './types';
 import type { Stylesheets } from '@lwc/shared';
 
 type EventListenerOrEventListenerObject = unknown;

--- a/packages/@lwc/ssr-runtime/src/mutation-tracker.ts
+++ b/packages/@lwc/ssr-runtime/src/mutation-tracker.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { LightningElement } from './lightning-element';
+import type { LightningElement } from './lightning-element';
 
 class MutationTracker {
     #enabledSet = new WeakSet<LightningElement>();

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -6,11 +6,8 @@
  */
 import { getOwnPropertyNames, isNull, isString, isUndefined, DEFAULT_SSR_MODE } from '@lwc/shared';
 import { mutationTracker } from './mutation-tracker';
-import {
-    LightningElement,
-    LightningElementConstructor,
-    SYMBOL__GENERATE_MARKUP,
-} from './lightning-element';
+import { SYMBOL__GENERATE_MARKUP } from './lightning-element';
+import type { LightningElement, LightningElementConstructor } from './lightning-element';
 import type { Attributes, Properties } from './types';
 
 const escapeAttrVal = (attrValue: string) =>

--- a/packages/@lwc/style-compiler/src/css-import/transform.ts
+++ b/packages/@lwc/style-compiler/src/css-import/transform.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Root, Result } from 'postcss';
 import valueParser from 'postcss-value-parser';
 
 import { importMessage } from '../utils/message';
+import type { Root, Result } from 'postcss';
 
 export default function process(root: Root, result: Result, isScoped: boolean) {
     root.walkAtRules('import', (node) => {

--- a/packages/@lwc/style-compiler/src/dir-pseudo-class/transform.ts
+++ b/packages/@lwc/style-compiler/src/dir-pseudo-class/transform.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { attribute, combinator, Root, isCombinator } from 'postcss-selector-parser';
+import { attribute, combinator, isCombinator } from 'postcss-selector-parser';
 import { isDirPseudoClass } from '../utils/rtl';
 import {
     DIR_ATTRIBUTE_NATIVE_LTR,
@@ -12,6 +12,7 @@ import {
     DIR_ATTRIBUTE_SYNTHETIC_LTR,
     DIR_ATTRIBUTE_SYNTHETIC_RTL,
 } from '../utils/dir-pseudoclass';
+import type { Root } from 'postcss-selector-parser';
 
 function isValidDirValue(value: string): boolean {
     return value === 'ltr' || value === 'rtl';

--- a/packages/@lwc/style-compiler/src/no-id-selectors/validate.ts
+++ b/packages/@lwc/style-compiler/src/no-id-selectors/validate.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Root } from 'postcss-selector-parser';
+import type { Root } from 'postcss-selector-parser';
 
 export default function (root: Root) {
     root.walkIds((node) => {

--- a/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
+++ b/packages/@lwc/style-compiler/src/postcss-lwc-plugin.ts
@@ -4,15 +4,16 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Rule, AtRule, TransformCallback } from 'postcss';
 import postCssSelector from 'postcss-selector-parser';
-import { APIVersion } from '@lwc/shared';
 
 import validateIdSelectors from './no-id-selectors/validate';
 import transformImport from './css-import/transform';
-import transformSelectorScoping, { SelectorScopingConfig } from './selector-scoping/transform';
+import transformSelectorScoping from './selector-scoping/transform';
 import transformDirPseudoClass from './dir-pseudo-class/transform';
 import transformAtRules from './scope-at-rules/transform';
+import type { SelectorScopingConfig } from './selector-scoping/transform';
+import type { APIVersion } from '@lwc/shared';
+import type { Rule, AtRule, TransformCallback } from 'postcss';
 
 function shouldTransformSelector(rule: Rule) {
     // @keyframe at-rules are special, rules inside are not standard selectors and should not be

--- a/packages/@lwc/style-compiler/src/scope-at-rules/transform.ts
+++ b/packages/@lwc/style-compiler/src/scope-at-rules/transform.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Root } from 'postcss';
 import { SHADOW_ATTRIBUTE } from '../utils/selectors-scoping';
+import type { Root } from 'postcss';
 
 // Subset of prefixes for animation-related names that we expect people might be using.
 // The most important is -webkit, which is actually part of the spec now. All -webkit prefixes

--- a/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/transform.ts
@@ -4,23 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    isPseudoElement,
-    isCombinator,
-    isPseudoClass,
-    Selector,
-    Root,
-    Node,
-    Pseudo,
-    Tag,
-    attribute,
-} from 'postcss-selector-parser';
+import { isPseudoElement, isCombinator, isPseudoClass, attribute } from 'postcss-selector-parser';
 
 import { isDirPseudoClass } from '../utils/rtl';
 import { SHADOW_ATTRIBUTE, HOST_ATTRIBUTE } from '../utils/selectors-scoping';
 import { findNode, replaceNodeWith, trimNodeWhitespaces } from '../utils/selector-parser';
 
 import validateSelectors from './validate';
+import type { Selector, Root, Node, Pseudo, Tag } from 'postcss-selector-parser';
 
 type ChildNode = Exclude<Node, Selector>;
 

--- a/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
+++ b/packages/@lwc/style-compiler/src/selector-scoping/validate.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Root } from 'postcss-selector-parser';
+import type { Root } from 'postcss-selector-parser';
 
 const DEPRECATED_SELECTORS = new Set(['/deep/', '::shadow', '>>>']);
 const UNSUPPORTED_SELECTORS = new Set([':root', ':host-context']);

--- a/packages/@lwc/style-compiler/src/serialize.ts
+++ b/packages/@lwc/style-compiler/src/serialize.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import postcss, { Result } from 'postcss';
+import postcss from 'postcss';
 import { KEY__SCOPED_CSS, LWC_VERSION_COMMENT, KEY__NATIVE_ONLY_CSS } from '@lwc/shared';
-import { Config } from './index';
 import { isImportMessage } from './utils/message';
 import { HOST_ATTRIBUTE, SHADOW_ATTRIBUTE } from './utils/selectors-scoping';
 import {
@@ -15,6 +14,8 @@ import {
     DIR_ATTRIBUTE_SYNTHETIC_RTL,
     DIR_ATTRIBUTE_SYNTHETIC_LTR,
 } from './utils/dir-pseudoclass';
+import type { Config } from './index';
+import type { Result } from 'postcss';
 
 enum TokenType {
     text = 'text',

--- a/packages/@lwc/style-compiler/src/utils/message.ts
+++ b/packages/@lwc/style-compiler/src/utils/message.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Message } from 'postcss';
+import type { Message } from 'postcss';
 
 interface ImportMessage extends Message {
     type: 'import';

--- a/packages/@lwc/style-compiler/src/utils/rtl.ts
+++ b/packages/@lwc/style-compiler/src/utils/rtl.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isPseudoClass, Node, Pseudo } from 'postcss-selector-parser';
+import { isPseudoClass } from 'postcss-selector-parser';
+import type { Node, Pseudo } from 'postcss-selector-parser';
 
 export function isDirPseudoClass(node: Node): node is Pseudo {
     return isPseudoClass(node) && node.value === ':dir';

--- a/packages/@lwc/style-compiler/src/utils/selector-parser.ts
+++ b/packages/@lwc/style-compiler/src/utils/selector-parser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Node, Container } from 'postcss-selector-parser';
+import type { Node, Container } from 'postcss-selector-parser';
 
 export function findNode<T extends Node>(
     container: Container,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/portal.ts
@@ -7,14 +7,10 @@
 import { isUndefined, forEach, defineProperty, isTrue } from '@lwc/shared';
 import { childNodesGetter, compareDocumentPosition, Node } from '../env/node';
 import { MutationObserver, MutationObserverObserve } from '../env/mutation-observer';
-import {
-    getShadowRootResolver,
-    isSyntheticShadowHost,
-    setShadowRootResolver,
-    ShadowRootResolver,
-} from './shadow-root';
+import { getShadowRootResolver, isSyntheticShadowHost, setShadowRootResolver } from './shadow-root';
 import { setShadowToken, getShadowToken } from './shadow-token';
 import { setLegacyShadowToken, getLegacyShadowToken } from './legacy-shadow-token';
+import type { ShadowRootResolver } from './shadow-root';
 
 const DomManualPrivateKey = '$$DomManualKey$$';
 

--- a/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/index.spec.ts
@@ -6,7 +6,8 @@
  */
 import { describe, it, expect } from 'vitest';
 import { DiagnosticLevel } from '@lwc/errors';
-import compile, { Config, parse } from '../index';
+import compile, { parse } from '../index';
+import type { Config } from '../index';
 
 describe('option validation', () => {
     it('validated presence of options', () => {

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -6,7 +6,6 @@
  */
 import { walk } from 'estree-walker';
 import {
-    APIVersion,
     getAPIVersionFromNumber,
     SVG_NAMESPACE,
     STATIC_PART_TOKEN_ID,
@@ -16,21 +15,7 @@ import {
 } from '@lwc/shared';
 
 import * as t from '../shared/estree';
-import {
-    ChildNode,
-    Expression,
-    ComplexExpression,
-    Literal,
-    LWCDirectiveRenderMode,
-    Root,
-    EventListener,
-    RefDirective,
-    Text,
-    StaticElement,
-    Attribute,
-    KeyDirective,
-    StaticChildNode,
-} from '../shared/types';
+import { LWCDirectiveRenderMode } from '../shared/types';
 import {
     PARSE_FRAGMENT_METHOD_NAME,
     PARSE_SVG_FRAGMENT_METHOD_NAME,
@@ -48,7 +33,6 @@ import {
     isStringLiteral,
 } from '../shared/ast';
 import { isArrayExpression } from '../shared/estree';
-import State from '../state';
 import {
     isAllowedFragOnlyUrlsXHTML,
     isFragmentOnlyUrl,
@@ -64,6 +48,22 @@ import {
 } from './static-element';
 import { serializeStaticElement } from './static-element-serializer';
 import { bindAttributeExpression, bindComplexExpression } from './expression';
+import type State from '../state';
+import type {
+    ChildNode,
+    Expression,
+    ComplexExpression,
+    Literal,
+    Root,
+    EventListener,
+    RefDirective,
+    Text,
+    StaticElement,
+    Attribute,
+    KeyDirective,
+    StaticChildNode,
+} from '../shared/types';
+import type { APIVersion } from '@lwc/shared';
 import type { Node } from 'estree';
 
 // structuredClone is only available in Node 17+

--- a/packages/@lwc/template-compiler/src/codegen/expression.ts
+++ b/packages/@lwc/template-compiler/src/codegen/expression.ts
@@ -9,7 +9,6 @@ import { walk } from 'estree-walker';
 import { ParserDiagnostics, invariant } from '@lwc/errors';
 import { isBooleanAttribute } from '@lwc/shared';
 import * as t from '../shared/estree';
-import { Attribute, BaseElement, ComplexExpression, Property } from '../shared/types';
 import { TEMPLATE_PARAMS } from '../shared/constants';
 import { isProperty, isStringLiteral } from '../shared/ast';
 import {
@@ -19,6 +18,7 @@ import {
     isIdReferencingAttribute,
     isSvgUseHref,
 } from '../parser/attribute';
+import type { Attribute, BaseElement, ComplexExpression, Property } from '../shared/types';
 import type { Node } from 'estree';
 import type CodeGen from './codegen';
 

--- a/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
+++ b/packages/@lwc/template-compiler/src/codegen/formatters/module.ts
@@ -16,9 +16,9 @@ import {
     IMPLICIT_STYLESHEET_IMPORTS,
 } from '../../shared/constants';
 
-import CodeGen from '../codegen';
 import { identifierFromComponentName, generateTemplateMetadata } from '../helpers';
 import { optimizeStaticExpressions } from '../optimize';
+import type CodeGen from '../codegen';
 
 function generateComponentImports(codeGen: CodeGen): t.ImportDeclaration[] {
     return Array.from(codeGen.referencedComponents).map((name) => {

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -7,10 +7,11 @@
 import { APIFeature, IMPORTANT_FLAG, isAPIFeatureEnabled } from '@lwc/shared';
 import * as t from '../shared/estree';
 import { toPropertyName } from '../shared/utils';
-import { ChildNode, LWCDirectiveRenderMode, Node } from '../shared/types';
+import { LWCDirectiveRenderMode } from '../shared/types';
 import { isBaseElement, isForBlock, isIf, isParentNode, isSlot } from '../shared/ast';
 import { IMPLICIT_STYLESHEET_IMPORTS, TEMPLATE_FUNCTION_NAME } from '../shared/constants';
-import CodeGen from './codegen';
+import type { ChildNode, Node } from '../shared/types';
+import type CodeGen from './codegen';
 
 export function identifierFromComponentName(name: string): t.Identifier {
     return t.identifier(`_${toPropertyName(name)}`);

--- a/packages/@lwc/template-compiler/src/codegen/index.ts
+++ b/packages/@lwc/template-compiler/src/codegen/index.ts
@@ -42,7 +42,28 @@ import {
     isLwcIsDirective,
 } from '../shared/ast';
 import { TEMPLATE_PARAMS, TEMPLATE_FUNCTION_NAME, RENDERER } from '../shared/constants';
+import * as t from '../shared/estree';
 import {
+    isAllowedFragOnlyUrlsXHTML,
+    isAttribute,
+    isFragmentOnlyUrl,
+    isIdReferencingAttribute,
+    isSvgUseHref,
+} from '../parser/attribute';
+import { isCustomRendererHookRequired } from '../shared/renderer-hooks';
+import CodeGen from './codegen';
+import {
+    identifierFromComponentName,
+    objectToAST,
+    shouldFlatten,
+    parseClassNames,
+    hasIdAttribute,
+    styleMapToStyleDeclsAST,
+} from './helpers';
+import { format as formatModule } from './formatters/module';
+import { bindAttributeExpression } from './expression';
+import type State from '../state';
+import type {
     Root,
     ParentNode,
     ChildNode,
@@ -60,27 +81,6 @@ import {
     ScopedSlotFragment,
     StaticElement,
 } from '../shared/types';
-import * as t from '../shared/estree';
-import {
-    isAllowedFragOnlyUrlsXHTML,
-    isAttribute,
-    isFragmentOnlyUrl,
-    isIdReferencingAttribute,
-    isSvgUseHref,
-} from '../parser/attribute';
-import State from '../state';
-import { isCustomRendererHookRequired } from '../shared/renderer-hooks';
-import CodeGen from './codegen';
-import {
-    identifierFromComponentName,
-    objectToAST,
-    shouldFlatten,
-    parseClassNames,
-    hasIdAttribute,
-    styleMapToStyleDeclsAST,
-} from './helpers';
-import { format as formatModule } from './formatters/module';
-import { bindAttributeExpression } from './expression';
 
 function transform(codeGen: CodeGen): t.Expression {
     const instrumentation = codeGen.state.config.instrumentation;

--- a/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element-serializer.ts
@@ -16,7 +16,6 @@ import {
     isIdReferencingAttribute,
     isSvgUseHref,
 } from '../parser/attribute';
-import { Comment, Element, Literal, StaticChildNode, StaticElement, Text } from '../shared/types';
 import {
     isBooleanLiteral,
     isComment,
@@ -26,6 +25,14 @@ import {
     isText,
 } from '../shared/ast';
 import { hasDynamicText, isContiguousText, transformStaticChildren } from './static-element';
+import type {
+    Comment,
+    Element,
+    Literal,
+    StaticChildNode,
+    StaticElement,
+    Text,
+} from '../shared/types';
 import type CodeGen from './codegen';
 
 // Implementation based on the parse5 serializer: https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/serializer/index.ts

--- a/packages/@lwc/template-compiler/src/codegen/static-element.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element.ts
@@ -6,7 +6,6 @@
  */
 import {
     APIFeature,
-    APIVersion,
     ArrayEvery,
     ArraySome,
     HTML_NAMESPACE,
@@ -14,14 +13,6 @@ import {
     isArray,
     isNull,
 } from '@lwc/shared';
-import {
-    BaseElement,
-    ChildNode,
-    Root,
-    StaticElement,
-    StaticChildNode,
-    Text,
-} from '../shared/types';
 import {
     isBaseElement,
     isComment,
@@ -31,8 +22,17 @@ import {
     isText,
 } from '../shared/ast';
 import { STATIC_SAFE_DIRECTIVES } from '../shared/constants';
-import State from '../state';
 import { isCustomRendererHookRequired } from '../shared/renderer-hooks';
+import type State from '../state';
+import type {
+    BaseElement,
+    ChildNode,
+    Root,
+    StaticElement,
+    StaticChildNode,
+    Text,
+} from '../shared/types';
+import type { APIVersion } from '@lwc/shared';
 
 // This set keeps track of static safe elements that have dynamic text in their direct children.
 const STATIC_ELEMENT_WITH_DYNAMIC_TEXT_SET = new WeakSet<StaticElement>();

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -4,15 +4,11 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    TemplateErrors,
-    invariant,
-    generateCompilerError,
-    InstrumentationObject,
-} from '@lwc/errors';
+import { TemplateErrors, invariant, generateCompilerError } from '@lwc/errors';
 import { getAPIVersionFromNumber, hasOwnProperty } from '@lwc/shared';
-import { CustomRendererConfig } from './shared/renderer-hooks';
 import { isCustomElementTag } from './shared/utils';
+import type { CustomRendererConfig } from './shared/renderer-hooks';
+import type { InstrumentationObject } from '@lwc/errors';
 
 export interface Config {
     /** The name of the component. For example, the name in `<my-component>` is `"component"`. */

--- a/packages/@lwc/template-compiler/src/index.ts
+++ b/packages/@lwc/template-compiler/src/index.ts
@@ -4,20 +4,17 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import {
-    CompilerDiagnostic,
-    DiagnosticLevel,
-    normalizeToDiagnostic,
-    ParserDiagnostics,
-} from '@lwc/errors';
+import { DiagnosticLevel, normalizeToDiagnostic, ParserDiagnostics } from '@lwc/errors';
 
 import State from './state';
-import { normalizeConfig, Config } from './config';
+import { normalizeConfig } from './config';
 
 import parseTemplate from './parser';
 import generate from './codegen';
+import type { Config } from './config';
+import type { CompilerDiagnostic } from '@lwc/errors';
 
-import { Root, TemplateCompileResult, TemplateParseResult } from './shared/types';
+import type { Root, TemplateCompileResult, TemplateParseResult } from './shared/types';
 
 export * from './shared/types';
 export { CustomRendererConfig, CustomRendererElementConfig } from './shared/renderer-hooks';

--- a/packages/@lwc/template-compiler/src/parser/attribute.ts
+++ b/packages/@lwc/template-compiler/src/parser/attribute.ts
@@ -13,14 +13,11 @@ import {
     SVG_NAMESPACE,
     ID_REFERENCING_ATTRIBUTES_SET,
 } from '@lwc/shared';
-import { Token } from 'parse5';
 
 import { isComponent, isExternalComponent, isLwcComponent } from '../shared/ast';
 import { toPropertyName } from '../shared/utils';
-import { Attribute, BaseElement, SourceLocation } from '../shared/types';
 
 import { DASHED_TAGNAME_ELEMENT_SET } from '../shared/constants';
-import ParserCtx from './parser';
 import {
     EXPRESSION_SYMBOL_END,
     EXPRESSION_SYMBOL_START,
@@ -38,6 +35,9 @@ import {
     TEMPLATE_DIRECTIVES,
 } from './constants';
 import { HTML_ATTRIBUTE_ELEMENT_MAP } from './utils/html-element-attributes';
+import type ParserCtx from './parser';
+import type { Attribute, BaseElement, SourceLocation } from '../shared/types';
+import type { Token } from 'parse5';
 
 function isQuotedAttribute(attrVal: string) {
     return attrVal && attrVal.startsWith('"') && attrVal.endsWith('"');

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -6,18 +6,11 @@
  */
 
 import { parseExpressionAt } from 'acorn';
-import {
-    DefaultTreeAdapterMap,
-    Parser,
-    ParserOptions,
-    Tokenizer,
-    TokenizerOptions,
-    TokenHandler,
-    ParserError,
-    Token,
-} from 'parse5';
+import { Parser, Tokenizer, Token } from 'parse5';
 import { ParserDiagnostics, invariant } from '@lwc/errors';
-import {
+import { TMPL_EXPR_ECMASCRIPT_EDITION } from '../constants';
+import { EXPRESSION_SYMBOL_START } from '../expression';
+import type {
     ChildNode,
     Document,
     DocumentFragment,
@@ -26,8 +19,13 @@ import {
     Template,
     TextNode,
 } from '@parse5/tools';
-import { TMPL_EXPR_ECMASCRIPT_EDITION } from '../constants';
-import { EXPRESSION_SYMBOL_START } from '../expression';
+import type {
+    DefaultTreeAdapterMap,
+    ParserOptions,
+    TokenizerOptions,
+    TokenHandler,
+    ParserError,
+} from 'parse5';
 import type ParserCtx from '../parser';
 import type { PreparsedExpressionMap, Preprocessor } from './types';
 

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { APIFeature, isAPIFeatureEnabled } from '@lwc/shared';
-import ParserCtx from '../parser';
+import type ParserCtx from '../parser';
 
 export * from './types';
 export * from './validate';

--- a/packages/@lwc/template-compiler/src/parser/expression.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression.ts
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Node, parseExpressionAt, isIdentifierStart, isIdentifierChar } from 'acorn';
+import { parseExpressionAt, isIdentifierStart, isIdentifierChar } from 'acorn';
 import { ParserDiagnostics, invariant } from '@lwc/errors';
 
-import { NormalizedConfig } from '../config';
 import * as ast from '../shared/ast';
 import * as t from '../shared/estree';
-import { Expression, Identifier, SourceLocation } from '../shared/types';
 import { validateExpressionAst } from './expression-complex';
-
-import ParserCtx from './parser';
 import { isReservedES6Keyword } from './utils/javascript';
+import type { Expression, Identifier, SourceLocation } from '../shared/types';
+
+import type ParserCtx from './parser';
+import type { NormalizedConfig } from '../config';
+import type { Node } from 'acorn';
 
 export const EXPRESSION_SYMBOL_START = '{';
 export const EXPRESSION_SYMBOL_END = '}';

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -11,9 +11,9 @@ import { ParserDiagnostics } from '@lwc/errors';
 import { APIFeature, isAPIFeatureEnabled } from '@lwc/shared';
 import { sourceLocation } from '../shared/ast';
 
-import ParserCtx from './parser';
 import { errorCodesToErrorOn, errorCodesToWarnOnInOlderAPIVersions } from './parse5Errors';
 import { parseFragment } from './expression-complex';
+import type ParserCtx from './parser';
 
 function getLwcErrorFromParse5Error(ctx: ParserCtx, code: string) {
     /* istanbul ignore else */

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -14,39 +14,16 @@ import {
 } from '@lwc/shared';
 import { ParserDiagnostics, DiagnosticLevel, CompilerMetrics } from '@lwc/errors';
 import * as parse5Tools from '@parse5/tools';
-import { Token as parse5Token } from 'parse5';
 
 import * as t from '../shared/estree';
 import * as ast from '../shared/ast';
-import State from '../state';
 import {
-    TemplateParseResult,
-    Attribute,
-    ForEach,
-    Identifier,
-    Literal,
-    Expression,
-    ForOf,
-    Slot,
-    Text,
-    Root,
-    ParentNode,
-    BaseElement,
-    Comment,
     LWCDirectiveRenderMode,
     LWCDirectiveDomMode,
-    If,
-    IfBlock,
-    ElseBlock,
-    ElseifBlock,
-    Property,
     ElementDirectiveName,
     RootDirectiveName,
-    ScopedSlotFragment,
     TemplateDirectiveName,
     LwcTagName,
-    LwcComponent,
-    Element,
 } from '../shared/types';
 import { isCustomElementTag, isLwcElementTag } from '../shared/utils';
 import { DASHED_TAGNAME_ELEMENT_SET } from '../shared/constants';
@@ -84,6 +61,31 @@ import {
     SUPPORTED_SVG_TAGS,
     VALID_IF_MODIFIER,
 } from './constants';
+import type {
+    TemplateParseResult,
+    Attribute,
+    ForEach,
+    Identifier,
+    Literal,
+    Expression,
+    ForOf,
+    Slot,
+    Text,
+    Root,
+    ParentNode,
+    BaseElement,
+    Comment,
+    If,
+    IfBlock,
+    ElseBlock,
+    ElseifBlock,
+    Property,
+    ScopedSlotFragment,
+    LwcComponent,
+    Element,
+} from '../shared/types';
+import type State from '../state';
+import type { Token as parse5Token } from 'parse5';
 
 function attributeExpressionReferencesForOfIndex(attribute: Attribute, forOf: ForOf): boolean {
     const { value } = attribute;

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -5,29 +5,31 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import {
-    CompilerDiagnostic,
     CompilerError,
-    InstrumentationObject,
     generateCompilerDiagnostic,
     generateCompilerError,
-    Location,
-    LWCErrorInfo,
     normalizeToDiagnostic,
 } from '@lwc/errors';
-import { APIVersion } from '@lwc/shared';
-import { NormalizedConfig } from '../config';
 import { isPreserveCommentsDirective, isRenderModeDirective } from '../shared/ast';
-import {
+import { LWCDirectiveRenderMode } from '../shared/types';
+import { TMPL_EXPR_ECMASCRIPT_EDITION } from './constants';
+import type {
+    CompilerDiagnostic,
+    InstrumentationObject,
+    Location,
+    LWCErrorInfo,
+} from '@lwc/errors';
+import type { APIVersion } from '@lwc/shared';
+import type { NormalizedConfig } from '../config';
+import type {
     Root,
     SourceLocation,
     ParentNode,
     BaseNode,
-    LWCDirectiveRenderMode,
     IfBlock,
     ElseifBlock,
     ElseBlock,
 } from '../shared/types';
-import { TMPL_EXPR_ECMASCRIPT_EDITION } from './constants';
 import type { ecmaVersion as EcmaVersion } from 'acorn';
 import type { PreparsedExpressionMap } from './expression-complex';
 

--- a/packages/@lwc/template-compiler/src/shared/ast.ts
+++ b/packages/@lwc/template-compiler/src/shared/ast.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { HTML_NAMESPACE } from '@lwc/shared';
-import { Token as parse5TokenInfo } from 'parse5';
-import {
+import type { Token as parse5TokenInfo } from 'parse5';
+import type {
     Literal,
     SourceLocation,
     Element,

--- a/packages/@lwc/template-compiler/src/shared/constants.ts
+++ b/packages/@lwc/template-compiler/src/shared/constants.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ElementDirectiveName } from './types';
+import type { ElementDirectiveName } from './types';
 
 export const SECURE_REGISTER_TEMPLATE_METHOD_NAME = 'registerTemplate';
 export const PARSE_FRAGMENT_METHOD_NAME = 'parseFragment';

--- a/packages/@lwc/template-compiler/src/shared/renderer-hooks.ts
+++ b/packages/@lwc/template-compiler/src/shared/renderer-hooks.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import State from '../state';
-import { BaseElement, ElementDirectiveName } from './types';
+import { ElementDirectiveName } from './types';
+import type State from '../state';
+import type { BaseElement } from './types';
 
 /**
  * Config representing criteria for an element match.

--- a/packages/@lwc/template-compiler/src/shared/types.ts
+++ b/packages/@lwc/template-compiler/src/shared/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { CompilerDiagnostic } from '@lwc/errors';
+import type { CompilerDiagnostic } from '@lwc/errors';
 import type { Node as AcornNode } from 'acorn';
 
 export interface TemplateParseResult {

--- a/packages/@lwc/template-compiler/src/state.ts
+++ b/packages/@lwc/template-compiler/src/state.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { BaseElement } from './shared/types';
 import { generateScopeTokens, type scopeTokens } from './scopeTokens';
+import type { BaseElement } from './shared/types';
 import type { NormalizedConfig } from './config';
 
 export default class State {

--- a/packages/@lwc/wire-service/src/__tests__/index.spec.ts
+++ b/packages/@lwc/wire-service/src/__tests__/index.spec.ts
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { vi, describe, it, expect } from 'vitest';
-import { register, WireEventTarget, ValueChangedEvent } from '../index';
+import { register, ValueChangedEvent } from '../index';
+import type { WireEventTarget } from '../index';
 
 describe('WireEventTarget from register', () => {
     describe('connected', () => {

--- a/packages/@lwc/wire-service/src/index.ts
+++ b/packages/@lwc/wire-service/src/index.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { isUndefined } from '@lwc/shared';
-import { WireConfigValue, WireAdapter, WireDataCallback } from '@lwc/engine-core';
 import { ValueChangedEvent } from './value-changed-event';
+import type { WireConfigValue, WireAdapter, WireDataCallback } from '@lwc/engine-core';
 
 const { freeze, defineProperty, isExtensible } = Object;
 


### PR DESCRIPTION
## Details

Enables [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/).

All changes were automated via lint --fix.

Not sure about effects in build-time and bundle size yet, but it should be easier to navigate the codebase if we can identify type-only imports at a glance. This might open up opportunities to remove some dependencies as well. 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
