### PR TITLE
[DO NOT MERGE] Trigger CI for #5234: fix(rollup-plugin): add default modules back

### DIFF
--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -40,12 +40,12 @@ async function runRollup(
 }
 
 describe('resolver', () => {
-    it('should be capable to resolve all the base LWC module imports', async () => {
+    it('should be capable to resolve all the base LWC module imports without @rollup/plugin-node-resolve', async () => {
         const { warnings } = await runRollup('lwc-modules/lwc-modules.js', { external: [] });
         expect(warnings).toHaveLength(0);
     });
 
-    it('should be capable of resolving all the base LWC modules using a custom resolver', async () => {
+    it('should be capable to resolve all the base LWC modules using @rollup/plugin-node-resolve', async () => {
         const { warnings } = await runRollup('lwc-modules/lwc-modules.js', {
             external: [],
             plugins: [nodeResolve()],
@@ -89,7 +89,7 @@ describe('resolver', () => {
         });
     });
 
-    it('should properly resolve modules with @rollup/rollup-node-resolve and third-party package', async () => {
+    it('should properly resolve modules with @rollup/plugin-node-resolve and third-party package', async () => {
         const { warnings } = await runRollup('third-party-import/src/main.js', {
             plugins: [nodeResolve()],
         });

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -10,20 +10,24 @@ import { describe, it, expect } from 'vitest';
 import { rollup, type RollupLog, type Plugin, type RollupBuild } from 'rollup';
 import nodeResolve from '@rollup/plugin-node-resolve';
 
-import lwc from '../../index';
+import lwc, { type RollupLwcOptions } from '../../index';
 
 const fixturesdir = path.resolve(__dirname, 'fixtures');
 
 async function runRollup(
     pathname: string,
-    { plugins = [] as Plugin[] } = {}
+    {
+        plugins = [] as Plugin[],
+        external = ['lwc', '@lwc/synthetic-shadow', '@lwc/wire-service'],
+        options = undefined as RollupLwcOptions | undefined,
+    } = {}
 ): Promise<{ bundle: RollupBuild; warnings: RollupLog[] }> {
     const warnings: RollupLog[] = [];
 
     const bundle = await rollup({
         input: path.resolve(fixturesdir, pathname),
-        plugins: [lwc(), ...plugins],
-        external: ['lwc', '@lwc/synthetic-shadow', '@lwc/wire-service'],
+        plugins: [lwc(options), ...plugins],
+        external,
         onwarn(warning) {
             warnings.push(warning);
         },
@@ -37,8 +41,7 @@ async function runRollup(
 
 describe('resolver', () => {
     it('should be capable to resolve all the base LWC module imports', async () => {
-        const { warnings } = await runRollup('lwc-modules/lwc-modules.js');
-
+        const { warnings } = await runRollup('lwc-modules/lwc-modules.js', { external: [] });
         expect(warnings).toHaveLength(0);
     });
 

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/resolver.spec.ts
@@ -45,6 +45,17 @@ describe('resolver', () => {
         expect(warnings).toHaveLength(0);
     });
 
+    it('should be capable of resolving all the base LWC modules using a custom resolver', async () => {
+        const { warnings } = await runRollup('lwc-modules/lwc-modules.js', {
+            external: [],
+            plugins: [nodeResolve()],
+            options: {
+                defaultModules: [],
+            },
+        });
+        expect(warnings).toHaveLength(0);
+    });
+
     it('should use lwc.config.json to resolve LWC modules', async () => {
         const { bundle } = await runRollup('lwc-config-json/src/index.js');
 

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -34,6 +34,8 @@ export interface RollupLwcOptions {
     sourcemap?: boolean | 'inline';
     /** The [module resolution](https://lwc.dev/guide/es_modules#module-resolution) overrides passed to the `@lwc/module-resolver`. */
     modules?: ModuleRecord[];
+    /** Default modules passed to the `@lwc/module-resolver`. */
+    defaultModules?: ModuleRecord[];
     /** The stylesheet compiler configuration to pass to the `@lwc/style-compiler` */
     stylesheetConfig?: StylesheetConfig;
     /** The configuration to pass to the `@lwc/template-compiler`. */
@@ -68,6 +70,12 @@ const EMPTY_IMPLICIT_HTML_CONTENT = 'export default void 0';
 const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css';
 const EMPTY_IMPLICIT_CSS_CONTENT = '';
 const SCRIPT_FILE_EXTENSIONS = ['.js', '.mjs', '.jsx', '.ts', '.mts', '.tsx'];
+
+const DEFAULT_MODULES = [
+    { npm: '@lwc/engine-dom' },
+    { npm: '@lwc/synthetic-shadow' },
+    { npm: '@lwc/wire-service' },
+];
 
 function isImplicitHTMLImport(importee: string, importer: string, importerExt: string): boolean {
     return (
@@ -158,6 +166,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
     const filter = pluginUtils.createFilter(pluginOptions.include, pluginOptions.exclude);
 
     let { rootDir, modules = [] } = pluginOptions;
+
     const {
         targetSSR,
         ssrMode,
@@ -172,6 +181,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
         experimentalComplexExpressions,
         disableSyntheticShadowSupport,
         apiVersion,
+        defaultModules = DEFAULT_MODULES,
     } = pluginOptions;
 
     return {
@@ -199,7 +209,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 rootDir = path.resolve(rootDir);
             }
 
-            modules = [...modules, { dir: rootDir }];
+            modules = [...modules, ...defaultModules, { dir: rootDir }];
         },
 
         resolveId(importee, importer) {


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5234.