### PR TITLE
chore(nucleus): remove always failing downstreams

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -13,7 +13,6 @@ branches:
                 - MobilePlatform/lsdk-modules
                 - MobilePlatform/lwr-lightning-platform
                 - MobilePlatform/ui-fsm-components
-                - Skilling-and-Enablement/ui-external-enablement
                 - automation-platform/ui-externalservices-builder-components
                 - communities/microsite-template-marketing
                 - communities/shared-experience-components
@@ -26,7 +25,9 @@ branches:
                 - salesforce-experience-platform-emu/lwr-everywhere
                 - salesforce-experience-platform-emu/lwr-recipes
                 - salesforce/lwc-test
-                - salesforce/o11y-sample-app
+                # Using old major versions; tests in PRs will always fail
+                # - salesforce/o11y-sample-app
+                # - Skilling-and-Enablement/ui-external-enablement
     release:
         pull-request:
             <<: *branch-definition


### PR DESCRIPTION
Outdated downstreams that always fail just create noise.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
