### PR TITLE
fix(ssr): fix constructor with args

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/utils/expected-failures.ts
@@ -26,7 +26,6 @@ export const expectedFailures = new Set([
     'slot-not-at-top-level/with-adjacent-text-nodes/lwcIf/light/index.js',
     'slot-not-at-top-level/with-adjacent-text-nodes/if/light/index.js',
     'slot-not-at-top-level/with-adjacent-text-nodes/if-as-sibling/light/index.js',
-    'superclass/with-props/index.js',
     'wire/errors/throws-on-computed-key/index.js',
     'wire/errors/throws-when-colliding-prop-then-method/index.js',
 ]);

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -168,7 +168,11 @@ const visitors: Visitors = {
 
         switch (node.key.name) {
             case 'constructor':
-                node.value.params = [b.identifier('propsAvailableAtConstruction')];
+                // add our own custom arg after any pre-existing constructor args
+                node.value.params = [
+                    ...structuredClone(node.value.params),
+                    b.identifier('propsAvailableAtConstruction'),
+                ];
                 break;
             case 'connectedCallback':
                 state.hasConnectedCallback = true;
@@ -196,7 +200,11 @@ const visitors: Visitors = {
             path.parentPath &&
             path.parentPath.node?.type === 'CallExpression'
         ) {
-            path.parentPath.node.arguments = [b.identifier('propsAvailableAtConstruction')];
+            // add our own custom arg after any pre-existing super() args
+            path.parentPath.node.arguments = [
+                ...structuredClone(path.parentPath.node.arguments),
+                b.identifier('propsAvailableAtConstruction'),
+            ];
         }
     },
     Program: {


### PR DESCRIPTION
## Details

Fixes #5080

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
