### PR TITLE
[DO NOT MERGE] Trigger CI for #4901: fix(engine-server): missing @lwc/features dependency

### DIFF
--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -45,6 +45,7 @@
         "@lwc/engine-core": "8.9.0",
         "@lwc/rollup-plugin": "8.9.0",
         "@lwc/shared": "8.9.0",
+        "@lwc/features": "8.9.0",
         "@rollup/plugin-virtual": "^3.0.2",
         "parse5": "^7.2.1"
     }


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4901.