### PR TITLE
test(wtr): remove duplicate code

### DIFF
--- a/packages/@lwc/integration-not-karma/helpers/matchers/errors.js
+++ b/packages/@lwc/integration-not-karma/helpers/matchers/errors.js
@@ -36,7 +36,7 @@ function windowErrorListener(callback) {
 // 2) We're using native lifecycle callbacks, so the error is thrown asynchronously and can
 //    only be caught with window.addEventListener('error')
 //      - Note native lifecycle callbacks are all thrown asynchronously.
-function customElementCallbackReactionErrorListener(callback) {
+export function customElementCallbackReactionErrorListener(callback) {
     return lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
         ? directErrorListener(callback)
         : windowErrorListener(callback);

--- a/packages/@lwc/integration-not-karma/helpers/utils.js
+++ b/packages/@lwc/integration-not-karma/helpers/utils.js
@@ -2,50 +2,6 @@
  * An as yet uncategorized mishmash of helpers, relics of Karma
  */
 
-// Listen for errors thrown directly by the callback
-function directErrorListener(callback) {
-    try {
-        callback();
-    } catch (error) {
-        return error;
-    }
-}
-
-// Listen for errors using window.addEventListener('error')
-function windowErrorListener(callback) {
-    let error;
-    function onError(event) {
-        event.preventDefault(); // don't log the error
-        error = event.error;
-    }
-
-    // Prevent jasmine from handling the global error. There doesn't seem to be another
-    // way to disable this behavior: https://github.com/jasmine/jasmine/pull/1860
-    const originalOnError = window.onerror;
-    window.onerror = null;
-    window.addEventListener('error', onError);
-
-    try {
-        callback();
-    } finally {
-        window.onerror = originalOnError;
-        window.removeEventListener('error', onError);
-    }
-    return error;
-}
-
-// For errors we expect to be thrown in the connectedCallback() phase
-// of a custom element, there are two possibilities:
-// 1) We're using non-native lifecycle callbacks, so the error is thrown synchronously
-// 2) We're using native lifecycle callbacks, so the error is thrown asynchronously and can
-//    only be caught with window.addEventListener('error')
-//      - Note native lifecycle callbacks are all thrown asynchronously.
-export function customElementCallbackReactionErrorListener(callback) {
-    return lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
-        ? directErrorListener(callback)
-        : windowErrorListener(callback);
-}
-
 export function extractDataIds(root) {
     const nodes = {};
 

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.attachInternals/api/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.attachInternals/api/index.spec.js
@@ -7,7 +7,7 @@ import {
     ENABLE_ELEMENT_INTERNALS_AND_FACE,
     IS_SYNTHETIC_SHADOW_LOADED,
 } from '../../../../helpers/constants.js';
-import { customElementCallbackReactionErrorListener } from '../../../../helpers/utils.js';
+import { customElementCallbackReactionErrorListener } from '../../../../helpers/matchers/errors.js';
 
 const testConnectedCallbackError = (elm, msg) => {
     const error = customElementCallbackReactionErrorListener(() => {

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.connectedCallback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.connectedCallback/index.spec.js
@@ -3,7 +3,7 @@ import { createElement } from 'lwc';
 import Test from 'x/test';
 import ConnectedCallbackThrow from 'x/connectedCallbackThrow';
 import XSlottedParent from 'x/slottedParent';
-import { customElementCallbackReactionErrorListener } from '../../../helpers/utils.js';
+import { customElementCallbackReactionErrorListener } from '../../../helpers/matchers/errors.js';
 
 function testConnectSlot(name, fn) {
     it(`should invoke the connectedCallback the root element is added in the DOM via ${name}`, () => {

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
@@ -6,7 +6,7 @@ import DisconnectedCallbackThrow from 'x/disconnectedCallbackThrow';
 import DualTemplate from 'x/dualTemplate';
 import ExplicitRender from 'x/explicitRender';
 import { jasmine } from '../../../helpers/jasmine.js';
-import { customElementCallbackReactionErrorListener } from '../../../helpers/utils.js';
+import { customElementCallbackReactionErrorListener } from '../../../helpers/matchers/errors.js';
 
 function testDisconnectSlot(name, fn) {
     it(`should invoke the disconnectedCallback when root element is removed from the DOM via ${name}`, () => {

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.render/index.spec.js
@@ -3,7 +3,7 @@ import { createElement, registerTemplate } from 'lwc';
 import DynamicTemplate, { template1, template2 } from 'x/dynamicTemplate';
 import RenderThrow from 'x/renderThrow';
 import RenderInvalid from 'x/renderInvalid';
-import { customElementCallbackReactionErrorListener } from '../../../helpers/utils.js';
+import { customElementCallbackReactionErrorListener } from '../../../helpers/matchers/errors.js';
 
 function testInvalidTemplate(type, template) {
     it(`throws an error if returns ${type}`, () => {


### PR DESCRIPTION
I had previously moved the code to a new file, but not removed the old code or updated references. Oops.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
