### PR TITLE
test(module-resolver): fix custom matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "@vitest/coverage-v8": "^2.1.5",
         "@vitest/eslint-plugin": "^1.1.10",
         "@vitest/ui": "^2.1.5",
-        "@vitest/utils": "^2.1.2",
         "bytes": "^3.1.2",
         "es-module-lexer": "^1.5.4",
         "eslint": "9.15.0",

--- a/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-code.ts
+++ b/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-code.ts
@@ -4,16 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-import diff from '@vitest/utils/diff';
-import type { MatcherState } from '@vitest/expect';
+import type { ExpectationResult, MatcherState } from '@vitest/expect';
 
 export function toThrowErrorWithCode(
     this: MatcherState,
     received: any,
     code: string,
     message?: string
-) {
+): ExpectationResult {
     let error: Error | undefined;
 
     try {
@@ -31,28 +29,24 @@ export function toThrowErrorWithCode(
 
     if (error === null || typeof error !== 'object' || (error as any).code !== code) {
         return {
-            message: () =>
-                `Expected function to throw an error with code \n\n` +
-                `Expected ${this.utils.printExpected(code)}\n` +
-                `Received ${this.utils.printReceived((error as any).code)}`,
+            message: () => `Expected function to throw an error with code`,
+            expected: code,
+            actual: (error as any).code,
             pass: false,
         };
     }
 
     if (error.message !== message) {
-        const errorDiff = diff.diffStringsUnified(message!, error.message);
         return {
-            message: () =>
-                `Expected function to throw an error with message\n\n` +
-                `Difference ${errorDiff}\n` +
-                `Expected ${this.utils.printExpected(message)}\n` +
-                `Received ${this.utils.printReceived(error!.message)}`,
+            message: () => 'Expected function to throw an error with message',
+            expected: message,
+            actual: error.message,
             pass: false,
         };
     }
 
     return {
-        message: () => `Expected function not to throw an error`,
+        message: () => 'Expected function not to throw an error',
         pass: true,
     };
 }

--- a/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-type.ts
+++ b/packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-type.ts
@@ -4,16 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-import diff from '@vitest/utils/diff';
-import type { MatcherState } from '@vitest/expect';
+import type { ExpectationResult, MatcherState } from '@vitest/expect';
 
 export function toThrowErrorWithType(
     this: MatcherState,
     received: any,
-    ctor: any,
+    ctor: ErrorConstructor,
     message?: string
-) {
+): ExpectationResult {
     let error: Error | undefined;
 
     try {
@@ -31,28 +29,24 @@ export function toThrowErrorWithType(
 
     if (error === null || typeof error !== 'object' || error.constructor !== ctor) {
         return {
-            message: () =>
-                `Expected function to throw an instance of\n\n` +
-                `Expected ${this.utils.printExpected(ctor.name)}\n` +
-                `Received ${this.utils.printReceived(error!.constructor.name)}`,
+            message: () => 'Expected function to throw an instance of',
+            expected: ctor.name,
+            actual: error.constructor.name,
             pass: false,
         };
     }
 
     if (error.message !== message) {
-        const errorDiff = diff.diffStringsUnified(message!, error.message);
         return {
-            message: () =>
-                `Expected function to throw an error with message\n\n` +
-                `Difference ${errorDiff}\n` +
-                `Expected ${this.utils.printExpected(message)}\n` +
-                `Received ${this.utils.printReceived(error!.message)}`,
+            message: () => 'Expected function to throw an error with message',
+            expected: message,
+            actual: error.message,
             pass: false,
         };
     }
 
     return {
-        message: () => `Expected function not to throw an error`,
+        message: () => 'Expected function not to throw an error',
         pass: true,
     };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,9 +2060,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4", "@napi-rs/wasm-runtime@^0.2.4":
   version "0.2.4"
@@ -3317,7 +3319,7 @@
     tinyglobby "^0.2.10"
     tinyrainbow "^1.2.0"
 
-"@vitest/utils@2.1.5", "@vitest/utils@^2.1.2":
+"@vitest/utils@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.5.tgz#0e19ce677c870830a1573d33ee86b0d6109e9546"
   integrity sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==


### PR DESCRIPTION
## Details

Turns out these matchers were broken, but went unnoticed because tests were passing. `diffStringsUnified` was supposed to be a named import and was undefined here. We don't need it with vitest since we can return `expected` and `actual` in the matcher result, so I just removed the '@vitest/utils' dependency altogether.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
