### PR TITLE
fix: provide template prop on LightningElement in SSRv2

### DIFF
--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -162,6 +162,12 @@ export class LightningElement implements PropsAvailableAtConstruction {
         // noop
     }
 
+    get template() {
+        return {
+            synthetic: false,
+        };
+    }
+
     // ----------------------------------------------------------- //
     // Props/methods explicitly not available in this environment  //
     // Getters are named "get*" for parity with @lwc/engine-server //


### PR DESCRIPTION
## Details

We had a fix for this in a branch but failed to introduce it into LWC proper. Some components will check `this.template.synthetic` to determine if the LWC instance is running in synthetic mode. It will never be running in synthetic mode in SSRv2, so the answer is to return `{ synthetic: false }` for any reference to `this.template`. In the future, we might want to make this frozen object constant that's referenced by `LightningElement`, but we can make those changes when we do the optimization work on SSRv2.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🔬 Yes, it does include an observable change.

Described above.

