### PR TITLE
test(ssr): add fixture for lwc:if and comment with no text nodes

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/expected.html
@@ -1,0 +1,9 @@
+<x-comments-text>
+  <template shadowrootmode="open">
+    <!---->
+    ‍
+    <!---->
+    <!-- preserved comment after true -->
+    <!-- preserved comment after false -->
+  </template>
+</x-comments-text>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-comments-text';
+export { default } from 'x/comments-text';
+export * from 'x/comments-text';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/modules/x/comments-text/comments-text.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/modules/x/comments-text/comments-text.html
@@ -1,0 +1,6 @@
+<template lwc:preserve-comments>
+    <template lwc:if={isTrue}>{foo}{bar}{baz}</template>
+    <!-- preserved comment after true -->
+    <template lwc:if={isFalse}>{foo}{bar}{baz}</template>
+    <!-- preserved comment after false -->
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/modules/x/comments-text/comments-text.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/adjacent-text-nodes/preserve-comments-on/empty copy/modules/x/comments-text/comments-text.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    isTrue = true;
+    isFalse = false;
+    foo = '';
+    bar = undefined;
+    baz = null;
+}


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
