### PR TITLE
chore: re-introduce new constructor validation with gate

### DIFF
--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -58,11 +58,10 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         // When Locker is enabled, the "instanceof" operator would not work since Locker Service
         // provides its own implementation of LightningElement, so we indirectly check
         // if the base constructor is invoked by accessing the component on the vm.
-        // When the DISABLE_LIGHTNING_CONSTRUCTOR_CHECK gate is true and LEGACY_LOCKER_ENABLED is false,
+        // When the ENABLE_LOCKER_VALIDATION gate is true and LEGACY_LOCKER_ENABLED is false,
         // then the instanceof LightningElement can be used.
         const useLegacyConstructorCheck =
-            lwcRuntimeFlags.DISABLE_LIGHTNING_CONSTRUCTOR_CHECK ||
-            lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
+            lwcRuntimeFlags.ENABLE_LEGACY_VALIDATION || lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
 
         const isInvalidConstructor = useLegacyConstructorCheck
             ? vmBeingConstructed.component !== result

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -54,16 +54,19 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         // job
         const result = new Ctor();
 
-        // Check indirectly if the constructor result is an instance of LightningElement. Using
-        // the "instanceof" operator would not work here since Locker Service provides its own
-        // implementation of LightningElement, so we indirectly check if the base constructor is
-        // invoked by accessing the component on the vm.
+        // Check indirectly if the constructor result is an instance of LightningElement.
+        // When Locker is enabled, the "instanceof" operator would not work since Locker Service
+        // provides its own implementation of LightningElement, so we indirectly check
+        // if the base constructor is invoked by accessing the component on the vm.
+        // When the ENABLE_LIGHTNING_CONSTRUCTOR_CHECK gate is true and LEGACY_LOCKER_ENABLED is false,
+        // then the instanceof LightningElement can be used.
+        const useLegacyConstructorCheck =
+            !lwcRuntimeFlags.ENABLE_LIGHTNING_CONSTRUCTOR_CHECK ||
+            lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
 
-        // TODO [W-17769475]: Restore this fix when we can reliably detect Locker enabled
-        // const isInvalidConstructor = lwcRuntimeFlags.LEGACY_LOCKER_ENABLED
-        //     ? vmBeingConstructed.component !== result
-        //     : !(result instanceof LightningElement);
-        const isInvalidConstructor = vmBeingConstructed.component !== result;
+        const isInvalidConstructor = useLegacyConstructorCheck
+            ? vmBeingConstructed.component !== result
+            : !(result instanceof LightningElement);
 
         if (isInvalidConstructor) {
             throw new TypeError(

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -61,7 +61,7 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         // When the DISABLE_LIGHTNING_CONSTRUCTOR_CHECK gate is true and LEGACY_LOCKER_ENABLED is false,
         // then the instanceof LightningElement can be used.
         const useLegacyConstructorCheck =
-            lwcRuntimeFlags.DISABLE_LIGHTNING_CONSTRUCTOR_CHECK &&
+            lwcRuntimeFlags.DISABLE_LIGHTNING_CONSTRUCTOR_CHECK ||
             lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
 
         const isInvalidConstructor = useLegacyConstructorCheck

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -11,7 +11,7 @@ import { addErrorComponentStack } from '../shared/error';
 import { evaluateTemplate, setVMBeingRendered, getVMBeingRendered } from './template';
 import { runWithBoundaryProtection } from './vm';
 import { logOperationStart, logOperationEnd, OperationId } from './profiler';
-import type { LightningElement } from './base-lightning-element';
+import { LightningElement } from './base-lightning-element';
 import type { Template } from './template';
 import type { VM } from './vm';
 import type { LightningElementConstructor } from './base-lightning-element';

--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -58,10 +58,10 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         // When Locker is enabled, the "instanceof" operator would not work since Locker Service
         // provides its own implementation of LightningElement, so we indirectly check
         // if the base constructor is invoked by accessing the component on the vm.
-        // When the ENABLE_LIGHTNING_CONSTRUCTOR_CHECK gate is true and LEGACY_LOCKER_ENABLED is false,
+        // When the DISABLE_LIGHTNING_CONSTRUCTOR_CHECK gate is true and LEGACY_LOCKER_ENABLED is false,
         // then the instanceof LightningElement can be used.
         const useLegacyConstructorCheck =
-            !lwcRuntimeFlags.ENABLE_LIGHTNING_CONSTRUCTOR_CHECK ||
+            lwcRuntimeFlags.DISABLE_LIGHTNING_CONSTRUCTOR_CHECK &&
             lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
 
         const isInvalidConstructor = useLegacyConstructorCheck

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -22,7 +22,7 @@ const features: FeatureFlagMap = {
     DISABLE_SYNTHETIC_SHADOW: null,
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     LEGACY_LOCKER_ENABLED: null,
-    ENABLE_LIGHTNING_CONSTRUCTOR_CHECK: null,
+    DISABLE_LIGHTNING_CONSTRUCTOR_CHECK: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -22,7 +22,7 @@ const features: FeatureFlagMap = {
     DISABLE_SYNTHETIC_SHADOW: null,
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     LEGACY_LOCKER_ENABLED: null,
-    DISABLE_LIGHTNING_CONSTRUCTOR_CHECK: null,
+    ENABLE_LEGACY_VALIDATION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -22,6 +22,7 @@ const features: FeatureFlagMap = {
     DISABLE_SYNTHETIC_SHADOW: null,
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     LEGACY_LOCKER_ENABLED: null,
+    ENABLE_LIGHTNING_CONSTRUCTOR_CHECK: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -91,7 +91,7 @@ export interface FeatureFlagMap {
      * If true, then the legacy constructor check is only used if
      * LEGACY_LOCKER_ENABLED is true.
      */
-    ENABLE_LIGHTNING_CONSTRUCTOR_CHECK: FeatureFlagValue;
+    DISABLE_LIGHTNING_CONSTRUCTOR_CHECK: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -88,10 +88,11 @@ export interface FeatureFlagMap {
     LEGACY_LOCKER_ENABLED: FeatureFlagValue;
 
     /**
-     * If true, then the legacy constructor check is only used if
-     * LEGACY_LOCKER_ENABLED is true.
+     * A manual override for `LEGACY_LOCKER_ENABLED`; should not be used if that flag is correctly set.
+     * If true, behave as if legacy Locker is enabled.
+     * If false or unset, then the value of the `LEGACY_LOCKER_ENABLED` flag is used.
      */
-    DISABLE_LIGHTNING_CONSTRUCTOR_CHECK: FeatureFlagValue;
+    ENABLE_LEGACY_VALIDATION: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -86,6 +86,12 @@ export interface FeatureFlagMap {
      * properly.
      */
     LEGACY_LOCKER_ENABLED: FeatureFlagValue;
+
+    /**
+     * If true, then the legacy constructor check is only used if
+     * LEGACY_LOCKER_ENABLED is true.
+     */
+    ENABLE_LIGHTNING_CONSTRUCTOR_CHECK: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -81,18 +81,18 @@ it("[W-6981076] shouldn't throw when a component with an invalid child in unmoun
     expect(() => document.body.removeChild(elm)).not.toThrow();
 });
 
-it('should fail when the constructor returns something other than LightningElement when ENABLE_LIGHTNING_CONSTRUCTOR_CHECK is true', () => {
-    setFeatureFlagForTest('ENABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
+it('should fail when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is true', () => {
+    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).toThrowError(
         TypeError,
         'Invalid component constructor, the class should extend LightningElement.'
     );
-    setFeatureFlagForTest('ENABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
+    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LIGHTNING_CONSTRUCTOR_CHECK is falsy', () => {
+it('should succeed when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is falsy', () => {
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).not.toThrow();

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -1,4 +1,4 @@
-import { LightningElement, createElement } from 'lwc';
+import { LightningElement, createElement, setFeatureFlagForTest } from 'lwc';
 
 import NotInvokingSuper from 'x/notInvokingSuper';
 import NotReturningThis from 'x/notReturningThis';
@@ -81,12 +81,19 @@ it("[W-6981076] shouldn't throw when a component with an invalid child in unmoun
     expect(() => document.body.removeChild(elm)).not.toThrow();
 });
 
-// TODO [W-17769475]: Restore this test when we can reliably detect Locker enabled
-xit('should fail when the constructor returns something other than an instance of itself', () => {
+it('should fail when the constructor returns something other than LightningElement when ENABLE_LIGHTNING_CONSTRUCTOR_CHECK is true', () => {
+    setFeatureFlagForTest('ENABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).toThrowError(
         TypeError,
         'Invalid component constructor, the class should extend LightningElement.'
     );
+    setFeatureFlagForTest('ENABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
+});
+
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LIGHTNING_CONSTRUCTOR_CHECK is falsy', () => {
+    expect(() => {
+        createElement('x-returning-bad', { is: ReturningBad });
+    }).not.toThrow();
 });

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -82,18 +82,18 @@ it("[W-6981076] shouldn't throw when a component with an invalid child in unmoun
 });
 
 it('should fail when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is true', () => {
-    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).toThrowError(
         TypeError,
         'Invalid component constructor, the class should extend LightningElement.'
     );
-    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
 });
 
 it('should succeed when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is falsy', () => {
+    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).not.toThrow();
+    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
 });

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -90,7 +90,7 @@ it('should fail when the constructor returns something other than LightningEleme
     );
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is true', () => {
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is true and LEGACY_LOCKER_ENABLED is falsy', () => {
     setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
@@ -98,8 +98,16 @@ it('should succeed when the constructor returns something other than LightningEl
     setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is false and LEGACY_LOCKER_ENABLED is true', () => {
-    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is true', () => {
+    setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', true);
+    expect(() => {
+        createElement('x-returning-bad', { is: ReturningBad });
+    }).not.toThrow();
+    setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', false);
+});
+
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is true', () => {
+    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', true);
     setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -81,7 +81,7 @@ it("[W-6981076] shouldn't throw when a component with an invalid child in unmoun
     expect(() => document.body.removeChild(elm)).not.toThrow();
 });
 
-it('should fail when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is true', () => {
+it('should fail when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is falsy', () => {
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).toThrowError(
@@ -90,10 +90,20 @@ it('should fail when the constructor returns something other than LightningEleme
     );
 });
 
-it('should succeed when the constructor returns something other than LightningElement when DISABLE_LIGHTNING_CONSTRUCTOR_CHECK is falsy', () => {
-    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', true);
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is true', () => {
+    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).not.toThrow();
-    setFeatureFlagForTest('DISABLE_LIGHTNING_CONSTRUCTOR_CHECK', false);
+    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
+});
+
+it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is false and LEGACY_LOCKER_ENABLED is true', () => {
+    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
+    setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', true);
+    expect(() => {
+        createElement('x-returning-bad', { is: ReturningBad });
+    }).not.toThrow();
+    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
+    setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', false);
 });


### PR DESCRIPTION
## Details

Re-introduce new constructor check with an additional gate to protect the rollout.

WHAT:
Adds the DISABLE_LIGHTNING_CONSTRUCTOR_CHECK gate to only do the component instanceof LightningElement check when this gate is false and LEGACY_LOCKER_ENABLED is false.

WHY?
Adding the gate allows us to disable the new constructor check if there are issues and it gives LWS a chance to correctly implement the LEGACY_LOCKER_ENABLED using the new logic.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

W-18174268