### PR TITLE
chore(integration-karma): remove programmatic DSD check

### DIFF
--- a/packages/@lwc/integration-karma/helpers/test-hydrate.js
+++ b/packages/@lwc/integration-karma/helpers/test-hydrate.js
@@ -10,50 +10,15 @@ window.HydrateTest = (function (lwc, testUtils) {
         sanitizeHtmlContent: (content) => content,
     });
 
-    // As of this writing, Firefox does not support programmatic access to parsing DSD,
-    // i.e. `Document.parseHTMLUnsafe`
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static
-    function testSupportsProgrammaticDSD() {
-        const html = '<div><template shadowrootmode="open"></template></div>';
-        try {
-            return !!Document.parseHTMLUnsafe(html).body.firstChild.shadowRoot;
-        } catch (_err) {
-            return false;
-        }
-    }
-
-    const browserSupportsProgrammaticDSD = testSupportsProgrammaticDSD();
-
     function parseStringToDom(html) {
-        if (browserSupportsProgrammaticDSD) {
-            return Document.parseHTMLUnsafe(html).body.firstChild;
-        } else {
-            return new DOMParser().parseFromString(html, 'text/html').body.firstChild;
-        }
-    }
-
-    function polyfillDeclarativeShadowDom(root) {
-        root.querySelectorAll('template[shadowrootmode]').forEach((template) => {
-            const mode = template.getAttribute('shadowrootmode');
-            const shadowRoot = template.parentNode.attachShadow({ mode });
-            shadowRoot.appendChild(template.content);
-            template.remove();
-
-            polyfillDeclarativeShadowDom(shadowRoot);
-        });
+        return Document.parseHTMLUnsafe(html).body.firstChild;
     }
 
     function appendTestTarget(ssrText) {
         const div = document.createElement('div');
-
         const testTarget = parseStringToDom(ssrText);
-        if (!browserSupportsProgrammaticDSD) {
-            polyfillDeclarativeShadowDom(testTarget);
-        }
         div.appendChild(testTarget);
-
         document.body.appendChild(div);
-
         return div;
     }
 
@@ -91,7 +56,5 @@ window.HydrateTest = (function (lwc, testUtils) {
         return testResult;
     }
 
-    return {
-        runTest,
-    };
+    return { runTest };
 })(window.LWC, window.TestUtils);


### PR DESCRIPTION
Nolan's comment says the workaround is for Firefox, which added support in version 128 (released 2024-07-09). So it shouldn't be necessary any more. (Unless we're still testing older versions.)

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
