### PR TITLE
test(karma): reduce #4889 even further

### DIFF
--- a/packages/@lwc/integration-karma/test/rendering/issue-4889/index.spec.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-4889/index.spec.js
@@ -1,10 +1,10 @@
 import { createElement } from 'lwc';
 import Table from 'x/table';
-import { dataStatesVariant1, dataStatesVariant2 } from 'x/data';
+import { dataStatesVariant1, dataStatesVariant2, dataStatesVariant3 } from 'x/data';
 
 // TODO [#4889]: fix issue with nested for:each loops and colliding keys
 xdescribe('issue-4889 - should render for:each correctly when nested', () => {
-    [dataStatesVariant1, dataStatesVariant2].forEach((dataStates, i) => {
+    [dataStatesVariant1, dataStatesVariant2, dataStatesVariant3].forEach((dataStates, i) => {
         it(`variant ${i + 1}`, async () => {
             const elm = createElement('x-table', { is: Table });
             document.body.appendChild(elm);

--- a/packages/@lwc/integration-karma/test/rendering/issue-4889/x/data/data.js
+++ b/packages/@lwc/integration-karma/test/rendering/issue-4889/x/data/data.js
@@ -127,3 +127,33 @@ export const dataStatesVariant2 = [
         },
     ],
 ];
+
+// Even more minimal repro of just the vdom diffing issue (no errors thrown)
+export const dataStatesVariant3 = [
+    [
+        {
+            id: 6,
+            renderMe: false,
+            children: [],
+        },
+        {
+            id: 13,
+            renderMe: true,
+        },
+        {
+            id: 8,
+            renderMe: false,
+            children: [],
+        },
+    ],
+    [
+        {
+            id: 11,
+            renderMe: true,
+        },
+        {
+            id: 13,
+            renderMe: true,
+        },
+    ],
+];


### PR DESCRIPTION
## Details

Reduces #4889 even further. I still don't have a solution, but I wanted to get this in, in case I need to timebox this work.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
