### PR TITLE
chore: use eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 .project/
 .nx
 .nx-cache
+.eslintcache
 
 lib/
 __benchmarks_results__/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "prepare": "husky && yarn build",
-        "lint": "eslint .",
+        "lint": "eslint . --cache",
         "format": "prettier --write .",
         "bundlesize": "node scripts/bundlesize/bundlesize.mjs",
         "build": "nx run-many --target=build --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests,lwc",

--- a/package.json
+++ b/package.json
@@ -74,11 +74,11 @@
         "vitest": "^2.1.8"
     },
     "lint-staged": {
-        "*.{js,mjs,ts}": "eslint",
+        "*.{js,mjs,ts}": "eslint --cache",
         "*.{css,js,json,md,mjs,ts,yaml,yml}": "prettier --write",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js",
         "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js",
-        "*.{only,skip}": "eslint --no-eslintrc --plugin '@lwc/eslint-plugin-lwc-internal' --rule '@lwc/lwc-internal/forbidden-filename: error'"
+        "*.{only,skip}": "eslint --cache --no-eslintrc --plugin '@lwc/eslint-plugin-lwc-internal' --rule '@lwc/lwc-internal/forbidden-filename: error'"
     },
     "workspaces": [
         "packages/@lwc/*",


### PR DESCRIPTION
## Details

Partially addresses #4911 . 

Linting currently takes almost 30s in my M1 Max 🤦 . I don't always run the lint command directly and lint-staged kinda does a similar job to caching, but when I have to this is definitely a help. 

```
% yarn lint
yarn run v1.22.22
$ eslint . --cache
✨  Done in 27.55s.
% yarn lint
yarn run v1.22.22
$ eslint . --cache
✨  Done in 1.72s.
```

Ref:
- https://eslint.org/docs/latest/use/command-line-interface#caching

This shouldn't affect CI.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
