### PR TITLE
fix: invert locker contructor gate

### DIFF
--- a/packages/@lwc/engine-core/src/framework/invoker.ts
+++ b/packages/@lwc/engine-core/src/framework/invoker.ts
@@ -58,10 +58,10 @@ export function invokeComponentConstructor(vm: VM, Ctor: LightningElementConstru
         // When Locker is enabled, the "instanceof" operator would not work since Locker Service
         // provides its own implementation of LightningElement, so we indirectly check
         // if the base constructor is invoked by accessing the component on the vm.
-        // When the ENABLE_LOCKER_VALIDATION gate is true and LEGACY_LOCKER_ENABLED is false,
+        // When the DISABLE_LOCKER_VALIDATION gate is false or LEGACY_LOCKER_ENABLED is false,
         // then the instanceof LightningElement can be used.
         const useLegacyConstructorCheck =
-            lwcRuntimeFlags.ENABLE_LEGACY_VALIDATION || lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
+            !lwcRuntimeFlags.DISABLE_LEGACY_VALIDATION || lwcRuntimeFlags.LEGACY_LOCKER_ENABLED;
 
         const isInvalidConstructor = useLegacyConstructorCheck
             ? vmBeingConstructed.component !== result

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -22,7 +22,7 @@ const features: FeatureFlagMap = {
     DISABLE_SYNTHETIC_SHADOW: null,
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     LEGACY_LOCKER_ENABLED: null,
-    ENABLE_LEGACY_VALIDATION: null,
+    DISABLE_LEGACY_VALIDATION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -92,7 +92,7 @@ export interface FeatureFlagMap {
      * If true, behave as if legacy Locker is enabled.
      * If false or unset, then the value of the `LEGACY_LOCKER_ENABLED` flag is used.
      */
-    ENABLE_LEGACY_VALIDATION: FeatureFlagValue;
+    DISABLE_LEGACY_VALIDATION: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
+++ b/packages/@lwc/integration-karma/test/component/LightningElement/index.spec.js
@@ -81,24 +81,24 @@ it("[W-6981076] shouldn't throw when a component with an invalid child in unmoun
     expect(() => document.body.removeChild(elm)).not.toThrow();
 });
 
-it('should fail when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is falsy', () => {
+it('should fail when the constructor returns something other than LightningElement when DISABLE_LEGACY_VALIDATION is true and LEGACY_LOCKER_ENABLED is falsy', () => {
+    setFeatureFlagForTest('DISABLE_LEGACY_VALIDATION', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).toThrowError(
         TypeError,
         'Invalid component constructor, the class should extend LightningElement.'
     );
+    setFeatureFlagForTest('DISABLE_LEGACY_VALIDATION', false);
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is true and LEGACY_LOCKER_ENABLED is falsy', () => {
-    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', true);
+it('should succeed when the constructor returns something other than LightningElement when DISABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is falsy', () => {
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).not.toThrow();
-    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is true', () => {
+it('should succeed when the constructor returns something other than LightningElement when DISABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is true', () => {
     setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
@@ -106,12 +106,12 @@ it('should succeed when the constructor returns something other than LightningEl
     setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', false);
 });
 
-it('should succeed when the constructor returns something other than LightningElement when ENABLE_LEGACY_VALIDATION is falsy and LEGACY_LOCKER_ENABLED is true', () => {
-    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', true);
+it('should succeed when the constructor returns something other than LightningElement when DISABLE_LEGACY_VALIDATION is true and LEGACY_LOCKER_ENABLED is true', () => {
+    setFeatureFlagForTest('DISABLE_LEGACY_VALIDATION', true);
     setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', true);
     expect(() => {
         createElement('x-returning-bad', { is: ReturningBad });
     }).not.toThrow();
-    setFeatureFlagForTest('ENABLE_LEGACY_VALIDATION', false);
+    setFeatureFlagForTest('DISABLE_LEGACY_VALIDATION', false);
     setFeatureFlagForTest('LEGACY_LOCKER_ENABLED', false);
 });


### PR DESCRIPTION
## Details

Invert locker constructor check so default gate value is false.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

## GUS work item

[W-18174268](https://gus.lightning.force.com/a07EE00002C20XEYAZ)
