### PR TITLE
fix: remove redundant optional chaining on process.env which is breaking testing

### DIFF
--- a/packages/@lwc/ssr-client-utils/src/index.ts
+++ b/packages/@lwc/ssr-client-utils/src/index.ts
@@ -62,6 +62,12 @@ export function registerLwcStyleComponent() {
 }
 
 // Only used in LWC's Karma tests
-if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test-karma-lwc') {
+// See PR-5281 for precedence on extra guards
+if (
+    typeof process === 'object' &&
+    typeof process?.env === 'object' &&
+    process.env &&
+    process.env.NODE_ENV === 'test-karma-lwc'
+) {
     (window as any).__lwcClearStylesheetCache = () => stylesheetCache.clear();
 }


### PR DESCRIPTION
## Details

Optional chaining on process.env fails tests due to rollup transformations which do not match. The optional checks are redundant given the preceding typeof check. 

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

[W-19309489](https://gus.lightning.force.com/a07EE00002JzEBAYA3)