### PR TITLE
fix(rollup-plugin): remove undeclared dependency on ssr-compiler

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -5,9 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { CompilerValidationErrors, invariant } from '@lwc/errors';
-import { isUndefined, isBoolean, getAPIVersionFromNumber, DEFAULT_SSR_MODE } from '@lwc/shared';
+import {
+    isUndefined,
+    isBoolean,
+    getAPIVersionFromNumber,
+    DEFAULT_SSR_MODE,
+    type CompilationMode,
+} from '@lwc/shared';
 import type { InstrumentationObject } from '@lwc/errors';
-import type { CompilationMode } from '@lwc/ssr-compiler';
 import type { CustomRendererConfig } from '@lwc/template-compiler';
 
 /**

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -16,9 +16,8 @@ import type { Plugin, SourceMapInput, RollupLog } from 'rollup';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { StylesheetConfig, DynamicImportConfig } from '@lwc/compiler';
 import type { ModuleRecord } from '@lwc/module-resolver';
-import type { APIVersion } from '@lwc/shared';
+import type { APIVersion, CompilationMode } from '@lwc/shared';
 import type { CompilerDiagnostic } from '@lwc/errors';
-import type { CompilationMode } from '@lwc/ssr-compiler';
 
 export interface RollupLwcOptions {
     /** A boolean indicating whether to compile for SSR runtime target. */

--- a/packages/@lwc/shared/src/ssr.ts
+++ b/packages/@lwc/shared/src/ssr.ts
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-export const DEFAULT_SSR_MODE = 'sync';
+
+/* SSR compilation mode. `async` refers to async functions, `sync` to sync functions, and `asyncYield` to async generator functions. */
+export type CompilationMode = 'asyncYield' | 'async' | 'sync';
+
+export const DEFAULT_SSR_MODE: CompilationMode = 'sync';

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -19,7 +19,7 @@ import { catalogWireAdapters } from './wire';
 import { removeDecoratorImport } from './remove-decorator-import';
 import type { Identifier as EsIdentifier, Program as EsProgram, Expression } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
-import type { CompilationMode } from '../shared';
+import type { CompilationMode } from '@lwc/shared';
 import type {
     PropertyDefinition as DecoratatedPropertyDefinition,
     MethodDefinition as DecoratatedMethodDefinition,

--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -16,7 +16,7 @@ import { transmogrify } from '../transmogrify';
 import { optimizeAdjacentYieldStmts } from './shared';
 import { templateIrToEsTree } from './ir-to-es';
 import type { ExportDefaultDeclaration as EsExportDefaultDeclaration } from 'estree';
-import type { CompilationMode } from '../shared';
+import type { CompilationMode } from '@lwc/shared';
 
 // TODO [#4663]: Render mode mismatch between template and compiler should throw.
 const bExportTemplate = esTemplate`

--- a/packages/@lwc/ssr-compiler/src/index.ts
+++ b/packages/@lwc/ssr-compiler/src/index.ts
@@ -5,17 +5,15 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { DEFAULT_SSR_MODE, generateCustomElementTagName } from '@lwc/shared';
+import { DEFAULT_SSR_MODE, type CompilationMode, generateCustomElementTagName } from '@lwc/shared';
 import compileJS from './compile-js';
 import compileTemplate from './compile-template';
-import type { CompilationMode, TransformOptions } from './shared';
+import type { TransformOptions } from './shared';
 
 export interface CompilationResult {
     code: string;
     map: unknown;
 }
-
-export type { CompilationMode };
 
 export function compileComponentForSSR(
     src: string,

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -60,9 +60,6 @@ export interface IHoistInstantiation {
 
 export type TransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
 
-/* SSR compilation mode. `async` refers to async functions, `sync` to sync functions, and `asyncYield` to async generator functions. */
-export type CompilationMode = 'asyncYield' | 'async' | 'sync';
-
 // This is a mostly-correct regular expression will only match if the entire string
 // provided is a valid ECMAScript identifier. Its imperfections lie in the fact that
 // it will match strings like "export" when "export" is actually a reserved keyword


### PR DESCRIPTION
## Details

Rollup plugin currently has an undeclared dependency on `@lwc/ssr-compiler` only to use the type `CompilationMode`.

Rather than declaring the dependency and since `@lwc/shared` already exports the constant `DEFAULT_SSR_MODE`, I think it's best that this type is moved there.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
