### PR TITLE
chore(deps): unpin semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,14 +98,12 @@
     "resolutions": {
         "//": {
             "http-cache-semantics": "Pinned to address security vulnerability",
-            "semver": "Pinned to address security vulnerability",
             "@types/estree": [
                 "Used by us and our dependencies. Because it's a type definition package,",
                 "we need everyone to use the same types (mixing versions breaks stuff)."
             ]
         },
         "http-cache-semantics": "4.1.1",
-        "semver": "7.6.0",
         "@types/estree": "^1.0.8"
     },
     "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2109,9 +2109,11 @@
 
 "@lwc/eslint-plugin-lwc-internal@link:./scripts/eslint-plugin":
   version "0.0.0"
+  uid ""
 
 "@lwc/test-utils-lwc-internals@link:./scripts/test-utils":
   version "0.0.0"
+  uid ""
 
 "@napi-rs/wasm-runtime@0.2.4":
   version "0.2.4"
@@ -12225,12 +12227,27 @@ semver-truncate@^1.1.2:
   dependencies:
     semver "^5.3.0"
 
-semver@7.6.0, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^6.3.0, semver@^6.3.1, semver@^7.1.1, semver@^7.3.2, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.2:
+semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.1.1, semver@^7.3.2, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3, semver@^7.7.2:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 send@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
Running `yarn install` (before):

```
yarn install v1.22.22
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^7.6.3"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.1"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^6.3.0"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^7.6.3"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^7.6.3"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^7.7.2"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^5.6.0"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^5.5.0"
warning Resolution field "semver@7.6.0" is incompatible with requested version "semver@^5.3.0"
warning Resolution field "http-cache-semantics@4.1.1" is incompatible with requested version "http-cache-semantics@3.8.1"
success Already up-to-date.
```

Running `yarn install` (after):
```
yarn install v1.22.22
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning Resolution field "http-cache-semantics@4.1.1" is incompatible with requested version "http-cache-semantics@3.8.1"
success Already up-to-date.
```

We originally pinned semver to patch a [vulnerability](https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795). That was a while ago, and all of our dependencies now used patched versions, so the pin is no longer necessary. And it makes `yarn install` way less noisy! You can verify that this is safe by running `yarn audit` and seeing that semver is not listed, or by running `yarn why semver` and seeing that all installed versions are not vulnerable.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
