### PR TITLE
fix(signals): avoid throwing when `in` check throws

### DIFF
--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -44,7 +44,7 @@ export function componentValueObserved(vm: VM, key: PropertyKey, target: any = {
         !isNull(target) &&
         safeHasProp(target, 'value') &&
         safeHasProp(target, 'subscribe') &&
-        isFunction((target as any).subscribe) &&
+        isFunction(target.subscribe) &&
         isTrustedSignal(target) &&
         // Only subscribe if a template is being rendered by the engine
         tro.isObserving()

--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -7,6 +7,7 @@
 import { isFunction, isNull, isObject, isTrustedSignal } from '@lwc/shared';
 import { ReactiveObserver, valueMutated, valueObserved } from '../libs/mutation-tracker';
 import { subscribeToSignal } from '../libs/signal-tracker';
+import { safeHasProp } from './utils';
 import type { Signal } from '@lwc/signals';
 import type { JobFunction, CallbackFunction } from '../libs/mutation-tracker';
 import type { VM } from './vm';
@@ -34,16 +35,16 @@ export function componentValueObserved(vm: VM, key: PropertyKey, target: any = {
     }
 
     // The portion of reactivity that's exposed to signals is to subscribe a callback to re-render the VM (templates).
-    // We check check the following to ensure re-render is subscribed at the correct time.
+    // We check the following to ensure re-render is subscribed at the correct time.
     //  1. The template is currently being rendered (there is a template reactive observer)
     //  2. There was a call to a getter to access the signal (happens during vnode generation)
     if (
         lwcRuntimeFlags.ENABLE_EXPERIMENTAL_SIGNALS &&
         isObject(target) &&
         !isNull(target) &&
-        'value' in target &&
-        'subscribe' in target &&
-        isFunction(target.subscribe) &&
+        safeHasProp(target, 'value') &&
+        safeHasProp(target, 'subscribe') &&
+        isFunction((target as any).subscribe) &&
         isTrustedSignal(target) &&
         // Only subscribe if a template is being rendered by the engine
         tro.isObserving()

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -107,9 +107,12 @@ export function shouldBeFormAssociated(Ctor: LightningElementConstructor) {
 
 // check if a property is in an object, and if the object throws an error merely because we are
 // checking if the property exists, return false
-export function safeHasProp<T extends object, K extends PropertyKey>(obj: T, prop: K): obj is Record<K, unknown> {
+export function safeHasProp<K extends PropertyKey>(
+    obj: unknown,
+    prop: K
+): obj is Record<K, unknown> {
     try {
-        return prop in obj;
+        return prop in (obj as any);
     } catch (_err) {
         return false;
     }

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -107,7 +107,7 @@ export function shouldBeFormAssociated(Ctor: LightningElementConstructor) {
 
 // check if a property is in an object, and if the object throws an error merely because we are
 // checking if the property exists, return false
-export function safeHasProp(obj: any, prop: string) {
+export function safeHasProp<T extends object, K extends PropertyKey>(obj: T, prop: K): obj is Record<K, unknown> {
     try {
         return prop in obj;
     } catch (_err) {

--- a/packages/@lwc/engine-core/src/framework/utils.ts
+++ b/packages/@lwc/engine-core/src/framework/utils.ts
@@ -104,3 +104,13 @@ export function shouldBeFormAssociated(Ctor: LightningElementConstructor) {
 
     return ctorFormAssociated && apiFeatureEnabled;
 }
+
+// check if a property is in an object, and if the object throws an error merely because we are
+// checking if the property exists, return false
+export function safeHasProp(obj: any, prop: string) {
+    try {
+        return prop in obj;
+    } catch (_err) {
+        return false;
+    }
+}

--- a/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
@@ -214,7 +214,7 @@ describe('signal protocol', () => {
         expect(subscribe).not.toHaveBeenCalled();
     });
 
-    fit('does not throw an error for objects that throw upon "in" checks', async () => {
+    it('does not throw an error for objects that throw upon "in" checks', async () => {
         const elm = createElement('x-throws', { is: Throws });
         document.body.appendChild(elm);
 

--- a/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/index.spec.js
@@ -6,6 +6,7 @@ import Parent from 'x/parent';
 import Child from 'x/child';
 import DuplicateSignalOnTemplate from 'x/duplicateSignalOnTemplate';
 import List from 'x/list';
+import Throws from 'x/throws';
 
 // Note for testing purposes the signal implementation uses LWC module resolution to simplify things.
 // In production the signal will come from a 3rd party library.
@@ -211,6 +212,15 @@ describe('signal protocol', () => {
         await Promise.resolve();
 
         expect(subscribe).not.toHaveBeenCalled();
+    });
+
+    fit('does not throw an error for objects that throw upon "in" checks', async () => {
+        const elm = createElement('x-throws', { is: Throws });
+        document.body.appendChild(elm);
+
+        await Promise.resolve();
+
+        expect(elm.shadowRoot.querySelector('h1').textContent).toBe('hello');
     });
 });
 

--- a/packages/@lwc/integration-karma/test/signal/protocol/x/throws/throws.html
+++ b/packages/@lwc/integration-karma/test/signal/protocol/x/throws/throws.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello</h1>
+</template>

--- a/packages/@lwc/integration-karma/test/signal/protocol/x/throws/throws.js
+++ b/packages/@lwc/integration-karma/test/signal/protocol/x/throws/throws.js
@@ -1,0 +1,23 @@
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    foo;
+
+    constructor() {
+        super();
+
+        this.foo = new Proxy(
+            {},
+            {
+                has() {
+                    throw new Error("oh no you don't!");
+                },
+            }
+        );
+    }
+
+    renderedCallback() {
+        // access `this.foo` to trigger mutation-tracker.ts
+        this.bar = this.foo;
+    }
+}


### PR DESCRIPTION
## Details

Fixes #5104

Avoids throwing an error when the `in` operator throws an error on an arbitrary object.

This should not cause any breaking changes, because we are trying to detect if an object "looks" like a signal, and if checking `'value' in object` throws, then we can conclusively say it's not a signal.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

