### PR TITLE
feat(rollup-plugin): expose version

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.ts
@@ -1,0 +1,7 @@
+import lwc from '@lwc/rollup-plugin';
+import { test, expect } from 'vitest';
+
+test('exposes plugin version', () => {
+    const plugin = lwc();
+    expect(plugin.version).toMatch(/^\d+\.\d+\.\d+/);
+});

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -182,6 +182,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
 
     return {
         name: PLUGIN_NAME,
+        // The version from the package.json is inlined by the build script
         version: process.env.LWC_VERSION,
         buildStart({ input }) {
             if (rootDir === undefined) {

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -182,7 +182,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
 
     return {
         name: PLUGIN_NAME,
-
+        version: process.env.LWC_VERSION,
         buildStart({ input }) {
             if (rootDir === undefined) {
                 if (Array.isArray(input)) {


### PR DESCRIPTION
## Details

This PR exposes the rollup plugin version to facilitate interoperability with other plugins, which is required for supporting scenarios like #4628 in the long run.

See: https://github.com/rollup/rollup/pull/4771

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
