### PR TITLE
perf(ssr): remove `filterProperties`

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -31,11 +31,6 @@ const bGenerateMarkup = esTemplate`
         tagName = tagName ?? ${/*component tag name*/ is.literal};
         attrs = attrs ?? Object.create(null);
         props = props ?? Object.create(null);
-        props = __filterProperties(
-            props,
-            publicFields,
-            privateFields,
-        );
         const instance = new ${/* Component class */ is.identifier}({
             tagName: tagName.toUpperCase(),
         });
@@ -43,7 +38,7 @@ const bGenerateMarkup = esTemplate`
         __establishContextfulRelationship(contextfulParent, instance);
         ${/*connect wire*/ is.statement}
 
-        instance[__SYMBOL__SET_INTERNALS](props, attrs);
+        instance[__SYMBOL__SET_INTERNALS](props, attrs, publicFields, privateFields);
         instance.isConnected = true;
         if (instance.connectedCallback) {
             __mutationTracker.enable(instance);
@@ -128,7 +123,6 @@ export function addGenerateMarkupFunction(
     program.body.unshift(
         bImportDeclaration({
             fallbackTmpl: '__fallbackTmpl',
-            filterProperties: '__filterProperties',
             hasScopedStaticStylesheets: undefined,
             mutationTracker: '__mutationTracker',
             renderAttrs: '__renderAttrs',

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -20,7 +20,6 @@ export {
     SYMBOL__SET_INTERNALS,
 } from './lightning-element';
 export { mutationTracker } from './mutation-tracker';
-export { filterProperties } from './reflection';
 export {
     fallbackTmpl,
     fallbackTmplNoYield,

--- a/packages/@lwc/ssr-runtime/src/reflection.ts
+++ b/packages/@lwc/ssr-runtime/src/reflection.ts
@@ -5,44 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import {
-    AriaAttrNameToPropNameMap,
-    create,
-    entries,
-    htmlPropertyToAttribute,
-    isAriaAttribute,
-    isNull,
-    keys,
-    REFLECTIVE_GLOBAL_PROPERTY_SET,
-    toString,
-} from '@lwc/shared';
+import { AriaAttrNameToPropNameMap, entries, isNull, toString } from '@lwc/shared';
 
 import type { LightningElement } from './lightning-element';
-
-/**
- * Filters out the following types of properties that should not be set.
- * - Properties that are not public.
- * - Properties that are not global.
- * - Properties that are global but are internally overridden.
- */
-export function filterProperties(
-    props: Record<string, unknown>,
-    publicFields: Set<string>,
-    privateFields: Set<string>
-): Record<string, unknown> {
-    const propsToAssign = create(null);
-    for (const propName of keys(props)) {
-        const attrName = htmlPropertyToAttribute(propName);
-        if (
-            publicFields.has(propName) ||
-            ((REFLECTIVE_GLOBAL_PROPERTY_SET.has(propName) || isAriaAttribute(attrName)) &&
-                !privateFields.has(propName))
-        ) {
-            propsToAssign[propName] = props[propName];
-        }
-    }
-    return propsToAssign;
-}
 
 /**
  * Descriptor for IDL attribute reflections that merely reflect the string, e.g. `title`.


### PR DESCRIPTION
## Details

This is another small perf improvement, on the order of 6-11%. The optimization here is to avoid creating an additional object via `filterProperties` and instead to do the filtering directly when setting properties on the component.

![Screenshot 2025-01-06 at 4 02 34 PM](https://github.com/user-attachments/assets/659ebb6a-1001-41f7-9df5-d00a9685781d)

There are probably more optimizations that can be done here, but starting with this small change.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
