### PR TITLE
[DO NOT MERGE] Trigger CI for #5147: test: @wire expects a function identifier as first parameter (LWC1097)

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/actual.js
@@ -1,0 +1,4 @@
+import { wire, LightningElement } from "lwc";
+export default class Test extends LightningElement {
+  @wire(function adapter() {}, {}) wiredProp;
+}

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/error.json
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/wire-decorator/decorator-expects-a-function-identifier-as-first-parameter/error.json
@@ -1,0 +1,10 @@
+{
+    "message": "LWC1097: @wire expects a function identifier as first parameter.",
+    "loc": {
+        "line": 3,
+        "column": 8,
+        "start": 107,
+        "length": 21
+    },
+    "filename": "test.js"
+}


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5147.