### PR TITLE
test: template provided through @api-decorated prop

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/config.json
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/config.json
@@ -1,0 +1,3 @@
+{
+    "entry": "x/outer"
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/expected.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/expected.html
@@ -1,0 +1,15 @@
+<fixture-test>
+  <x-inner>
+    a
+    <!---->
+    slotted content
+    <!---->
+    b
+    <!---->
+    <div>
+      named slotted content
+    </div>
+    <!---->
+    c
+  </x-inner>
+</fixture-test>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/inner/inner.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/inner/inner.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    @api tmpl;
+
+    render() {
+        return this.tmpl;
+    }
+}

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/innerTemplateFn.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/innerTemplateFn.html
@@ -1,0 +1,7 @@
+<template lwc:render-mode="light">
+    a
+    <slot>fallback for default</slot>
+    b
+    <slot name=foo>fallback for foo</slot>
+    c
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.html
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.html
@@ -1,0 +1,6 @@
+<template lwc:render-mode="light">
+    <x-inner tmpl={innerTemplateFn}>
+        slotted content
+        <div slot="foo">named slotted content</div>
+    </x-inner>
+</template>

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.js
@@ -6,6 +6,8 @@ export default class extends LightningElement {
     static renderMode = 'light';
     innerTemplateFn = innerTemplateFn;
 
+    // This isn't strictly necessary and has no functional value relative to an implicit template. It is present
+    // only to disambiguate the outer component's template from the one we're passing to the child.
     render() {
         return tmpl;
     }

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.js
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/slots-light-evil-template-as-prop/modules/x/outer/outer.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc';
+import innerTemplateFn from './innerTemplateFn.html';
+import tmpl from './outer.html';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+    innerTemplateFn = innerTemplateFn;
+
+    render() {
+        return tmpl;
+    }
+}


### PR DESCRIPTION
## Details

This adds a passing test. I originally thought this was a repro for an issue we're seeing, but it must be something else. The test still has value though.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.
- 
## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.
