### PR TITLE
[DO NOT MERGE] Trigger CI for #5194: feat(rollup-plugin): expose version

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/index.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/index.spec.ts
@@ -1,0 +1,7 @@
+import lwc from '@lwc/rollup-plugin';
+import { test, expect } from 'vitest';
+
+test('exposes plugin version', () => {
+    const plugin = lwc();
+    expect(plugin.version).toMatch(/^\d+\.\d+\.\d+/);
+});

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -182,6 +182,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
 
     return {
         name: PLUGIN_NAME,
+        // The version from the package.json is inlined by the build script
         version: process.env.LWC_VERSION,
         buildStart({ input }) {
             if (rootDir === undefined) {

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -182,7 +182,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
 
     return {
         name: PLUGIN_NAME,
-
+        version: process.env.LWC_VERSION,
         buildStart({ input }) {
             if (rootDir === undefined) {
                 if (Array.isArray(input)) {


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5194.