### PR TITLE
always use / when splitting filename to get name and namespace

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -328,6 +328,8 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             // Specifier will only exist for modules with alias paths.
             // Otherwise, use the file directory structure to resolve namespace and name.
             const [namespace, name] =
+                // Note we do not need to use path.sep here because this filename contains
+                // a '/' regardless of Windows vs Unix, since it comes from the Rollup `id`
                 specifier?.split('/') ?? path.dirname(filename).split('/').slice(-2);
 
             const apiVersionToUse = getAPIVersionFromNumber(apiVersion);

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -328,7 +328,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             // Specifier will only exist for modules with alias paths.
             // Otherwise, use the file directory structure to resolve namespace and name.
             const [namespace, name] =
-                specifier?.split('/') ?? path.dirname(filename).split(path.sep).slice(-2);
+                specifier?.split('/') ?? path.dirname(filename).split('/').slice(-2);
 
             const apiVersionToUse = getAPIVersionFromNumber(apiVersion);
 


### PR DESCRIPTION
## Details

Fixes a bug that caused dynamic component names to contain illegal characters on Windows platforms

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.


## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

<!-- Work ID in text, if applicable. -->
