### PR TITLE
chore(dependabot): separate out all @wdio packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,6 @@ updates:
               patterns:
                   - 'webdriverio'
                   - '@wdio/*'
-              update-types:
-                  - 'major'
           prettier:
               patterns:
                   - 'prettier'


### PR DESCRIPTION
Something's broken in a recent update. Not sure what and don't want to look into it, at the moment. Pulling the packages out separately means we can still get the other dependabot bumps.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
