### PR TITLE
feat(ssr): add LWC version comment to end of compiled template

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { describe, test, expect } from 'vitest';
 import { CompilerError } from '@lwc/errors';
 import { LWC_VERSION_COMMENT_REGEX } from '@lwc/shared';
-import { compileComponentForSSR } from '../index';
+import { compileComponentForSSR, compileTemplateForSSR } from '../index';
 
 expect.addSnapshotSerializer({
     test(val) {
@@ -135,5 +135,14 @@ export default class Test extends LightningElement {
               }
             `);
         });
+    });
+});
+
+describe('template compilation', () => {
+    test('template include LWC version comment', () => {
+        const src = `<template></template>`;
+        const filename = path.resolve('component.html');
+        const { code } = compileTemplateForSSR(src, filename, {});
+        expect(code).toMatch(LWC_VERSION_COMMENT_REGEX);
     });
 });


### PR DESCRIPTION
## Details

In #5186 we added the version comment to compiled component JS, but we forgot to also do it for compiled template files. This does it! The compiled output of a template now looks like the following:

```js
export default function tmpl($$emit, shadowSlottedContent, lightSlottedContent, scopedSlottedContent, Cmp, instance) {
  ...
  /*LWC compiler v8.13.1*/
}
```

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
