### PR TITLE
perf(ssr): avoid proxying entire props object

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
@@ -17,7 +17,7 @@ import type { Transformer } from '../../types';
 
 const bYieldFromChildGenerator = esTemplateWithYield`
     {
-        const childProps = __getReadOnlyProxy(${/* child props */ is.objectExpression});
+        const childProps = ${/* child props */ is.objectExpression};
         const childAttrs = ${/* child attrs */ is.objectExpression};
         ${
             /*
@@ -51,7 +51,6 @@ export const Component: Transformer<IrComponent> = function Component(node, cxt)
     const importPath = kebabcaseToCamelcase(node.name);
     cxt.import({ default: childComponentLocalName }, importPath);
     cxt.import({
-        getReadOnlyProxy: '__getReadOnlyProxy',
         SYMBOL__GENERATE_MARKUP: '__SYMBOL__GENERATE_MARKUP',
     });
     const childTagName = node.name;

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
@@ -23,7 +23,7 @@ const bYieldFromDynamicComponentConstructorGenerator = esTemplateWithYield`
         if (typeof Ctor !== 'function' || !(Ctor.prototype instanceof LightningElement)) {
             throw new Error(\`Invalid constructor: "\${String(Ctor)}" is not a LightningElement constructor.\`)
         }
-        const childProps = __getReadOnlyProxy(${/* child props */ is.objectExpression});
+        const childProps = ${/* child props */ is.objectExpression};
         const childAttrs = ${/* child attrs */ is.objectExpression};
         ${
             /*
@@ -56,7 +56,6 @@ export const LwcComponent: Transformer<IrLwcComponent> = function LwcComponent(n
     const lwcIs = directives.find((directive) => directive.name === 'Is');
     if (!isUndefined(lwcIs)) {
         cxt.import({
-            getReadOnlyProxy: '__getReadOnlyProxy',
             LightningElement: undefined,
             SYMBOL__GENERATE_MARKUP: '__SYMBOL__GENERATE_MARKUP',
         });

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -11,7 +11,6 @@ export * from './stubs';
 export { htmlEscape, setHooks, sanitizeHtmlContent, normalizeClass } from '@lwc/shared';
 
 export { ClassList } from './class-list';
-export { getReadOnlyProxy } from './get-read-only-proxy';
 export {
     LightningElement,
     LightningElementConstructor,

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -28,6 +28,7 @@ import {
 import { ClassList } from './class-list';
 import { mutationTracker } from './mutation-tracker';
 import { descriptors as reflectionDescriptors } from './reflection';
+import { getReadOnlyProxy } from './get-read-only-proxy';
 import type { Attributes, Properties } from './types';
 import type { Stylesheets } from '@lwc/shared';
 
@@ -94,7 +95,9 @@ export class LightningElement implements PropsAvailableAtConstruction {
                 ((REFLECTIVE_GLOBAL_PROPERTY_SET.has(propName) || isAriaAttribute(attrName)) &&
                     !privateFields.has(propName))
             ) {
-                (this as any)[propName] = props[propName];
+                // For props passed from parents to children, they are intended to be read-only
+                // to avoid a child mutating its parent's state
+                (this as any)[propName] = getReadOnlyProxy(props[propName]);
             }
         }
     }


### PR DESCRIPTION
## Details

Another relatively low-hanging 8-13% perf improvement. We don't need to create a read-only proxy for the entire child props object – the intention is for each individual object to be read-only, but the whole thing doesn't need to be.

This is especially nice for prop objects like `{ foo: 'string', bar: 123 }` where the values are primitives, and thus don't even need to be wrapped, so `readOnlyProxy` will just return the primitive.

<img width="1190" alt="Screenshot 2025-01-10 at 1 44 14 PM" src="https://github.com/user-attachments/assets/da4775ec-d1de-43f9-9662-1f814993cfd7" />

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
