### PR TITLE
fix: remove perf regression for signals re-enablement (256 patch)

### DIFF
--- a/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
+++ b/packages/@lwc/engine-core/src/framework/mutation-tracker.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { isFunction, isNull, isObject, isTrustedSignal } from '@lwc/shared';
+import { isNull, isObject, isTrustedSignal } from '@lwc/shared';
 import { ReactiveObserver, valueMutated, valueObserved } from '../libs/mutation-tracker';
 import { subscribeToSignal } from '../libs/signal-tracker';
-import { safeHasProp } from './utils';
 import type { Signal } from '@lwc/signals';
 import type { JobFunction, CallbackFunction } from '../libs/mutation-tracker';
 import type { VM } from './vm';
@@ -42,9 +41,6 @@ export function componentValueObserved(vm: VM, key: PropertyKey, target: any = {
         lwcRuntimeFlags.ENABLE_EXPERIMENTAL_SIGNALS &&
         isObject(target) &&
         !isNull(target) &&
-        safeHasProp(target, 'value') &&
-        safeHasProp(target, 'subscribe') &&
-        isFunction(target.subscribe) &&
         isTrustedSignal(target) &&
         // Only subscribe if a template is being rendered by the engine
         tro.isObserving()


### PR DESCRIPTION
## Details

Backport signals perf regression to 256 patch

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

[W-18328598](https://gus.lightning.force.com/a07EE00002DAb1vYAD)
