### PR TITLE
[DO NOT MERGE] Trigger CI for #4900: fix(engine-dom): missing @lwc/features dependency

### DIFF
--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -43,7 +43,8 @@
     },
     "devDependencies": {
         "@lwc/engine-core": "8.9.0",
-        "@lwc/shared": "8.9.0"
+        "@lwc/shared": "8.9.0",
+        "@lwc/features": "8.9.0"
     },
     "lwc": {
         "modules": [


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4900.