### PR TITLE
fix(playground): add node module resolution

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -11,6 +11,7 @@
     "devDependencies": {
         "@lwc/rollup-plugin": "8.13.3",
         "@rollup/plugin-replace": "^6.0.2",
+        "@rollup/plugin-node-resolve": "^16.0.0",
         "lwc": "8.13.3",
         "rollup": "^4.34.6",
         "rollup-plugin-livereload": "^2.0.5",

--- a/playground/rollup.config.js
+++ b/playground/rollup.config.js
@@ -2,12 +2,13 @@ import lwc from '@lwc/rollup-plugin';
 import replace from '@rollup/plugin-replace';
 import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
-
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 const __ENV__ = process.env.NODE_ENV ?? 'development';
 
 export default (args) => {
     return {
         input: 'src/main.js',
+        external: [/node_modules/],
 
         output: {
             file: 'dist/main.js',
@@ -20,6 +21,7 @@ export default (args) => {
                 preventAssignment: true,
             }),
             lwc(),
+            nodeResolve(),
             args.watch &&
                 serve({
                     open: false,

--- a/playground/rollup.config.js
+++ b/playground/rollup.config.js
@@ -8,7 +8,6 @@ const __ENV__ = process.env.NODE_ENV ?? 'development';
 export default (args) => {
     return {
         input: 'src/main.js',
-        external: [/node_modules/],
 
         output: {
             file: 'dist/main.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,9 +1910,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4":
   version "0.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,11 +1910,9 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
-  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
-  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4":
   version "0.2.4"


### PR DESCRIPTION
## Details

This should fix the playground by using @rollup/plugin-node-resolve .

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
