### PR TITLE
test: @wire expects a function identifier as first parameter (LWC1097)

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/actual.js
@@ -1,0 +1,4 @@
+import { wire, LightningElement } from "lwc";
+export default class Test extends LightningElement {
+  @wire(function adapter() {}, {}) wiredProp;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/error.json
@@ -1,0 +1,10 @@
+{
+    "message": "LWC1097: @wire expects a function identifier as first parameter.",
+    "loc": {
+        "line": 3,
+        "column": 8,
+        "start": 107,
+        "length": 21
+    },
+    "filename": "test.js"
+}


### PR DESCRIPTION
## Details

This error was missing a test in babel-plugin-component. It can later be replicated for ssr.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
