### PR TITLE
fix(babel-plugin-component): missing @types/babel__traverse dependency

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -51,6 +51,7 @@
     },
     "devDependencies": {
         "@types/babel__helper-module-imports": "~7.18.3",
+        "@types/babel__traverse": "^7.20.6",
         "@types/line-column": "~1.0.2"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,6 +2919,13 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/babel__traverse@^7.20.6":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.20.6.tgz#8dc9f0ae0f202c08d8d4dab648912c8d6038e3f7"
+  integrity sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==
+  dependencies:
+    "@babel/types" "^7.20.7"
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"


### PR DESCRIPTION
## Details

- Surfaced while working on #4897 
- Explanation: [Creating a non-flat node_modules directory](https://pnpm.io/motivation#creating-a-non-flat-node_modules-directory)

File:

https://github.com/salesforce/lwc/blob/74b53a87cbcab32a0e8eada3643247aef9f89fca/packages/%40lwc/babel-plugin-component/src/component.ts#L19

```
│ [!] (plugin typescript) RollupError: [plugin typescript] src/component.ts (19:31): @rollup/plugin-typescript TS7016: Could not find a declaration fi…
│   If the '@babel/traverse' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/Defini…
│ src/component.ts (19:31)
│ 
│ 19 import type { NodePath } from '@babel/traverse';
│                                  ~~~~~~~~~~~~~~~~~
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
