### PR TITLE
perf(ssr): speed up setting props

### DIFF
--- a/packages/@lwc/ssr-runtime/src/class-list.ts
+++ b/packages/@lwc/ssr-runtime/src/class-list.ts
@@ -61,7 +61,7 @@ export class ClassList implements DOMTokenList {
     replace(oldClassName: string, newClassName: string) {
         let classWasReplaced = false;
         const className = this.el.className;
-        const listOfClasses = className.split(MULTI_SPACE).filter(Boolean);
+        const listOfClasses = className.split(MULTI_SPACE).filter(Boolean) as string[];
         listOfClasses.forEach((value, idx) => {
             if (value === oldClassName) {
                 classWasReplaced = true;

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -13,14 +13,7 @@
 // and be located before import statements.
 // /// <reference lib="dom" />
 
-import {
-    assign,
-    defineProperty,
-    defineProperties,
-    hasOwnProperty,
-    StringToLowerCase,
-    toString,
-} from '@lwc/shared';
+import { assign, defineProperties, hasOwnProperty, StringToLowerCase, toString } from '@lwc/shared';
 
 import { ClassList } from './class-list';
 import { mutationTracker } from './mutation-tracker';
@@ -59,11 +52,11 @@ export class LightningElement implements PropsAvailableAtConstruction {
     title!: string;
 
     isConnected = false;
-    className = '';
 
     // Using ! because it's assigned in the constructor via `Object.assign`, which TS can't detect
     tagName!: string;
 
+    #props!: Properties;
     #attrs!: Attributes;
     #classList: ClassList | null = null;
 
@@ -72,19 +65,19 @@ export class LightningElement implements PropsAvailableAtConstruction {
     }
 
     [SYMBOL__SET_INTERNALS](props: Properties, attrs: Attributes) {
+        this.#props = props;
         this.#attrs = attrs;
         assign(this, props);
+    }
 
-        defineProperty(this, 'className', {
-            get() {
-                return props.class ?? '';
-            },
-            set(newVal) {
-                props.class = newVal;
-                attrs.class = newVal;
-                mutationTracker.add(this, 'class');
-            },
-        });
+    get className() {
+        return this.#props.class ?? '';
+    }
+
+    set className(newVal: any) {
+        this.#props.class = newVal;
+        this.#attrs.class = newVal;
+        mutationTracker.add(this, 'class');
     }
 
     get classList() {

--- a/packages/@lwc/ssr-runtime/src/reflection.ts
+++ b/packages/@lwc/ssr-runtime/src/reflection.ts
@@ -27,22 +27,20 @@ import type { LightningElement } from './lightning-element';
  */
 export function filterProperties(
     props: Record<string, unknown>,
-    publicFields: Array<string>,
-    privateFields: Array<string>
+    publicFields: Set<string>,
+    privateFields: Set<string>
 ): Record<string, unknown> {
     const propsToAssign = create(null);
-    const publicFieldSet = new Set(publicFields);
-    const privateFieldSet = new Set(privateFields);
-    keys(props).forEach((propName) => {
+    for (const propName of keys(props)) {
         const attrName = htmlPropertyToAttribute(propName);
         if (
-            publicFieldSet.has(propName) ||
+            publicFields.has(propName) ||
             ((REFLECTIVE_GLOBAL_PROPERTY_SET.has(propName) || isAriaAttribute(attrName)) &&
-                !privateFieldSet.has(propName))
+                !privateFields.has(propName))
         ) {
             propsToAssign[propName] = props[propName];
         }
-    });
+    }
     return propsToAssign;
 }
 


### PR DESCRIPTION
## Details

This is a 4-8% perf improvement to the `ssr-tablecmp-render-10k` test by optimizing how we set and filter child component props.

<img width="1194" alt="Screenshot 2025-01-03 at 2 58 09 PM" src="https://github.com/user-attachments/assets/ff78d5f6-0a3f-4c82-92f8-7ef6747db8f5" />

Most of the improvement likely comes from not re-creating `Array`s and `Set`s over and over again. Instead we just create one `Set` and re-use it.

Future improvements we could do:

- For empty `Set`s, just use a single `EMPTY_SET` instead of recreating them
- Don't do `filterProperties` at all – most of the time, we should be able to reuse the original object instead of creating a new filtered object

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
