### PR TITLE
[DO NOT MERGE] Trigger CI for #4968: chore(ssr): disable snapshot updates in fixtures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/runner.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/runner.ts
@@ -1,0 +1,19 @@
+import { VitestTestRunner } from 'vitest/runners';
+import type { RunnerTask } from 'vitest';
+
+export default class SsrTestRunner extends VitestTestRunner {
+    override onAfterRunTask(task: RunnerTask): void {
+        // In the test file `src/__tests__/fixtures.spec.ts` we are matching snapshots from engine-server
+        // We want to avoid updating snapshots here, so we replace 'Snapshot' with 'SSR Fixture' in error messages
+        // This is a workaround while vitest does not provide a way to skip updating snapshots for specific tests
+        // https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/utils/tasks.ts#L12-L20
+        // This shouldn't be a problem in CI, as updating snapshots is globally disabled
+        if (task.file.name === 'src/__tests__/fixtures.spec.ts') {
+            task.result?.errors?.forEach((error) => {
+                error.message = error.message.replaceAll('Snapshot', 'SSR Fixture');
+            });
+        }
+
+        return super.onAfterRunTask(task);
+    }
+}

--- a/packages/@lwc/ssr-compiler/vitest.config.mjs
+++ b/packages/@lwc/ssr-compiler/vitest.config.mjs
@@ -5,6 +5,7 @@ export default mergeConfig(
     baseConfig,
     defineProject({
         test: {
+            runner: './src/__tests__/utils/runner.ts',
             name: 'lwc-ssr-compiler',
         },
     })


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4968.