### PR TITLE
feat(engine): support imperative wire adapters & fix wire adapter config handling

### DIFF
--- a/packages/@lwc/engine-core/src/framework/decorators/wire.ts
+++ b/packages/@lwc/engine-core/src/framework/decorators/wire.ts
@@ -11,8 +11,8 @@ import { updateComponentValue } from '../update-component-value';
 import type { LightningElement } from '../base-lightning-element';
 import type {
     ConfigValue,
+    ConfigWithReactiveValues,
     ContextValue,
-    ReplaceReactiveValues,
     WireAdapterConstructor,
 } from '../wiring';
 
@@ -59,15 +59,17 @@ interface WireDecorator<Value, Class> {
  * }
  */
 export default function wire<
-    ReactiveConfig extends ConfigValue = ConfigValue,
+    ExpectedConfig extends ConfigValue = ConfigValue,
     Value = any,
     Context extends ContextValue = ContextValue,
     Class = LightningElement,
 >(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    adapter: WireAdapterConstructor<ReplaceReactiveValues<ReactiveConfig, Class>, Value, Context>,
+    adapter:
+        | WireAdapterConstructor<ExpectedConfig, Value, Context>
+        | { adapter: WireAdapterConstructor<ExpectedConfig, Value, Context> },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    config?: ReactiveConfig
+    config?: ConfigWithReactiveValues<ExpectedConfig, Class>
 ): WireDecorator<Value, Class> {
     if (process.env.NODE_ENV !== 'production') {
         assert.fail('@wire(adapter, config?) may only be used as a decorator.');

--- a/packages/@lwc/engine-core/src/framework/wiring/index.ts
+++ b/packages/@lwc/engine-core/src/framework/wiring/index.ts
@@ -10,12 +10,12 @@ export { createContextProviderWithRegister, createContextWatcher } from './conte
 export {
     ConfigCallback,
     ConfigValue,
+    ConfigWithReactiveValues,
     ContextConsumer,
     ContextProvider,
     ContextProviderOptions,
     ContextValue,
     DataCallback,
-    ReplaceReactiveValues,
     WireAdapter,
     WireAdapterConstructor,
     WireAdapterSchemaValue,


### PR DESCRIPTION
## Details
Improve the type definition of `wire` decorator to support Imperative functions that also carry wire adapters.

This change also improves the type checking for the config param. The types are more closely validated, error messages are scoped better and are more concise.

## Does this pull request introduce a breaking change?

- 💔 Yes, it does introduce a breaking change.

This is a breaking change for TypeScript users only. This expands what is allowed to be passed to the decorator as an adapter and tightens config types.

## Does this pull request introduce an observable change?

- 🔬 Yes, it does include an observable change.

`wire` decorator type checking is different. No runtime behavior changes.
