### PR TITLE
fix(ssr): add `experimentalDynamicComponent` aka dynamic imports

### DIFF
--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -100,9 +100,10 @@ export interface TransformOptions {
     namespace?: string;
     /** @deprecated Ignored by compiler. */
     stylesheetConfig?: StylesheetConfig;
-    // TODO [#3331]: deprecate / rename this compiler option in 246
+    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     /** Config applied in usage of dynamic import statements in javascript */
     experimentalDynamicComponent?: DynamicImportConfig;
+    // TODO [#3331]: deprecate and remove lwc:dynamic
     /** Flag to enable usage of dynamic component(lwc:dynamic) directive in HTML template */
     experimentalDynamicDirective?: boolean;
     /** Flag to enable usage of dynamic component(lwc:is) directive in HTML template */

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -33,6 +33,7 @@ export default function scriptTransform(
 ): TransformResult {
     const {
         isExplicitImport,
+        // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
         experimentalDynamicComponent: dynamicImports,
         outputConfig: { sourcemap },
         enableLightningWebSecurityTransforms,

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -38,8 +38,10 @@ export interface RollupLwcOptions {
     stylesheetConfig?: StylesheetConfig;
     /** The configuration to pass to the `@lwc/template-compiler`. */
     preserveHtmlComments?: boolean;
+    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     /** The configuration to pass to `@lwc/compiler`. */
     experimentalDynamicComponent?: DynamicImportConfig;
+    // TODO [#3331]: deprecate and remove lwc:dynamic
     /** The configuration to pass to `@lwc/template-compiler`. */
     experimentalDynamicDirective?: boolean;
     /** The configuration to pass to `@lwc/template-compiler`. */

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -58,6 +58,7 @@
         "meriyah": "^5.0.0"
     },
     "devDependencies": {
+        "@lwc/babel-plugin-component": "8.12.0",
         "@types/estree": "^1.0.6"
     }
 }

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { init, parse } from 'es-module-lexer';
+import { compileComponentForSSR } from '../index';
+
+describe('dynamic imports', () => {
+    type CompileOptions = {
+        strictSpecifier: boolean;
+        loader: undefined | string;
+        isStrict: boolean;
+    };
+
+    beforeAll(async () => {
+        await init;
+    });
+
+    // Generate all possible combinations of options
+    const combinations = [false, true]
+        .map((strictSpecifier) =>
+            [undefined, 'myLoader'].map((loader) =>
+                [false, true].map((isStrict) => ({
+                    strictSpecifier,
+                    loader,
+                    isStrict,
+                }))
+            )
+        )
+        .flat(Infinity) as Array<CompileOptions>;
+
+    test.each(combinations)(
+        'strictSpecifier=$strictSpecifier, loader=$loader, isStrict=$isStrict',
+        ({ strictSpecifier, loader, isStrict }: CompileOptions) => {
+            const source = `
+            import { LightningElement } from 'lwc';
+            export default class extends LightningElement {}
+            
+            export default async function rando () {
+                await import(${isStrict ? '"x/foo"' : 'woohoo'});
+            }
+        `;
+            const filename = path.resolve('component.js');
+            let code;
+
+            const callback = () => {
+                code = compileComponentForSSR(source, filename, {
+                    experimentalDynamicComponent: {
+                        loader,
+                        strictSpecifier,
+                    },
+                }).code;
+            };
+
+            if (strictSpecifier && !isStrict) {
+                expect(callback).toThrowError(/INVALID_DYNAMIC_IMPORT_SOURCE_STRICT/);
+                return;
+            } else {
+                callback();
+            }
+
+            const imports = parse(code!)[0];
+
+            const expectedImports = expect.arrayContaining([
+                expect.objectContaining({
+                    n: 'myLoader',
+                }),
+            ]);
+
+            if (loader) {
+                expect(imports).toEqual(expectedImports);
+            } else {
+                expect(imports).not.toEqual(expectedImports);
+            }
+        }
+    );
+});

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -100,6 +100,7 @@ describe('dynamic imports', () => {
             ])
         );
 
+        // Validate that there is exactly one import of the loader
         expect(imports.filter((_) => _.n === 'myLoader')).toHaveLength(1);
 
         expect(code).toContain(`x/foo`);

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -31,13 +31,13 @@ describe('dynamic imports', () => {
         'strictSpecifier=$strictSpecifier, loader=$loader, isStrict=$isStrict',
         ({ strictSpecifier, loader, isStrict }: CompileOptions) => {
             const source = `
-            import { LightningElement } from 'lwc';
-            export default class extends LightningElement {}
-            
-            export default async function rando () {
-                await import(${isStrict ? '"x/foo"' : 'woohoo'});
-            }
-        `;
+                import { LightningElement } from 'lwc';
+                export default class extends LightningElement {}
+                
+                export default async function rando () {
+                    await import(${isStrict ? '"x/foo"' : 'woohoo'});
+                }
+            `;
             const filename = path.resolve('component.js');
             let code;
 

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -59,16 +59,16 @@ describe('dynamic imports', () => {
 
             const imports = parse(code!)[0];
 
-            const expectedImports = expect.arrayContaining([
+            const importsWithLoader = expect.arrayContaining([
                 expect.objectContaining({
                     n: 'myLoader',
                 }),
             ]);
 
             if (loader) {
-                expect(imports).toEqual(expectedImports);
+                expect(imports).toEqual(importsWithLoader);
             } else {
-                expect(imports).not.toEqual(expectedImports);
+                expect(imports).not.toEqual(importsWithLoader);
             }
         }
     );

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -55,6 +55,10 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
                 // TODO [#3331]: remove usage of lwc:dynamic in 246
                 experimentalDynamicDirective: true,
                 modules: [{ dir: modulesDir }],
+                experimentalDynamicComponent: {
+                    loader: path.join(__dirname, './utils/custom-loader.js'),
+                    strictSpecifier: false,
+                },
             }),
         ],
         onwarn({ message, code }) {

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/custom-loader.js
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/custom-loader.js
@@ -1,0 +1,3 @@
+export function load() {
+    return Promise.resolve('stub');
+}

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -10,6 +10,7 @@ import { traverse, builders as b, is } from 'estree-toolkit';
 import { parseModule } from 'meriyah';
 
 import { transmogrify } from '../transmogrify';
+import { ImportManager } from '../imports';
 import { replaceLwcImport } from './lwc-import';
 import { catalogTmplImport } from './catalog-tmpls';
 import { catalogStaticStylesheets, catalogAndReplaceStyleImports } from './stylesheets';
@@ -17,6 +18,7 @@ import { addGenerateMarkupFunction } from './generate-markup';
 import { catalogWireAdapters } from './wire';
 
 import { removeDecoratorImport } from './remove-decorator-import';
+import type { ComponentTransformOptions } from '../shared';
 import type { Identifier as EsIdentifier, Program as EsProgram } from 'estree';
 import type { Visitors, ComponentMetaState } from './types';
 import type { CompilationMode } from '@lwc/shared';
@@ -33,13 +35,25 @@ const visitors: Visitors = {
         catalogAndReplaceStyleImports(path, state);
         removeDecoratorImport(path);
     },
-    ImportExpression(path) {
-        return path.replaceWith(
-            b.callExpression(
-                b.memberExpression(b.identifier('Promise'), b.identifier('resolve')),
-                []
-            )
-        );
+    ImportExpression(path, state) {
+        const { dynamicImports, importManager } = state;
+        if (!dynamicImports) {
+            return;
+        }
+        if (dynamicImports.strictSpecifier) {
+            if (!is.literal(path.node?.source) || typeof path.node.source.value !== 'string') {
+                throw new Error('todo - LWCClassErrors.INVALID_DYNAMIC_IMPORT_SOURCE_STRICT');
+            }
+        }
+        const loader = dynamicImports.loader;
+        if (!loader) {
+            return;
+        }
+        const source = path.node!.source!;
+        // 1. insert `import { load as __load } from '${loader}' at top of program
+        importManager.add({ load: '__load' }, loader);
+        // 2. replace this import with `__load(${source})`
+        path.replaceWith(b.callExpression(b.identifier('__load'), [structuredClone(source)]));
     },
     ClassDeclaration(path, state) {
         const { node } = path;
@@ -171,12 +185,21 @@ const visitors: Visitors = {
             path.parentPath.node.arguments = [b.identifier('propsAvailableAtConstruction')];
         }
     },
+    Program: {
+        leave(path, state) {
+            const importDeclarations = state.importManager.getImportDeclarations();
+            if (importDeclarations.length > 0) {
+                path.node?.body.unshift(...importDeclarations);
+            }
+        },
+    },
 };
 
 export default function compileJS(
     src: string,
     filename: string,
     tagName: string,
+    options: ComponentTransformOptions,
     compilationMode: CompilationMode
 ) {
     let ast = parseModule(src, {
@@ -200,6 +223,8 @@ export default function compileJS(
         publicFields: [],
         privateFields: [],
         wireAdapters: [],
+        dynamicImports: options.dynamicImports,
+        importManager: new ImportManager(),
     };
 
     traverse(ast, visitors, state);

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -38,6 +38,7 @@ const visitors: Visitors = {
     ImportExpression(path, state) {
         const { experimentalDynamicComponent, importManager } = state;
         if (!experimentalDynamicComponent) {
+            // if no `experimentalDynamicComponent` config, then leave dynamic `import()`s as-is
             return;
         }
         if (experimentalDynamicComponent.strictSpecifier) {

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -49,6 +49,7 @@ const visitors: Visitors = {
         }
         const loader = experimentalDynamicComponent.loader;
         if (!loader) {
+            // if no `loader` defined, then leave dynamic `import()`s as-is
             return;
         }
         const source = path.node!.source!;

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -42,6 +42,7 @@ const visitors: Visitors = {
         }
         if (experimentalDynamicComponent.strictSpecifier) {
             if (!is.literal(path.node?.source) || typeof path.node.source.value !== 'string') {
+                // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
                 throw new Error('todo - LWCClassErrors.INVALID_DYNAMIC_IMPORT_SOURCE_STRICT');
             }
         }

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -36,16 +36,16 @@ const visitors: Visitors = {
         removeDecoratorImport(path);
     },
     ImportExpression(path, state) {
-        const { dynamicImports, importManager } = state;
-        if (!dynamicImports) {
+        const { experimentalDynamicComponent, importManager } = state;
+        if (!experimentalDynamicComponent) {
             return;
         }
-        if (dynamicImports.strictSpecifier) {
+        if (experimentalDynamicComponent.strictSpecifier) {
             if (!is.literal(path.node?.source) || typeof path.node.source.value !== 'string') {
                 throw new Error('todo - LWCClassErrors.INVALID_DYNAMIC_IMPORT_SOURCE_STRICT');
             }
         }
-        const loader = dynamicImports.loader;
+        const loader = experimentalDynamicComponent.loader;
         if (!loader) {
             return;
         }
@@ -223,7 +223,7 @@ export default function compileJS(
         publicFields: [],
         privateFields: [],
         wireAdapters: [],
-        dynamicImports: options.dynamicImports,
+        experimentalDynamicComponent: options.experimentalDynamicComponent,
         importManager: new ImportManager(),
     };
 

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -52,7 +52,7 @@ const visitors: Visitors = {
             return;
         }
         const source = path.node!.source!;
-        // 1. insert `import { load as __load } from '${loader}' at top of program
+        // 1. insert `import { load as __load } from '${loader}'` at top of program
         importManager.add({ load: '__load' }, loader);
         // 2. replace this import with `__load(${source})`
         path.replaceWith(b.callExpression(b.identifier('__load'), [structuredClone(source)]));

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -190,6 +190,7 @@ const visitors: Visitors = {
     },
     Program: {
         leave(path, state) {
+            // After parsing the whole tree, insert needed imports
             const importDeclarations = state.importManager.getImportDeclarations();
             if (importDeclarations.length > 0) {
                 path.node?.body.unshift(...importDeclarations);

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
+import type { ImportManager } from '../imports';
+import type { ComponentTransformOptions } from '../shared';
 import type { traverse } from 'estree-toolkit';
 import type {
     Identifier,
@@ -54,4 +56,8 @@ export interface ComponentMetaState {
     privateFields: Array<string>;
     // indicates whether the LightningElement has any wired props
     wireAdapters: WireAdapter[];
+    // dynamic imports configuration
+    dynamicImports: ComponentTransformOptions['dynamicImports'];
+    // imports to add to the top of the program after parsing
+    importManager: ImportManager;
 }

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -57,7 +57,7 @@ export interface ComponentMetaState {
     // indicates whether the LightningElement has any wired props
     wireAdapters: WireAdapter[];
     // dynamic imports configuration
-    dynamicImports: ComponentTransformOptions['dynamicImports'];
+    experimentalDynamicComponent: ComponentTransformOptions['experimentalDynamicComponent'];
     // imports to add to the top of the program after parsing
     importManager: ImportManager;
 }

--- a/packages/@lwc/ssr-compiler/src/compile-js/wire.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/wire.ts
@@ -42,22 +42,26 @@ function getWireParams(
     const { decorators } = node;
 
     if (decorators.length > 1) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - multiple decorators at once');
     }
 
     // validate the parameters
     const wireDecorator = decorators[0].expression;
     if (!is.callExpression(wireDecorator)) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - invalid usage');
     }
 
     const args = wireDecorator.arguments;
     if (args.length === 0 || args.length > 2) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - wrong number of args');
     }
 
     const [id, config] = args;
     if (is.spreadElement(id) || is.spreadElement(config)) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - spread in params');
     }
     return [id, config];
@@ -72,13 +76,16 @@ function validateWireId(
 
     if (is.memberExpression(id)) {
         if (id.computed) {
+            // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
             throw new Error('todo - FUNCTION_IDENTIFIER_CANNOT_HAVE_COMPUTED_PROPS');
         }
         if (!is.identifier(id.object)) {
+            // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
             throw new Error('todo - FUNCTION_IDENTIFIER_CANNOT_HAVE_NESTED_MEMBER_EXRESSIONS');
         }
         wireAdapterVar = id.object.name;
     } else if (!is.identifier(id)) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - invalid adapter name');
     } else {
         wireAdapterVar = id.name;
@@ -86,6 +93,7 @@ function validateWireId(
 
     // This is not the exact same validation done in @lwc/babel-plugin-component but it accomplishes the same thing
     if (path.scope?.getBinding(wireAdapterVar)?.kind !== 'module') {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - WIRE_ADAPTER_SHOULD_BE_IMPORTED');
     }
 }
@@ -95,6 +103,7 @@ function validateWireConfig(
     path: NodePath<PropertyDefinition | MethodDefinition>
 ): asserts config is NoSpreadObjectExpression {
     if (!is.objectExpression(config)) {
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - CONFIG_OBJECT_SHOULD_BE_SECOND_PARAMETER');
     }
     for (const property of config.properties) {
@@ -113,12 +122,14 @@ function validateWireConfig(
             if (is.templateLiteral(key)) {
                 // A template literal is not guaranteed to always result in the same value
                 // (e.g. `${Math.random()}`), so we disallow them entirely.
+                // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
                 throw new Error('todo - COMPUTED_PROPERTY_CANNOT_BE_TEMPLATE_LITERAL');
             } else if (!('regex' in key)) {
                 // A literal can be a regexp, template literal, or primitive; only allow primitives
                 continue;
             }
         }
+        // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
         throw new Error('todo - COMPUTED_PROPERTY_MUST_BE_CONSTANT_OR_LITERAL');
     }
 }

--- a/packages/@lwc/ssr-compiler/src/compile-template/context.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/context.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { bImportDeclaration } from '../estree/builders';
+import { ImportManager } from '../imports';
 import type { ImportDeclaration as EsImportDeclaration } from 'estree';
 import type { TemplateOpts, TransformerContext } from './types';
 
@@ -13,42 +13,7 @@ export function createNewContext(templateOptions: TemplateOpts): {
     getImports: () => EsImportDeclaration[];
     cxt: TransformerContext;
 } {
-    /** Map of source to imported name to local name. */
-    const importMap = new Map<string, Map<string, string | undefined>>();
-    /**
-     * Hoist an import declaration to the top of the file. If source is not specified, defaults to
-     * `@lwc/ssr-runtime`.
-     */
-    const _import = (
-        imports: string | string[] | Record<string, string | undefined>,
-        source = '@lwc/ssr-runtime'
-    ): void => {
-        let specifiers: Array<[string, string | undefined]>;
-        if (typeof imports === 'string') {
-            specifiers = [[imports, undefined]];
-        } else if (Array.isArray(imports)) {
-            specifiers = imports.map((name) => [name, undefined]);
-        } else {
-            specifiers = Object.entries(imports);
-        }
-
-        let specifierMap = importMap.get(source);
-        if (specifierMap) {
-            for (const [imported, local] of specifiers) {
-                specifierMap.set(imported, local);
-            }
-        } else {
-            specifierMap = new Map(specifiers);
-            importMap.set(source, specifierMap);
-        }
-    };
-
-    const getImports = (): EsImportDeclaration[] => {
-        return Array.from(importMap, ([source, specifierMap]) => {
-            return bImportDeclaration(Object.fromEntries(specifierMap), source);
-        });
-    };
-
+    const importManager = new ImportManager();
     const localVarStack: Set<string>[] = [];
 
     const pushLocalVars = (vars: string[]) => {
@@ -70,13 +35,13 @@ export function createNewContext(templateOptions: TemplateOpts): {
     };
 
     return {
-        getImports,
+        getImports: () => importManager.getImportDeclarations(),
         cxt: {
             pushLocalVars,
             popLocalVars,
             isLocalVar,
             templateOptions,
-            import: _import,
+            import: importManager.add.bind(importManager),
         },
     };
 }

--- a/packages/@lwc/ssr-compiler/src/imports.ts
+++ b/packages/@lwc/ssr-compiler/src/imports.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { bImportDeclaration } from './estree/builders';
+import type { ImportDeclaration } from 'estree';
+
+export class ImportManager {
+    #map = new Map</*source*/ string, Map</*imported*/ string, /*local*/ string | undefined>>();
+
+    /** Add an import to a collection of imports, probably for adding to the AST later. */
+    add(
+        imports: string | string[] | Record<string, string | undefined>,
+        source = '@lwc/ssr-runtime'
+    ): void {
+        let specifiers: Array<[string, string | undefined]>;
+        if (typeof imports === 'string') {
+            specifiers = [[imports, undefined]];
+        } else if (Array.isArray(imports)) {
+            specifiers = imports.map((name) => [name, undefined]);
+        } else {
+            specifiers = Object.entries(imports);
+        }
+
+        let specifierMap = this.#map.get(source);
+        if (specifierMap) {
+            for (const [imported, local] of specifiers) {
+                specifierMap.set(imported, local);
+            }
+        } else {
+            specifierMap = new Map(specifiers);
+            this.#map.set(source, specifierMap);
+        }
+    }
+
+    /** Get the collection of imports for adding to the AST, probably soon! */
+    getImportDeclarations(): ImportDeclaration[] {
+        return Array.from(this.#map, ([source, specifierMap]) => {
+            return bImportDeclaration(Object.fromEntries(specifierMap), source);
+        });
+    }
+}

--- a/packages/@lwc/ssr-compiler/src/index.ts
+++ b/packages/@lwc/ssr-compiler/src/index.ts
@@ -8,7 +8,7 @@
 import { DEFAULT_SSR_MODE, type CompilationMode, generateCustomElementTagName } from '@lwc/shared';
 import compileJS from './compile-js';
 import compileTemplate from './compile-template';
-import type { TransformOptions } from './shared';
+import type { ComponentTransformOptions, TemplateTransformOptions } from './shared';
 
 export interface CompilationResult {
     code: string;
@@ -18,18 +18,18 @@ export interface CompilationResult {
 export function compileComponentForSSR(
     src: string,
     filename: string,
-    options: TransformOptions,
+    options: ComponentTransformOptions,
     mode: CompilationMode = DEFAULT_SSR_MODE
 ): CompilationResult {
     const tagName = generateCustomElementTagName(options.namespace, options.name);
-    const { code } = compileJS(src, filename, tagName, mode);
+    const { code } = compileJS(src, filename, tagName, options, mode);
     return { code, map: undefined };
 }
 
 export function compileTemplateForSSR(
     src: string,
     filename: string,
-    options: TransformOptions,
+    options: TemplateTransformOptions,
     mode: CompilationMode = DEFAULT_SSR_MODE
 ): CompilationResult {
     const { code } = compileTemplate(src, filename, options, mode);

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import type { LwcBabelPluginOptions } from '@lwc/babel-plugin-component';
 import type { Config as TemplateCompilerConfig } from '@lwc/template-compiler';
 
 export type Expression = string;
@@ -57,4 +58,8 @@ export interface IHoistInstantiation {
     kind: 'hoistInstantiation';
 }
 
-export type TransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
+export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
+export type ComponentTransformOptions = Pick<
+    LwcBabelPluginOptions,
+    'name' | 'namespace' | 'dynamicImports'
+>;

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -61,5 +61,5 @@ export interface IHoistInstantiation {
 export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
 export type ComponentTransformOptions = Pick<LwcBabelPluginOptions, 'name' | 'namespace'> & {
     // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
-    experimentalDynamicComponent: LwcBabelPluginOptions['dynamicImports'];
+    experimentalDynamicComponent?: LwcBabelPluginOptions['dynamicImports'];
 };

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -59,7 +59,7 @@ export interface IHoistInstantiation {
 }
 
 export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
-export type ComponentTransformOptions = Pick<
-    LwcBabelPluginOptions,
-    'name' | 'namespace' | 'dynamicImports'
->;
+export type ComponentTransformOptions = Pick<LwcBabelPluginOptions, 'name' | 'namespace'> & {
+    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
+    experimentalDynamicComponent: LwcBabelPluginOptions['dynamicImports'];
+};


### PR DESCRIPTION
## Details

Fixes #5021

Related: #5031 #5032

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
