### PR TITLE
[DO NOT MERGE] Trigger CI for #5148: test: wire identifier cannot contain computed properties (LWC1131)

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-computed-props/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-computed-props/actual.js
@@ -1,0 +1,5 @@
+import { wire, LightningElement } from "lwc";
+import Foo from "foo";
+export default class Test extends LightningElement {
+  @wire(Foo['Bar'], {}) wiredProp;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-computed-props/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-rejects-computed-props/error.json
@@ -1,0 +1,10 @@
+{
+    "message": "LWC1131: @wire identifier cannot contain computed properties",
+    "loc": {
+        "line": 4,
+        "column": 8,
+        "start": 130,
+        "length": 10
+    },
+    "filename": "test.js"
+}


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5148.