### PR TITLE
perf(ssr): speed up rendering stylesheets

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -28,9 +28,10 @@ const bExportTemplate = esTemplate`
         
         const { stylesheets: staticStylesheets } = Cmp;
         if (defaultStylesheets || defaultScopedStylesheets || staticStylesheets) {
-            const stylesheets = [defaultStylesheets, defaultScopedStylesheets, staticStylesheets];
             yield renderStylesheets(
-                stylesheets, 
+                defaultStylesheets, 
+                defaultScopedStylesheets, 
+                staticStylesheets,
                 stylesheetScopeToken, 
                 Cmp, 
                 hasScopedStylesheets,

--- a/packages/@lwc/ssr-runtime/src/styles.ts
+++ b/packages/@lwc/ssr-runtime/src/styles.ts
@@ -14,7 +14,7 @@ type ForgivingStylesheets =
     | Stylesheet
     | undefined
     | null
-    | Array<Stylesheets | undefined>;
+    | Array<Stylesheets | undefined | null>;
 
 // Traverse in the same order as `flattenStylesheets` but without creating unnecessary additional arrays
 function traverseStylesheets(

--- a/packages/@lwc/ssr-runtime/src/styles.ts
+++ b/packages/@lwc/ssr-runtime/src/styles.ts
@@ -4,43 +4,70 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { flattenStylesheets } from '@lwc/shared';
+import { isArray } from '@lwc/shared';
 import { validateStyleTextContents } from './validate-style-text-contents';
 import type { LightningElementConstructor } from './lightning-element';
-import type { Stylesheets } from '@lwc/shared';
+import type { Stylesheets, Stylesheet } from '@lwc/shared';
+
+type ForgivingStylesheets =
+    | Stylesheets
+    | Stylesheet
+    | undefined
+    | null
+    | Array<Stylesheets | undefined>;
+
+// Traverse in the same order as `flattenStylesheets` but without creating unnecessary additional arrays
+function traverseStylesheets(
+    stylesheets: ForgivingStylesheets,
+    callback: (stylesheet: Stylesheet) => void
+): void {
+    if (isArray(stylesheets)) {
+        for (let i = 0; i < stylesheets.length; i++) {
+            traverseStylesheets(stylesheets[i], callback);
+        }
+    } else if (stylesheets) {
+        callback(stylesheets);
+    }
+}
 
 export function hasScopedStaticStylesheets(Component: LightningElementConstructor): boolean {
-    const { stylesheets } = Component;
-    if (stylesheets) {
-        return flattenStylesheets(stylesheets).some((stylesheet) => stylesheet.$scoped$);
-    }
-    return false;
+    let scoped: boolean = false;
+    traverseStylesheets(Component.stylesheets, (stylesheet) => {
+        scoped ||= !!stylesheet.$scoped$;
+    });
+    return scoped;
 }
 
 export function renderStylesheets(
-    stylesheets: Array<Stylesheets | undefined>,
+    defaultStylesheets: ForgivingStylesheets,
+    defaultScopedStylesheets: ForgivingStylesheets,
+    staticStylesheets: ForgivingStylesheets,
     scopeToken: string,
     Component: LightningElementConstructor,
     hasScopedTemplateStyles: boolean
 ): string {
     const hasAnyScopedStyles = hasScopedTemplateStyles || hasScopedStaticStylesheets(Component);
+    const { renderMode } = Component;
 
     let result = '';
 
-    const truthyStylesheets = stylesheets.filter(Boolean) as Array<Stylesheets>;
-    for (const stylesheet of flattenStylesheets(truthyStylesheets)) {
-        // TODO [#2869]: `<style>`s should not have scope token classes
-        result += `<style${hasAnyScopedStyles ? ` class="${scopeToken}"` : ''} type="text/css">`;
+    const renderStylesheet = (stylesheet: Stylesheet) => {
+        const { $scoped$: scoped } = stylesheet;
 
-        const token = stylesheet.$scoped$ ? scopeToken : undefined;
-        const useActualHostSelector = !stylesheet.$scoped$ || Component.renderMode !== 'light';
+        const token = scoped ? scopeToken : undefined;
+        const useActualHostSelector = !scoped || renderMode !== 'light';
         const useNativeDirPseudoclass = true;
 
         const styleContents = stylesheet(token, useActualHostSelector, useNativeDirPseudoclass);
         validateStyleTextContents(styleContents);
 
-        result += styleContents + '</style>';
-    }
+        // TODO [#2869]: `<style>`s should not have scope token classes
+        result += `<style${hasAnyScopedStyles ? ` class="${scopeToken}"` : ''} type="text/css">${styleContents}</style>`;
+    };
+
+    traverseStylesheets(defaultStylesheets, renderStylesheet);
+    traverseStylesheets(defaultScopedStylesheets, renderStylesheet);
+    traverseStylesheets(staticStylesheets, renderStylesheet);
 
     return result;
 }


### PR DESCRIPTION
## Details

Another small micro-optimization, this time in the 1-7% range:

![Screenshot 2024-11-22 at 10 41 35 AM](https://github.com/user-attachments/assets/597ce16d-c731-4a50-b293-d9d3a7f62d4c)

The perf benefit here is basically just avoiding creating a lot of temporary arrays that get thrown away. I noticed we were spending a lot of time in GC.

Instead of creating arrays and `filter`ing them, we can just traverse the stylesheet arrays as-is.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.


<!-- If yes, please describe the anticipated observable changes. -->
