### PR TITLE
[DO NOT MERGE] Trigger CI for #5275: chore(ci): update sauce-connect-action to v3.0.0

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -17,6 +17,7 @@ on:
             - 'winter*'
 
 env:
+    SAUCE_REGION: 'us' # https://github.com/saucelabs/node-saucelabs?tab=readme-ov-file#region
     SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
     SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
     PUPPETEER_SKIP_DOWNLOAD: 'true' # only needed for @best/runner-local, unused here
@@ -46,11 +47,12 @@ jobs:
               run: yarn install --frozen-lockfile
               working-directory: ./
 
-            - uses: saucelabs/sauce-connect-action@v2
+            - uses: saucelabs/sauce-connect-action@v3.0.0
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelName: ${{ env.SAUCE_TUNNEL_ID }}
+                  region: ${{ env.SAUCE_REGION }}
 
             - run: yarn sauce:ci
             - run: DISABLE_SYNTHETIC=1 yarn sauce:ci
@@ -86,11 +88,12 @@ jobs:
               run: yarn install --frozen-lockfile
               working-directory: ./
 
-            - uses: saucelabs/sauce-connect-action@v2
+            - uses: saucelabs/sauce-connect-action@v3.0.0
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelName: ${{ env.SAUCE_TUNNEL_ID }}
+                  region: ${{ env.SAUCE_REGION }}
 
             - run: API_VERSION=58 yarn sauce:ci
             - run: API_VERSION=58 DISABLE_SYNTHETIC=1 yarn sauce:ci
@@ -126,11 +129,12 @@ jobs:
               run: yarn install --frozen-lockfile
               working-directory: ./
 
-            - uses: saucelabs/sauce-connect-action@v2
+            - uses: saucelabs/sauce-connect-action@v3.0.0
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelName: ${{ env.SAUCE_TUNNEL_ID }}
+                  region: ${{ env.SAUCE_REGION }}
 
             - run: API_VERSION=61 yarn sauce:ci
             - run: API_VERSION=61 DISABLE_SYNTHETIC=1 yarn sauce:ci
@@ -168,11 +172,12 @@ jobs:
               run: yarn install --frozen-lockfile
               working-directory: ./
 
-            - uses: saucelabs/sauce-connect-action@v2
+            - uses: saucelabs/sauce-connect-action@v3.0.0
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
                   tunnelName: ${{ env.SAUCE_TUNNEL_ID }}
+                  region: ${{ env.SAUCE_REGION }}
 
             - run: DISABLE_STATIC_CONTENT_OPTIMIZATION=1 yarn sauce:ci
             - run: DISABLE_STATIC_CONTENT_OPTIMIZATION=1 DISABLE_SYNTHETIC=1 yarn sauce:ci

--- a/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
+++ b/packages/@lwc/integration-karma/scripts/karma-configs/utils.js
@@ -13,6 +13,7 @@ const {
     SAUCE_ACCESS_KEY,
     SAUCE_TUNNEL_ID,
     SAUCE_USERNAME,
+    SAUCE_REGION,
 } = require('../shared/options');
 
 function getSauceSection({ suiteName, customData }) {
@@ -35,6 +36,7 @@ function getSauceSection({ suiteName, customData }) {
         username,
         accessKey,
         tunnelIdentifier: SAUCE_TUNNEL_ID,
+        region: SAUCE_REGION,
 
         build,
         testName,

--- a/packages/@lwc/integration-karma/scripts/shared/options.js
+++ b/packages/@lwc/integration-karma/scripts/shared/options.js
@@ -67,6 +67,7 @@ module.exports = {
     COVERAGE_DIR_FOR_OPTIONS,
 
     // Sauce labs
+    SAUCE_REGION: process.env.SAUCE_REGION || 'us',
     SAUCE_USERNAME: process.env.SAUCE_USERNAME,
     SAUCE_ACCESS_KEY: process.env.SAUCE_ACCESS_KEY || process.env.SAUCE_KEY,
     SAUCE_TUNNEL_ID: process.env.SAUCE_TUNNEL_ID,

--- a/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
+++ b/packages/@lwc/integration-tests/scripts/wdio.sauce.conf.js
@@ -51,6 +51,8 @@ const browsers = [
 
 const mode = process.env.MODE;
 
+const region = process.env.SAUCE_REGION || 'us';
+
 const username = process.env.SAUCE_USERNAME;
 if (!username) {
     throw new TypeError('Missing SAUCE_USERNAME environment variable');
@@ -105,6 +107,7 @@ function getCapabilities() {
 }
 
 exports.config = merge(baseConfig.config, {
+    region,
     user: username,
     key: accessKey,
 


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5275.