### PR TITLE
[DO NOT MERGE] Trigger CI for #5083: chore: emit type declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "strict": true,
 
         "declaration": true,
+        "declarationMap": true,
         "sourceMap": true,
 
         "module": "commonjs",


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5083.