### PR TITLE
chore: remove structuredClone workaround

### DIFF
--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -66,13 +66,6 @@ import type {
 import type { APIVersion } from '@lwc/shared';
 import type { Node } from 'estree';
 
-// structuredClone is only available in Node 17+
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#browser_compatibility
-const doStructuredClone =
-    typeof structuredClone === 'function'
-        ? structuredClone
-        : (obj: any) => JSON.parse(JSON.stringify(obj));
-
 type RenderPrimitive =
     | 'iterator'
     | 'flatten'
@@ -629,7 +622,7 @@ export default class CodeGen {
         if (this.state.config.experimentalComplexExpressions) {
             // Cloning here is necessary because `this.replace()` is destructive, and we might use the
             // node later during static content optimization
-            expression = doStructuredClone(expression);
+            expression = structuredClone(expression);
             return bindComplexExpression(expression as ComplexExpression, this);
         }
 
@@ -639,7 +632,7 @@ export default class CodeGen {
 
         // Cloning here is necessary because `this.replace()` is destructive, and we might use the
         // node later during static content optimization
-        expression = doStructuredClone(expression);
+        expression = structuredClone(expression);
         // TODO [#3370]: when the template expression flag is removed, the
         // ComplexExpression type should be redefined as an ESTree Node. Doing
         // so when the flag is still in place results in a cascade of required


### PR DESCRIPTION
We only support environments where it exists, now.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
