### PR TITLE
chore: don't use custom test timeout for fixtures

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -22,8 +22,6 @@ interface FixtureModule {
     features?: any[];
 }
 
-vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
-
 vi.mock('lwc', async () => {
     const lwcEngineServer = await import('../index');
     try {

--- a/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/html-serialization.spec.ts
@@ -7,7 +7,7 @@
 
 import path from 'node:path';
 import vm from 'node:vm';
-import { vi, describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { parseFragment, serialize } from 'parse5';
 import { rollup } from 'rollup';
 import replace from '@rollup/plugin-replace';
@@ -21,8 +21,6 @@ import type { RollupLog } from 'rollup';
  * HTML parser to ensure that the serialized content is correct. It's slightly more
  * robust than snapshots, which may have invalid/incorrect HTML.
  */
-
-vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
 
 // Compile a component to an HTML string, using the full LWC compilation pipeline
 async function compileComponent(tagName: string, componentName: string) {

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -22,8 +22,6 @@ interface FixtureModule {
     features?: FeatureFlagName[];
 }
 
-vi.setConfig({ testTimeout: 10_000 /* 10 seconds */ });
-
 vi.mock('@lwc/ssr-runtime', async () => {
     const runtime = await import('@lwc/ssr-runtime');
     try {

--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -5,7 +5,10 @@ import pkg from './package.json';
 export default defineConfig({
     test: {
         // Don't time out if we detect a debugger attached
-        testTimeout: inspector.url() ? 2147483647 : undefined,
+        testTimeout: inspector.url()
+            ? // Largest allowed delay, see https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value
+              2147483647
+            : undefined,
         include: ['**/*.{test,spec}.{mjs,js,ts}'],
         snapshotFormat: {
             printBasicPrototype: true,


### PR DESCRIPTION
## Details

In #4624, we set the test timeout to the max value, so that we can run the debugger and still see the test output. However, some test files with long-running tests set custom timeouts. These take precedence over the debugger extended timeout, making the tests annoying to debug.

This PR removes those custom extended timeouts. Even with the reduced time, the tests all still pass on my old, slow machine. Hopefully CI passes, too! If it turns out to be flaky, we can always re-visit.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
