### PR TITLE
chore(deps): bump @types/estree and parse5

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,10 +98,15 @@
     "resolutions": {
         "//": {
             "http-cache-semantics": "Pinned to address security vulnerability",
-            "semver": "Pinned to address security vulnerability"
+            "semver": "Pinned to address security vulnerability",
+            "@types/estree": [
+                "Used by us and our dependencies. Because it's a type definition package,",
+                "we need everyone to use the same types (mixing versions breaks stuff)."
+            ]
         },
         "http-cache-semantics": "4.1.1",
-        "semver": "7.6.0"
+        "semver": "7.6.0",
+        "@types/estree": "^1.0.8"
     },
     "dependencies": {}
 }

--- a/packages/@lwc/engine-server/package.json
+++ b/packages/@lwc/engine-server/package.json
@@ -51,6 +51,6 @@
         "@lwc/shared": "8.20.0",
         "@lwc/features": "8.20.0",
         "@rollup/plugin-virtual": "^3.0.2",
-        "parse5": "^7.2.1"
+        "parse5": "^7.3.0"
     }
 }

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -60,6 +60,6 @@
     },
     "devDependencies": {
         "@lwc/babel-plugin-component": "8.20.0",
-        "@types/estree": "^1.0.7"
+        "@types/estree": "^1.0.8"
     }
 }

--- a/packages/@lwc/template-compiler/package.json
+++ b/packages/@lwc/template-compiler/package.json
@@ -53,10 +53,10 @@
         "he": "~1.2.0"
     },
     "devDependencies": {
-        "@parse5/tools": "^0.5.0",
-        "@types/estree": "1.0.7",
+        "@parse5/tools": "^0.6.0",
+        "@types/estree": "^1.0.8",
         "@types/he": "^1.2.3",
         "estree-walker": "~3.0.3",
-        "parse5": "^7.2.1"
+        "parse5": "^7.3.0"
     }
 }

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -65,7 +65,7 @@ import type {
     OnDirective,
 } from '../shared/types';
 import type { APIVersion } from '@lwc/shared';
-import type { Node } from 'estree';
+import type { Node } from 'estree-walker';
 
 type RenderPrimitive =
     | 'iterator'
@@ -666,7 +666,9 @@ export default class CodeGen {
                     parent.object === node &&
                     !scope.isLocalIdentifier(node)
                 ) {
-                    this.replace(t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), node));
+                    this.replace(
+                        t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), node) as Node
+                    );
                 }
             },
         });

--- a/packages/@lwc/template-compiler/src/codegen/expression.ts
+++ b/packages/@lwc/template-compiler/src/codegen/expression.ts
@@ -19,7 +19,7 @@ import {
     isSvgUseHref,
 } from '../parser/attribute';
 import type { Attribute, BaseElement, ComplexExpression, Property } from '../shared/types';
-import type { Node } from 'estree';
+import type { Node } from 'estree-walker';
 import type CodeGen from './codegen';
 
 type VariableName = string;
@@ -79,7 +79,9 @@ export function bindComplexExpression(
                 !codeGen.isLocalIdentifier(node) &&
                 !expressionScopes.isScopedToExpression(node)
             ) {
-                this.replace(t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), node));
+                this.replace(
+                    t.memberExpression(t.identifier(TEMPLATE_PARAMS.INSTANCE), node) as Node
+                );
             }
         },
     });

--- a/packages/@lwc/template-compiler/src/codegen/optimize.ts
+++ b/packages/@lwc/template-compiler/src/codegen/optimize.ts
@@ -7,6 +7,7 @@
 import * as astring from 'astring';
 import { walk } from 'estree-walker';
 import * as t from '../shared/estree';
+import type { Node } from 'estree-walker';
 
 /**
  * Given a template function, extract all static objects/arrays (e.g. `{ key : 1 }`)
@@ -88,7 +89,7 @@ export function optimizeStaticExpressions(
         return t.identifier(keysToVariableNames.get(key));
     }
 
-    walk(templateFn, {
+    walk(templateFn as Node, {
         enter(node) {
             // For deeply-nested static object, we only want to extract the top-level node
             if (isStaticObjectOrArray(node)) {

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/validate.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/validate.ts
@@ -8,7 +8,8 @@
 import { ParserDiagnostics, invariant } from '@lwc/errors';
 import { walk } from 'estree-walker';
 import * as t from '../../shared/estree';
-import type { BaseNode, Node } from 'estree';
+import type { BaseNode } from 'estree';
+import type { Node } from 'estree-walker';
 
 const ALWAYS_INVALID_TYPES = new Map(
     Object.entries({

--- a/packages/@lwc/template-compiler/src/parser/html.ts
+++ b/packages/@lwc/template-compiler/src/parser/html.ts
@@ -13,6 +13,7 @@ import { sourceLocation } from '../shared/ast';
 
 import { errorCodesToErrorOn, errorCodesToWarnOnInOlderAPIVersions } from './parse5Errors';
 import { parseFragment } from './expression-complex';
+import type { DocumentFragment } from '@parse5/tools';
 import type ParserCtx from './parser';
 
 function getLwcErrorFromParse5Error(ctx: ParserCtx, code: string) {
@@ -36,7 +37,7 @@ function getLwcErrorFromParse5Error(ctx: ParserCtx, code: string) {
     }
 }
 
-export function parseHTML(ctx: ParserCtx, source: string) {
+export function parseHTML(ctx: ParserCtx, source: string): DocumentFragment {
     const onParseError = (err: parse5.ParserError) => {
         const { code, ...location } = err;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,12 +2275,12 @@
   resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-5.0.0.tgz#1575b4aaf6f46faf5b95003be2a5dfd8ea1e10e0"
   integrity sha512-ylppfPEg63NuRXOPNsXFlgyl37JrtRn0QMO26X3K3Ytp5HtLrMreQMGVtgr30e1l2YmAWqhvmKlCryOqzGPD/g==
 
-"@parse5/tools@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@parse5/tools/-/tools-0.5.0.tgz#9b5cafd8b5fedc3180823ea5938579216bbeb876"
-  integrity sha512-vyYK20atGm9Kwwk/vi5jTFxb7m67EG1PLTUN31+WAUsvgOThu/PjsZD57P6A1hAm2TunkzxSD9esnYv6gcWrdA==
+"@parse5/tools@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@parse5/tools/-/tools-0.6.0.tgz#9fb398bc8a3597892aadcc109a8ccad0a820ad06"
+  integrity sha512-T2mU5ZhgPHvwUdiXHweliSVt6mKPNIs3yOitW46LrhUzw/nfde6SaEjOWSXMtdiYKqyxszH2e3Uu/cAMzPi+vg==
   dependencies:
-    parse5 "^7.0.0"
+    parse5 "^7.3.0"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -2963,12 +2963,12 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@1.0.7", "@types/estree@>=1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@^1.0.7":
+"@types/estree@*", "@types/estree@1.0.7", "@types/estree@>=1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
-"@types/estree@1.0.8":
+"@types/estree@1.0.8", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -6170,6 +6170,11 @@ entities@^4.2.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
@@ -10507,6 +10512,13 @@ parse5@^7.0.0, parse5@^7.1.2, parse5@^7.2.1:
   integrity sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==
   dependencies:
     entities "^4.5.0"
+
+parse5@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
 
 parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,12 +2963,7 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@1.0.7", "@types/estree@>=1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
-  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
-
-"@types/estree@1.0.8", "@types/estree@^1.0.8":
+"@types/estree@*", "@types/estree@1.0.7", "@types/estree@1.0.8", "@types/estree@>=1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==


### PR DESCRIPTION
## Details

Dependabot PRs have been blocked for a while (see https://github.com/salesforce/lwc/pull/5355#issuecomment-2845441078, #5390). `@types/estree` and `parse5` have some minor type def changes that are a mild nuisance, so I pulled them out into their own PR.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
