### PR TITLE
chore: use `__lwc` for transmogrified function names

### DIFF
--- a/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
@@ -31,7 +31,7 @@ describe('component compilation', () => {
         `;
         const filename = path.resolve('component.js');
         const { code } = compileComponentForSSR(src, filename, {});
-        expect(code).toContain('import tmpl from "./component.html"');
+        expect(code).toContain('import __lwcTmpl from "./component.html"');
     });
     test('explicit templates imports do not use full file paths', () => {
         const src = `
@@ -59,7 +59,7 @@ describe('component compilation', () => {
         `;
         const filename = path.resolve('component.ts');
         const { code } = compileComponentForSSR(src, filename, {});
-        expect(code).toContain('import tmpl from "./component.html"');
+        expect(code).toContain('import __lwcTmpl from "./component.html"');
     });
 
     describe('wire decorator', () => {

--- a/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
@@ -27,7 +27,7 @@ const COMPILED_CMP = `
       }
     }
     const __REFLECTED_PROPS__ = [];
-    async function* generateMarkup(tagName, props, attrs, slotted) {
+    async function* __lwcGenerateMarkup(tagName, props, attrs, slotted) {
       attrs = attrs ?? ({});
       const instance = new Basic({
         tagName: tagName.toUpperCase()
@@ -65,10 +65,10 @@ describe('transmogrify', () => {
     });
 
     describe('in sync mode', () => {
-        test('generateMarkup is transformed into sync mode', () => {
-            expect(COMPILED_CMP_SYNC).not.toContain('async function* generateMarkup');
-            expect(COMPILED_CMP_SYNC).not.toContain('async function generateMarkup');
-            expect(COMPILED_CMP_SYNC).toContain('function generateMarkup($$emit');
+        test('__lwcGenerateMarkup is transformed into sync mode', () => {
+            expect(COMPILED_CMP_SYNC).not.toContain('async function* __lwcGenerateMarkup');
+            expect(COMPILED_CMP_SYNC).not.toContain('async function __lwcGenerateMarkup');
+            expect(COMPILED_CMP_SYNC).toContain('function __lwcGenerateMarkup($$emit');
 
             expect(COMPILED_CMP_SYNC).not.toContain('yield* renderAttrs');
             expect(COMPILED_CMP_SYNC).toContain('renderAttrs($$emit');
@@ -102,9 +102,9 @@ describe('transmogrify', () => {
     });
 
     describe('in async mode', () => {
-        test('generateMarkup is transformed into async mode', () => {
-            expect(COMPILED_CMP_ASYNC).not.toContain('async function* generateMarkup');
-            expect(COMPILED_CMP_ASYNC).toContain('async function generateMarkup($$emit');
+        test('__lwcGenerateMarkup is transformed into async mode', () => {
+            expect(COMPILED_CMP_ASYNC).not.toContain('async function* __lwcGenerateMarkup');
+            expect(COMPILED_CMP_ASYNC).toContain('async function __lwcGenerateMarkup($$emit');
 
             expect(COMPILED_CMP_ASYNC).not.toContain('yield* renderAttrs');
             expect(COMPILED_CMP_ASYNC).toContain('renderAttrs($$emit');

--- a/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/transmogrify.spec.ts
@@ -5,7 +5,7 @@ import { transmogrify } from '../transmogrify';
 import type { Program as EsProgram } from 'estree';
 
 const COMPILED_CMP = `
-    async function* tmpl(props, attrs, slottedContent, Cmp, instance) {
+    async function* __lwcTmpl(props, attrs, slottedContent, Cmp, instance) {
       yield "<p";
       yield stylesheetScopeTokenClass;
       yield ">Hello</p>";
@@ -78,10 +78,10 @@ describe('transmogrify', () => {
             expect(COMPILED_CMP_SYNC).toContain('$$emit(">")');
         });
 
-        test('tmpl is transformed into sync mode', () => {
-            expect(COMPILED_CMP_SYNC).not.toContain('async function* tmpl');
-            expect(COMPILED_CMP_SYNC).not.toContain('async function tmpl');
-            expect(COMPILED_CMP_SYNC).toContain('function tmpl($$emit');
+        test('__lwcTmpl is transformed into sync mode', () => {
+            expect(COMPILED_CMP_SYNC).not.toContain('async function* __lwcTmpl');
+            expect(COMPILED_CMP_SYNC).not.toContain('async function __lwcTmpl');
+            expect(COMPILED_CMP_SYNC).toContain('function __lwcTmpl($$emit');
 
             expect(COMPILED_CMP_SYNC).not.toContain('yield "<p"');
             expect(COMPILED_CMP_SYNC).toContain('$$emit("<p")');
@@ -114,9 +114,9 @@ describe('transmogrify', () => {
             expect(COMPILED_CMP_ASYNC).toContain('$$emit(">")');
         });
 
-        test('tmpl is transformed into async mode', () => {
-            expect(COMPILED_CMP_ASYNC).not.toContain('async function* tmpl');
-            expect(COMPILED_CMP_ASYNC).toContain('async function tmpl($$emit');
+        test('__lwcTmpl is transformed into async mode', () => {
+            expect(COMPILED_CMP_ASYNC).not.toContain('async function* __lwcTmpl');
+            expect(COMPILED_CMP_ASYNC).toContain('async function __lwcTmpl($$emit');
 
             expect(COMPILED_CMP_ASYNC).not.toContain('yield "<p"');
             expect(COMPILED_CMP_ASYNC).toContain('$$emit("<p")');

--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -139,7 +139,7 @@ export function addGenerateMarkupFunction(
     let exposeTemplateBlock: IfStatement | null = null;
     if (!tmplExplicitImports) {
         const defaultTmplPath = `./${pathParse(filename).name}.html`;
-        const tmplVar = b.identifier('tmpl');
+        const tmplVar = b.identifier('__lwcTmpl');
         program.body.unshift(bImportDeclaration({ default: tmplVar.name }, defaultTmplPath));
         program.body.unshift(
             bImportDeclaration({ SYMBOL__DEFAULT_TEMPLATE: '__SYMBOL__DEFAULT_TEMPLATE' })

--- a/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/generate-markup.ts
@@ -26,7 +26,7 @@ const bGenerateMarkup = esTemplate`
         configurable: false,
         enumerable: false,
         writable: false,
-        value: async function* generateMarkup(
+        value: async function* __lwcGenerateMarkup(
             // The $$emit function is magically inserted here
             tagName, 
             props, 

--- a/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/stylesheet-scope-token.ts
@@ -40,5 +40,5 @@ export function addScopeTokenDeclarations(
         bHasScopedStylesheetsDeclaration()
     );
 
-    program.body.push(...tmplAssignmentBlock(b.identifier('tmpl')));
+    program.body.push(...tmplAssignmentBlock(b.identifier('__lwcTmpl')));
 }

--- a/packages/@lwc/ssr-compiler/src/compile-template/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/index.ts
@@ -23,7 +23,7 @@ import type {
 
 // TODO [#4663]: Render mode mismatch between template and compiler should throw.
 const bExportTemplate = esTemplate`
-    export default async function* tmpl(
+    export default async function* __lwcTmpl(
             // This is where $$emit comes from
             shadowSlottedContent,
             lightSlottedContent,

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/slotted-content.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/slotted-content.ts
@@ -38,7 +38,7 @@ import type { TransformerContext } from '../../types';
 
 const bGenerateSlottedContent = esTemplateWithYield`
         const shadowSlottedContent = ${/* hasShadowSlottedContent */ is.literal}
-            ? async function* generateSlottedContent(contextfulParent) {
+            ? async function* __lwcGenerateSlottedContent(contextfulParent) {
                 // The 'contextfulParent' variable is shadowed here so that a contextful relationship
                 // is established between components rendered in slotted content & the "parent"
                 // component that contains the <slot>.
@@ -72,11 +72,11 @@ const bGenerateSlottedContent = esTemplateWithYield`
         ${/* scoped slot addLightContent statements */ is.expressionStatement}
 `<EsStatement[]>;
 
-// Note that this function name (`generateSlottedContent`) does not need to be scoped even though
+// Note that this function name (`__lwcGenerateSlottedContent`) does not need to be scoped even though
 // it may be repeated multiple times in the same scope, because it's a function _expression_ rather
 // than a function _declaration_, so it isn't available to be referenced anywhere.
 const bAddSlottedContent = esTemplate`
-    addSlottedContent(${/* slot name */ is.expression} ?? "", async function* generateSlottedContent(contextfulParent, ${
+    addSlottedContent(${/* slot name */ is.expression} ?? "", async function* __lwcGenerateSlottedContent(contextfulParent, ${
         /* scoped slot data variable */ isNullableOf(is.identifier)
     }, slotAttributeValue) {
         // FIXME: make validation work again  

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -22,7 +22,7 @@ const EMIT_IDENT = b.identifier('$$emit');
 // Rollup may rename variables to prevent shadowing. When it does, it uses the format `foo$0`, `foo$1`, etc.
 const TMPL_FN_PATTERN = /__lwcTmpl($\d+)?/;
 const GEN_MARKUP_OR_GEN_SLOTTED_CONTENT_PATTERN =
-    /(?:generateMarkup|__lwcGenerateSlottedContent)($\d+)?/;
+    /(?:__lwcGenerateMarkup|__lwcGenerateSlottedContent)($\d+)?/;
 
 const isWithinFn = (pattern: RegExp, nodePath: NodePath): boolean => {
     const { node } = nodePath;

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -22,7 +22,7 @@ const EMIT_IDENT = b.identifier('$$emit');
 // Rollup may rename variables to prevent shadowing. When it does, it uses the format `foo$0`, `foo$1`, etc.
 const TMPL_FN_PATTERN = /__lwcTmpl($\d+)?/;
 const GEN_MARKUP_OR_GEN_SLOTTED_CONTENT_PATTERN =
-    /(?:generateMarkup|generateSlottedContent)($\d+)?/;
+    /(?:generateMarkup|__lwcGenerateSlottedContent)($\d+)?/;
 
 const isWithinFn = (pattern: RegExp, nodePath: NodePath): boolean => {
     const { node } = nodePath;

--- a/packages/@lwc/ssr-compiler/src/transmogrify.ts
+++ b/packages/@lwc/ssr-compiler/src/transmogrify.ts
@@ -20,7 +20,7 @@ export type Visitors = Parameters<typeof traverse<Node, TransmogrificationState>
 
 const EMIT_IDENT = b.identifier('$$emit');
 // Rollup may rename variables to prevent shadowing. When it does, it uses the format `foo$0`, `foo$1`, etc.
-const TMPL_FN_PATTERN = /tmpl($\d+)?/;
+const TMPL_FN_PATTERN = /__lwcTmpl($\d+)?/;
 const GEN_MARKUP_OR_GEN_SLOTTED_CONTENT_PATTERN =
     /(?:generateMarkup|generateSlottedContent)($\d+)?/;
 
@@ -152,7 +152,7 @@ const visitors: Visitors = {
  * Is compiled into the following JavaScript, intended for execution during SSR & stripped down
  * for the purposes of this example:
  *
- *   async function* tmpl(props, attrs, slottedContent, Cmp, instance) {
+ *   async function* __lwcTmpl(props, attrs, slottedContent, Cmp, instance) {
  *       yield '<div>foobar</div>';
  *       const childProps = {};
  *       const childAttrs = {};
@@ -161,7 +161,7 @@ const visitors: Visitors = {
  *
  * When transmogrified in async-mode, the above generated template function becomes the following:
  *
- *   async function tmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
+ *   async function __lwcTmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
  *       $$emit('<div>foobar</div>');
  *       const childProps = {};
  *       const childAttrs = {};
@@ -170,7 +170,7 @@ const visitors: Visitors = {
  *
  * When transmogrified in sync-mode, the template function becomes the following:
  *
- *   function tmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
+ *   function __lwcTmpl($$emit, props, attrs, slottedContent, Cmp, instance) {
  *       $$emit('<div>foobar</div>');
  *       const childProps = {};
  *       const childAttrs = {};


### PR DESCRIPTION
## Details

When we transmogrify the SSR compiler's output, we only want to target functions created by the compiler, not the component's implementation. We check for specific function names, but technically a component could implement a function with the same name (or even _containing_ the same name, like `omgwtftmplbbq`, because we don't use `^$` in the regex check). However, we already prevent components from using names starting with `__lwc`, so we can prevent accidental transmogrification by using that namespace for the functions we own.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
