### PR TITLE
refactor(ssr): reduce duplicated text rendering logic

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
@@ -24,7 +24,7 @@ import type { Transformer } from '../types';
 
 const bBufferTextContent = esTemplateWithYield`
     didBufferTextContent = true;
-    textContentBuffer += renderTextContent(${/* string value */ is.expression});
+    textContentBuffer += massageTextContent(${/* string value */ is.expression});
 `<EsExpressionStatement[]>;
 
 function isLiteral(node: IrLiteral | IrExpression | IrComplexExpression): node is IrLiteral {
@@ -32,7 +32,7 @@ function isLiteral(node: IrLiteral | IrExpression | IrComplexExpression): node i
 }
 
 export const Text: Transformer<IrText> = function Text(node, cxt): EsStatement[] {
-    cxt.import(['htmlEscape', 'renderTextContent']);
+    cxt.import(['htmlEscape', 'massageTextContent']);
 
     const isLastInSeries = isLastConcatenatedNode(cxt);
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/text.ts
@@ -10,7 +10,10 @@ import { esTemplateWithYield } from '../../estemplate';
 import { expressionIrToEs } from '../expression';
 
 import { bYieldTextContent, isLastConcatenatedNode } from '../adjacent-text-nodes';
-import type { Statement as EsStatement } from 'estree';
+import type {
+    Statement as EsStatement,
+    ExpressionStatement as EsExpressionStatement,
+} from 'estree';
 import type {
     ComplexExpression as IrComplexExpression,
     Expression as IrExpression,
@@ -21,20 +24,15 @@ import type { Transformer } from '../types';
 
 const bBufferTextContent = esTemplateWithYield`
     didBufferTextContent = true;
-    {
-        const value = ${/* string value */ is.expression};
-        // Using non strict equality to align with original implementation (ex. undefined == null)
-        // See: https://github.com/salesforce/lwc/blob/348130f/packages/%40lwc/engine-core/src/framework/api.ts#L548
-        textContentBuffer += value == null ? '' : String(value);
-    }
-`<EsStatement[]>;
+    textContentBuffer += renderTextContent(${/* string value */ is.expression});
+`<EsExpressionStatement[]>;
 
 function isLiteral(node: IrLiteral | IrExpression | IrComplexExpression): node is IrLiteral {
     return node.type === 'Literal';
 }
 
 export const Text: Transformer<IrText> = function Text(node, cxt): EsStatement[] {
-    cxt.import('htmlEscape');
+    cxt.import(['htmlEscape', 'renderTextContent']);
 
     const isLastInSeries = isLastConcatenatedNode(cxt);
 

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -31,6 +31,7 @@ export {
     // renderComponent is an alias for serverSideRenderComponent
     serverSideRenderComponent as renderComponent,
 } from './render';
+export { renderTextContent } from './render-text-content';
 export { hasScopedStaticStylesheets, renderStylesheets } from './styles';
 export { toIteratorDirective } from './to-iterator-directive';
 export { validateStyleTextContents } from './validate-style-text-contents';

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -31,7 +31,7 @@ export {
     // renderComponent is an alias for serverSideRenderComponent
     serverSideRenderComponent as renderComponent,
 } from './render';
-export { renderTextContent } from './render-text-content';
+export { massageTextContent } from './render-text-content';
 export { hasScopedStaticStylesheets, renderStylesheets } from './styles';
 export { toIteratorDirective } from './to-iterator-directive';
 export { validateStyleTextContents } from './validate-style-text-contents';

--- a/packages/@lwc/ssr-runtime/src/render-text-content.ts
+++ b/packages/@lwc/ssr-runtime/src/render-text-content.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Given an object, render it for use as a text content node.
+ * @param value
+ */
+export function renderTextContent(value: any): string {
+    // Using non strict equality to align with original implementation (ex. undefined == null)
+    // See: https://github.com/salesforce/lwc/blob/348130f/packages/%40lwc/engine-core/src/framework/api.ts#L548
+    return value == null ? '' : String(value);
+}

--- a/packages/@lwc/ssr-runtime/src/render-text-content.ts
+++ b/packages/@lwc/ssr-runtime/src/render-text-content.ts
@@ -9,7 +9,7 @@
  * Given an object, render it for use as a text content node.
  * @param value
  */
-export function massageTextContent(value: any): string {
+export function massageTextContent(value: unknown): string {
     // Using non strict equality to align with original implementation (ex. undefined == null)
     // See: https://github.com/salesforce/lwc/blob/348130f/packages/%40lwc/engine-core/src/framework/api.ts#L548
     return value == null ? '' : String(value);

--- a/packages/@lwc/ssr-runtime/src/render-text-content.ts
+++ b/packages/@lwc/ssr-runtime/src/render-text-content.ts
@@ -9,7 +9,7 @@
  * Given an object, render it for use as a text content node.
  * @param value
  */
-export function renderTextContent(value: any): string {
+export function massageTextContent(value: any): string {
     // Using non strict equality to align with original implementation (ex. undefined == null)
     // See: https://github.com/salesforce/lwc/blob/348130f/packages/%40lwc/engine-core/src/framework/api.ts#L548
     return value == null ? '' : String(value);


### PR DESCRIPTION
## Details

I got bugged by seeing so much repeated code in the generated JS. So I extracted some of it into a shared runtime helper.

Before:

```js
didBufferTextContent = true;
{
  const value = instance.foo;
  textContentBuffer += value == null ? '' : String(value);
}
didBufferTextContent = true;
{
  const value = instance.bar;
  textContentBuffer += value == null ? '' : String(value);
}
didBufferTextContent = true;
{
  const value = instance.baz;
  textContentBuffer += value == null ? '' : String(value);
}
```

After:

```js
didBufferTextContent = true;
textContentBuffer += renderTextContent(instance.foo);
didBufferTextContent = true;
textContentBuffer += renderTextContent(instance.bar);
didBufferTextContent = true;
textContentBuffer += renderTextContent(instance.baz);
```

No we just need to have `optimizeAdjacentYieldStmts` also optimize for adjacent text content boilerplate, since Terser doesn't seem smart enough to collapse this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
