### PR TITLE
[DO NOT MERGE] Trigger CI for #4975: fix(ssr): correct import alias for generateMarkup symbol in lwc-component

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -22,7 +22,6 @@ export const expectedFailures = new Set([
     'attribute-namespace/index.js',
     'attribute-style/basic/index.js',
     'attribute-style/dynamic/index.js',
-    'dynamic-components/mixed/index.js',
     'dynamic-slots/index.js',
     'exports/component-as-default/index.js',
     'if-conditional-slot-content/index.js',

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
@@ -37,7 +37,7 @@ const bYieldFromDynamicComponentConstructorGenerator = esTemplateWithYield`
 
         const scopeToken = hasScopedStylesheets ? stylesheetScopeToken : undefined;
 
-        yield* Ctor[SYMBOL__GENERATE_MARKUP](
+        yield* Ctor[__SYMBOL__GENERATE_MARKUP](
             null, 
             childProps,
             childAttrs,
@@ -56,7 +56,7 @@ export const LwcComponent: Transformer<IrLwcComponent> = function LwcComponent(n
         cxt.import({
             getReadOnlyProxy: '__getReadOnlyProxy',
             LightningElement: undefined,
-            SYMBOL__GENERATE_MARKUP: undefined,
+            SYMBOL__GENERATE_MARKUP: '__SYMBOL__GENERATE_MARKUP',
         });
 
         return bYieldFromDynamicComponentConstructorGenerator(


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #4975.