### PR TITLE
[DO NOT MERGE] Trigger CI for #4904: chore(babel-plugin-component): remove redundant type-only dependencies

### DIFF
--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -43,8 +43,6 @@
     },
     "dependencies": {
         "@babel/helper-module-imports": "7.25.9",
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.8",
         "@lwc/errors": "8.9.0",
         "@lwc/shared": "8.9.0",
         "line-column": "~1.0.2"

--- a/packages/@lwc/babel-plugin-component/src/component.ts
+++ b/packages/@lwc/babel-plugin-component/src/component.ts
@@ -15,9 +15,7 @@ import {
     API_VERSION_KEY,
     COMPONENT_CLASS_ID,
 } from './constants';
-import type * as types from '@babel/types';
-import type { NodePath } from '@babel/traverse';
-import type { Visitor } from '@babel/core';
+import type { types, NodePath, Visitor } from '@babel/core';
 import type { BabelAPI, BabelTypes, LwcBabelPluginPass } from './types';
 
 function getBaseName(classPath: string) {

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/transform.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/transform.ts
@@ -6,8 +6,7 @@
  */
 import { DECORATOR_TYPES, LWC_COMPONENT_PROPERTIES } from '../../constants';
 import { isApiDecorator } from './shared';
-import type { types } from '@babel/core';
-import type { NodePath } from '@babel/traverse';
+import type { types, NodePath } from '@babel/core';
 import type { DecoratorMeta } from '../index';
 import type { BabelTypes } from '../../types';
 import type { ClassBodyItem } from '../types';

--- a/packages/@lwc/babel-plugin-component/src/decorators/api/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/api/validate.ts
@@ -13,8 +13,7 @@ import {
     LWC_PACKAGE_EXPORTS,
 } from '../../constants';
 import { isApiDecorator } from './shared';
-import type { NodePath } from '@babel/traverse';
-import type { types } from '@babel/core';
+import type { types, NodePath } from '@babel/core';
 import type { LwcBabelPluginPass } from '../../types';
 import type { DecoratorMeta } from '../index';
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/index.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/index.ts
@@ -126,22 +126,7 @@ function validateImportedLwcDecoratorUsage(
         });
 }
 
-/**
- * Validate the usage of decorator by calling each validation function
- * @param decorators
- * @param state
- */
-function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
-    for (const { name, path } of decorators) {
-        const binding = path.scope.getBinding(name);
-        if (!binding || validateBinding(binding.path)) {
-            throw generateInvalidDecoratorError(path, state);
-        }
-    }
-    DECORATOR_TRANSFORMS.forEach(({ validate }) => validate(decorators, state));
-}
-
-function validateBinding(path: NodePath) {
+function isImportedFromLwcSource(path: NodePath) {
     if (path.isImportSpecifier()) {
         return false;
     }
@@ -151,6 +136,21 @@ function validateBinding(path: NodePath) {
     }
 
     return path.parent.source.value === 'lwc';
+}
+
+/**
+ * Validate the usage of decorator by calling each validation function
+ * @param decorators
+ * @param state
+ */
+function validate(decorators: DecoratorMeta[], state: LwcBabelPluginPass) {
+    for (const { name, path } of decorators) {
+        const binding = path.scope.getBinding(name);
+        if (!binding || isImportedFromLwcSource(binding.path)) {
+            throw generateInvalidDecoratorError(path, state);
+        }
+    }
+    DECORATOR_TRANSFORMS.forEach(({ validate }) => validate(decorators, state));
 }
 
 /**

--- a/packages/@lwc/babel-plugin-component/src/decorators/types.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/types.ts
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import type { NodePath } from '@babel/traverse';
-import type { types } from '@babel/core';
+import type { types, NodePath } from '@babel/core';
 import type { LWCErrorInfo } from '@lwc/errors';
-import type * as t from '@babel/types';
 
 export type ImportSpecifier = {
     name: string;
@@ -24,8 +22,8 @@ export type DecoratorErrorOptions = {
 // Copied from:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a767e24/types/babel__traverse/index.d.ts#L143-L148
 export type BindingOptions = {
-    id: t.LVal;
-    init?: t.Expression | undefined;
+    id: types.LVal;
+    init?: types.Expression | undefined;
     unique?: boolean | undefined;
     kind?: 'var' | 'let' | 'const' | undefined;
 };

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
@@ -45,7 +45,6 @@ function validateWireId(id: NodePath | undefined, path: NodePath, state: LwcBabe
         );
     }
 
-    // TODO [#3444]: improve member expression computed typechecking
     if (id.isMemberExpression()) {
         const object = id.get('object');
 

--- a/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
+++ b/packages/@lwc/babel-plugin-component/src/decorators/wire/validate.ts
@@ -25,27 +25,41 @@ function validateWireId(id: NodePath | undefined, path: NodePath, state: LwcBabe
         );
     }
 
-    if (!id.isIdentifier() && !id.isMemberExpression()) {
-        throw generateError(
-            id,
-            {
-                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
-            },
-            state
-        );
-    }
+    if (id.isIdentifier()) {
+        const binding = path.scope.getBinding(id.node.name);
 
-    if (id.isMemberExpression() && id.node.computed) {
-        throw generateError(
-            id,
-            {
-                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS,
-            },
-            state
-        );
-    }
+        if (!binding) {
+            throw generateError(
+                id,
+                {
+                    errorInfo: DecoratorErrors.WIRE_ADAPTER_SHOULD_BE_IMPORTED,
+                    messageArgs: [id.node.name],
+                },
+                state
+            );
+        }
 
-    if (id.isMemberExpression()) {
+        if (!binding.path.isImportSpecifier() && !binding.path.isImportDefaultSpecifier()) {
+            throw generateError(
+                id,
+                {
+                    errorInfo:
+                        DecoratorErrors.IMPORTED_FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
+                },
+                state
+            );
+        }
+    } else if (id.isMemberExpression()) {
+        if (id.node.computed) {
+            throw generateError(
+                id,
+                {
+                    errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS,
+                },
+                state
+            );
+        }
+
         const object = id.get('object');
 
         if (!object.isIdentifier()) {
@@ -72,29 +86,13 @@ function validateWireId(id: NodePath | undefined, path: NodePath, state: LwcBabe
             );
         }
     } else {
-        const binding = path.scope.getBinding(id.node.name);
-
-        if (!binding) {
-            throw generateError(
-                id,
-                {
-                    errorInfo: DecoratorErrors.WIRE_ADAPTER_SHOULD_BE_IMPORTED,
-                    messageArgs: [id.node.name],
-                },
-                state
-            );
-        }
-
-        if (!binding.path.isImportSpecifier() && !binding.path.isImportDefaultSpecifier()) {
-            throw generateError(
-                id,
-                {
-                    errorInfo:
-                        DecoratorErrors.IMPORTED_FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
-                },
-                state
-            );
-        }
+        throw generateError(
+            id,
+            {
+                errorInfo: DecoratorErrors.FUNCTION_IDENTIFIER_SHOULD_BE_FIRST_PARAMETER,
+            },
+            state
+        );
     }
 }
 

--- a/packages/@lwc/babel-plugin-component/src/dedupe-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dedupe-imports.ts
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import type { types } from '@babel/core';
-import type { NodePath } from '@babel/traverse';
+import type { types, NodePath } from '@babel/core';
 import type { BabelAPI, BabelTypes } from './types';
 
 function defaultImport(

--- a/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/dynamic-imports.ts
@@ -7,8 +7,7 @@
 import { addNamed } from '@babel/helper-module-imports';
 import { CompilerMetrics, LWCClassErrors } from '@lwc/errors';
 import { generateError, incrementMetricCounter } from './utils';
-import type { types, Visitor } from '@babel/core';
-import type { NodePath } from '@babel/traverse';
+import type { types, Visitor, NodePath } from '@babel/core';
 import type { LwcBabelPluginPass } from './types';
 
 function getImportSource(path: NodePath<types.Import>): NodePath<types.Node> {

--- a/packages/@lwc/babel-plugin-component/src/scope-css-imports.ts
+++ b/packages/@lwc/babel-plugin-component/src/scope-css-imports.ts
@@ -7,8 +7,7 @@
 
 // Add ?scoped=true to any imports ending with .scoped.css. This signals that the stylesheet
 // should be treated as "scoped".
-import type { Node } from '@babel/core';
-import type { NodePath } from '@babel/traverse';
+import type { Node, NodePath } from '@babel/core';
 import type { BabelAPI } from './types';
 
 export default function ({ types: t }: BabelAPI, path: NodePath): void {

--- a/packages/@lwc/babel-plugin-component/src/utils.ts
+++ b/packages/@lwc/babel-plugin-component/src/utils.ts
@@ -7,8 +7,7 @@
 import lineColumn from 'line-column';
 import { generateErrorMessage } from '@lwc/errors';
 import { LWC_PACKAGE_ALIAS } from './constants';
-import type { types } from '@babel/core';
-import type { NodePath } from '@babel/traverse';
+import type { types, NodePath } from '@babel/core';
 import type { CompilerMetrics } from '@lwc/errors';
 import type { DecoratorErrorOptions, ImportSpecifier } from './decorators/types';
 import type { LwcBabelPluginPass } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,7 +1063,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse@^7.16.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.4.5":
+"@babel/traverse@^7.16.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.4.5":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
   integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
@@ -1076,7 +1076,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.10", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.4", "@babel/types@^7.25.8", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.10", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.4", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.4.4":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.0.tgz#deabd08d6b753bc8e0f198f8709fb575e31774ff"
   integrity sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4904.