### PR TITLE
fix(rollup-plugin): module is not defined in ES module scope

### DIFF
--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -391,4 +391,6 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
 }
 
 // For backward compatibility with commonjs format
-module.exports = lwc;
+if (typeof module !== 'undefined') {
+    module.exports = lwc;
+}


### PR DESCRIPTION
## Details

Fixes `ReferenceError: module is not defined in ES module scope` when running the esm build of rollup-plugin in pure es module environment. 

In certain use cases where the esm version of rollup-plugin is loaded, this can cause a failure:

```bash
examples/csr build: failed to load config from /home/runner/work/vite-plugin-lwc/vite-plugin-lwc/examples/csr/vite.config.ts
examples/csr build: error during build:
examples/csr build: ReferenceError: module is not defined in ES module scope
examples/csr build:     at file:///home/runner/work/vite-plugin-lwc/vite-plugin-lwc/node_modules/.pnpm/@lwc+rollup-plugin@8.15.1_rollup@4.34.9/node_modules/@lwc/rollup-plugin/dist/index.js:261:1
```

This fix should not break anything™ 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
