### PR TITLE
chore(ssr): update `generateMarkup` type defs

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -30,13 +30,13 @@ const bGenerateMarkup = esTemplate`
         value: async function* generateMarkup(
             tagName, 
             props, 
-            attrs, 
+            attrs,
+            parent, 
+            scopeToken,
+            contextfulParent,
             shadowSlottedContent,
             lightSlottedContent, 
             scopedSlottedContent,
-            parent, 
-            scopeToken,
-            contextfulParent
         ) {
             tagName = tagName ?? ${/*component tag name*/ is.literal};
             attrs = attrs ?? Object.create(null);

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/component.ts
@@ -44,13 +44,13 @@ const bYieldFromChildGenerator = esTemplateWithYield`
             yield* generateMarkup(
                 tagName, 
                 childProps, 
-                childAttrs, 
-                shadowSlottedContent,
-                lightSlottedContentMap,
-                scopedSlottedContentMap,
+                childAttrs,
                 instance,
                 scopeToken,
-                contextfulParent
+                contextfulParent,
+                shadowSlottedContent,
+                lightSlottedContentMap,
+                scopedSlottedContentMap
             );
         } else {
             yield \`<\${tagName}>\`;

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/lwc-component.ts
@@ -48,12 +48,12 @@ const bYieldFromDynamicComponentConstructorGenerator = esTemplateWithYield`
             null, 
             childProps,
             childAttrs,
-            shadowSlottedContent,
-            lightSlottedContentMap,
-            scopedSlottedContentMap,
             instance,
             scopeToken,
-            contextfulParent
+            contextfulParent,
+            shadowSlottedContent,
+            lightSlottedContentMap,
+            scopedSlottedContentMap
         );
     }
 `<EsStatement[]>;

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -22,7 +22,7 @@ export { mutationTracker } from './mutation-tracker';
 export {
     fallbackTmpl,
     fallbackTmplNoYield,
-    GenerateMarkupAsyncYield as GenerateMarkupFn,
+    GenerateMarkupAsyncYield,
     renderAttrs,
     renderAttrsNoYield,
     serverSideRenderComponent,

--- a/packages/@lwc/ssr-runtime/src/index.ts
+++ b/packages/@lwc/ssr-runtime/src/index.ts
@@ -22,7 +22,7 @@ export { mutationTracker } from './mutation-tracker';
 export {
     fallbackTmpl,
     fallbackTmplNoYield,
-    GenerateMarkupFn,
+    GenerateMarkupAsyncYield as GenerateMarkupFn,
     renderAttrs,
     renderAttrsNoYield,
     serverSideRenderComponent,

--- a/packages/@lwc/ssr-runtime/src/lightning-element.ts
+++ b/packages/@lwc/ssr-runtime/src/lightning-element.ts
@@ -50,6 +50,9 @@ export const SYMBOL__DEFAULT_TEMPLATE = Symbol('default-template');
 export class LightningElement implements PropsAvailableAtConstruction {
     static renderMode?: 'light' | 'shadow';
     static stylesheets?: Stylesheets;
+    static delegatesFocus?: boolean;
+    static formAssociated?: boolean;
+    static shadowSupportMode?: 'any' | 'reset' | 'native';
 
     // Using ! because these are defined by descriptors in ./reflection
     accessKey!: string;

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -155,17 +155,24 @@ export function renderAttrsNoYield(
     emit(renderAttrsPrivate(instance, attrs, hostScopeToken, scopeToken));
 }
 
-export function* fallbackTmpl(
+export async function* fallbackTmpl(
     shadowSlottedContent: SlottedContentGenerator | null,
-    _lightSlottedContent: SlottedContentGeneratorMap | null,
+    lightSlottedContent: SlottedContentGeneratorMap | null,
     _scopedSlottedContent: SlottedContentGeneratorMap | null,
     Cmp: LightningElementConstructor,
     instance: LightningElement
-) {
+): AsyncGenerator<string> {
     if (Cmp.renderMode !== 'light') {
         yield `<template shadowrootmode="open"></template>`;
         if (shadowSlottedContent) {
-            yield shadowSlottedContent(instance);
+            yield* shadowSlottedContent(instance);
+        }
+    } else if (lightSlottedContent) {
+        const defaultSlot = lightSlottedContent[''];
+        if (defaultSlot?.length > 0) {
+            for (const content of defaultSlot) {
+                yield* content(instance);
+            }
         }
     }
 }
@@ -173,15 +180,22 @@ export function* fallbackTmpl(
 export function fallbackTmplNoYield(
     emit: Emit,
     shadowSlottedContent: SlottedContentEmitter | null,
-    _lightSlottedContent: SlottedContentEmitterMap | null,
+    lightSlottedContent: SlottedContentEmitterMap | null,
     _scopedSlottedContent: SlottedContentEmitterMap | null,
     Cmp: LightningElementConstructor,
     instance: LightningElement
-) {
+): void {
     if (Cmp.renderMode !== 'light') {
         emit(`<template shadowrootmode="open"></template>`);
         if (shadowSlottedContent) {
             shadowSlottedContent(emit, instance);
+        }
+    } else if (lightSlottedContent) {
+        const defaultSlot = lightSlottedContent[''];
+        if (defaultSlot?.length > 0) {
+            for (const content of defaultSlot) {
+                content(emit, instance);
+            }
         }
     }
 }

--- a/packages/@lwc/ssr-runtime/src/render.ts
+++ b/packages/@lwc/ssr-runtime/src/render.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -157,7 +157,7 @@ export function renderAttrsNoYield(
 
 export async function* fallbackTmpl(
     shadowSlottedContent: SlottedContentGenerator | null,
-    lightSlottedContent: SlottedContentGeneratorMap | null,
+    _lightSlottedContent: SlottedContentGeneratorMap | null,
     _scopedSlottedContent: SlottedContentGeneratorMap | null,
     Cmp: LightningElementConstructor,
     instance: LightningElement
@@ -167,20 +167,13 @@ export async function* fallbackTmpl(
         if (shadowSlottedContent) {
             yield* shadowSlottedContent(instance);
         }
-    } else if (lightSlottedContent) {
-        const defaultSlot = lightSlottedContent[''];
-        if (defaultSlot?.length > 0) {
-            for (const content of defaultSlot) {
-                yield* content(instance);
-            }
-        }
     }
 }
 
 export function fallbackTmplNoYield(
     emit: Emit,
     shadowSlottedContent: SlottedContentEmitter | null,
-    lightSlottedContent: SlottedContentEmitterMap | null,
+    _lightSlottedContent: SlottedContentEmitterMap | null,
     _scopedSlottedContent: SlottedContentEmitterMap | null,
     Cmp: LightningElementConstructor,
     instance: LightningElement
@@ -189,13 +182,6 @@ export function fallbackTmplNoYield(
         emit(`<template shadowrootmode="open"></template>`);
         if (shadowSlottedContent) {
             shadowSlottedContent(emit, instance);
-        }
-    } else if (lightSlottedContent) {
-        const defaultSlot = lightSlottedContent[''];
-        if (defaultSlot?.length > 0) {
-            for (const content of defaultSlot) {
-                content(emit, instance);
-            }
         }
     }
 }


### PR DESCRIPTION
## Details

With all the indirection between the generated code fragments (and their lack of types) and the transmogrifier, the types in `render.ts` got a bit out of date. I updated them to be accurate and tried to DRY it up a bit. But it's not _that_ repetitive, so the abstraction might be too much in the other direction? 🤷

Note that TypeScript knows to expand the rest params, so that the tooltips still look as if the functions had been defined the regular way.
![screenshot of VS Code tooltip for `GenerateMarkupAsyncYield`](https://github.com/user-attachments/assets/eb02e88d-5f6f-4dd0-96dd-fc363c6d121e)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
