### PR TITLE
test(ssr): add test for superclass with args passed in

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/expected.html
@@ -1,0 +1,7 @@
+<x-component>
+  <template shadowrootmode="open">
+    <div>
+      Hello hahaha yolo
+    </div>
+  </template>
+</x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-component';
+export { default } from 'x/component';
+export * from 'x/component';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/component/component.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/component/component.js
@@ -1,0 +1,7 @@
+import FancyElement from 'x/fancyElement';
+
+export default class extends FancyElement {
+    constructor() {
+        super('hahaha', 'yolo');
+    }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/fancyElement/fancyElement.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/fancyElement/fancyElement.html
@@ -1,0 +1,3 @@
+<template>
+    <div>Hello {something} {somethingElse}</div>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/fancyElement/fancyElement.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/superclass/with-props/modules/x/fancyElement/fancyElement.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    something;
+    somethingElse;
+
+    constructor(something, somethingElse) {
+        super();
+        this.something = something;
+        this.somethingElse = somethingElse;
+    }
+}

--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -26,6 +26,7 @@ export const expectedFailures = new Set([
     'slot-not-at-top-level/with-adjacent-text-nodes/lwcIf/light/index.js',
     'slot-not-at-top-level/with-adjacent-text-nodes/if/light/index.js',
     'slot-not-at-top-level/with-adjacent-text-nodes/if-as-sibling/light/index.js',
+    'superclass/with-props/index.js',
     'wire/errors/throws-on-computed-key/index.js',
     'wire/errors/throws-when-colliding-prop-then-method/index.js',
 ]);


### PR DESCRIPTION
## Details

If you have a superclass with arguments in its `constructor`, and if the subclass tries to pass in those arguments via `super`, then this currently fails in SSR compiler. The reason is that the SSR compiler overwrites the constructor's args with its own `propsAvailableAtConstruction` object.

This adds a test to repro this.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
