### PR TITLE
chore: add work items to expected failures

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -7,43 +7,107 @@
 
 // We should slowly drive down these test failures or at least document where we expect the failures
 // TODO [#4815]: enable all SSR v2 tests
-export const expectedFailures = new Set([
-    'attribute-aria/dynamic/index.js',
-    'attribute-class/with-scoped-styles-only-in-child/dynamic/index.js',
-    'attribute-class/with-scoped-styles/dynamic/index.js',
-    'attribute-component-global-html/index.js',
-    'attribute-global-html/as-component-prop/undeclared/index.js',
-    'attribute-global-html/as-component-prop/without-@api/index.js',
-    'attribute-namespace/index.js',
-    'attribute-style/basic/index.js',
-    'attribute-style/dynamic/index.js',
-    'exports/component-as-default/index.js',
-    'known-boolean-attributes/default-def-html-attributes/static-on-component/index.js',
-    'render-dynamic-value/index.js',
-    'scoped-slots/advanced/index.js',
-    'scoped-slots/expression/index.js',
-    'scoped-slots/mixed-with-light-dom-slots-inside/index.js',
-    'scoped-slots/mixed-with-light-dom-slots-outside/index.js',
-    'slot-forwarding/scoped-slots/index.js',
-    'slot-forwarding/slots/mixed/index.js',
-    'slot-forwarding/slots/dangling/index.js',
-    'slot-forwarding/slots/light/index.js',
-    'slot-not-at-top-level/advanced/lwcIf/light/index.js',
-    'slot-not-at-top-level/advanced/lwcIf/shadow/index.js',
-    'slot-not-at-top-level/lwcIf/light/index.js',
-    'slot-not-at-top-level/lwcIf/shadow/index.js',
-    'superclass/render-in-superclass/no-template-in-subclass/index.js',
-    'superclass/render-in-superclass/unused-default-in-subclass/index.js',
-    'superclass/render-in-superclass/unused-default-in-superclass/index.js',
-    'svgs/index.js',
-    'wire/errors/throws-on-computed-key/index.js',
-    'wire/errors/throws-when-colliding-prop-then-method/index.js',
-    'wire/errors/throws-when-computed-prop-is-expression/index.js',
-    'wire/errors/throws-when-computed-prop-is-let-variable/index.js',
-    'wire/errors/throws-when-computed-prop-is-regexp-literal/index.js',
-    'wire/errors/throws-when-computed-prop-is-template-literal/index.js',
-    'wire/errors/throws-when-using-2-wired-decorators/index.js',
-    'wire/errors/throws-when-wired-method-is-combined-with-@api/index.js',
-    'wire/errors/throws-when-wired-property-is-combined-with-@api/index.js',
-    'wire/errors/throws-when-wired-property-is-combined-with-@track/index.js',
-]);
+const workMap: Record<`W-${number}` | `TO BE FILED:${string}`, `${string}/index.js`[]> = {
+    'W-16871512': [
+        // self closing tags
+        'svgs/index.js',
+        // self-closing tag missing
+        'attribute-namespace/index.js',
+    ],
+    'W-17150207': [
+        // bookends and missing content
+        'scoped-slots/advanced/index.js',
+        // throws error
+        'scoped-slots/expression/index.js',
+        // throws error
+        'scoped-slots/mixed-with-light-dom-slots-inside/index.js',
+        // renders content, but it shouldn't
+        'scoped-slots/mixed-with-light-dom-slots-outside/index.js',
+    ],
+    'W-17150130': [
+        // bonus bookends
+        'slot-not-at-top-level/advanced/lwcIf/light/index.js',
+        // bonus bookends
+        'slot-not-at-top-level/advanced/lwcIf/shadow/index.js',
+        // bonus bookends
+        'slot-not-at-top-level/lwcIf/light/index.js',
+        // bonus bookends
+        'slot-not-at-top-level/lwcIf/shadow/index.js',
+    ],
+    'W-17017336': [
+        // bonus bookends
+        'slot-forwarding/scoped-slots/index.js',
+        // missing slot attr, bonus bookends
+        'slot-forwarding/slots/mixed/index.js',
+        // missing slot attr, bonus bookends
+        'slot-forwarding/slots/dangling/index.js',
+        // bonus bookends
+        'slot-forwarding/slots/light/index.js',
+    ],
+    'TO BE FILED: align error messages': [
+        // divergent error
+        'wire/errors/throws-on-computed-key/index.js',
+        // divergent error
+        'wire/errors/throws-when-colliding-prop-then-method/index.js',
+        // divergent error
+        'wire/errors/throws-when-computed-prop-is-expression/index.js',
+        // divergent error
+        'wire/errors/throws-when-computed-prop-is-let-variable/index.js',
+        // divergent error
+        'wire/errors/throws-when-computed-prop-is-regexp-literal/index.js',
+        // divergent error
+        'wire/errors/throws-when-computed-prop-is-template-literal/index.js',
+        // divergent error
+        'wire/errors/throws-when-using-2-wired-decorators/index.js',
+    ],
+    'TO BE FILED: add validation': [
+        // renders but shouldn't
+        'wire/errors/throws-when-wired-method-is-combined-with-@api/index.js',
+        // renders but shouldn't
+        'wire/errors/throws-when-wired-property-is-combined-with-@api/index.js',
+        // renders but shouldn't
+        'wire/errors/throws-when-wired-property-is-combined-with-@track/index.js',
+    ],
+    'TO BE FILED: fix superclass rendering': [
+        // missing content
+        'superclass/render-in-superclass/no-template-in-subclass/index.js',
+        // incorrect content
+        'superclass/render-in-superclass/unused-default-in-subclass/index.js',
+        // missing content
+        'superclass/render-in-superclass/unused-default-in-superclass/index.js',
+    ],
+    'TO BE FILED: ARIA': [
+        // aria attributes not rendered
+        'attribute-aria/dynamic/index.js',
+    ],
+    'TO BE FILED: global attributes': [
+        // some props not rendered
+        'attribute-component-global-html/index.js',
+        // incorrect values rendered
+        'attribute-global-html/as-component-prop/undeclared/index.js',
+        // incorrect draggable rendered
+        'known-boolean-attributes/default-def-html-attributes/static-on-component/index.js',
+    ],
+    'TO BE FILED: style': [
+        // incorrect style rendered
+        'attribute-style/basic/index.js',
+        // incorrect style rendered
+        'attribute-style/dynamic/index.js',
+    ],
+    'TO BE FILED: scope token': [
+        // scope token not rendered
+        'attribute-class/with-scoped-styles-only-in-child/dynamic/index.js',
+        // scope token not rendered
+        'attribute-class/with-scoped-styles/dynamic/index.js',
+    ],
+    'TO BE FILED: unique issues': [
+        // aria attributes not rendered
+        'attribute-global-html/as-component-prop/without-@api/index.js',
+        // test fixture formatting needs fixed?
+        'render-dynamic-value/index.js',
+        // throws error
+        'exports/component-as-default/index.js',
+    ],
+};
+
+export const expectedFailures = new Set(Object.values(workMap).flat());


### PR DESCRIPTION
## Details

For easier work tracking, changes the list of failures to a map from work item to failures

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
