### PR TITLE
chore(dependabot): separate all webdriverio versions and add group for vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,6 @@ updates:
                   - '@rollup/*'
               update-types:
                   - 'major'
-          webdriverio:
-              patterns:
-                  - 'webdriverio'
-                  - '@wdio/*'
           prettier:
               patterns:
                   - 'prettier'
@@ -47,6 +43,22 @@ updates:
                   # Prettier can introduce formatting differences in minor versions,
                   # which causes formatting checks to fail in CI.
                   - 'minor'
+          webdriverio:
+              patterns:
+                  - 'webdriverio'
+                  - '@wdio/*'
+              update-types:
+                  - 'major'
+                  - 'minor'
+                  - 'patch'
+          vitest:
+              patterns:
+                  - 'vitest'
+                  - '@vitest/*'
+              update-types:
+                  - 'major'
+                  - 'minor'
+                  - 'patch'
           # Non-major version bumps hopefully shouldn't break anything,
           # so let's group them together into a single PR!
           theoretically-non-breaking:


### PR DESCRIPTION
We still haven't fixed the vite issues in #5355 and I'm pretty sure the webdriver deps also have issues? So separating them out will hopefully unblock the rest of the dependency treadmill. (Also I alphabetized the groups.)

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
