### PR TITLE
chore: refine fixture error message

### DIFF
--- a/scripts/test-utils/test-fixture-dir.ts
+++ b/scripts/test-utils/test-fixture-dir.ts
@@ -194,7 +194,7 @@ export function testFixtureDir<T extends TestFixtureConfig>(
                                     ? outputName
                                     : otherName;
                                 const contentErr = new AssertionError({
-                                    message: `Expected content in ${expectedContentName}, but found content in ${actualContentName}.`,
+                                    message: `Expected ${relpath} to have content in ${expectedContentName}, but found content in ${actualContentName}.`,
                                     expected: brokenSnapshotHasContent
                                         ? brokenSnapshot
                                         : otherSnapshot,


### PR DESCRIPTION
## Details

In #4985, I updated the fixtures to have a custom error when we go from having `expected.html` to `error.txt`, or vice versa. However, vitest tries to be clever and merges test output that has the same error message. This isn't helpful when the underlying errors are completely different, so I added the fixture name to the error message to avoid deduping.

**Before:**

```vitest
 FAIL |lwc-ssr-compiler|  src/__tests__/fixtures.spec.ts > fixtures > scoped-slots/expression/index.js
 FAIL |lwc-ssr-compiler|  src/__tests__/fixtures.spec.ts > fixtures > exports/component-as-default/index.js
AssertionError: Expected content in expected.html, but found content in error.txt.

- Expected
+ Received

- <x-parent>
-   <template shadowrootmode="open">
-     <x-child>
-       <div>
-         <!---->
-         <!---->
-         <span>
-           99
-         </span>
-         <!---->
-         <!---->
-       </div>
-     </x-child>
-   </template>
- </x-parent>
+ mySlot is not defined
```

**After:**
```vitest
 FAIL |lwc-ssr-compiler|  src/__tests__/fixtures.spec.ts > fixtures > scoped-slots/expression/index.js
AssertionError: Expected scoped-slots/expression/index.js to have content in expected.html, but found content in error.txt.

- Expected
+ Received

- <x-parent>
-   <template shadowrootmode="open">
-     <x-child>
-       <div>
-         <!---->
-         <!---->
-         <span>
-           99
-         </span>
-         <!---->
-         <!---->
-       </div>
-     </x-child>
-   </template>
- </x-parent>
+ mySlot is not defined

 FAIL |lwc-ssr-compiler|  src/__tests__/fixtures.spec.ts > fixtures > exports/component-as-default/index.js
AssertionError: Expected exports/component-as-default/index.js to have content in expected.html, but found content in error.txt.

- Expected
+ Received

- <x-cmp>
-   <template shadowrootmode="open">
-   </template>
- </x-cmp>
+ generateMarkup is not a function
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
