### PR TITLE
fix: attribute cte syntax in integration tests

### DIFF
--- a/packages/@lwc/integration-karma/test/template-expressions/errors/x/throwDuringCallChild/throwDuringCallChild.html
+++ b/packages/@lwc/integration-karma/test/template-expressions/errors/x/throwDuringCallChild/throwDuringCallChild.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={runRunAsFastAsYouCan()}></div>
+    <div foo="{runRunAsFastAsYouCan()}"></div>
 </template>

--- a/packages/@lwc/integration-karma/test/template-expressions/errors/x/undefinedMemberExpressionObjChild/undefinedMemberExpressionObjChild.html
+++ b/packages/@lwc/integration-karma/test/template-expressions/errors/x/undefinedMemberExpressionObjChild/undefinedMemberExpressionObjChild.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={nonexistent.thing}></div>
+    <div foo="{nonexistent.thing}"></div>
 </template>

--- a/packages/@lwc/integration-karma/test/template-expressions/smoke-test/x/test/test.html
+++ b/packages/@lwc/integration-karma/test/template-expressions/smoke-test/x/test/test.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={bar()}></div>
+    <div foo="{bar()}"></div>
 </template>

--- a/packages/@lwc/integration-not-karma/test/template-expressions/errors/x/throwDuringCallChild/throwDuringCallChild.html
+++ b/packages/@lwc/integration-not-karma/test/template-expressions/errors/x/throwDuringCallChild/throwDuringCallChild.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={runRunAsFastAsYouCan()}></div>
+    <div foo="{runRunAsFastAsYouCan()}"></div>
 </template>

--- a/packages/@lwc/integration-not-karma/test/template-expressions/errors/x/undefinedMemberExpressionObjChild/undefinedMemberExpressionObjChild.html
+++ b/packages/@lwc/integration-not-karma/test/template-expressions/errors/x/undefinedMemberExpressionObjChild/undefinedMemberExpressionObjChild.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={nonexistent.thing}></div>
+    <div foo="{nonexistent.thing}"></div>
 </template>

--- a/packages/@lwc/integration-not-karma/test/template-expressions/smoke-test/x/test/test.html
+++ b/packages/@lwc/integration-not-karma/test/template-expressions/smoke-test/x/test/test.html
@@ -1,3 +1,3 @@
 <template>
-    <div foo={bar()}></div>
+    <div foo="{bar()}"></div>
 </template>


### PR DESCRIPTION
## Details

CTE expressions should have "{}" syntax now, this was missing from the integration tests.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item
