### PR TITLE
Fix a component namespace and name parsing issue

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -332,7 +332,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             const [namespace, name] =
                 // Note we do not need to use path.sep here because this filename contains
                 // a '/' regardless of Windows vs Unix, since it comes from the Rollup `id`
-                specifier?.split('/') ?? /(?:([^\\/]+?)[\\/])?([^\\/]+?)(?:[\\/]\2)?(?:\.scoped)?\.[^.]+$/.exec(filename)?.slice(1);
+                specifier?.split('/') ?? path.dirname(filename).split(/[\\/]/).slice(-2);
 
             /* v8 ignore next */
             if (!namespace || !name) {

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -332,7 +332,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             const [namespace, name] =
                 // Note we do not need to use path.sep here because this filename contains
                 // a '/' regardless of Windows vs Unix, since it comes from the Rollup `id`
-                specifier?.split('/') ?? path.dirname(filename).split('/').slice(-2);
+                specifier?.split('/') ?? /(?:([^\\/]+?)[\\/])?([^\\/]+?)(?:[\\/]\2)?(?:\.scoped)?\.[^.]+$/.exec(filename)?.slice(1);
 
             /* v8 ignore next */
             if (!namespace || !name) {


### PR DESCRIPTION
As per **issue** #5113 :

The original approach cannot correctly parse `namespace` and `name` from file path in Windows as the path may contain `\` as delimeters.

It doesn't work well for relative paths start with `./` either which derives from implicit reference to CSS files from HTML templates.

The fix still cannot extract the `namespace` for relative paths since there's only a `./`. However, it does correctly identify the `name` for the component.

## Details

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.
