### PR TITLE
chore(git2gus): integrate is lame

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,5 +1,6 @@
 {
     "productTag": "a1aB0000000g309IAA",
     "defaultBuild": "252",
-    "hideWorkItemUrl": true
+    "hideWorkItemUrl": true,
+    "statusWhenClosed": "CLOSED"
 }


### PR DESCRIPTION
We never pay attention to the distinction between integrate/closed, so this just saves a few clicks.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
