### PR TITLE
fix(ssr-compiler): namespace & name are optional in CompilerTransformOptions

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
@@ -8,6 +8,7 @@
 import { is, builders as b } from 'estree-toolkit';
 import { describe, test, expect } from 'vitest';
 import { esTemplate, esTemplateWithYield } from '../estemplate';
+import type { ClassDeclaration, FunctionDeclaration } from 'estree';
 
 if (process.env.NODE_ENV !== 'production') {
     // vitest seems to bypass the modifications we do in src/estree/validators.ts 🤷
@@ -33,7 +34,7 @@ describe.each(
         test('when attempting to replace unreplaceable code constructs', () => {
             // Someone might try to create a template where 'class' or 'function'
             // is provided as an argument to the ES template.
-            const isFunctionOrClass = (node: any) =>
+            const isFunctionOrClass = (node: any): node is FunctionDeclaration | ClassDeclaration =>
                 is.functionDeclaration(node) || is.classDeclaration(node);
             const createTemplate = () => topLevelFn`
                     ${isFunctionOrClass} classOrFunctionDecl {}

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -59,7 +59,9 @@ export interface IHoistInstantiation {
 }
 
 export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
-export type ComponentTransformOptions = Pick<LwcBabelPluginOptions, 'name' | 'namespace'> & {
+export type ComponentTransformOptions = Partial<
+    Pick<LwcBabelPluginOptions, 'name' | 'namespace'>
+> & {
     // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     experimentalDynamicComponent?: LwcBabelPluginOptions['dynamicImports'];
 };


### PR DESCRIPTION
## Details

This is a type-only fix.

It was probably an unintended change introduced in #5033 which caused some type errors in tests:

<img width="831" alt="Screenshot 2024-12-18 at 13 39 48" src="https://github.com/user-attachments/assets/dfad59fe-29f1-4f92-993b-ecf287fb6af0" />

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
