### PR TITLE
[DO NOT MERGE] Trigger CI for #5137: chore!: bump typescript to 5.7.3

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,10 @@ export default tseslint.config(
             globals: {
                 ...globals.es2021,
             },
+
+            parserOptions: {
+                projectService: true,
+            },
         },
 
         rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,17 +46,6 @@ export default tseslint.config(
             globals: {
                 ...globals.es2021,
             },
-
-            parserOptions: {
-                projectService: {
-                    allowDefaultProject: [
-                        // I'm not sure why these files aren't picked up... :\
-                        'packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-code.ts',
-                        'packages/@lwc/module-resolver/scripts/test/matchers/to-throw-error-with-type.ts',
-                        'packages/@lwc/module-resolver/scripts/test/setup-test.ts',
-                    ],
-                },
-            },
         },
 
         rules: {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "rollup": "^4.30.1",
         "terser": "^5.37.0",
         "tslib": "^2.8.1",
-        "typescript": "5.4.5",
+        "typescript": "5.7.3",
         "typescript-eslint": "8.19.1",
         "vitest": "^2.1.8"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,9 +2104,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4", "@napi-rs/wasm-runtime@^0.2.4":
   version "0.2.4"
@@ -12167,10 +12169,10 @@ typescript-eslint@8.19.1:
     "@typescript-eslint/parser" "8.19.1"
     "@typescript-eslint/utils" "8.19.1"
 
-typescript@5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5137.