### PR TITLE
chore: expose `lwc-style` register util

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     },
     "lint-staged": {
         "*.{js,mjs,ts}": "eslint --cache",
-        "*.{css,js,json,md,mjs,ts,yaml,yml}": "prettier --write",
-        "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js",
-        "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js",
+        "*.{css,js,json,md,mjs,ts,yaml,yml}": "prettier --check",
+        "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js --test",
+        "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js --test",
         "*.{only,skip}": "eslint --cache --plugin '@lwc/eslint-plugin-lwc-internal' --rule '@lwc/lwc-internal/forbidden-filename: error'"
     },
     "workspaces": [

--- a/packages/@lwc/ssr-client-utils/package.json
+++ b/packages/@lwc/ssr-client-utils/package.json
@@ -32,7 +32,8 @@
     "types": "dist/index.d.ts",
     "files": [
         "dist/**/*.js",
-        "dist/**/*.d.ts"
+        "dist/**/*.d.ts",
+        "register-lwc-style.js"
     ],
     "scripts": {
         "build": "rollup --config ../../../scripts/rollup/rollup.config.js",

--- a/scripts/tasks/check-and-rewrite-package-json.js
+++ b/scripts/tasks/check-and-rewrite-package-json.js
@@ -71,7 +71,7 @@ for (const dir of globSync('./packages/@lwc/*')) {
             module: 'dist/index.js',
             types: 'dist/index.d.ts',
             // It's important _not_ to use `./dist` here (with the `./`), because npm does not understand that
-            files: ['dist/**/*.js', 'dist/**/*.d.ts'],
+            files: Array.from(new Set(['dist/**/*.js', 'dist/**/*.d.ts', ...pkg.files])),
             scripts: {
                 build: 'rollup --config ../../../scripts/rollup/rollup.config.js',
                 dev: 'rollup  --config ../../../scripts/rollup/rollup.config.js --watch --no-watch.clearScreen',


### PR DESCRIPTION
## Details

In #5264, we introduced a method to register the `lwc-style` custom element. We also tried to add a helper file, so that users can do a bare import (`import "@lwc/ssr-client-utils/register-lwc-style"`), rather than needing to import and call a function. But we didn't add it to the package.json `files` array! 😳 This PR adds it, so that users can receive it!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
