### PR TITLE
fix(ssr): remove `generateMarkup` export

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -13,7 +13,6 @@ import { bImportDeclaration } from '../estree/builders';
 import { bWireAdaptersPlumbing } from './wire';
 
 import type {
-    ExportNamedDeclaration,
     Program,
     SimpleCallExpression,
     Identifier,
@@ -21,6 +20,7 @@ import type {
     Statement,
     ExpressionStatement,
     IfStatement,
+    FunctionDeclaration,
 } from 'estree';
 import type { ComponentMetaState } from './types';
 
@@ -30,7 +30,7 @@ type RenderCallExpression = SimpleCallExpression & {
 };
 
 const bGenerateMarkup = esTemplate`
-    export async function* generateMarkup(tagName, props, attrs, slotted, parent, scopeToken) {
+    async function* generateMarkup(tagName, props, attrs, slotted, parent, scopeToken) {
         tagName = tagName ?? ${/*component tag name*/ is.literal};
         attrs = attrs ?? Object.create(null);
         props = props ?? Object.create(null);
@@ -67,7 +67,7 @@ const bGenerateMarkup = esTemplate`
         yield \`</\${tagName}>\`;
     }
     ${/* component class */ 3}[__SYMBOL__GENERATE_MARKUP] = generateMarkup;
-`<[ExportNamedDeclaration, ExpressionStatement]>;
+`<[FunctionDeclaration, ExpressionStatement]>;
 
 const bExposeTemplate = esTemplate`
     if (${/*template*/ is.identifier}) {
@@ -87,7 +87,7 @@ const bExposeTemplate = esTemplate`
  *  - yielding the tag name & attributes
  *  - deferring to the template function for yielding child content
  */
-export function addGenerateMarkupExport(
+export function addGenerateMarkupFunction(
     program: Program,
     state: ComponentMetaState,
     tagName: string,

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -13,7 +13,7 @@ import { transmogrify } from '../transmogrify';
 import { replaceLwcImport } from './lwc-import';
 import { catalogTmplImport } from './catalog-tmpls';
 import { catalogStaticStylesheets, catalogAndReplaceStyleImports } from './stylesheets';
-import { addGenerateMarkupExport } from './generate-markup';
+import { addGenerateMarkupFunction } from './generate-markup';
 import { catalogWireAdapters } from './wire';
 
 import { removeDecoratorImport } from './remove-decorator-import';
@@ -192,7 +192,7 @@ export default function compileJS(
         };
     }
 
-    addGenerateMarkupExport(ast, state, tagName, filename);
+    addGenerateMarkupFunction(ast, state, tagName, filename);
 
     if (compilationMode === 'async' || compilationMode === 'sync') {
         ast = transmogrify(ast, compilationMode);

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
@@ -29,8 +29,9 @@ const bYieldFromChildGenerator = esTemplateWithYield`
         }
 
         const scopeToken = hasScopedStylesheets ? stylesheetScopeToken : undefined;
+        const Ctor = ${/* Component */ is.identifier};
 
-        yield* ${/* generateMarkup */ is.identifier}(
+        yield* Ctor[__SYMBOL__GENERATE_MARKUP](
             ${/* tag name */ is.literal}, 
             childProps, 
             childAttrs, 
@@ -43,10 +44,13 @@ const bYieldFromChildGenerator = esTemplateWithYield`
 
 export const Component: Transformer<IrComponent> = function Component(node, cxt) {
     // Import the custom component's generateMarkup export.
-    const childGeneratorLocalName = `generateMarkup_${toPropertyName(node.name)}`;
+    const childComponentLocalName = `ChildComponentCtor_${toPropertyName(node.name)}`;
     const importPath = kebabcaseToCamelcase(node.name);
-    cxt.import({ generateMarkup: childGeneratorLocalName }, importPath);
-    cxt.import({ getReadOnlyProxy: '__getReadOnlyProxy' });
+    cxt.import({ default: childComponentLocalName }, importPath);
+    cxt.import({
+        getReadOnlyProxy: '__getReadOnlyProxy',
+        SYMBOL__GENERATE_MARKUP: '__SYMBOL__GENERATE_MARKUP',
+    });
     const childTagName = node.name;
 
     return [
@@ -54,7 +58,7 @@ export const Component: Transformer<IrComponent> = function Component(node, cxt)
             getChildAttrsOrProps(node.properties, cxt),
             getChildAttrsOrProps(node.attributes, cxt),
             getSlottedContent(node, cxt),
-            b.identifier(childGeneratorLocalName),
+            b.identifier(childComponentLocalName),
             b.literal(childTagName)
         ),
     ];

--- a/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
+++ b/packages/@lwc/ssr-runtime/src/__tests__/render-component.spec.ts
@@ -68,13 +68,6 @@ describe('renderComponent', () => {
         module = (await import(outputFile)) as ComponentModule;
     });
 
-    // TODO [#4726]: remove `generateMarkup` export
-    test('can call `renderComponent()` on `generateMarkup`', async () => {
-        const result = await renderComponent('x-component', module!.generateMarkup, {});
-
-        expect(result).toContain('<h1>Hello world</h1>');
-    });
-
     test('can call `renderComponent()` on the default export', async () => {
         const result = await renderComponent('x-component', module!.default, {});
 

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -138,7 +138,7 @@ interface ComponentWithGenerateMarkup {
 
 export async function serverSideRenderComponent(
     tagName: string,
-    Component: GenerateMarkupFnVariants | ComponentWithGenerateMarkup,
+    Component: ComponentWithGenerateMarkup,
     props: Properties = {},
     mode: 'asyncYield' | 'async' | 'sync' = DEFAULT_SSR_MODE
 ): Promise<string> {
@@ -146,9 +146,7 @@ export async function serverSideRenderComponent(
         throw new Error(`tagName must be a string, found: ${tagName}`);
     }
 
-    // TODO [#4726]: remove `generateMarkup` export
-    const generateMarkup =
-        SYMBOL__GENERATE_MARKUP in Component ? Component[SYMBOL__GENERATE_MARKUP] : Component;
+    const generateMarkup = Component[SYMBOL__GENERATE_MARKUP];
 
     let markup = '';
     const emit = (segment: string) => {


### PR DESCRIPTION
## Details

Fixes #4726

I've confirmed this isn't used anymore by LWR or CLWR, so we can remove it.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   💔 Yes, it does introduce a breaking change.

The `generateMarkup` export from an SSR-compiled component is no longer supported. You can use the default export just like any other LWC component.

Technically this is breaking, but the new SSR compiler is marked as unstable so we don't consider this worthy of a major version bump.

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->


-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->
