### PR TITLE
refactor(ssr): do not pass props/attrs to `tmpl`

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -67,11 +67,9 @@ const bGenerateMarkup = esTemplate`
         yield* __renderAttrs(instance, attrs, hostScopeToken, scopeToken);
         yield '>';
         yield* tmplFn(
-            props, 
-            attrs, 
             shadowSlottedContent,
-            lightSlottedContent, 
-            ${/*component class*/ 3}, 
+            lightSlottedContent,
+            ${/*component class*/ 3},
             instance
         );
         yield \`</\${tagName}>\`;

--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -21,11 +21,9 @@ import type { CompilationMode } from '@lwc/shared';
 // TODO [#4663]: Render mode mismatch between template and compiler should throw.
 const bExportTemplate = esTemplate`
     export default async function* tmpl(
-            props, 
-            attrs, 
             shadowSlottedContent,
-            lightSlottedContent, 
-            Cmp, 
+            lightSlottedContent,
+            Cmp,
             instance
     ) {
         // Deliberately using let so we can mutate as many times as we want in the same scope.

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -96,8 +96,6 @@ export function renderAttrsNoYield(
 }
 
 export function* fallbackTmpl(
-    _props: unknown,
-    _attrs: unknown,
     _shadowSlottedContent: unknown,
     _lightSlottedContent: unknown,
     Cmp: LightningElementConstructor,
@@ -110,8 +108,6 @@ export function* fallbackTmpl(
 
 export function fallbackTmplNoYield(
     emit: (segment: string) => void,
-    _props: unknown,
-    _attrs: unknown,
     _shadowSlottedContent: unknown,
     _lightSlottedContent: unknown,
     Cmp: LightningElementConstructor,


### PR DESCRIPTION
## Details

I'm not sure what the original intention was here, but the `tmpl` function never uses the `props` or `attrs` parameters, so we don't need to pass them to it.

(Instead, the way it works is that the `tmpl` function calls `instance.foo`/`instance.bar` etc., and `props` are pre-applied to the `instance` via `SYMBOL__SET_INTERNALS`.)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
