### PR TITLE
feat(ssr-compiler): only mutate things if we're in a component @W-17748892

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -9,6 +9,7 @@ import { type traverse } from 'estree-toolkit';
 import type { ImportManager } from '../imports';
 import type { ComponentTransformOptions } from '../shared';
 import type {
+    ClassDeclaration,
     Identifier,
     MemberExpression,
     MethodDefinition,
@@ -26,8 +27,10 @@ export interface WireAdapter {
 }
 
 export interface ComponentMetaState {
-    /** indicates whether the LightningElement subclass is found in the JS being traversed */
+    /** indicates whether a subclass of LightningElement is found in the JS being traversed */
     isLWC: boolean;
+    /** the class declaration currently being traversed, if it is an LWC component */
+    currentComponent: ClassDeclaration | null;
     /** indicates whether the LightningElement subclass includes a constructor method */
     hasConstructor: boolean;
     /** indicates whether the subclass has a connectedCallback method */

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -26,36 +26,36 @@ export interface WireAdapter {
 }
 
 export interface ComponentMetaState {
-    // indicates whether the LightningElement subclass is found in the JS being traversed
+    /** indicates whether the LightningElement subclass is found in the JS being traversed */
     isLWC: boolean;
-    // indicates whether the LightningElement subclass includes a constructor method
+    /** indicates whether the LightningElement subclass includes a constructor method */
     hasConstructor: boolean;
-    // indicates whether the subclass has a connectedCallback method
+    /** indicates whether the subclass has a connectedCallback method */
     hasConnectedCallback: boolean;
-    // indicates whether the subclass has a renderedCallback method
+    /** indicates whether the subclass has a renderedCallback method */
     hadRenderedCallback: boolean;
-    // indicates whether the subclass has a disconnectedCallback method
+    /** indicates whether the subclass has a disconnectedCallback method */
     hadDisconnectedCallback: boolean;
-    // indicates whether the subclass has a errorCallback method
+    /** indicates whether the subclass has a errorCallback method */
     hadErrorCallback: boolean;
-    // the local name corresponding to the `LightningElement` import
+    /** the local name corresponding to the `LightningElement` import */
     lightningElementIdentifier: string | null;
-    // the class name of the subclass
+    /** the class name of the subclass */
     lwcClassName: string | null;
-    // ties local variable names to explicitly-imported HTML templates
+    /** ties local variable names to explicitly-imported HTML templates */
     tmplExplicitImports: Map<string, string> | null;
-    // ties local variable names to explicitly-imported CSS files
+    /** ties local variable names to explicitly-imported CSS files */
     cssExplicitImports: Map<string, string> | null;
-    // the set of variable names associated with explicitly imported CSS files
+    /** the set of variable names associated with explicitly imported CSS files */
     staticStylesheetIds: Set<string> | null;
-    // the public (`@api`-annotated) properties of the component class
+    /** the public (`@api`-annotated) properties of the component class */
     publicProperties: Map<string, (MethodDefinition | PropertyDefinition) & { key: Identifier }>;
-    // the private properties of the component class
+    /** the private properties of the component class */
     privateProperties: Set<string>;
-    // indicates whether the LightningElement has any wired props
+    /** indicates whether the LightningElement has any wired props */
     wireAdapters: WireAdapter[];
-    // dynamic imports configuration
+    /** dynamic imports configuration */
     experimentalDynamicComponent: ComponentTransformOptions['experimentalDynamicComponent'];
-    // imports to add to the top of the program after parsing
+    /** imports to add to the top of the program after parsing */
     importManager: ImportManager;
 }

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -58,4 +58,6 @@ export interface ComponentMetaState {
     experimentalDynamicComponent: ComponentTransformOptions['experimentalDynamicComponent'];
     /** imports to add to the top of the program after parsing */
     importManager: ImportManager;
+    /** identifiers starting with __lwc that we added */
+    trustedLwcIdentifiers: WeakSet<Identifier>;
 }


### PR DESCRIPTION
## Details

1. Changed the `__load` identifier to `__lwcLoad` so that users can't sneaky hijack that. But that change gets caught by our `__lwc` check, so I added a way to check which `__lwc` identifiers we trust.
2. We only want to mutate things that belong to the actual LWC component. The existing `isLWC` logic potentially breaks if there's more than one class in a file (e.g. `class Cmp extends LightningElement { ... }; class Helper { ... };`), so I added a way of tracking whether we're actually inside the LWC component itself.
3. PR best viewed with whitespace diff ignored.

Closes #5189.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
