### PR TITLE
chore(eslint): update config to catch .only and .skip files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import gitignore from 'eslint-config-flat-gitignore';
 import vitest from '@vitest/eslint-plugin';
+import * as espree from 'espree';
+
 import { PUBLIC_PACKAGES as publicPackageData } from './scripts/shared/packages.mjs';
 // convert filepath to eslint glob
 const PUBLIC_PACKAGES = publicPackageData.map(({ path }) => `${path}/**`);
@@ -403,18 +405,35 @@ export default tseslint.config(
 
     {
         // These are empty files used to help debug test fixtures
-        files: ['**/.only'],
+        files: ['**/.only', '**/.skip'],
         plugins: { '@lwc/lwc-internal': lwcInternal },
+        languageOptions: {
+            // Using the default eslint parser because typescript-eslint doesn't
+            // seem to correctly support `extraFileExtensions`
+            parser: espree,
+            parserOptions: {
+                extraFileExtensions: ['only', 'skip'],
+            },
+        },
         rules: {
             '@lwc/lwc-internal/forbidden-filename': 'error',
+            // Disable all TS rules because they complain about the parser being espree
+            ...Object.fromEntries(
+                tseslint.configs.all
+                    .flatMap((cfg) => Object.keys(cfg.rules ?? {}))
+                    .map((rule) => [rule, 'off'])
+            ),
         },
     },
     {
-        // These are empty files used to help debug test fixtures
         files: ['**/.skip'],
-        plugins: { '@lwc/lwc-internal': lwcInternal },
         rules: {
-            '@lwc/lwc-internal/forbidden-filename': 'off',
+            // We want to avoid accidentally committing .skip files, but sometimes there are
+            // legitimate reasons to do so. So we complain when trying to commit, but not any
+            // other time.
+            '@lwc/lwc-internal/forbidden-filename':
+                // eslint-disable-next-line no-undef
+                process.env.npm_lifecycle_event === 'lint-staged' ? 'error' : 'off',
         },
     }
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,7 @@ export default tseslint.config(
 
     gitignore(),
     {
-        ignores: ['**/fixtures'],
+        ignores: ['packages/**/fixtures/**/*.js'],
     },
     js.configs.recommended,
     ...tseslint.configs.recommendedTypeChecked,

--- a/package.json
+++ b/package.json
@@ -76,11 +76,10 @@
         "vitest": "^3.0.8"
     },
     "lint-staged": {
-        "*.{js,mjs,ts}": "eslint --cache",
+        "*.{js,mjs,ts,only,skip}": "eslint --cache",
         "*.{css,js,json,md,mjs,ts,yaml,yml}": "prettier --check",
         "{packages/**/package.json,scripts/tasks/check-and-rewrite-package-json.js}": "node ./scripts/tasks/check-and-rewrite-package-json.js --test",
-        "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js --test",
-        "*.{only,skip}": "eslint --cache --plugin '@lwc/eslint-plugin-lwc-internal' --rule '@lwc/lwc-internal/forbidden-filename: error'"
+        "{LICENSE-CORE.md,**/LICENSE.md,yarn.lock,scripts/tasks/generate-license-files.js,scripts/shared/bundled-dependencies.js}": "node ./scripts/tasks/generate-license-files.js --test"
     },
     "workspaces": [
         "packages/@lwc/*",

--- a/packages/@lwc/engine-server/src/__tests__/fixtures/scope-token/.skip
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/scope-token/.skip
@@ -1,3 +1,3 @@
-W-17972327
+// W-17972327
 
-This test fails in CI and has been doing so intermittently in recent PRs. Unfortunately, it has been difficult to reproduce and resolve when running locally. Since the failure is unrelated to this PR, we're disabling the test and have filed a work item (reference above) to investigate separately.
+// This test fails in CI and has been doing so intermittently in recent PRs. Unfortunately, it has been difficult to reproduce and resolve when running locally. Since the failure is unrelated to this PR, we're disabling the test and have filed a work item (reference above) to investigate separately.

--- a/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/typescript.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/resolver/fixtures/inherited-templates/src/typescript.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Extension from 'x/ext-ts';


### PR DESCRIPTION
## Details

We noticed recently that `.only` files could be accidentally committed, which breaks test coverage. Turns out they've been broken since we switched to flat ESLint config!

This was more annoying than I'd like it to have been because it seems `typescript-eslint` doesn't play nice with mixing and matching.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
