### PR TITLE
[DO NOT MERGE] Trigger CI for #5058: fix(ssr-compiler): namespace & name are optional in CompilerTransformOptions

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/estemplate.spec.ts
@@ -8,6 +8,7 @@
 import { is, builders as b } from 'estree-toolkit';
 import { describe, test, expect } from 'vitest';
 import { esTemplate, esTemplateWithYield } from '../estemplate';
+import type { ClassDeclaration, FunctionDeclaration } from 'estree';
 
 if (process.env.NODE_ENV !== 'production') {
     // vitest seems to bypass the modifications we do in src/estree/validators.ts 🤷
@@ -33,7 +34,7 @@ describe.each(
         test('when attempting to replace unreplaceable code constructs', () => {
             // Someone might try to create a template where 'class' or 'function'
             // is provided as an argument to the ES template.
-            const isFunctionOrClass = (node: any) =>
+            const isFunctionOrClass = (node: any): node is FunctionDeclaration | ClassDeclaration =>
                 is.functionDeclaration(node) || is.classDeclaration(node);
             const createTemplate = () => topLevelFn`
                     ${isFunctionOrClass} classOrFunctionDecl {}

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -59,7 +59,9 @@ export interface IHoistInstantiation {
 }
 
 export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
-export type ComponentTransformOptions = Pick<LwcBabelPluginOptions, 'name' | 'namespace'> & {
+export type ComponentTransformOptions = Partial<
+    Pick<LwcBabelPluginOptions, 'name' | 'namespace'>
+> & {
     // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     experimentalDynamicComponent?: LwcBabelPluginOptions['dynamicImports'];
 };


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5058.