### PR TITLE
feat!: use const in generic for @wire

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -59,7 +59,7 @@ interface WireDecorator<Value, Class> {
  * }
  */
 export default function wire<
-    ReactiveConfig extends ConfigValue = ConfigValue,
+    const ReactiveConfig extends ConfigValue = ConfigValue,
     Value = any,
     Context extends ContextValue = ContextValue,
     Class = LightningElement,


### PR DESCRIPTION
## Details

```py
declare const Adapter: WireAdapterConstructor<{key: 'value'}, any, any>;
class Wired extends LightningElement {
  @wire(Adapter, {key: 'incorrect'}) prop;
}
```

In the example above, the wire adapter only accepts a config with `key` set to `"value"`, but we have provided it with `"incorrect"`. Despite being a runtime error, this passes type validation because the config is inferred as `{key: string}`. We don't know if it's the right string literal, the wrong string literal, or a reactive string (`$prop`) that points to a right or wrong value.

I recently learned about the [`const` modifier in generics](https://xebia.com/blog/typescript-5-0-and-the-new-const-modifier-on-type-parameters/) which solves this use case. So let's use it! Now the example above will correctly be a type error.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 💔 Yes, it does introduce a breaking change.

This is a breaking change for **TypeScript users only**.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
