### PR TITLE
chore(release): update scripts for other git configs and backports

### DIFF
--- a/scripts/release/version.sh
+++ b/scripts/release/version.sh
@@ -44,8 +44,10 @@ if ! gh >/dev/null; then
 fi
 
 # Use GitHub CLI to create a PR and wait for it to be merged before exiting
-gh pr create -t "$VERSION_BUMP_MESSAGE" -b ''
-gh pr merge --auto --squash --delete-branch
+gh pr create -t "$VERSION_BUMP_MESSAGE" -b '' -B "$BASE_BRANCH" -H "$BRANCH"
+# Squash on master, but not backports
+[ "$BASE_BRANCH" == 'master' ] && SQUASH='--squash'
+gh pr merge --auto --delete-branch $SQUASH
 git switch "$BASE_BRANCH"
 git branch -D "$BRANCH"
 


### PR DESCRIPTION
## Details

1. We can create and push a branch without checking it out, which is faster.
2. `git push` needs `-u` if you just use the default git config.
3. Made the branch explicit for some `gh` commands, so that they don't rely on the default.
4. Made `--squash` conditional for backports.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
