### PR TITLE
chore(ci): backport perf testing config @W-18882666

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -1,0 +1,59 @@
+name: Run Performance Benchmarks
+
+on:
+    push:
+        branches:
+            - winter*
+            - spring*
+            - summer*
+
+jobs:
+    run-performance-tests:
+        # It is important to use this image so that we have a consistent IP address
+        runs-on: salesforce-Ubuntu
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20.18.1'
+                  cache: 'yarn'
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Get Previous Release
+              id: previous_release
+              run: |
+                  # Parse current season and year from branch name
+                  [[ "$GITHUB_REF_NAME" =~ ^(winter|spring|summer)([0-9]+)$ ]]
+                  season="${BASH_REMATCH[1]}"
+                  year="${BASH_REMATCH[2]}"
+
+                  # Get previous season and year
+                  case $season in
+                      winter) previous="summer$((year - 1))";;
+                      spring) previous="winter$year";;
+                      summer) previous="spring$year";;
+                  esac
+                  # Expose to GitHub Actions
+                  echo "branch=$previous" >> "$GITHUB_OUTPUT"
+
+            - name: Build benchmarks
+              env:
+                  BENCHMARK_REF: ${{steps.previous_release.outputs.branch}}
+              run: yarn build:performance
+
+            - name: Run benchmarks
+              working-directory: ./packages/@lwc/perf-benchmarks
+              env:
+                  BENCHMARK_REF: ${{steps.previous_release.outputs.branch}}
+              run: |
+                  echo "Running benchmarks for $GITHUB_REF_NAME against $BENCHMARK_REF"
+                  yarn test:run
+
+            - name: Format results
+              working-directory: ./packages/@lwc/perf-benchmarks
+              run: yarn --silent test:format >> "$GITHUB_STEP_SUMMARY"

--- a/nx.json
+++ b/nx.json
@@ -24,5 +24,8 @@
     },
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "cacheDirectory": "./.nx-cache",
-    "defaultBase": "master"
+    "defaultBase": "master",
+    "tui": {
+        "enabled": false
+    }
 }

--- a/packages/@lwc/perf-benchmarks/package.json
+++ b/packages/@lwc/perf-benchmarks/package.json
@@ -27,7 +27,7 @@
         "@best/runner-remote": "^14.0.0",
         "folder-hash": "4.1.1",
         "markdown-table": "^3.0.4",
-        "tachometer": "^0.7.1"
+        "tachometer": "^0.7.2"
     },
     "nx": {
         "targets": {

--- a/packages/@lwc/perf-benchmarks/scripts/build.js
+++ b/packages/@lwc/perf-benchmarks/scripts/build.js
@@ -112,8 +112,10 @@ function createTachometerJson(htmlFilename, benchmarkName, directoryHash, cpuThr
                                             // We want to recompile whatever benchmarks we've added with the
                                             // compiler code from tip-of-tree, but we also want Tachometer to serve
                                             // `@lwc/perf-benchmarks-components` itself.
-                                            'rm -fr ./packages/@lwc/perf-benchmarks-components/{src,scripts}',
-                                            `cp -R ${benchmarkComponentsDir}/{src,scripts} ./packages/@lwc/perf-benchmarks-components`,
+                                            'rm -fr ./packages/@lwc/perf-benchmarks-components/src',
+                                            'rm -fr ./packages/@lwc/perf-benchmarks-components/scripts',
+                                            `cp -R ${benchmarkComponentsDir}/src ./packages/@lwc/perf-benchmarks-components`,
+                                            `cp -R ${benchmarkComponentsDir}/scripts ./packages/@lwc/perf-benchmarks-components`,
                                             'yarn --frozen-lockfile',
                                             // bust the Tachometer cache in case these files change locally
                                             `echo '${directoryHash}'`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,9 +1975,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4":
   version "0.2.4"
@@ -12022,10 +12024,10 @@ table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tachometer@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/tachometer/-/tachometer-0.7.1.tgz#5564e04f7b752cc1c7baa23c6cae7c80033015f2"
-  integrity sha512-gOc7NfhriHamSFG9bBVzhB80V97jUoIPKz3QOO8vDma7hUwJSulShCUm+dS7qu2r+qH/dcvB1jFQnt/m2Z4O+w==
+tachometer@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/tachometer/-/tachometer-0.7.2.tgz#111c6b179f90399c9207cfa3cad41429cd1714cd"
+  integrity sha512-e9dtDyWuMFyomQxo16vzti6ymoJd3Dp2yGfKrhAiNzCkb2HiP6A0+SWtqE84hcO6tSKZF8eTFqrxM2uKbliJyQ==
   dependencies:
     ansi-escape-sequences "^6.0.1"
     command-line-args "^5.0.2"


### PR DESCRIPTION
## Details

See #5408 for details; this backports the configuration so that we can have perf tests run if we make changes to the current release.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
