### PR TITLE
chore(ssr-compiler): remove fixed FIXMEs

### DIFF
--- a/packages/@lwc/ssr-compiler/src/compile-js/decorators/wire.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/decorators/wire.ts
@@ -171,7 +171,6 @@ export function catalogWireAdapters(
             }
         });
     } else {
-        // FIXME: for `@wire(Adapter), does engine-server use `undefined` or `{}` for config?
         reactiveConfig = b.objectExpression([]); // empty object
     }
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/slotted-content.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/component/slotted-content.ts
@@ -79,8 +79,7 @@ const bAddSlottedContent = esTemplate`
     addSlottedContent(${/* slot name */ is.expression} ?? "", async function* __lwcGenerateSlottedContent(contextfulParent, ${
         /* scoped slot data variable */ isNullableOf(is.identifier)
     }, slotAttributeValue) {
-        // FIXME: make validation work again  
-        ${/* slot content */ false}
+        ${/* slot content */ is.statement}
     }, ${/* content map */ is.identifier});
 `<EsCallExpression>;
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
@@ -67,7 +67,6 @@ const bConditionalSlot = esTemplateWithYield`
             // something. It's impossible for a slottedContent["foo"] to exist
             // without the generator yielding at least a text node / element.
             // FIXME: how does this work with comments and lwc:preserve-comments?
-            // TODO: default/fallback slot content
             ${/* slot fallback content */ is.statement}
         }
 

--- a/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-template/transformers/slot.ts
@@ -66,7 +66,6 @@ const bConditionalSlot = esTemplateWithYield`
             // If we're in this else block, then the generator _must_ have yielded
             // something. It's impossible for a slottedContent["foo"] to exist
             // without the generator yielding at least a text node / element.
-            // FIXME: how does this work with comments and lwc:preserve-comments?
             ${/* slot fallback content */ is.statement}
         }
 


### PR DESCRIPTION
## Details

We added a bunch of `FIXME`s while doing the initial implementation of SSR v2. Turns out we've fixed just about all of them. There's only one left, that we can probably address when we do perf optimizations.

https://github.com/salesforce/lwc/blob/9a75843839bea264dd579cbce33102ea59798022/packages/%40lwc/ssr-compiler/src/compile-template/transformers/slot.ts#L92

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
