### PR TITLE
[DO NOT MERGE] Trigger CI for #4899: fix(ssr-compiler): missing @lwc/errors dependency

### DIFF
--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -45,6 +45,7 @@
     },
     "dependencies": {
         "@lwc/shared": "8.9.0",
+        "@lwc/errors": "8.9.0",
         "@lwc/template-compiler": "8.9.0",
         "acorn": "8.14.0",
         "astring": "^1.9.0",


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4899.