### PR TITLE
chore: release v8.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc-monorepo",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "private": true,
     "description": "Lightning Web Components",
     "repository": {

--- a/packages/@lwc/aria-reflection/package.json
+++ b/packages/@lwc/aria-reflection/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/aria-reflection",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "ARIA element reflection polyfill for strings",
     "keywords": [
         "aom",

--- a/packages/@lwc/babel-plugin-component/package.json
+++ b/packages/@lwc/babel-plugin-component/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/babel-plugin-component",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Babel plugin to transform a LWC module",
     "keywords": [
         "lwc"
@@ -43,8 +43,8 @@
     },
     "dependencies": {
         "@babel/helper-module-imports": "7.25.9",
-        "@lwc/errors": "8.10.1",
-        "@lwc/shared": "8.10.1",
+        "@lwc/errors": "8.11.0",
+        "@lwc/shared": "8.11.0",
         "line-column": "~1.0.2"
     },
     "devDependencies": {

--- a/packages/@lwc/compiler/package.json
+++ b/packages/@lwc/compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/compiler",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "LWC compiler",
     "keywords": [
         "lwc"
@@ -48,11 +48,11 @@
         "@babel/plugin-transform-class-properties": "7.25.9",
         "@babel/plugin-transform-object-rest-spread": "7.25.9",
         "@locker/babel-plugin-transform-unforgeables": "0.22.0",
-        "@lwc/babel-plugin-component": "8.10.1",
-        "@lwc/errors": "8.10.1",
-        "@lwc/shared": "8.10.1",
-        "@lwc/ssr-compiler": "8.10.1",
-        "@lwc/style-compiler": "8.10.1",
-        "@lwc/template-compiler": "8.10.1"
+        "@lwc/babel-plugin-component": "8.11.0",
+        "@lwc/errors": "8.11.0",
+        "@lwc/shared": "8.11.0",
+        "@lwc/ssr-compiler": "8.11.0",
+        "@lwc/style-compiler": "8.11.0",
+        "@lwc/template-compiler": "8.11.0"
     }
 }

--- a/packages/@lwc/engine-core/package.json
+++ b/packages/@lwc/engine-core/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-core",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Core LWC engine APIs.",
     "keywords": [
         "lwc"
@@ -42,9 +42,9 @@
         }
     },
     "dependencies": {
-        "@lwc/features": "8.10.1",
-        "@lwc/shared": "8.10.1",
-        "@lwc/signals": "8.10.1"
+        "@lwc/features": "8.11.0",
+        "@lwc/shared": "8.11.0",
+        "@lwc/signals": "8.11.0"
     },
     "devDependencies": {
         "observable-membrane": "2.0.0"

--- a/packages/@lwc/engine-dom/package.json
+++ b/packages/@lwc/engine-dom/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-dom",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Renders LWC components in a DOM environment.",
     "keywords": [
         "lwc"
@@ -42,9 +42,9 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "8.10.1",
-        "@lwc/shared": "8.10.1",
-        "@lwc/features": "8.10.1"
+        "@lwc/engine-core": "8.11.0",
+        "@lwc/shared": "8.11.0",
+        "@lwc/features": "8.11.0"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/engine-server",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Renders LWC components in a server environment.",
     "keywords": [
         "lwc"
@@ -42,10 +42,10 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "8.10.1",
-        "@lwc/rollup-plugin": "8.10.1",
-        "@lwc/shared": "8.10.1",
-        "@lwc/features": "8.10.1",
+        "@lwc/engine-core": "8.11.0",
+        "@lwc/rollup-plugin": "8.11.0",
+        "@lwc/shared": "8.11.0",
+        "@lwc/features": "8.11.0",
         "@rollup/plugin-virtual": "^3.0.2",
         "parse5": "^7.2.1"
     }

--- a/packages/@lwc/errors/package.json
+++ b/packages/@lwc/errors/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/errors",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "LWC Error Utilities",
     "keywords": [
         "lwc"

--- a/packages/@lwc/features/package.json
+++ b/packages/@lwc/features/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/features",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "LWC Features Flags",
     "keywords": [
         "lwc"
@@ -42,6 +42,6 @@
         }
     },
     "dependencies": {
-        "@lwc/shared": "8.10.1"
+        "@lwc/shared": "8.11.0"
     }
 }

--- a/packages/@lwc/integration-karma/package.json
+++ b/packages/@lwc/integration-karma/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-karma",
     "private": true,
-    "version": "8.10.1",
+    "version": "8.11.0",
     "scripts": {
         "start": "KARMA_MODE=watch karma start ./scripts/karma-configs/test/local.js",
         "test": "karma start ./scripts/karma-configs/test/local.js --single-run --browsers ChromeHeadless",
@@ -17,11 +17,11 @@
         "karma-sauce-launcher-fix-firefox": "using a fork to work around https://github.com/karma-runner/karma-sauce-launcher/issues/275"
     },
     "devDependencies": {
-        "@lwc/compiler": "8.10.1",
-        "@lwc/engine-dom": "8.10.1",
-        "@lwc/engine-server": "8.10.1",
-        "@lwc/rollup-plugin": "8.10.1",
-        "@lwc/synthetic-shadow": "8.10.1",
+        "@lwc/compiler": "8.11.0",
+        "@lwc/engine-dom": "8.11.0",
+        "@lwc/engine-server": "8.11.0",
+        "@lwc/rollup-plugin": "8.11.0",
+        "@lwc/synthetic-shadow": "8.11.0",
         "@types/jasmine": "^5.1.4",
         "chokidar": "^4.0.1",
         "istanbul-lib-coverage": "^3.2.2",

--- a/packages/@lwc/integration-tests/package.json
+++ b/packages/@lwc/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-tests",
     "private": true,
-    "version": "8.10.1",
+    "version": "8.11.0",
     "scripts": {
         "build": "node scripts/build.js",
         "build:dev": "MODE=dev yarn build",
@@ -18,7 +18,7 @@
         "sauce:prod:ci": "MODE=prod yarn build:prod && MODE=prod ../../../scripts/ci/retry.sh wdio ./scripts/wdio.sauce.conf.js"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "8.10.1",
+        "@lwc/rollup-plugin": "8.11.0",
         "@wdio/cli": "^9.3.1",
         "@wdio/local-runner": "^9.3.1",
         "@wdio/mocha-framework": "^9.2.8",
@@ -27,7 +27,7 @@
         "@wdio/static-server-service": "^9.2.2",
         "deepmerge": "^4.3.1",
         "dotenv": "^16.4.5",
-        "lwc": "8.10.1",
+        "lwc": "8.11.0",
         "minimist": "^1.2.8",
         "webdriverio": "^9.0.7"
     }

--- a/packages/@lwc/integration-types/package.json
+++ b/packages/@lwc/integration-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lwc/integration-types",
     "private": true,
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Type validation for LWC packages",
     "type": "module",
     "scripts": {
@@ -9,8 +9,8 @@
         "playground": "rollup -c src/playground/rollup.config.js --watch"
     },
     "dependencies": {
-        "@lwc/rollup-plugin": "8.10.1",
-        "lwc": "8.10.1"
+        "@lwc/rollup-plugin": "8.11.0",
+        "lwc": "8.11.0"
     },
     "devDependencies": {
         "@rollup/plugin-replace": "^6.0.1",

--- a/packages/@lwc/module-resolver/package.json
+++ b/packages/@lwc/module-resolver/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/module-resolver",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Resolves paths for LWC components",
     "keywords": [
         "lwc"

--- a/packages/@lwc/perf-benchmarks-components/package.json
+++ b/packages/@lwc/perf-benchmarks-components/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lwc/perf-benchmarks-components",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c ./rollup.config.mjs"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "8.10.1"
+        "@lwc/rollup-plugin": "8.11.0"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lwc/perf-benchmarks",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "private": true,
     "scripts": {
         "build": "rm -fr dist && rollup -c  ./rollup.config.mjs && node scripts/build.js && ./scripts/fix-deps.sh",
@@ -15,11 +15,11 @@
         "Don't forget to add these to fix-deps.sh as well."
     ],
     "dependencies": {
-        "@lwc/engine-dom": "8.10.1",
-        "@lwc/engine-server": "8.10.1",
-        "@lwc/perf-benchmarks-components": "8.10.1",
-        "@lwc/ssr-runtime": "8.10.1",
-        "@lwc/synthetic-shadow": "8.10.1"
+        "@lwc/engine-dom": "8.11.0",
+        "@lwc/engine-server": "8.11.0",
+        "@lwc/perf-benchmarks-components": "8.11.0",
+        "@lwc/ssr-runtime": "8.11.0",
+        "@lwc/synthetic-shadow": "8.11.0"
     },
     "devDependencies": {
         "@best/cli": "^13.0.0",

--- a/packages/@lwc/rollup-plugin/package.json
+++ b/packages/@lwc/rollup-plugin/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/rollup-plugin",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Rollup plugin to compile LWC",
     "keywords": [
         "lwc"
@@ -42,13 +42,13 @@
         }
     },
     "dependencies": {
-        "@lwc/compiler": "8.10.1",
-        "@lwc/module-resolver": "8.10.1",
-        "@lwc/shared": "8.10.1",
+        "@lwc/compiler": "8.11.0",
+        "@lwc/module-resolver": "8.11.0",
+        "@lwc/shared": "8.11.0",
         "@rollup/pluginutils": "~5.1.3"
     },
     "devDependencies": {
-        "@lwc/errors": "8.10.1"
+        "@lwc/errors": "8.11.0"
     },
     "peerDependencies": {
         "rollup": "^1.2.0||^2.0.0||^3.0.0||^4.0.0"

--- a/packages/@lwc/shared/package.json
+++ b/packages/@lwc/shared/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/shared",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Utilities and methods that are shared across packages",
     "keywords": [
         "lwc"

--- a/packages/@lwc/signals/package.json
+++ b/packages/@lwc/signals/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/signals",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Provides the interface to interact with reactivity from outside the framework",
     "keywords": [
         "lwc"
@@ -42,6 +42,6 @@
         }
     },
     "devDependencies": {
-        "@lwc/shared": "8.10.1"
+        "@lwc/shared": "8.11.0"
     }
 }

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/ssr-compiler",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Compile component for use during server-side rendering",
     "keywords": [
         "compiler",
@@ -44,9 +44,9 @@
         }
     },
     "dependencies": {
-        "@lwc/shared": "8.10.1",
-        "@lwc/errors": "8.10.1",
-        "@lwc/template-compiler": "8.10.1",
+        "@lwc/shared": "8.11.0",
+        "@lwc/errors": "8.11.0",
+        "@lwc/template-compiler": "8.11.0",
         "acorn": "8.14.0",
         "astring": "^1.9.0",
         "estree-toolkit": "^1.7.8",

--- a/packages/@lwc/ssr-runtime/package.json
+++ b/packages/@lwc/ssr-runtime/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/ssr-runtime",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Runtime complement to @lwc/ssr-compiler",
     "keywords": [
         "lwc",
@@ -44,8 +44,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/shared": "8.10.1",
-        "@lwc/engine-core": "8.10.1",
+        "@lwc/shared": "8.11.0",
+        "@lwc/engine-core": "8.11.0",
         "observable-membrane": "2.0.0"
     }
 }

--- a/packages/@lwc/style-compiler/package.json
+++ b/packages/@lwc/style-compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/style-compiler",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Transform style sheet to be consumed by the LWC engine",
     "keywords": [
         "lwc"
@@ -42,7 +42,7 @@
         }
     },
     "dependencies": {
-        "@lwc/shared": "8.10.1",
+        "@lwc/shared": "8.11.0",
         "postcss": "~8.4.49",
         "postcss-selector-parser": "~7.0.0",
         "postcss-value-parser": "~4.2.0"

--- a/packages/@lwc/synthetic-shadow/package.json
+++ b/packages/@lwc/synthetic-shadow/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/synthetic-shadow",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Synthetic Shadow Root for LWC",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/features": "8.10.1",
-        "@lwc/shared": "8.10.1"
+        "@lwc/features": "8.11.0",
+        "@lwc/shared": "8.11.0"
     },
     "lwc": {
         "modules": [

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/template-compiler",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Template compiler package",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "dependencies": {
-        "@lwc/errors": "8.10.1",
-        "@lwc/shared": "8.10.1",
+        "@lwc/errors": "8.11.0",
+        "@lwc/shared": "8.11.0",
         "acorn": "~8.14.0",
         "astring": "~1.9.0",
         "he": "~1.2.0"

--- a/packages/@lwc/types/package.json
+++ b/packages/@lwc/types/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/types",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "keywords": [
         "lwc",
         "types",
@@ -29,6 +29,6 @@
         "*.d.ts"
     ],
     "dependencies": {
-        "@lwc/engine-core": "8.10.1"
+        "@lwc/engine-core": "8.11.0"
     }
 }

--- a/packages/@lwc/wire-service/package.json
+++ b/packages/@lwc/wire-service/package.json
@@ -4,7 +4,7 @@
         "You can safely modify dependencies, devDependencies, keywords, etc., but other props will be overwritten."
     ],
     "name": "@lwc/wire-service",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "@wire service",
     "keywords": [
         "lwc"
@@ -42,8 +42,8 @@
         }
     },
     "devDependencies": {
-        "@lwc/engine-core": "8.10.1",
-        "@lwc/shared": "8.10.1"
+        "@lwc/engine-core": "8.11.0",
+        "@lwc/shared": "8.11.0"
     },
     "lwc": {
         "modules": [

--- a/packages/lwc/package.json
+++ b/packages/lwc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Lightning Web Components (LWC)",
     "homepage": "https://lwc.dev/",
     "repository": {
@@ -21,24 +21,24 @@
         "!vitest.config.*"
     ],
     "dependencies": {
-        "@lwc/aria-reflection": "8.10.1",
-        "@lwc/babel-plugin-component": "8.10.1",
-        "@lwc/compiler": "8.10.1",
-        "@lwc/engine-core": "8.10.1",
-        "@lwc/engine-dom": "8.10.1",
-        "@lwc/engine-server": "8.10.1",
-        "@lwc/errors": "8.10.1",
-        "@lwc/features": "8.10.1",
-        "@lwc/module-resolver": "8.10.1",
-        "@lwc/rollup-plugin": "8.10.1",
-        "@lwc/shared": "8.10.1",
-        "@lwc/ssr-compiler": "8.10.1",
-        "@lwc/ssr-runtime": "8.10.1",
-        "@lwc/style-compiler": "8.10.1",
-        "@lwc/synthetic-shadow": "8.10.1",
-        "@lwc/template-compiler": "8.10.1",
-        "@lwc/types": "8.10.1",
-        "@lwc/wire-service": "8.10.1"
+        "@lwc/aria-reflection": "8.11.0",
+        "@lwc/babel-plugin-component": "8.11.0",
+        "@lwc/compiler": "8.11.0",
+        "@lwc/engine-core": "8.11.0",
+        "@lwc/engine-dom": "8.11.0",
+        "@lwc/engine-server": "8.11.0",
+        "@lwc/errors": "8.11.0",
+        "@lwc/features": "8.11.0",
+        "@lwc/module-resolver": "8.11.0",
+        "@lwc/rollup-plugin": "8.11.0",
+        "@lwc/shared": "8.11.0",
+        "@lwc/ssr-compiler": "8.11.0",
+        "@lwc/ssr-runtime": "8.11.0",
+        "@lwc/style-compiler": "8.11.0",
+        "@lwc/synthetic-shadow": "8.11.0",
+        "@lwc/template-compiler": "8.11.0",
+        "@lwc/types": "8.11.0",
+        "@lwc/wire-service": "8.11.0"
     },
     "lwc": {
         "modules": [

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@lwc/playground",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "type": "module",
     "description": "Playground project to experiment with LWC.",
     "scripts": {
@@ -9,9 +9,9 @@
         "build": "NODE_ENV=production rollup -c"
     },
     "devDependencies": {
-        "@lwc/rollup-plugin": "8.10.1",
+        "@lwc/rollup-plugin": "8.11.0",
         "@rollup/plugin-replace": "^6.0.1",
-        "lwc": "8.10.1",
+        "lwc": "8.11.0",
         "rollup": "^4.27.4",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^3.0.0"


### PR DESCRIPTION
## Details

Minor version bump for CLCO. 8.10.x series is now for `spring25`.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
