### PR TITLE
chore(tests): support NODE_ENV=production

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "copy-fork": "./scripts/tasks/unsafe-external-contributor-ci-workaround.sh",
         "dev": "nx run-many --target=dev --all --parallel=999 --exclude=@lwc/perf-benchmarks,@lwc/perf-benchmarks-components,@lwc/integration-tests",
         "test": "vitest --workspace vitest.workspace.mjs",
+        "test:production": "VITE_NODE_ENV=production vitest --workspace vitest.workspace.mjs",
         "test:bespoke": "nx run-many --target=test",
         "test:debug": "vitest --workspace vitest.workspace.mjs --inspect-brk --no-file-parallelism",
         "test:ci": "vitest run --workspace vitest.workspace.mjs --coverage",

--- a/vitest.shared.mjs
+++ b/vitest.shared.mjs
@@ -1,9 +1,12 @@
 import inspector from 'node:inspector';
+import process from 'node:process';
 import { defineConfig } from 'vitest/config';
 import pkg from './package.json';
-
 export default defineConfig({
     test: {
+        env: {
+            NODE_ENV: process.env.VITE_NODE_ENV,
+        },
         // Don't time out if we detect a debugger attached
         testTimeout: inspector.url()
             ? // Largest allowed delay, see https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value


### PR DESCRIPTION
## Details

Setting NODE_ENV directly will override vite's mode and break vitest, so the correct way to do this is by using a different env var (VITE_NODE_ENV) and setting NODE_ENV in the shared test config.

Added a `test:production` command for convenience.

- [Env Variables and Modes | Vite](https://vite.dev/guide/env-and-mode.html#node-env-and-modes)

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
