### PR TITLE
chore: test usage of default slot with scoped data

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/expected.html
@@ -1,0 +1,15 @@
+<x-parent>
+  <template shadowrootmode="open">
+    <x-child>
+      <div>
+        <!---->
+        <!---->
+        <span>
+          Slotted content within template 99
+        </span>
+        <!---->
+        <!---->
+      </div>
+    </x-child>
+  </template>
+</x-parent>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-parent';
+export { default } from 'x/parent';
+export * from 'x/parent';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/child/child.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/child/child.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <div>
+        <slot lwc:slot-bind={item}>Fallback slot content</slot>
+    </div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/child/child.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/child/child.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+export default class Child extends LightningElement {
+    static renderMode = 'light';
+    item = { id: 99, name: 'ssr' };
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.html
@@ -1,5 +1,6 @@
 <template>
     <x-child>
+        <!-- TODO [#5020]: Fix rendering of scoped slot content, so that content outside of the template renders correctly with engine-server -->
         <span>Slotted content outside of template</span>
         <template lwc:slot-data="data">
             <span>Slotted content within template {data.id}</span>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.html
@@ -1,0 +1,8 @@
+<template>
+    <x-child>
+        <span>Slotted content outside of template</span>
+        <template lwc:slot-data="data">
+            <span>Slotted content within template {data.id}</span>
+        </template>
+    </x-child>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scoped-slots/default-slot/modules/x/parent/parent.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {
+    foo = 'bar';
+}

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -21,6 +21,7 @@ export const expectedFailures = new Set([
     'known-boolean-attributes/default-def-html-attributes/static-on-component/index.js',
     'render-dynamic-value/index.js',
     'scoped-slots/advanced/index.js',
+    'scoped-slots/default-slot/index.js',
     'scoped-slots/expression/index.js',
     'scoped-slots/mixed-with-light-dom-slots-inside/index.js',
     'scoped-slots/mixed-with-light-dom-slots-outside/index.js',


### PR DESCRIPTION
## Details

Add specific coverage for scoped default slots (currently, `engine-server` does not render all content, see #5020)

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.
