### PR TITLE
chore: extra guards process.env @W-17994335

### DIFF
--- a/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
+++ b/packages/@lwc/engine-core/src/framework/check-version-mismatch.ts
@@ -38,7 +38,12 @@ export function checkVersionMismatch(
 ) {
     const versionMatcher = func.toString().match(LWC_VERSION_COMMENT_REGEX);
     if (!isNull(versionMatcher) && !warned) {
-        if (typeof process === 'object' && process.env.SKIP_LWC_VERSION_MISMATCH_CHECK === 'true') {
+        if (
+            typeof process === 'object' &&
+            typeof process?.env === 'object' &&
+            process.env &&
+            process.env.SKIP_LWC_VERSION_MISMATCH_CHECK === 'true'
+        ) {
             warned = true; // skip printing out version mismatch errors when env var is set
             return;
         }


### PR DESCRIPTION
evidently some places have `process` but not `process.env`

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
