### PR TITLE
test(ssr): add fixture for computed prop exploding

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/error.txt
@@ -1,0 +1,1 @@
+get bothDecorated should not be called

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/error.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/error.txt
@@ -1,1 +1,1 @@
-get bothDecorated should not be called
+getter should not be called

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-wire';
+export { default } from 'x/wire';
+export * from 'x/wire';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/adapter.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/adapter.js
@@ -1,0 +1,13 @@
+export class adapter {
+    constructor(dataCallback) {
+        this.dc = dataCallback;
+    }
+
+    connect() {}
+
+    update(config) {
+        this.dc(config.name);
+    }
+
+    disconnect() {}
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.html
@@ -1,0 +1,3 @@
+<template>
+    {exposedSymbol}
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.js
@@ -5,12 +5,12 @@ const sym = Symbol('computed prop');
 export default class Wire extends LightningElement {
     @wire(adapter, { name: 'symbol' })
     get [sym]() {
-        throw new Error('get bothDecorated should not be called');
+        throw new Error('getter should not be called');
     }
 
     @wire(adapter, { name: 'symbol' })
     set [sym](v) {
-        throw new Error('set bothDecorated should not be called');
+        throw new Error('setter should not be called');
     }
 
     get exposedSymbol() {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-key/modules/x/wire/wire.js
@@ -1,0 +1,19 @@
+import { LightningElement, wire } from 'lwc';
+import { adapter } from './adapter';
+const sym = Symbol('computed prop');
+
+export default class Wire extends LightningElement {
+    @wire(adapter, { name: 'symbol' })
+    get [sym]() {
+        throw new Error('get bothDecorated should not be called');
+    }
+
+    @wire(adapter, { name: 'symbol' })
+    set [sym](v) {
+        throw new Error('set bothDecorated should not be called');
+    }
+
+    get exposedSymbol() {
+        return this[sym];
+    }
+}


### PR DESCRIPTION
## Details

Adds a fixture for #4988.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
