### PR TITLE
test(ssr): remove env var, test coverage

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -66,9 +66,6 @@ jobs:
               run: yarn test:types
             - name: Run unit tests
               run: yarn test:ci
-            # TODO [#4815]: enable all SSR v2 tests
-            - name: Run experimental SSR fixture tests
-              run: TEST_SSR_COMPILER=1 yarn test packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
             - name: Upload unit test coverage report
               uses: actions/upload-artifact@v4
               with:

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -77,9 +77,7 @@ async function compileFixture({ input, dirname }: { input: string; dirname: stri
     return outputFile;
 }
 
-// We will enable this for realsies once all the tests are passing, but for now having the env var avoids
-// running these tests in CI while still allowing for local testing.
-describe.runIf(process.env.TEST_SSR_COMPILER).concurrent('fixtures', () => {
+describe.concurrent('fixtures', () => {
     testFixtureDir(
         {
             root: path.resolve(__dirname, '../../../engine-server/src/__tests__/fixtures'),

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -29,17 +29,24 @@ export default defineConfig({
                 '**/packages/@lwc/perf-benchmarks-components/**',
                 '**/packages/@lwc/perf-benchmarks/**',
                 '**/playground/**',
-                // These are not production-ready yet
-                '**/packages/@lwc/ssr-compiler/**',
-                '**/packages/@lwc/ssr-runtime/**',
                 // This just re-exports other packages
                 '**/packages/lwc/**',
             ],
             thresholds: {
-                branches: 95,
-                functions: 95,
-                lines: 95,
-                statements: 95,
+                // SSR compiler/runtime is relatively newer, so has lower thresholds for now
+                '**/packages/@lwc/ssr-*/**': {
+                    branches: 90,
+                    functions: 60,
+                    lines: 85,
+                    statements: 85,
+                },
+
+                '!**/packages/@lwc/ssr-*/**': {
+                    branches: 95,
+                    functions: 95,
+                    lines: 95,
+                    statements: 95,
+                },
             },
             reporter: [
                 'clover',


### PR DESCRIPTION
## Details

Removes the `TEST_SSR_COMPILER` and runs the SSR compiler tests as part of the main `yarn test` suite. Also adds coverage thresholds.

The main benefit of this PR is that we now get coverage numbers for the SSR compiler, and plus the test infra is much simpler. The only downside is that there is a somewhat annoying and distracting red "9 failed" message for the mismatched snapshots:

![Screenshot 2025-01-17 at 9 52 19 AM](https://github.com/user-attachments/assets/c2f6ce0b-2884-4995-a640-0100073d4973)

These snapshot failures should ideally be driven down to zero soon. We are reaching the point where many of the differences between `engine-server` and `ssr-compiler` are expected or unimportant. E.g. for HTML global attributes, both systems are wrong (https://github.com/salesforce/lwc/issues/5123). So it may be time to just deprecate `engine-server` and move forward with fixing `ssr-compiler`.

Partially addresses #4815.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
