### PR TITLE
feat(types): add hidden helper to make inferring element types better @W-18442478

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -98,21 +98,28 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 /**
- * Properties defined on the component class, excluding those inherited from `LightningElement`.
+ * Gets the public properties of a component class. If the `__lwc_public_property_types__` property
+ * is defined, it will be used as the source of truth for the property types. Otherwise, all of the
+ * properties defined on the component class are used, excluding those inherited from `LightningElement`.
+ *
+ * IMPORTANT: If the fallback is used, then _all_ component properties are returned, rather than
+ * just the public properties.
  */
-// TODO [#4292]: Restrict this to only @api props
-type ComponentClassProperties<T> = Omit<T, keyof LightningElement>;
+type ComponentClassProperties<T> = T extends {
+    __lwc_public_property_types__?: infer Props extends object;
+}
+    ? Props
+    : Omit<T, keyof LightningElement>;
 
 /**
  * The custom element returned when calling {@linkcode createElement} with the given component
  * constructor.
  *
- * NOTE: The returned type incorrectly includes _all_ properties defined on the component class,
+ * NOTE: By default, the returned type includes _all_ properties defined on the component class,
  * even though the runtime object only uses those decorated with `@api`. This is due to a
- * limitation of TypeScript. To avoid inferring incorrect properties, provide an explicit generic
- * parameter, e.g. `createElement<typeof LightningElement>('x-foo', { is: FooCtor })`.
+ * limitation of TypeScript. For example:
  *
- * @example ```
+ * ```
  * class Example extends LightningElement {
  *   @api exposed = 'hello'
  *   internal = 'secret'
@@ -123,6 +130,29 @@ type ComponentClassProperties<T> = Omit<T, keyof LightningElement>;
  * console.log(exposed) // prints 'hello'
  * const internal = example.internal // type is 'string'
  * console.log(internal) // prints `undefined`
+ * ```
+ *
+ * One way to avoid inferring incorrect properties, is to provide an explicit generic parameter.
+ * For example:
+ * ```
+ * const example = createElement<{exposed: string}>('c-example', { is: Example })
+ * const exposed = example.exposed // type is 'string'
+ * const internal = example.internal // Now a type error! ✅
+ * ```
+ *
+ * Alternatively, you can define a type for property on the component, `__lwc_public_property_types__`,
+ * that explicitly lists only the public properties, and the types will be inferred from that prop.
+ * The property should be optional, because it does not actually exist at runtime.
+ * For example:
+ * ```
+ * class Example extends LightningElement {
+ *   @api exposed = 'hello'
+ *   internal = 'secret'
+ *   __lwc_public_property_types__?: { exposed: string }
+ * }
+ * const example = createElement('c-example', { is: Example })
+ * const exposed = example.exposed // type is 'string'
+ * const internal = example.internal // Now a type error! ✅
  * ```
  */
 export type LightningHTMLElement<T> = HTMLElement & ComponentClassProperties<T>;

--- a/packages/@lwc/engine-dom/src/apis/create-element.ts
+++ b/packages/@lwc/engine-dom/src/apis/create-element.ts
@@ -106,7 +106,7 @@ if (process.env.NODE_ENV !== 'production') {
  * just the public properties.
  */
 type ComponentClassProperties<T> = T extends {
-    __lwc_public_property_types__?: infer Props extends object;
+    readonly __lwc_public_property_types__?: infer Props extends object;
 }
     ? Props
     : Omit<T, keyof LightningElement>;

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -279,7 +279,7 @@ class TemplateHtmlParser extends Parser<DefaultTreeAdapterMap> {
     // that, we create a new text node for the template expression rather than
     // allowing the concatenation to proceed.
     _insertCharacters(token: Token.CharacterToken) {
-        const parentNode = this.openElements.current!;
+        const parentNode = this.openElements.current;
         const previousPeer = parentNode.childNodes.at(-1);
         const html = this.tokenizer.preprocessor.html;
         if (

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/html.ts
@@ -279,7 +279,7 @@ class TemplateHtmlParser extends Parser<DefaultTreeAdapterMap> {
     // that, we create a new text node for the template expression rather than
     // allowing the concatenation to proceed.
     _insertCharacters(token: Token.CharacterToken) {
-        const parentNode = this.openElements.current;
+        const parentNode = this.openElements.current!;
         const previousPeer = parentNode.childNodes.at(-1);
         const html = this.tokenizer.preprocessor.html;
         if (


### PR DESCRIPTION
## Details

When rendering an LWC component, the component instance and element instance are two connected but distinct objects. The component instance inherits from `LightningElement`, while the element is an instance of `HTMLElement` with a few additional properties. Those properties are the `@api`-decorated properties from the component instance.

When the class in the following example gets used, the component instance would have two props, `exposed` and `internal`. The element instance only has one, `exposed`.

```js
class Example extends LightningElement {
  @api exposed = 'hello'
  internal = 'secret'
}
```

Because component authors create components, but largely consume elements, we added a new helper type in [LWC v7.0.0](https://github.com/salesforce/lwc/releases/tag/v7.0.0#user-content-improved-typescript) to bridge the gap. The new `LightningHTMLElement` type accepts a component interface and returns the corresponding element interface. However, it has a critical limitation. There is no way, in TypeScript, to distinguish decorated properties from non-decorated properties. And so, by default, `LightningHTMLElement` returns an interface with _all_ properties defined on the component, not just `@api`-decorated properties.

```ts
const example = createElement('c-example', { is: Example });
example.exposed satisfies string // ✅
example.internal satisfies string // ❌ not a type error, but it should be!
```

The workaround originally provided for this was to explicitly provide the correct interface.

```ts
createElement<{ exposed: string }>('c-example', { is: Example });
this.querySelector('c-example') as LightningHTMLElement<{ exposed: string }>
```

However, this approach is limited, as it must be done for every single usage of `createElement`/`LightningHTMLElement`. More importantly, it requires the component _consumer_ to provide the interface, rather than the component _author_. Thus, this PR introduces an new hidden/"fake" property that components can use. If a component defines `__lwc_public_property_types__`, then the type from that property is used as the public interface. This new property is "fake", in that it only exists as a hint to the type system; it never has a value at runtime. And it's "hidden" because it's not part of the public `LightningElement` interface, it's just sniffed by the helper type.

```ts
class Example {
  @api exposed = 'hello'
  internal = 'secret'
  __lwc_public_property_types__?: { exposed: string }
}

const example = createElement('c-example', { is: Example });
example.exposed satisfies string // ✅
example.internal // ✅ type error, as expected!
```

Closes #4292.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
