### PR TITLE
fix(ssr): avoid reserved keyword collision

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/expected.html
@@ -1,0 +1,7 @@
+<x-cmp>
+  <template shadowrootmode="open">
+    <h1>
+      hello
+    </h1>
+  </template>
+</x-cmp>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-cmp';
+export { default } from 'x/cmp';
+export * from 'x/cmp';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/modules/x/cmp/cmp.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/modules/x/cmp/cmp.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello</h1>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/modules/x/cmp/cmp.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/reserved-keywords/modules/x/cmp/cmp.js
@@ -1,0 +1,23 @@
+import { LightningElement } from 'lwc';
+
+const privateFields = undefined;
+const publicFields = undefined;
+const stylesheetScopeToken = undefined;
+const hasScopedStylesheets = undefined;
+const defaultScopedStylesheets = undefined;
+
+export default class extends LightningElement {
+    connectedCallback() {
+        // just use the variables to avoid them being tree-shaken
+        Object.assign(
+            {},
+            {
+                privateFields,
+                publicFields,
+                stylesheetScopeToken,
+                hasScopedStylesheets,
+                defaultScopedStylesheets,
+            }
+        );
+    }
+}

--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -111,7 +111,7 @@ export function addGenerateMarkupFunction(
     let exposeTemplateBlock: IfStatement | null = null;
     if (!tmplExplicitImports) {
         const defaultTmplPath = `./${pathParse(filename).name}.html`;
-        const tmplVar = b.identifier('__lwcTmpl');
+        const tmplVar = b.identifier('tmpl');
         program.body.unshift(bImportDeclaration({ default: tmplVar.name }, defaultTmplPath));
         program.body.unshift(
             bImportDeclaration({ SYMBOL__DEFAULT_TEMPLATE: '__SYMBOL__DEFAULT_TEMPLATE' })


### PR DESCRIPTION
## Details

If a component author happens to use the variable names `privateFields`/`publicFields` in their component, then they will conflict with the SSR compiler's usage of those same variables, and result in an error at compile time:

```
Identifier "privateFields" has already been declared
```

Note this was introduced by https://github.com/salesforce/lwc/pull/5092

This PR fixes that.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
