### PR TITLE
[DO NOT MERGE] Trigger CI for #5203: fix(rollup-plugin): remove default modules

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -63,12 +63,6 @@ export interface RollupLwcOptions {
 
 const PLUGIN_NAME = 'rollup-plugin-lwc-compiler';
 
-const DEFAULT_MODULES = [
-    { npm: '@lwc/engine-dom' },
-    { npm: '@lwc/synthetic-shadow' },
-    { npm: '@lwc/wire-service' },
-];
-
 const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js';
 const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
@@ -205,7 +199,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 rootDir = path.resolve(rootDir);
             }
 
-            modules = [...modules, ...DEFAULT_MODULES, { dir: rootDir }];
+            modules = [...modules, { dir: rootDir }];
         },
 
         resolveId(importee, importer) {


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5203.