### PR TITLE
chore: remove dead code

### DIFF
--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -20,12 +20,11 @@ import { logError } from '../shared/logger';
 
 import api from './api';
 import { RenderMode, ShadowMode } from './vm';
-import { computeHasScopedStyles, hasStyles } from './template';
+import { hasStyles } from './template';
 import { getStyleOrSwappedStyle } from './hot-swaps';
 import { checkVersionMismatch } from './check-version-mismatch';
-import { getComponentInternalDef } from './def';
 import { assertNotProd, EmptyArray } from './utils';
-import type { VCustomElement, VNode } from './vnodes';
+import type { VNode } from './vnodes';
 import type { Template } from './template';
 import type { VM } from './vm';
 import type { Stylesheet, Stylesheets } from '@lwc/shared';
@@ -319,22 +318,6 @@ export function getScopeTokenClass(owner: VM, legacy: boolean): string | null {
             (legacy ? cmpTemplate?.legacyStylesheetToken : cmpTemplate?.stylesheetToken)) ||
         null
     );
-}
-
-/**
- * This function returns the host style token for a custom element if it
- * exists. Otherwise it returns null.
- *
- * A host style token is applied to the component if scoped styles are used.
- * @param vnode
- */
-export function getStylesheetTokenHost(vnode: VCustomElement): string | null {
-    const { template } = getComponentInternalDef(vnode.ctor);
-    const { vm } = vnode;
-    const { stylesheetToken } = template;
-    return !isUndefined(stylesheetToken) && computeHasScopedStyles(template, vm)
-        ? makeHostToken(stylesheetToken)
-        : null;
 }
 
 function getNearestNativeShadowComponent(vm: VM): VM | null {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -471,7 +471,7 @@ function computeHasScopedStylesInStylesheets(stylesheets: Stylesheets | undefine
     return false;
 }
 
-export function computeHasScopedStyles(template: Template, vm: VM | undefined): boolean {
+function computeHasScopedStyles(template: Template, vm: VM | undefined): boolean {
     const { stylesheets } = template;
     const vmStylesheets = !isUndefined(vm) ? vm.stylesheets : null;
 


### PR DESCRIPTION
`getStylesheetTokenHost` was removed in #4865

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
