### PR TITLE
test(karma): remove unnecessary IE11-related code

### DIFF
--- a/packages/@lwc/integration-karma/test/events/focus-event-composed/index.spec.js
+++ b/packages/@lwc/integration-karma/test/events/focus-event-composed/index.spec.js
@@ -1,25 +1,12 @@
-// IE11 doesn't support FocusEvent constructor
-// https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent#Browser_compatibility
-function isFocusEventConstructorSupported() {
-    try {
-        new FocusEvent();
-        return true;
-    } catch (_error) {
-        return false;
-    }
-}
+it('should set composed to false by default', () => {
+    const focusEvent = new FocusEvent('focus');
+    expect(focusEvent.composed).toBe(false);
+});
 
-describe.runIf(isFocusEventConstructorSupported())('FocusEvent constructor supported', () => {
-    it('should set composed to false by default', () => {
-        const focusEvent = new FocusEvent('focus');
-        expect(focusEvent.composed).toBe(false);
-    });
+it('should set composed to the value specified in the option', () => {
+    const composedEvt = new FocusEvent('focus', { composed: true });
+    expect(composedEvt.composed).toBe(true);
 
-    it('should set composed to the value specified in the option', () => {
-        const composedEvt = new FocusEvent('focus', { composed: true });
-        expect(composedEvt.composed).toBe(true);
-
-        const nonComposedEvt = new FocusEvent('focus', { composed: false });
-        expect(nonComposedEvt.composed).toBe(false);
-    });
+    const nonComposedEvt = new FocusEvent('focus', { composed: false });
+    expect(nonComposedEvt.composed).toBe(false);
 });


### PR DESCRIPTION
## Details

`FocusEvent` is widely supported now: https://caniuse.com/mdn-api_focusevent

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
