### PR TITLE
chore: rename ephemeral placeholder variable

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -244,7 +244,7 @@ const visitors: Visitors = {
     },
     Identifier(path, _state) {
         const { node } = path;
-        if (node?.name.startsWith('__lwc') && node.name.endsWith('__')) {
+        if (node?.name.startsWith('__lwc')) {
             // TODO [#5032]: Harmonize errors thrown in `@lwc/ssr-compiler`
             throw new Error(`LWCTODO: identifier name '${node.name}' cannot start with '__lwc'`);
         }

--- a/packages/@lwc/ssr-compiler/src/estemplate.ts
+++ b/packages/@lwc/ssr-compiler/src/estemplate.ts
@@ -20,6 +20,12 @@ import type { Checker } from 'estree-toolkit/dist/generated/is-type';
 /** Placeholder value to use to opt out of validation. */
 const NO_VALIDATION = false;
 
+/**
+ * `esTemplate` generates JS code with "holes" to be filled later. In order to have a valid AST,
+ * it uses identifiers with this prefix at the location of the holes.
+ */
+const PLACEHOLDER_PREFIX = '__lwc_ESTEMPLATE_PLACEHOLDER__';
+
 /** A function that accepts a node and checks that it is a particular type of node. */
 type Validator<T extends EsNode | null = EsNode | null> = (
     node: EsNode | null | undefined
@@ -64,8 +70,6 @@ type ToReplacementParameters<Arr extends unknown[]> = Arr extends [infer Head, .
         : // `Head` is a validator, extract the type that it validates
           [ValidatedType<Head>, ...ToReplacementParameters<Rest>]
     : []; // `Arr` is an empty array -- nothing to transform
-
-const PLACEHOLDER_PREFIX = `__ESTEMPLATE_${Math.random().toString().slice(2)}_PLACEHOLDER__`;
 
 interface TraversalState {
     placeholderToValidator: Map<number, Validator>;


### PR DESCRIPTION
## Details

We prevent component authors from using `__lwc` variables, so the temporary placeholder variable should use that prefix, to avoid any nasty surprises.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
