### PR TITLE
chore(@lwc/compiler): fix type error in transform-html.spec.ts

### DIFF
--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-html.spec.ts
@@ -9,10 +9,10 @@ import { APIVersion, noop } from '@lwc/shared';
 import { transformSync } from '../transformer';
 import type { TransformOptions } from '../../options';
 
-const TRANSFORMATION_OPTIONS: TransformOptions = {
+const TRANSFORMATION_OPTIONS = {
     namespace: 'x',
     name: 'foo',
-};
+} satisfies TransformOptions;
 
 describe('transformSync', () => {
     it('should throw when processing an invalid HTML file', () => {
@@ -74,7 +74,10 @@ describe('transformSync', () => {
         ];
         it.for(configs)('$name', ({ config, expected }) => {
             const template = `<template><img src="http://example.com/img.png" crossorigin="anonymous"></template>`;
-            const { code, warnings } = transformSync(template, 'foo.html', config);
+            const { code, warnings } = transformSync(template, 'foo.html', {
+                ...TRANSFORMATION_OPTIONS,
+                ...config,
+            });
             expect(warnings!.length).toBe(0);
             if (expected) {
                 expect(code).toContain('<img');


### PR DESCRIPTION
## Details

This error seems to have been introduced in #4825 , which made namespace and name required in TransformOptions:

https://github.com/salesforce/lwc/blob/423240cb9deb76442fcb6aae4f74f0c5f3155095/packages/%40lwc/compiler/src/options.ts#L96-L100

Tests aren't really type-checked until opened in an editor, so it slipped by.  In #4458 similar type errors were fixed, but by changing the types instead of the tests.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
