### PR TITLE
fix(track): don't throw on revoked proxies @W-17739481

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/expected.html
@@ -1,0 +1,5 @@
+<x-component>
+  <template shadowrootmode="open">
+    I should render!
+  </template>
+</x-component>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/index.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/index.js
@@ -1,0 +1,3 @@
+export const tagName = 'x-component';
+export { default } from 'x/component';
+export * from 'x/component';

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/modules/x/component/component.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/modules/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    I should render!
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/modules/x/component/component.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/track-revoked-proxy-fails/modules/x/component/component.js
@@ -1,0 +1,26 @@
+import { LightningElement, track } from 'lwc';
+import tmpl from './component.html';
+
+const { revoke, proxy } = Proxy.revocable({}, {});
+revoke();
+
+export default class Rehydration extends LightningElement {
+    // Doesn't need to be used, just needs to be tracked; see W-17739481
+    @track reactive = proxy;
+
+    connectedCallback() {
+        Promise.resolve().then(() => {
+            this.reactive = 1;
+        });
+    }
+
+    render() {
+        if (!this.rendered) {
+            this.rendered = true;
+        } else {
+            throw new Error('Reactivity should be disabled on SSR.');
+        }
+
+        return tmpl;
+    }
+}


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
