### PR TITLE
chore(ssr): use `htmlEscape` consistently

### DIFF
--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -4,14 +4,18 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { getOwnPropertyNames, isNull, isString, isUndefined, DEFAULT_SSR_MODE } from '@lwc/shared';
+import {
+    getOwnPropertyNames,
+    isNull,
+    isString,
+    isUndefined,
+    DEFAULT_SSR_MODE,
+    htmlEscape,
+} from '@lwc/shared';
 import { mutationTracker } from './mutation-tracker';
 import { SYMBOL__GENERATE_MARKUP } from './lightning-element';
 import type { LightningElement, LightningElementConstructor } from './lightning-element';
 import type { Attributes, Properties } from './types';
-
-const escapeAttrVal = (attrValue: string) =>
-    attrValue.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 
 function renderAttrsPrivate(
     instance: LightningElement,
@@ -58,7 +62,8 @@ function renderAttrsPrivate(
             }
         }
 
-        result += attrValue === '' ? ` ${attrName}` : ` ${attrName}="${escapeAttrVal(attrValue)}"`;
+        result +=
+            attrValue === '' ? ` ${attrName}` : ` ${attrName}="${htmlEscape(attrValue, true)}"`;
     }
 
     // If we didn't render any `class` attribute, render one for the scope token(s)


### PR DESCRIPTION
## Details

For some reason, we had a custom attribute value serializer here rather than using `htmlEscape` like we do elsewhere. The two functions do the same thing.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
