### PR TITLE
[DO NOT MERGE] Trigger CI for #5038: always use / when splitting filename to get name and namespace

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -328,7 +328,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             // Specifier will only exist for modules with alias paths.
             // Otherwise, use the file directory structure to resolve namespace and name.
             const [namespace, name] =
-                specifier?.split('/') ?? path.dirname(filename).split(path.sep).slice(-2);
+                specifier?.split('/') ?? path.dirname(filename).split('/').slice(-2);
 
             const apiVersionToUse = getAPIVersionFromNumber(apiVersion);
 


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5038.