### PR TITLE
chore(test-utils): check parent directories for .only

### DIFF
--- a/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
+++ b/packages/@lwc/integration-karma/scripts/karma-plugins/hydration-tests.js
@@ -176,6 +176,16 @@ async function getTestModuleCode(input) {
     return { code, watchFiles };
 }
 
+async function existsUp(dir, file) {
+    while (true) {
+        if (await exists(path.join(dir, file))) return true;
+        dir = path.join(dir, '..');
+        const basename = path.basename(dir);
+        // We should always hit __tests__, but check for system root as an escape hatch
+        if (basename === '__tests__' || basename === '') return false;
+    }
+}
+
 function createHCONFIG2JSPreprocessor(config, logger, emitter) {
     const { basePath } = config;
     const log = logger.create('preprocessor-lwc');
@@ -193,7 +203,7 @@ function createHCONFIG2JSPreprocessor(config, logger, emitter) {
             const { code: componentDef, watchFiles: componentWatchFiles } =
                 await getCompiledModule(suiteDir);
             // You can add an `.only` file alongside an `index.spec.js` file to make it `fdescribe()`
-            const onlyFileExists = await exists(path.join(suiteDir, '.only'));
+            const onlyFileExists = await existsUp(suiteDir, '.only');
 
             const ssrOutput = getSsrCode(componentDef, testCode, path.join(suiteDir, 'ssr.js'));
 

--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -14,6 +14,16 @@ const { globSync } = glob;
 
 type TestFixtureOutput = { [filename: string]: unknown };
 
+function existsUp(dir: string, file: string): boolean {
+    while (true) {
+        if (fs.existsSync(path.join(dir, file))) return true;
+        dir = path.join(dir, '..');
+        const basename = path.basename(dir);
+        // We should always hit __tests__, but check for system root as an escape hatch
+        if (basename === '__tests__' || basename === '') return false;
+    }
+}
+
 /**
  * Facilitates the use of vitest's `test.only`/`test.skip` in fixture files.
  * @param dirname fixture directory to check for "directive" files
@@ -22,8 +32,8 @@ type TestFixtureOutput = { [filename: string]: unknown };
  * @example getTestOptions('/fixtures/some-test')
  */
 function getTestOptions(dirname: string) {
-    const isOnly = fs.existsSync(path.join(dirname, '.only'));
-    const isSkip = fs.existsSync(path.join(dirname, '.skip'));
+    const isOnly = existsUp(dirname, '.only');
+    const isSkip = existsUp(dirname, '.skip');
     if (isOnly && isSkip) {
         const relpath = path.relative(process.cwd(), dirname);
         throw new Error(`Cannot have both .only and .skip in ${relpath}`);


### PR DESCRIPTION
## Details

Currently, we can put `.only` in a fixture directory to focus on that test. But we also sometimes group similar fixtures into directories, so it would be nice to be able to just put a single `.only` in that directory. Now we can!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.
-   💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.
-   🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
