### PR TITLE
chore(ssr): use real error messages for errors @W-17408217

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/prohibited-variable-name/error-ssr.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/prohibited-variable-name/error-ssr.txt
@@ -1,1 +1,1 @@
-LWCTODO: identifier name '__lwcThrowAnError__' cannot start with '__lwc'
+LWC1202: Identifier name cannot start with "__lwc".

--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,9 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1202
+ * Next error code: 1203
  */
 
 export * from './compiler';
 export * from './lwc-class';
 export * from './template-transform';
+export * from './ssr';

--- a/packages/@lwc/errors/src/compiler/error-info/ssr.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/ssr.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { DiagnosticLevel } from '../../shared/types';
+
+/*
+ * For the next available error code, reference (and update!) the value in ./index.ts
+ */
+
+export const SsrCompilerErrors = {
+    RESERVED_IDENTIFIER_PREFIX: {
+        code: 1202,
+        message: 'Identifier name cannot start with "__lwc".',
+        level: DiagnosticLevel.Error,
+        url: '',
+    },
+} as const;

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -50,7 +50,7 @@ describe('dynamic imports', () => {
             };
 
             if (strictSpecifier && !isStrict) {
-                expect(callback).toThrowError(/INVALID_DYNAMIC_IMPORT_SOURCE_STRICT/);
+                expect(callback).toThrowError(/LWC1121/);
                 return;
             } else {
                 callback();


### PR DESCRIPTION
## Details

Updates `ssr-compiler` to use the shared error messages, for a more consistent user experience.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
