### PR TITLE
feat: allow skip hydration for LWR islands

### DIFF
--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -368,6 +368,10 @@ function hydrateCustomElement(
     vnode: VCustomElement,
     renderer: RendererAPI
 ): Node | null {
+    if (elm.hasAttribute('data-lwc-skip-hydrate')) {
+        return elm;
+    }
+    
     const { validationOptOut } = vnode.ctor;
     const shouldValidateAttr = getValidationPredicate(elm, renderer, validationOptOut);
 


### PR DESCRIPTION
LWR islands hydration can be optimized by skipping hydration for children of hydrated parent nodes, e.g.:

```html
<!-- parent root component that requires hydration --> 
<my-cmp-island lwr-hydrate="load"> 
  <!-- child that needs hydration --> 
  <my-hydrate-child></my-hydrate-child>
  <!-- child that is SSR only (i.e. static), and can be skipped --> 
  <my-ssr-only-child data-lwc-skip-hydrate></my-ssr-only-child>
</my-cmp-island>
```

This has the benefit of:

- Avoiding unnecesary hydration compute on the browser
- Reducing LWR JS bundle size by not sending the JS for the child component

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

TD-0234873

