### PR TITLE
fix(rollup-plugin): remove default modules

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -63,12 +63,6 @@ export interface RollupLwcOptions {
 
 const PLUGIN_NAME = 'rollup-plugin-lwc-compiler';
 
-const DEFAULT_MODULES = [
-    { npm: '@lwc/engine-dom' },
-    { npm: '@lwc/synthetic-shadow' },
-    { npm: '@lwc/wire-service' },
-];
-
 const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
@@ -205,7 +199,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 rootDir = path.resolve(rootDir);
             }
 
-            modules = [...modules, ...DEFAULT_MODULES, { dir: rootDir }];
+            modules = [...modules, { dir: rootDir }];
         },
 
         resolveId(importee, importer) {


### PR DESCRIPTION
[StackBlitz Repro](https://stackblitz.com/~/github.com/cardoso/salesforce-lwc-dshanxfr). (The only difference from the playground is using pnpm instead of npm)

This PR proposes removing:

https://github.com/salesforce/lwc/blob/a12a3cd9150c4b967e479f58a3a849ea502343db/packages/%40lwc/rollup-plugin/src/index.ts#L58-L62

All tests are passing locally and no breaking changes are intended. If nucleus catches any downstream breakages, this PR can be closed.

## Details

There are at least a few drawbacks related to declaring these default modules in advance.

1. if you don't use synthetic shadow you're still required to have it in your dependency graph, even if you configure `disableSyntheticShadowSupport: true` and don't import it at all.

2. If your setup doesn't handle transitive dependencies in the same way the [resolve](https://github.com/browserify/resolve/issues) package expects, you're forced to make changes.

3. The errors thrown when those packages cannot be resolved seem to imply the user declared them in the lwc config:

```
Error: Invalid LWC configuration in "/home/cardoso/salesforce-lwc-dshanxfr".
Invalid npm module record "{"npm":"@lwc/engine-dom"}",
"@lwc/engine-dom" npm module can't be resolved
```

The drawbacks stem from using the lwc module resolver to resolve those modules instead of letting the bundler (in this case rollup) handle them. This results in tooling compatibility issues with no apparent benefit.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
