### PR TITLE
fix(ssr-compiler): missing @lwc/errors dependency

### DIFF
--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -45,6 +45,7 @@
     },
     "dependencies": {
         "@lwc/shared": "8.9.0",
+        "@lwc/errors": "8.9.0",
         "@lwc/template-compiler": "8.9.0",
         "acorn": "8.14.0",
         "astring": "^1.9.0",


### PR DESCRIPTION
## Details

- Surfaced while working on #4897 
- Explanation: [Creating a non-flat node_modules directory](https://pnpm.io/motivation#creating-a-non-flat-node_modules-directory)

File:

https://github.com/salesforce/lwc/blob/8e1b1cfe4b2636aa91947f98d293ef6cceac646e/packages/%40lwc/ssr-compiler/src/compile-template/index.ts#L11



## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
