### PR TITLE
fix: check process is defined in ssr-client-utils

### DIFF
--- a/packages/@lwc/ssr-client-utils/src/index.ts
+++ b/packages/@lwc/ssr-client-utils/src/index.ts
@@ -62,6 +62,6 @@ export function registerLwcStyleComponent() {
 }
 
 // Only used in LWC's Karma tests
-if (process.env.NODE_ENV === 'test-karma-lwc') {
+if (typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test-karma-lwc') {
     (window as any).__lwcClearStylesheetCache = () => stylesheetCache.clear();
 }


### PR DESCRIPTION
## Details

The `process` object is not defined when imported and this scenario needs to be protected.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

W-19292529