### PR TITLE
chore(ssr): disable snapshot updates in fixtures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/runner.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/runner.ts
@@ -1,0 +1,19 @@
+import { VitestTestRunner } from 'vitest/runners';
+import type { RunnerTask } from 'vitest';
+
+export default class SsrTestRunner extends VitestTestRunner {
+    override onAfterRunTask(task: RunnerTask): void {
+        // In the test file `src/__tests__/fixtures.spec.ts` we are matching snapshots from engine-server
+        // We want to avoid updating snapshots here, so we replace 'Snapshot' with 'SSR Fixture' in error messages
+        // This is a workaround while vitest does not provide a way to skip updating snapshots for specific tests
+        // https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/utils/tasks.ts#L12-L20
+        // This shouldn't be a problem in CI, as updating snapshots is globally disabled
+        if (task.file.name === 'src/__tests__/fixtures.spec.ts') {
+            task.result?.errors?.forEach((error) => {
+                error.message = error.message.replaceAll('Snapshot', 'SSR Fixture');
+            });
+        }
+
+        return super.onAfterRunTask(task);
+    }
+}

--- a/packages/@lwc/ssr-compiler/vitest.config.mjs
+++ b/packages/@lwc/ssr-compiler/vitest.config.mjs
@@ -5,6 +5,7 @@ export default mergeConfig(
     baseConfig,
     defineProject({
         test: {
+            runner: './src/__tests__/utils/runner.ts',
             name: 'lwc-ssr-compiler',
         },
     })


### PR DESCRIPTION
## Details

This avoids accidentally updating snapshots from the ssr fixtures.

Besides hitting the 'u' button accidentally, it can happen when adding new tests and rerunning everything ( eg: #4958 ).

Not sure it's worth it just for this, but in a future PR the custom runner could be used to verify changes in the expected failures to spot regressions or improvements.

### Before
<img width="742" alt="Screenshot 2024-11-27 at 12 38 16" src="https://github.com/user-attachments/assets/0bd63926-2e55-4f26-aa98-8bc99f126404">

### After

<img width="745" alt="Screenshot 2024-11-27 at 12 36 22" src="https://github.com/user-attachments/assets/c1bf7439-5edb-49d4-8cf8-e827360c2b8d">


## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
