### PR TITLE
fix(ssr): correct import alias for generateMarkup symbol in lwc-component

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -22,7 +22,6 @@ export const expectedFailures = new Set([
     'attribute-namespace/index.js',
     'attribute-style/basic/index.js',
     'attribute-style/dynamic/index.js',
-    'dynamic-components/mixed/index.js',
     'dynamic-slots/index.js',
     'exports/component-as-default/index.js',
     'if-conditional-slot-content/index.js',

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
@@ -37,7 +37,7 @@ const bYieldFromDynamicComponentConstructorGenerator = esTemplateWithYield`
 
         const scopeToken = hasScopedStylesheets ? stylesheetScopeToken : undefined;
 
-        yield* Ctor[SYMBOL__GENERATE_MARKUP](
+        yield* Ctor[__SYMBOL__GENERATE_MARKUP](
             null, 
             childProps,
             childAttrs,
@@ -56,7 +56,7 @@ export const LwcComponent: Transformer<IrLwcComponent> = function LwcComponent(n
         cxt.import({
             getReadOnlyProxy: '__getReadOnlyProxy',
             LightningElement: undefined,
-            SYMBOL__GENERATE_MARKUP: undefined,
+            SYMBOL__GENERATE_MARKUP: '__SYMBOL__GENERATE_MARKUP',
         });
 
         return bYieldFromDynamicComponentConstructorGenerator(


### PR DESCRIPTION
## Details

Fixes 1 expected failure: `dynamic-components/mixed/index.js`

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

-   😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

-   🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
